### PR TITLE
Weaveworks quay is disabled.

### DIFF
--- a/consul/consul.libsonnet
+++ b/consul/consul.libsonnet
@@ -7,7 +7,7 @@ k {
 
   _images+:: {
     consul: 'consul:1.4.0',
-    consulSidekick: 'quay.io/weaveworks/consul-sidekick:master-f18ad13',
+    consulSidekick: 'weaveworks/consul-sidekick:master-f18ad13',
     statsdExporter: 'prom/statsd-exporter:v0.8.1',
     consulExporter: 'prom/consul-exporter:v0.4.0',
   },

--- a/prometheus-ksonnet/images.libsonnet
+++ b/prometheus-ksonnet/images.libsonnet
@@ -4,7 +4,6 @@
     grafana: 'grafana/grafana:6.0.2',
     watch: 'weaveworks/watch:master-5b2a6e5',
     kubeStateMetrics: 'gcr.io/google_containers/kube-state-metrics:v1.4.0',
-    gfdatasource: 'quay.io/weaveworks/gfdatasource:master-2bda599',
     alertmanager: 'prom/alertmanager:v0.16.2',
     nodeExporter: 'prom/node-exporter:v0.16.0',
     nginx: 'nginx:1.15.1-alpine',


### PR DESCRIPTION
```
Failed to pull image "quay.io/weaveworks/consul-sidekick:master-f18ad13": rpc error: code = Unknown desc = Error response from daemon: Get https://quay.io/v2/weaveworks/consul-sidekick/manifests/master-f18ad13: unknown: Namespace weaveworks has been disabled. Please contact a system administrator.
```

Further, the gfdatasource image is not being used anywhere.

Signed-off-by: Goutham Veeramachaneni <gouthamve@gmail.com>