### PR TITLE
Pin kube-mixin as master is compatible with only 1.14

### DIFF
--- a/prometheus-ksonnet/jsonnetfile.json
+++ b/prometheus-ksonnet/jsonnetfile.json
@@ -8,7 +8,7 @@
                     "subdir": ""
                 }
             },
-            "version": "master"
+            "version": "release-0.1"
         },
         {
             "name": "prometheus-mixin",


### PR DESCRIPTION
Signed-off-by: Goutham Veeramachaneni <gouthamve@gmail.com>