### PR TITLE
Adding websocket headers in nginx conf for grafana server

### DIFF
--- a/prometheus-ksonnet/lib/config.libsonnet
+++ b/prometheus-ksonnet/lib/config.libsonnet
@@ -8,7 +8,7 @@
 
     // Overrides for the nginx frontend for all these services.
     admin_services: [
-      { title: 'Grafana', path: 'grafana', url: 'http://grafana.%(namespace)s.svc.%(cluster_dns_suffix)s/' % $._config },
+      { title: 'Grafana', path: 'grafana', url: 'http://grafana.%(namespace)s.svc.%(cluster_dns_suffix)s/' % $._config, allowWebsockets: true},
       { title: 'Prometheus', path: 'prometheus', url: 'http://prometheus.%(namespace)s.svc.%(cluster_dns_suffix)s/prometheus/' % $._config },
       { title: 'Alertmanager', path: 'alertmanager', url: 'http://alertmanager.%(namespace)s.svc.%(cluster_dns_suffix)s/alertmanager/' % $._config },
     ],

--- a/prometheus-ksonnet/lib/nginx.libsonnet
+++ b/prometheus-ksonnet/lib/nginx.libsonnet
@@ -8,7 +8,7 @@
             proxy_set_header    X-Forwarded-Proto $scheme;
             proxy_set_header    X-Forwarded-Host $http_host;
     ||| % service + if allowWebsockets then |||
-            # Allow websocket connections
+            # Allow websocket connections https://www.nginx.com/blog/websocket-nginx/
             proxy_set_header    Upgrade $http_upgrade;
             proxy_set_header    Connection "Upgrade";
     ||| else '',

--- a/prometheus-ksonnet/lib/nginx.libsonnet
+++ b/prometheus-ksonnet/lib/nginx.libsonnet
@@ -1,20 +1,33 @@
 {
-  local configMap = $.core.v1.configMap,
-
-  nginx_config_map:
-    local vars = {
-      location_stanzas: [
-        |||
-          location ~ ^/%(path)s(/?)(.*)$ {
+  local buildHeaders(service, allowWebsockets) =
+    |||
             proxy_pass      %(url)s$2$is_args$args;
             proxy_set_header    Host $host;
             proxy_set_header    X-Real-IP $remote_addr;
             proxy_set_header    X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header    X-Forwarded-Proto $scheme;
             proxy_set_header    X-Forwarded-Host $http_host;
+    ||| % service + if allowWebsockets then |||
+            # Allow websocket connections
+            proxy_set_header    Upgrade $http_upgrade;
+            proxy_set_header    Connection "Upgrade";
+    ||| else '',
+
+  local buildLocation(service) =
+    |||
+          location ~ ^/%(path)s(/?)(.*)$ {
+    ||| % service +
+              buildHeaders(service, if 'allowWebsockets' in service then service.allowWebsockets else false) +
+    |||
           }
-        ||| % service
-        for service in $._config.admin_services
+    |||,
+
+  local configMap = $.core.v1.configMap,
+
+  nginx_config_map:
+    local vars = {
+      location_stanzas: [
+        buildLocation(service) for service in $._config.admin_services
       ],
       locations: std.join('\n', self.location_stanzas),
       link_stanzas: [


### PR DESCRIPTION
Without this change, websocket connections are not working with grafana server since it needs to pass on some additional headers. This is needed to get live tailing working.