### PR TITLE
update node exporter job to keep instance label as pod name and node …

### DIFF
--- a/prometheus-ksonnet/lib/prometheus-config.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus-config.libsonnet
@@ -198,11 +198,18 @@
             action: 'keep',
           },
 
+          // Rename instances to be the pod name
+          {
+            source_labels: ['__meta_kubernetes_pod_name'],
+            action: 'replace',
+            target_label: 'instance',
+          },
+
           // Rename instances to be the node name.
           {
             source_labels: ['__meta_kubernetes_pod_node_name'],
             action: 'replace',
-            target_label: 'instance',
+            target_label: 'node',
           },
         ],
       },


### PR DESCRIPTION
This PR reverts the instance label on the node exporter job to the pod name and adds a node label with the name of the node. This fixes the following rule which currently is not being evaluated correctly.

```
{
  record: 'node:node_num_cpu:sum',
  expr: |||
    count by (node) (sum by (node, cpu) (
      node_cpu{%(nodeExporterSelector)s}
    * on (namespace, %(podLabel)s) group_left(node)
      node_namespace_pod:kube_pod_info:
   ))
}
```