### PR TITLE
Adjust to new node mixin version.

### DIFF
--- a/prometheus-ksonnet/lib/config.libsonnet
+++ b/prometheus-ksonnet/lib/config.libsonnet
@@ -51,11 +51,14 @@
     kubeControllerManagerSelector: 'job="kube-system/kube-controller-manager"',
     kubeApiserverSelector: 'job="kube-system/kube-apiserver"',
     podLabel: 'instance',
-    grafanaPrefix: '/grafana',
+    grafanaPrefix: '/grafana',  // Also used by node-mixin.
 
     // Prometheus mixin overrides.
     prometheusSelector: 'job="default/prometheus"',
     alertmanagerSelector: 'job="default/alertmanager"',
+
+    // Node mixin overrides.
+    nodeCriticalSeverity: 'warning', // Do not page if nodes run out of disk space.
 
     // oauth2-proxy
     oauth_enabled: false,

--- a/prometheus-ksonnet/prometheus-ksonnet.libsonnet
+++ b/prometheus-ksonnet/prometheus-ksonnet.libsonnet
@@ -12,3 +12,13 @@
 (import 'alertmanager-mixin/mixin.libsonnet') +
 (import 'node-mixin/mixin.libsonnet') +
 (import 'lib/config.libsonnet')
+
+{
+  // Delete obsolete node-related dashboards from the k8s mixin.
+  // Once we can use the current version of the k8s mixin, those
+  // overrides can be removed.
+  grafanaDashboards+: {
+    'k8s-cluster-rsrc-use.json': null,
+    'k8s-node-rsrc-use.json': null,
+  },
+}


### PR DESCRIPTION
For one, this disables paging alerts for disks running full. The nodes
we monitor are K8s nodes. If individual notes kill themselves by
filling their disk, we don't need to wake somebody up. K8s will cope
with it. Hence, those alerts should all be just warnings.

The other change here is to kick out the node-related dashboards from
the k8s mixin. They are obsolete now. Much better versions are
contained in the node mixin. In fact, the current version of the
k8s-mixin has kicked those out upstream. However, the current version
of the k8s-mixin also requires K8s 1.14+ (which changed a lot of the
metrics names). Since we are stuck on 1.13 and before for a while, we
have to keep using an older version of the k8s-mixin.