### PR TITLE
Add _config in to prometheus.libsonnet 

### DIFF
--- a/prometheus-ksonnet/lib/prometheus.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus.libsonnet
@@ -78,7 +78,9 @@
     local deployment = $.apps.v1beta1.deployment,
 
     prometheus_deployment:
-      if $._config.stateful
+      local _config = self._config;
+
+      if _config.stateful
       then {}
       else (
         deployment.new(self.name, 1, [
@@ -86,9 +88,9 @@
           self.prometheus_watch_container,
         ]) +
         $.util.configVolumeMount('%s-config' % self.name, '/etc/prometheus') +
-        deployment.mixin.spec.template.metadata.withAnnotations({ 'prometheus.io.path': '%smetrics' % $._config.prometheus_web_route_prefix }) +
+        deployment.mixin.spec.template.metadata.withAnnotations({ 'prometheus.io.path': '%smetrics' % _config.prometheus_web_route_prefix }) +
         deployment.mixin.spec.template.spec.securityContext.withRunAsUser(0) +
-        if $._config.enable_rbac
+        if _config.enable_rbac
         then deployment.mixin.spec.template.spec.withServiceAccount('prometheus')
         else {}
       ),

--- a/prometheus-ksonnet/lib/prometheus.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus.libsonnet
@@ -79,7 +79,6 @@
 
     prometheus_deployment:
       local _config = self._config;
-
       if _config.stateful
       then {}
       else (
@@ -111,6 +110,7 @@
     local volumeMount = $.core.v1.volumeMount,
 
     prometheus_statefulset:
+      local _config = self._config;
       if !($._config.stateful)
       then {}
       else (
@@ -122,7 +122,7 @@
         ], self.prometheus_pvc) +
         $.util.configVolumeMount('%s-config' % self.name, '/etc/prometheus') +
         statefulset.mixin.spec.withServiceName('prometheus') +
-        statefulset.mixin.spec.template.metadata.withAnnotations({ 'prometheus.io.path': '%smetrics' % $._config.prometheus_web_route_prefix }) +
+        statefulset.mixin.spec.template.metadata.withAnnotations({ 'prometheus.io.path': '%smetrics' % _config.prometheus_web_route_prefix }) +
         statefulset.mixin.spec.template.spec.securityContext.withRunAsUser(0) +
         if $._config.enable_rbac
         then statefulset.mixin.spec.template.spec.withServiceAccount(self.name)


### PR DESCRIPTION
Add `_config` the same way we add `prometheus_config` and other objects so that we can overwrite
certain fields when creating new prometheus instances, such as
changing the web prefix and hostname to differentiate between
instances with different purposes.

@jtlisi note that I also added `_config` in to the watch container so that we have the right port and web route prefix there if they've been overwritten for the prometheus container.

Signed-off-by: Callum Styan <callumstyan@gmail.com>