### PR TITLE
Add service name to alertmanager's statefulset

### DIFF
--- a/prometheus-ksonnet/lib/alertmanager.libsonnet
+++ b/prometheus-ksonnet/lib/alertmanager.libsonnet
@@ -79,6 +79,7 @@
       $.alertmanager_container,
       $.alertmanager_watch_container,
     ], self.alertmanager_pvc) +
+    statefulset.mixin.spec.withServiceName('alertmanager') +
     statefulset.mixin.spec.template.metadata.withAnnotations({ 'prometheus.io.path': '%smetrics' % $._config.alertmanager_path }) +
     statefulset.mixin.spec.template.spec.securityContext.withRunAsUser(0) +
     statefulset.mixin.spec.template.spec.securityContext.withFsGroup(0) +


### PR DESCRIPTION
My K8s foo is too weak to be confident that this is the right
approach. Please doublecheck.

If it works, it should fix https://github.com/raintank/deployment_tools/issues/1455 .