### PR TITLE
Update consul to use statsd-exporter 0.12.2

### DIFF
--- a/consul/consul.libsonnet
+++ b/consul/consul.libsonnet
@@ -8,7 +8,7 @@ k {
   _images+:: {
     consul: 'consul:1.4.0',
     consulSidekick: 'weaveworks/consul-sidekick:master-f18ad13',
-    statsdExporter: 'prom/statsd-exporter:v0.8.1',
+    statsdExporter: 'prom/statsd-exporter:v0.12.2',
     consulExporter: 'prom/consul-exporter:v0.5.0',
   },
 


### PR DESCRIPTION
Under high load the statsd-exporter can panic when trying to makeslice for hashing labels: https://github.com/prometheus/statsd_exporter/pull/253

v0.12.2 includes a fix.

cc @gouthamve @jtlisi @tomwilkie 

Signed-off-by: Callum Styan <callumstyan@gmail.com>