### PR TITLE
remove config.file from container.withArgs for prometheus

### DIFF
--- a/prometheus-ksonnet/lib/prometheus.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus.libsonnet
@@ -19,7 +19,6 @@
     container.new('prometheus', $._images.prometheus) +
     container.withPorts($.core.v1.containerPort.new('http-metrics', 80)) +
     container.withArgs([
-      '--config.file=/etc/prometheus/prometheus.yml',
       '--web.listen-address=:%s' % $._config.prometheus_port,
       '--web.external-url=%s%s' % [$._config.prometheus_external_hostname, $._config.prometheus_path],
       '--web.enable-lifecycle',


### PR DESCRIPTION
The Prometheus Dockerfile was changed recently (prometheus/prometheus#4796) to use `Entrypoint` only instead of `Entrypoint` and `Cmd`. This meant that args we passed in here were appended to the end of the Prometheus command inside the container, rather than overriding the defaults that were there previously via `Cmd`, so `--config.file` was being passed twice.

We don't pass a value for config file that's any different than the default anyways.

cc @tomwilkie 

Signed-off-by: Callum Styan <callumstyan@gmail.com>