### PR TITLE
Only deploy Prometheus as statefulset, deploy replicas.

### DIFF
--- a/prometheus-ksonnet/lib/config.libsonnet
+++ b/prometheus-ksonnet/lib/config.libsonnet
@@ -1,8 +1,5 @@
 {
   _config+:: {
-    // Should this prometheus installation be stateful?
-    stateful: false,
-
     // Cluster specific overrides.
     cluster_dns_suffix: 'cluster.local',
 

--- a/prometheus-ksonnet/lib/kube-state-metrics.libsonnet
+++ b/prometheus-ksonnet/lib/kube-state-metrics.libsonnet
@@ -98,9 +98,7 @@
     // Stop the default pod discovery scraping this pod - we use a special
     // scrape config to preserve namespace etc labels.
     deployment.mixin.spec.template.metadata.withAnnotationsMixin({ 'prometheus.io.scrape': 'false' }) +
-    (if $._config.enable_rbac
-     then deployment.mixin.spec.template.spec.withServiceAccount('kube-state-metrics')
-     else {}) +
+    deployment.mixin.spec.template.spec.withServiceAccount('kube-state-metrics') +
     $.util.podPriority('critical'),
 
   kube_state_metrics_service:


### PR DESCRIPTION
This PR removes the ability to deploy Prometheus as a deployment, it will always deploy Prom as a statefulset. Also adds Prometheus replicas/removes `main_prometheus`.

If we want I can make it so the statefulset/replicas are default but deployment/`main_prometheus` are still available via config vars.

Signed-off-by: Callum Styan <callumstyan@gmail.com>