### PR TITLE
Add option for best effort anti-affinity

### DIFF
--- a/ksonnet-util/kausal.libsonnet
+++ b/ksonnet-util/kausal.libsonnet
@@ -321,5 +321,20 @@ k {
           podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecutionType.withTopologyKey('kubernetes.io/hostname'),
         ]).spec,
       },
+
+    antiAffinityBestEffort:
+      {
+        local deployment = $.apps.v1beta1.deployment,
+        local podAntiAffinity = deployment.mixin.spec.template.spec.affinity.podAntiAffinity,
+        local weightedPodAffinityTerm = podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecutionType,
+        local name = super.spec.template.metadata.labels.name,
+
+        spec+: podAntiAffinity.withPreferredDuringSchedulingIgnoredDuringExecution([
+          weightedPodAffinityTerm.new() +
+          weightedPodAffinityTerm.withWeight(100) +
+          weightedPodAffinityTerm.mixin.podAffinityTerm.labelSelector.withMatchLabels({ name: name }) +
+          weightedPodAffinityTerm.mixin.podAffinityTerm.withTopologyKey('kubernetes.io/hostname'),
+        ]).spec,
+      },
   },
 }


### PR DESCRIPTION
Most applications don't require strict anti-affinity, only best effort. If I were to use the strict version on a local minikube setup, I wouldn't be able to deploy new version. 