### PR TITLE
helper to set up cron job with proper name label on pod

### DIFF
--- a/ksonnet-util/kausal.libsonnet
+++ b/ksonnet-util/kausal.libsonnet
@@ -88,6 +88,30 @@ k {
     },
   },
 
+  batch+: {
+    v1beta1+: {
+      cronJob+: {
+        new(name='', schedule='', containers=[])::
+          super.new() +
+          (
+            if name != '' then
+              super.mixin.metadata.withName(name) +
+              // set name label on pod
+              super.mixin.spec.jobTemplate.spec.template.metadata.withLabels({ name: name })
+            else
+              {}
+          ) +
+          (
+            if schedule != '' then
+              super.mixin.spec.withSchedule(schedule)
+            else
+              {}
+          ) +
+          super.mixin.spec.jobTemplate.spec.template.spec.withContainers(containers),
+      },
+    },
+  },
+
   local appsExtentions = {
     daemonSet+: {
       new(name, containers)::


### PR DESCRIPTION
This maintains backward compatibility with the standard library, but sets the name down into the pod labels if it is specified.  It also accepts schedule and container(s) similar to the other helpers.

Not sure whether we'd like to be a bit more prescriptive about defaults for things like successful/failed jobs history or parallelism?