### PR TITLE
add jaeger mixin

### DIFF
--- a/ksonnet-util/jaeger.libsonnet
+++ b/ksonnet-util/jaeger.libsonnet
@@ -1,0 +1,19 @@
+{
+  _config+:: {
+    cluster: error 'Must define a cluster',
+    namespace: error 'Must define a namespace',
+    jaeger_agent_host: null,
+  },
+
+  local container = $.core.v1.container,
+
+  jaeger_mixin::
+    if $._config.jaeger_agent_host == null
+    then {}
+    else
+      container.withEnvMixin([
+        container.envType.new('JAEGER_AGENT_HOST', $._config.jaeger_agent_host),
+        container.envType.new('JAEGER_TAGS', 'namespace=%s,cluster=%s' % [$._config.namespace, $._config.cluster]),
+        container.envType.new('JAEGER_SAMPLER_MANAGER_HOST_PORT', 'http://%s:5778/sampling' % $._config.jaeger_agent_host),
+      ]),
+}


### PR DESCRIPTION
This is used i multiple jsonnet libs beyond just the cortex lib. This puts the mixin in a centralized place.
Signed-off-by: Jacob Lisi <jacob.t.lisi@gmail.com>