### PR TITLE
Prometheus puts config file in the entrypoint now

### DIFF
--- a/prometheus-ksonnet/lib/prometheus.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus.libsonnet
@@ -19,7 +19,6 @@
     container.new('prometheus', $._images.prometheus) +
     container.withPorts($.core.v1.containerPort.new('http-metrics', 80)) +
     container.withArgs([
-      '--config.file=/etc/prometheus/prometheus.yml',
       '--web.listen-address=:%s' % $._config.prometheus_port,
       '--web.external-url=%s%s' % [$._config.prometheus_external_hostname, $._config.prometheus_path],
       '--web.enable-lifecycle',


### PR DESCRIPTION
https://github.com/prometheus/prometheus/blob/master/Dockerfile#L22

Repeated flags means Prometheus will fail to start. This should not
break anything as the flag value is the default in the Dockerfile also

Signed-off-by: Goutham Veeramachaneni <gouthamve@gmail.com>