### PR TITLE
Fix sts with no volumes

### DIFF
--- a/ksonnet-util/kausal.libsonnet
+++ b/ksonnet-util/kausal.libsonnet
@@ -155,10 +155,20 @@ k {
     },
 
     statefulSet+: {
-      new(name, replicas, containers, volumeClaims, podLabels={})::
-        super.new(name, replicas, containers, volumeClaims, podLabels { name: name }) +
-        super.mixin.spec.updateStrategy.withType('RollingUpdate'),
-    },
+       new(name, replicas, containers, volumeClaims, podLabels={})::
+        { kind: 'StatefulSet'} + 
+        { apiVersion: 'apps/v1beta1' } + 
+        self.mixin.metadata.withName(name) + 
+        self.mixin.spec.withReplicas(replicas) + 
+        self.mixin.spec.template.spec.withContainers(containers) + 
+        self.mixin.spec.template.metadata.withLabels(podLabels { name: name }) +
+        if std.length(volumeClaims)>0
+          then self.mixin.spec.withVolumeClaimTemplates(volumeClaims)
+          else {} +
+         super.mixin.spec.updateStrategy.withType('RollingUpdate'),
+     },
+   },
+
   },
 
   extensions+: {

--- a/ksonnet-util/kausal.libsonnet
+++ b/ksonnet-util/kausal.libsonnet
@@ -155,20 +155,18 @@ k {
     },
 
     statefulSet+: {
-       new(name, replicas, containers, volumeClaims, podLabels={})::
+      new(name, replicas, containers, volumeClaims, podLabels={})::
         { kind: 'StatefulSet'} + 
         { apiVersion: 'apps/v1beta1' } + 
         self.mixin.metadata.withName(name) + 
         self.mixin.spec.withReplicas(replicas) + 
         self.mixin.spec.template.spec.withContainers(containers) + 
         self.mixin.spec.template.metadata.withLabels(podLabels { name: name }) +
-        if std.length(volumeClaims)>0
-          then self.mixin.spec.withVolumeClaimTemplates(volumeClaims)
-          else {} +
-         super.mixin.spec.updateStrategy.withType('RollingUpdate'),
-     },
-   },
-
+        (if std.length(volumeClaims)>0
+        then self.mixin.spec.withVolumeClaimTemplates(volumeClaims)
+        else {}) +
+        super.mixin.spec.updateStrategy.withType('RollingUpdate'),
+    },
   },
 
   extensions+: {


### PR DESCRIPTION
This change prevents a statefulset without volumes from showing a perpetual diff. (e.g. when statefulset is required for consistent naming but not volumes).