### PR TITLE
Hide main_prometheus since we're optionally deploying replicas now.

### DIFF
--- a/prometheus-ksonnet/lib/prometheus.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus.libsonnet
@@ -139,7 +139,7 @@
       ),
   },
 
-  main_prometheus: $.prometheus {
+  main_prometheus:: $.prometheus {
     name: 'prometheus',
   },
 }


### PR DESCRIPTION
Since we're deploying replicas now, and only deploying main_prometheus if the config is set to not deploy replicas, main_prometheus should be hidden by default.

Signed-off-by: Callum Styan <callumstyan@gmail.com>