### PR TITLE
Add node-mixin to prometheus-ksonnet

### DIFF
--- a/prometheus-ksonnet/jsonnetfile.json
+++ b/prometheus-ksonnet/jsonnetfile.json
@@ -31,6 +31,16 @@
             "version": "mixin"
         },
         {
+            "name": "node-mixin",
+            "source": {
+                "git": {
+                    "remote": "https://github.com/prometheus/node_exporter",
+                    "subdir": "docs/node-mixin"
+                }
+            },
+            "version": "master"
+        },
+        {
             "name": "oauth2_proxy",
             "source": {
                 "git": {

--- a/prometheus-ksonnet/lib/config.libsonnet
+++ b/prometheus-ksonnet/lib/config.libsonnet
@@ -45,7 +45,7 @@
     cadvisorSelector: 'job="kube-system/cadvisor"',
     kubeletSelector: 'job="kube-system/kubelet"',
     kubeStateMetricsSelector: 'job="%s/kube-state-metrics"' % $._config.namespace,
-    nodeExporterSelector: 'job="%s/node-exporter"' % $._config.namespace,
+    nodeExporterSelector: 'job="%s/node-exporter"' % $._config.namespace, // Also used by node-mixin.
     notKubeDnsSelector: 'job!="kube-system/kube-dns"',
     kubeSchedulerSelector: 'job="kube-system/kube-scheduler"',
     kubeControllerManagerSelector: 'job="kube-system/kube-controller-manager"',

--- a/prometheus-ksonnet/prometheus-ksonnet.libsonnet
+++ b/prometheus-ksonnet/prometheus-ksonnet.libsonnet
@@ -10,4 +10,5 @@
 (import 'kubernetes-mixin/mixin.libsonnet') +
 (import 'prometheus-mixin/mixin.libsonnet') +
 (import 'alertmanager-mixin/mixin.libsonnet') +
+(import 'node-mixin/mixin.libsonnet') +
 (import 'lib/config.libsonnet')


### PR DESCRIPTION
There is a non-empty intersection between the kubernetes-mixin and the
node-mixin in terms of rules and dashboards. However, the names are
actually all different (kind of deliberate for the dashboards - for
the rules we are "lucky" that the kubernetes-mixin is totally not
following the Prometheus rule naming conventions, while the node-mixin
is by now).

So this should just play well along each other for now. Of course, we
want to deduplicate the more or less similar dashboards eventually. We
still have to figure out on which level this should happen. We either
kick out some dashboards here in prometheus-ksonnet or, probably
better, make upstream kubernetes-mixin use the node-mixin instead of
doing their own stuff.

Historically, I guess, the node-mixin parts that overlap with the
kubernetes-mixin were copied over from or at least inspired by the
kubernetes-mixin. It probably makes a lot of sense to let the
kubernetes-mixin use the node-mixin maintained in the
prometheus/node_exporter repo directly.

But let's first play with it and then make that call later.