### PR TITLE
WIP Use __meta_kubernetes_pod_controller_name instead of pod name label.

### DIFF
--- a/prometheus-ksonnet/lib/prometheus-config.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus-config.libsonnet
@@ -97,16 +97,9 @@
             replacement: '$1:$3',
           },
 
-          // Drop pods without a name label
+          // Rename jobs to be <namespace>/<name, pod controller name>
           {
-            source_labels: ['__meta_kubernetes_pod_label_name'],
-            action: 'drop',
-            regex: '^$',
-          },
-
-          // Rename jobs to be <namespace>/<name, from pod name label>
-          {
-            source_labels: ['__meta_kubernetes_namespace', '__meta_kubernetes_pod_label_name'],
+            source_labels: ['__meta_kubernetes_namespace', '__meta_kubernetes_pod_controller_name'],
             action: 'replace',
             separator: '/',
             target_label: 'job',


### PR DESCRIPTION
This means we don't need to rely on there being a name label on the pods, should be more generic across different clusters.

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>