### PR TITLE
Don't let diff show empty configmaps as differences

### DIFF
--- a/ksonnet-util/kausal.libsonnet
+++ b/ksonnet-util/kausal.libsonnet
@@ -12,6 +12,12 @@ k {
       configMap+: {
         new(name)::
           super.new(name, {}),
+        withData(data)::
+          if (data == {}) then {}
+          else super.withData(data),
+        withDataMixin(data)::
+          if (data == {}) then {}
+          else super.withData(data),
       },
 
       // Expose containerPort type.

--- a/ksonnet-util/kausal.libsonnet
+++ b/ksonnet-util/kausal.libsonnet
@@ -17,7 +17,7 @@ k {
           else super.withData(data),
         withDataMixin(data)::
           if (data == {}) then {}
-          else super.withData(data),
+          else super.withDataMixin(data),
       },
 
       // Expose containerPort type.


### PR DESCRIPTION
Without this change, we see a diff if a configmap is empty. This prevents change ksonnet from creating empty configmap entries, and keeps ksonnet diff happy.

Will this create any issues for applications that expect a config map entry to be present, but empty?