### PR TITLE
Only support prom datasources in prometheus-ksonnet

### DIFF
--- a/prometheus-ksonnet/lib/grafana.libsonnet
+++ b/prometheus-ksonnet/lib/grafana.libsonnet
@@ -64,13 +64,13 @@
                              'http://prometheus.%(namespace)s.svc.%(cluster_dns_suffix)s%(prometheus_web_route_prefix)s' % $._config,
                              default=true),
 
-  grafana_add_datasource(name, url, type='prometheus', default=false)::
+  grafana_add_datasource(name, url, default=false)::
     configMap.withDataMixin({
       ['%s.yml' % name]: $.util.manifestYaml({
         apiVersion: 1,
         datasources: [{
           name: name,
-          type: type,
+          type: 'prometheus',
           access: 'proxy',
           url: url,
           isDefault: default,
@@ -80,13 +80,13 @@
       }),
     }),
 
-  grafana_add_datasource_with_basicauth(name, url, username, password, type='prometheus', default=false)::
+  grafana_add_datasource_with_basicauth(name, url, username, password, default=false)::
     configMap.withDataMixin({
       ['%s.yml' % name]: $.util.manifestYaml({
         apiVersion: 1,
         datasources: [{
           name: name,
-          type: type,
+          type: 'prometheus',
           access: 'proxy',
           url: url,
           isDefault: default,


### PR DESCRIPTION
This undoes a change that in theory supports non-prometheus data sources. Apparently, this will only work with graphite data sources.

To add others we should use code such as:

    grafana_datasource_config_map+:
      configMap.withDataMixin({
        'other-datasource.yml': $.util.manifestYaml({
          apiVersion: 1,
          datasources: [{
            <data source definition>
          }],
        }),
      }),