### PR TITLE
Fix name variable in memcached dashboard

### DIFF
--- a/memcached-mixin/dashboards.libsonnet
+++ b/memcached-mixin/dashboards.libsonnet
@@ -104,7 +104,7 @@ local g = (import 'grafana-builder/grafana.libsonnet');
               options: [],
               query: 'query_result(max by (owner_name) (kube_pod_container_info{image=~".*memcached.*"} * on(cluster, namespace, pod) group_left(owner_name) kube_pod_owner))',
               refresh: 1,
-              regex: '/owner_name=\\"(.*?)(?:-([a-z0-9]+))?\\"/',
+              regex: '/owner_name=\\"(.*?)\\"/',
               sort: 2,
               tagValuesQuery: '',
               tags: [],


### PR DESCRIPTION
The `memcached` jsonnet is configured to run memcached as a stateful set, so the `owner_name` is the name of the stateful set. Because of this, the current regex used to extract the `owner_name` - while fetching values for the `$name` dashboard variable - is not correct, because strips away the last part of the stateful set name.

Before this PR:

![Screen Shot 2019-12-04 at 17 05 51](https://user-images.githubusercontent.com/1701904/70159253-e598a080-16b8-11ea-9960-225174a6cb9c.png)

After this PR:

![Screen Shot 2019-12-04 at 17 05 41](https://user-images.githubusercontent.com/1701904/70159240-e3cedd00-16b8-11ea-89a9-0e5b96aa0747.png)
