### PR TITLE
Add another dashboard to override

### DIFF
--- a/prometheus-ksonnet/prometheus-ksonnet.libsonnet
+++ b/prometheus-ksonnet/prometheus-ksonnet.libsonnet
@@ -11,14 +11,14 @@
 (import 'prometheus-mixin/mixin.libsonnet') +
 (import 'alertmanager-mixin/mixin.libsonnet') +
 (import 'node-mixin/mixin.libsonnet') +
-(import 'lib/config.libsonnet')
-
+(import 'lib/config.libsonnet') +
 {
   // Delete obsolete node-related dashboards from the k8s mixin.
   // Once we can use the current version of the k8s mixin, those
   // overrides can be removed.
-  grafanaDashboards+: {
+  grafanaDashboards+:: {
     'k8s-cluster-rsrc-use.json': null,
     'k8s-node-rsrc-use.json': null,
+    'k8s-multicluster-rsrc-use.json': null,
   },
 }


### PR DESCRIPTION
I also used a different syntax. The effect on ks-diff seems to be the
same, but this syntax appears "more correct" to me.

Still, in the ks-diff, the `null` shows up as `"null"`. The jsonnet
tutorial promises that `null` elements will not be rendered. Hmmm...