### PR TITLE
Make is possible to launch multiple Prometheus instances in the same namespace using this library.

### DIFF
--- a/prometheus-ksonnet/lib/prometheus-config.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus-config.libsonnet
@@ -410,14 +410,4 @@
   // We changes to using camelCase, but here we try and make it backwards compatible.
   prometheusAlerts+:: $.prometheus_alerts,
   prometheusRules+:: $.prometheus_rules,
-
-  local configMap = $.core.v1.configMap,
-
-  prometheus_config_map:
-    configMap.new('prometheus-config') +
-    configMap.withData({
-      'prometheus.yml': $.util.manifestYaml($.prometheus_config),
-      'alerts.rules': $.util.manifestYaml($.prometheusAlerts),
-      'recording.rules': $.util.manifestYaml($.prometheusRules),
-    }),
 }

--- a/prometheus-ksonnet/lib/prometheus.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus.libsonnet
@@ -1,106 +1,137 @@
 {
-  local policyRule = $.rbac.v1beta1.policyRule,
+  prometheus:: {
+    name:: error 'must specify name',
 
-  prometheus_rbac:
-    $.util.rbac('prometheus', [
-      policyRule.new() +
-      policyRule.withApiGroups(['']) +
-      policyRule.withResources(['nodes', 'nodes/proxy', 'services', 'endpoints', 'pods']) +
-      policyRule.withVerbs(['get', 'list', 'watch']),
+    local policyRule = $.rbac.v1beta1.policyRule,
 
-      policyRule.new() +
-      policyRule.withNonResourceUrls('/metrics') +
-      policyRule.withVerbs(['get']),
-    ]),
+    prometheus_rbac:
+      $.util.rbac(self.name, [
+        policyRule.new() +
+        policyRule.withApiGroups(['']) +
+        policyRule.withResources(['nodes', 'nodes/proxy', 'services', 'endpoints', 'pods']) +
+        policyRule.withVerbs(['get', 'list', 'watch']),
 
-  local container = $.core.v1.container,
+        policyRule.new() +
+        policyRule.withNonResourceUrls('/metrics') +
+        policyRule.withVerbs(['get']),
+      ]),
 
-  prometheus_container::
-    container.new('prometheus', $._images.prometheus) +
-    container.withPorts($.core.v1.containerPort.new('http-metrics', 80)) +
-    container.withArgs([
-      '--config.file=/etc/prometheus/prometheus.yml',
-      '--web.listen-address=:%s' % $._config.prometheus_port,
-      '--web.external-url=%s%s' % [$._config.prometheus_external_hostname, $._config.prometheus_path],
-      '--web.enable-lifecycle',
-      '--web.route-prefix=%s' % $._config.prometheus_web_route_prefix,
-      '--storage.tsdb.path=/prometheus/data',
-    ]) +
-    $.util.resourcesRequests('250m', '1536Mi') +
-    $.util.resourcesLimits('500m', '2Gi'),
+    // We bounce through various layers of indirection so user can:
+    // a) override config for all Prometheus' by merging into $.prometheus_config,
+    // b) override config for a specific Prometheus instance by merging in here.
+    local configMap = $.core.v1.configMap,
 
-  prometheus_watch_container::
-    container.new('watch', $._images.watch) +
-    container.withArgs([
-      '-v',
-      '-t',
-      '-p=/etc/prometheus',
-      'curl',
-      '-X',
-      'POST',
-      '--fail',
-      '-o',
-      '-',
-      '-sS',
-      'http://localhost:%s%s-/reload' % [$._config.prometheus_port, $._config.prometheus_web_route_prefix],
-    ]),
+    prometheus_config:: $.prometheus_config,
+    prometheusAlerts:: $.prometheusAlerts,
+    prometheusRules:: $.prometheusRules,
 
-  local deployment = $.apps.v1beta1.deployment,
+    prometheus_config_map:
+      // Can't reference self.foo below as we're in a map context, so
+      // need to capture reference to the configs in scope here.
+      local prometheus_config = self.prometheus_config;
+      local prometheusAlerts = self.prometheusAlerts;
+      local prometheusRules = self.prometheusRules;
 
-  prometheus_deployment:
-    if $._config.stateful
-    then {}
-    else (
-      deployment.new('prometheus', 1, [
-        $.prometheus_container,
-        $.prometheus_watch_container,
+      configMap.new('%s-config' % self.name) +
+      configMap.withData({
+        'prometheus.yml': $.util.manifestYaml(prometheus_config),
+        'alerts.rules': $.util.manifestYaml(prometheusAlerts),
+        'recording.rules': $.util.manifestYaml(prometheusRules),
+      }),
+
+    local container = $.core.v1.container,
+
+    prometheus_container::
+      container.new('prometheus', $._images.prometheus) +
+      container.withPorts($.core.v1.containerPort.new('http-metrics', 80)) +
+      container.withArgs([
+        '--config.file=/etc/prometheus/prometheus.yml',
+        '--web.listen-address=:%s' % $._config.prometheus_port,
+        '--web.external-url=%s%s' % [$._config.prometheus_external_hostname, $._config.prometheus_path],
+        '--web.enable-lifecycle',
+        '--web.route-prefix=%s' % $._config.prometheus_web_route_prefix,
+        '--storage.tsdb.path=/prometheus/data',
       ]) +
-      $.util.configVolumeMount('prometheus-config', '/etc/prometheus') +
-      deployment.mixin.spec.template.metadata.withAnnotations({ 'prometheus.io.path': '%smetrics' % $._config.prometheus_web_route_prefix }) +
-      deployment.mixin.spec.template.spec.securityContext.withRunAsUser(0) +
-      if $._config.enable_rbac
-      then deployment.mixin.spec.template.spec.withServiceAccount('prometheus')
-      else {}
-    ),
+      $.util.resourcesRequests('250m', '1536Mi') +
+      $.util.resourcesLimits('500m', '2Gi'),
 
-  local pvc = $.core.v1.persistentVolumeClaim,
+    prometheus_watch_container::
+      container.new('watch', $._images.watch) +
+      container.withArgs([
+        '-v',
+        '-t',
+        '-p=/etc/prometheus',
+        'curl',
+        '-X',
+        'POST',
+        '--fail',
+        '-o',
+        '-',
+        '-sS',
+        'http://localhost:%s%s-/reload' % [$._config.prometheus_port, $._config.prometheus_web_route_prefix],
+      ]),
 
-  prometheus_pvc::
-    if !($._config.stateful)
-    then {}
-    else (
-      pvc.new() +
-      pvc.mixin.metadata.withName('prometheus-data') +
-      pvc.mixin.spec.withAccessModes('ReadWriteOnce') +
-      pvc.mixin.spec.resources.withRequests({ storage: '300Gi' })
-    ),
+    local deployment = $.apps.v1beta1.deployment,
 
-  local statefulset = $.apps.v1beta1.statefulSet,
-  local volumeMount = $.core.v1.volumeMount,
-
-  prometheus_statefulset:
-    if !($._config.stateful)
-    then {}
-    else (
-      statefulset.new('prometheus', 1, [
-        $.prometheus_container.withVolumeMountsMixin(
-          volumeMount.new('prometheus-data', '/prometheus')
-        ),
-        $.prometheus_watch_container,
-      ], $.prometheus_pvc) +
-      $.util.configVolumeMount('prometheus-config', '/etc/prometheus') +
-      statefulset.mixin.spec.withServiceName('prometheus') +
-      statefulset.mixin.spec.template.metadata.withAnnotations({ 'prometheus.io.path': '%smetrics' % $._config.prometheus_web_route_prefix }) +
-      statefulset.mixin.spec.template.spec.securityContext.withRunAsUser(0) +
-      if $._config.enable_rbac
-      then statefulset.mixin.spec.template.spec.withServiceAccount('prometheus')
-      else {}
-    ),
-
-  prometheus_service:
-    $.util.serviceFor(
+    prometheus_deployment:
       if $._config.stateful
-      then $.prometheus_statefulset
-      else $.prometheus_deployment
-    ),
+      then {}
+      else (
+        deployment.new(self.name, 1, [
+          self.prometheus_container,
+          self.prometheus_watch_container,
+        ]) +
+        $.util.configVolumeMount('%s-config' % self.name, '/etc/prometheus') +
+        deployment.mixin.spec.template.metadata.withAnnotations({ 'prometheus.io.path': '%smetrics' % $._config.prometheus_web_route_prefix }) +
+        deployment.mixin.spec.template.spec.securityContext.withRunAsUser(0) +
+        if $._config.enable_rbac
+        then deployment.mixin.spec.template.spec.withServiceAccount('prometheus')
+        else {}
+      ),
+
+    local pvc = $.core.v1.persistentVolumeClaim,
+
+    prometheus_pvc::
+      if !($._config.stateful)
+      then {}
+      else (
+        pvc.new() +
+        pvc.mixin.metadata.withName('%s-data' % (self.name)) +
+        pvc.mixin.spec.withAccessModes('ReadWriteOnce') +
+        pvc.mixin.spec.resources.withRequests({ storage: '300Gi' })
+      ),
+
+    local statefulset = $.apps.v1beta1.statefulSet,
+    local volumeMount = $.core.v1.volumeMount,
+
+    prometheus_statefulset:
+      if !($._config.stateful)
+      then {}
+      else (
+        statefulset.new(self.name, 1, [
+          self.prometheus_container.withVolumeMountsMixin(
+            volumeMount.new('%s-data' % self.name, '/prometheus')
+          ),
+          self.prometheus_watch_container,
+        ], self.prometheus_pvc) +
+        $.util.configVolumeMount('%s-config' % self.name, '/etc/prometheus') +
+        statefulset.mixin.spec.withServiceName('prometheus') +
+        statefulset.mixin.spec.template.metadata.withAnnotations({ 'prometheus.io.path': '%smetrics' % $._config.prometheus_web_route_prefix }) +
+        statefulset.mixin.spec.template.spec.securityContext.withRunAsUser(0) +
+        if $._config.enable_rbac
+        then statefulset.mixin.spec.template.spec.withServiceAccount(self.name)
+        else {}
+      ),
+
+    prometheus_service:
+      $.util.serviceFor(
+        if $._config.stateful
+        then self.prometheus_statefulset
+        else self.prometheus_deployment
+      ),
+  },
+
+  main_prometheus: $.prometheus {
+    name: "prometheus",
+  },
 }


### PR DESCRIPTION
But try and be backwards compatible.  Some overrides will now fail and need to be updated.  If you had:

```
{
  prometheus_container+:	  
    $.util.resourcesRequests('2', '8Gi'),
}
```

You will need to update it to:

```
{
  main_prometheus+: {
    prometheus_container+:	  
      $.util.resourcesRequests('2', '8Gi'),
  },
}
```