### PR TITLE
Re-add prometheus service.

### DIFF
--- a/prometheus-ksonnet/lib/prometheus.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus.libsonnet
@@ -107,5 +107,8 @@
       statefulset.mixin.spec.template.spec.securityContext.withRunAsUser(0) +
       statefulset.mixin.spec.template.spec.withServiceAccount(self.name) +
       $.util.podPriority('critical'),
+
+    prometheus_service:
+      $.util.serviceFor(self.prometheus_statefulset),
   },
 }


### PR DESCRIPTION
I think this was accidentally removed in https://github.com/grafana/jsonnet-libs/pull/new/prometheus-service

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>