### PR TITLE
feat(ksonnet-util): k.libsonnet using jb package

### DIFF
--- a/ksonnet-util/.gitignore
+++ b/ksonnet-util/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+jsonnetfile.lock.json

--- a/ksonnet-util/jsonnetfile.json
+++ b/ksonnet-util/jsonnetfile.json
@@ -1,0 +1,14 @@
+{
+  "dependencies": [
+    {
+      "name": "ksonnet.beta.3",
+      "source": {
+        "git": {
+          "remote": "https://github.com/ksonnet/ksonnet-lib",
+          "subdir": "ksonnet.beta.3"
+        }
+      },
+      "version": "master"
+    }
+  ]
+}

--- a/ksonnet-util/kausal.libsonnet
+++ b/ksonnet-util/kausal.libsonnet
@@ -1,5 +1,5 @@
 // Override defaults paramters for objects in the ksonnet libs here.
-local k = import 'k.libsonnet';
+local k = import 'ksonnet.beta.3/k.libsonnet';
 
 k {
   _config+:: {


### PR DESCRIPTION
Switches from the "magic" `k.libsonnet` import of `ksonnet` to the more future
proof approach of using the actual package installed using `jb`.

Fixes #188 