### PR TITLE
latest kube-state-metrics needs access to configmaps and secrets

### DIFF
--- a/prometheus-ksonnet/lib/kube-state-metrics.libsonnet
+++ b/prometheus-ksonnet/lib/kube-state-metrics.libsonnet
@@ -6,6 +6,8 @@
       policyRule.new() +
       policyRule.withApiGroups(['']) +
       policyRule.withResources([
+        'configmaps',
+        'secrets',
         'nodes',
         'pods',
         'services',


### PR DESCRIPTION
support for configmaps and secrets was added in kube-state-metrics 1.3.
so we need to grant the role access to read them as per
https://github.com/kubernetes/kube-state-metrics/blob/release-1.3/kubernetes/kube-state-metrics-cluster-role.yaml