### PR TITLE
Revert "Prometheus puts config file in the entrypoint now"

### DIFF
--- a/prometheus-ksonnet/lib/prometheus.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus.libsonnet
@@ -19,6 +19,7 @@
     container.new('prometheus', $._images.prometheus) +
     container.withPorts($.core.v1.containerPort.new('http-metrics', 80)) +
     container.withArgs([
+      '--config.file=/etc/prometheus/prometheus.yml',
       '--web.listen-address=:%s' % $._config.prometheus_port,
       '--web.external-url=%s%s' % [$._config.prometheus_external_hostname, $._config.prometheus_path],
       '--web.enable-lifecycle',


### PR DESCRIPTION
Reverts grafana/jsonnet-libs#96


Ughh, I don't know what I was thinking back then. This is why I should stop working when tired. This does break things when we deploy using `2.6`