### PR TITLE
Port statefulset changes from Malcom's PR.

### DIFF
--- a/ksonnet-util/kausal.libsonnet
+++ b/ksonnet-util/kausal.libsonnet
@@ -156,7 +156,15 @@ k {
 
     statefulSet+: {
       new(name, replicas, containers, volumeClaims, podLabels={})::
-        super.new(name, replicas, containers, volumeClaims, podLabels { name: name }) +
+        { kind: 'StatefulSet' } +
+        { apiVersion: 'apps/v1beta1' } +
+        self.mixin.metadata.withName(name) +
+        self.mixin.spec.withReplicas(replicas) +
+        self.mixin.spec.template.spec.withContainers(containers) +
+        self.mixin.spec.template.metadata.withLabels(podLabels { name: name }) +
+        (if std.length(volumeClaims) > 0
+        then self.mixin.spec.withVolumeClaimTemplates(volumeClaims)
+        else {}) +
         super.mixin.spec.updateStrategy.withType('RollingUpdate'),
     },
   },


### PR DESCRIPTION
Porting the statefulset changes Malcom made + the volume claim fix to make sure the proper update strategy `RollingUpdate` remains.

Signed-off-by: Callum Styan <callumstyan@gmail.com>