### PR TITLE
allow redirect instead of proxy

### DIFF
--- a/prometheus-ksonnet/lib/nginx.libsonnet
+++ b/prometheus-ksonnet/lib/nginx.libsonnet
@@ -1,6 +1,8 @@
 {
-  local buildHeaders(service, allowWebsockets, subfilter) =
-    |||
+  local buildHeaders(service, redirect, allowWebsockets, subfilter) =
+    if redirect then |||
+      return 302 %(url)s;
+    ||| % service else |||
       proxy_pass      %(url)s$2$is_args$args;
       proxy_set_header    Host $host;
       proxy_set_header    X-Real-IP $remote_addr;
@@ -27,6 +29,7 @@
     ||| % service +
               buildHeaders(
                 service,
+                if 'redirect' in service then service.redirect else false,
                 if 'allowWebsockets' in service then service.allowWebsockets else false,
                 if 'subfilter' in service then service.subfilter else false,
               ) +


### PR DESCRIPTION
When trying to create links to a specific grafana URL (in my use case to Explore->Loki) there is no easy way to accomplish this via a proxy request, 

Especially if you park the loki URL at the /loki path for the nginx location matching and then try to proxy this to grafana it creates some difficulties in navigating as now you are going to be accessing grafana via the /loki path.

Instead for this use case a redirect seems simpler WDYT?