### PR TITLE
Defaulting to dark mode

### DIFF
--- a/prometheus-ksonnet/lib/grafana.libsonnet
+++ b/prometheus-ksonnet/lib/grafana.libsonnet
@@ -13,7 +13,7 @@
         reporting_enabled: false,
       },
       users: {
-        default_theme: 'light',
+        default_theme: 'dark',
       },
       explore+: {
         enabled: true,


### PR DESCRIPTION
Default to dark mode as it is the superior method of viewing graphs.