### PR TITLE
Remove redundant anchoring from Prometheus regexp's

### DIFF
--- a/prometheus-ksonnet/lib/prometheus-config.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus-config.libsonnet
@@ -76,7 +76,7 @@
             source_labels: ['__meta_kubernetes_pod_annotation_prometheus_io_scheme'],
             action: 'replace',
             target_label: '__scheme__',
-            regex: '^(https?)$',
+            regex: '(https?)',
             replacement: '$1',
           },
 
@@ -85,7 +85,7 @@
             source_labels: ['__meta_kubernetes_pod_annotation_prometheus_io_path'],
             action: 'replace',
             target_label: '__metrics_path__',
-            regex: '^(.+)$',
+            regex: '(.+)',
             replacement: '$1',
           },
 
@@ -102,7 +102,7 @@
           {
             source_labels: ['__meta_kubernetes_pod_label_name'],
             action: 'drop',
-            regex: '^$',
+            regex: '',
           },
 
           // Rename jobs to be <namespace>/<name, from pod name label>
@@ -138,7 +138,7 @@
           {
             source_labels: ['__meta_kubernetes_pod_phase'],
             action: 'drop',
-            regex: '^(Succeeded|Failed)$',
+            regex: 'Succeeded|Failed',
           },
         ],
       },


### PR DESCRIPTION
Regexp's in Prometheus are always anchored by default. Adding
redundant anchoring is not only a humungus waste of bytes, but also
confuses people into believing the regexp's are not anchored by
default (which can backfire badly elsewhere).

(Same thing as https://github.com/raintank/deployment_tools/pull/1755 , just in this repo.)