### PR TITLE
Panel ids should start at 1

### DIFF
--- a/grafana-builder/grafana.libsonnet
+++ b/grafana-builder/grafana.libsonnet
@@ -1,7 +1,7 @@
 {
   dashboard(title, uid=''):: {
     // Stuff that isn't materialised.
-    _nextPanel:: 0,
+    _nextPanel:: 1,
     addRow(row):: self {
       // automatically number panels in added rows.
       local n = std.length(row.panels),


### PR DESCRIPTION
Panel ids should start with 1 (as most DB / auto increment ids). 