### PR TITLE
All statefulsets should use RollingUpdate by default.

### DIFF
--- a/ksonnet-util/kausal.libsonnet
+++ b/ksonnet-util/kausal.libsonnet
@@ -125,7 +125,8 @@ k {
 
     statefulSet+: {
       new(name, replicas, containers, volumeClaims, podLabels={})::
-        super.new(name, replicas, containers, volumeClaims, podLabels { name: name }),
+        super.new(name, replicas, containers, volumeClaims, podLabels { name: name }) +
+        super.mixin.spec.updateStrategy.withType("RollingUpdate"),
     },
   },
 


### PR DESCRIPTION
Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>