### PR TITLE
Support Grafana 6.1 Notification channel provisioning

### DIFF
--- a/prometheus-ksonnet/lib/grafana.libsonnet
+++ b/prometheus-ksonnet/lib/grafana.libsonnet
@@ -101,6 +101,32 @@
 
   grafanaNotificationChannels+:: {},
 
+  /*
+    to add a notification channel:
+
+    grafanaNotificationChannels+:: {
+      'my-notification-channel.yml': grafana_add_notification_channel('my-email', 'email', 'my-email', 1, true, true, '1h', false, {addresses: 'me@example.com'}),
+    }
+    See https://grafana.com/docs/administration/provisioning/#alert-notification-channels
+  */
+
+  grafana_add_notification_channel(name, type, uid, org_id, settings, is_default=false, send_reminders=true, frequency='1h', disable_resolve_message=false)::
+    $.util.manifestYaml({ 
+      notifiers: [
+	{
+	  name: name,
+	  type: type,
+	  uid: uid,
+	  org_id: org_id,
+	  is_default: is_default,
+	  send_reminders: send_reminders,
+	  frequency: frequency,
+	  disable_resolve_message: disable_resolve_message,
+	  settings: settings,
+	},
+      ],
+    }),
+
   notification_channel_config_map:
     configMap.new('grafana-notification-channels') +
     configMap.withDataMixin({

--- a/prometheus-ksonnet/lib/grafana.libsonnet
+++ b/prometheus-ksonnet/lib/grafana.libsonnet
@@ -64,13 +64,13 @@
                              'http://prometheus.%(namespace)s.svc.%(cluster_dns_suffix)s%(prometheus_web_route_prefix)s' % $._config,
                              default=true),
 
-  grafana_add_datasource(name, url, default=false)::
+  grafana_add_datasource(name, url, type='prometheus', default=false)::
     configMap.withDataMixin({
       ['%s.yml' % name]: $.util.manifestYaml({
         apiVersion: 1,
         datasources: [{
           name: name,
-          type: 'prometheus',
+          type: type,
           access: 'proxy',
           url: url,
           isDefault: default,
@@ -80,13 +80,13 @@
       }),
     }),
 
-  grafana_add_datasource_with_basicauth(name, url, username, password, default=false)::
+  grafana_add_datasource_with_basicauth(name, url, username, password, type='prometheus', default=false)::
     configMap.withDataMixin({
       ['%s.yml' % name]: $.util.manifestYaml({
         apiVersion: 1,
         datasources: [{
           name: name,
-          type: 'prometheus',
+          type: type,
           access: 'proxy',
           url: url,
           isDefault: default,

--- a/prometheus-ksonnet/lib/grafana.libsonnet
+++ b/prometheus-ksonnet/lib/grafana.libsonnet
@@ -99,6 +99,15 @@
       }),
     }),
 
+  grafanaNotificationChannels+:: {},
+
+  notification_channel_config_map:
+    configMap.new('grafana-notification-channels') +
+    configMap.withDataMixin({
+      [name]: std.toString($.grafanaNotificationChannels[name])
+      for name in std.objectFields($.grafanaNotificationChannels)
+    }),
+
   local container = $.core.v1.container,
 
   grafana_container::
@@ -119,6 +128,7 @@
     $.util.configVolumeMount('grafana-config', '/etc/grafana-config') +
     $.util.configVolumeMount('grafana-dashboard-provisioning', '%(grafana_provisioning_dir)s/dashboards' % $._config) +
     $.util.configVolumeMount('grafana-datasources', '%(grafana_provisioning_dir)s/datasources' % $._config) +
+    $.util.configVolumeMount('grafana-notification-channels', '%(grafana_provisioning_dir)s/notifiers' % $._config) +
     $.util.configVolumeMount('dashboards', '/grafana/dashboards'),
 
   grafana_service:


### PR DESCRIPTION
This allows for the provisioning of notification channels as well as dashboards/alerts.