### PR TITLE
Automatically add the hash of the config maps to the pod.

### DIFF
--- a/ksonnet-util/kausal.libsonnet
+++ b/ksonnet-util/kausal.libsonnet
@@ -309,9 +309,9 @@ k {
         volume.fromConfigMap(name, name),
       ]),
 
-    // configMapVolumeMount adds a configMap to deployment-like object.
+    // configMapVolumeMount adds a configMap to deployment-like objects.
     // It will also add an annotation hash to ensure the pods are re-deployed
-    // then the config map changes.
+    // when the config map changes.
     configMapVolumeMount(configMap, path, volumeMountMixin={})::
       local name = configMap.metadata.name,
             hash = std.md5(std.toString(configMap)),

--- a/ksonnet-util/kausal.libsonnet
+++ b/ksonnet-util/kausal.libsonnet
@@ -309,6 +309,29 @@ k {
         volume.fromConfigMap(name, name),
       ]),
 
+    // configMapVolumeMount adds a configMap to deployment-like object.
+    // It will also add an annotation hash to ensure the pods are re-deployed
+    // then the config map changes.
+    configMapVolumeMount(configMap, path, volumeMountMixin={})::
+      local name = configMap.metadata.name,
+            hash = std.md5(std.toString(configMap)),
+            container = $.core.v1.container,
+            deployment = $.extensions.v1beta1.deployment,
+            volumeMount = $.core.v1.volumeMount,
+            volume = $.core.v1.volume,
+            addMount(c) = c + container.withVolumeMountsMixin(
+        volumeMount.new(name, path) +
+        volumeMountMixin,
+      );
+
+      deployment.mapContainers(addMount) +
+      deployment.mixin.spec.template.spec.withVolumesMixin([
+        volume.fromConfigMap(name, name),
+      ]) + 
+      deployment.mixin.spec.template.metadata.withAnnotationsMixin({
+        ['%s-hash' % name]: hash,
+      }),
+
     hostVolumeMount(name, hostPath, path, readOnly=false, volumeMountMixin={})::
       local container = $.core.v1.container,
             deployment = $.extensions.v1beta1.deployment,

--- a/prometheus-ksonnet/lib/nginx.libsonnet
+++ b/prometheus-ksonnet/lib/nginx.libsonnet
@@ -106,7 +106,7 @@
 
   nginx_deployment:
     deployment.new('nginx', 1, [$.nginx_container]) +
-    $.util.configVolumeMount('nginx-config', '/etc/nginx') +
+    $.util.configMapVolumeMount($.nginx_config_map, '/etc/nginx') +
     $.util.podPriority('critical'),
 
   nginx_service:


### PR DESCRIPTION
This will trigger a new rollout when you change the config.  

Also plumb it in for the nginx used to server admin endpoints.

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>