### PR TITLE
Add option to scrape api-server via the kubernetes service, and not via the service endpoints.

### DIFF
--- a/prometheus-ksonnet/images.libsonnet
+++ b/prometheus-ksonnet/images.libsonnet
@@ -1,7 +1,7 @@
 {
   _images+:: {
     prometheus: 'prom/prometheus:v2.6.1',
-    grafana: 'grafana/grafana:6.0.0-beta3',
+    grafana: 'grafana/grafana:6.0.2',
     watch: 'weaveworks/watch:master-5b2a6e5',
     kubeStateMetrics: 'gcr.io/google_containers/kube-state-metrics:v1.4.0',
     gfdatasource: 'quay.io/weaveworks/gfdatasource:master-2bda599',

--- a/prometheus-ksonnet/lib/config.libsonnet
+++ b/prometheus-ksonnet/lib/config.libsonnet
@@ -19,6 +19,7 @@
 
     // Prometheus config options.
     prometheus_api_server_address: self.apiServerAddress,
+    scrape_api_server_endpoints: true,
     prometheus_insecure_skip_verify: self.insecureSkipVerify,
     prometheus_external_hostname: 'http://prometheus.%(namespace)s.svc.%(cluster_dns_suffix)s' % self,
     prometheus_path: '/prometheus/',

--- a/prometheus-ksonnet/lib/prometheus-config.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus-config.libsonnet
@@ -302,11 +302,14 @@
       },
 
       // If running on GKE, you cannot scrape API server pods, and must instead
-      // scrape the API server service.
+      // scrape the API server service endpoints.  On AKS this doesn't work.
       {
         job_name: 'default/kubernetes',
         kubernetes_sd_configs: [{
-          role: 'endpoints',
+          role:
+            if $._config.scrape_api_server_endpoints
+            then 'endpoints'
+            else 'service',
         }],
         scheme: 'https',
 


### PR DESCRIPTION
We used the endpoints as on GKE you can't discover the pods (they don't run on your nodes), and we wanted to deal with the case where we might end up with multiple masters.

This doesn't work on AKS.

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>