### PR TITLE
fix(ksonnet-util): Kubernetes 1.16 deployments

### DIFF
--- a/ksonnet-util/kausal.libsonnet
+++ b/ksonnet-util/kausal.libsonnet
@@ -160,16 +160,8 @@ k {
 
     statefulSet+: {
       new(name, replicas, containers, volumeClaims, podLabels={})::
-        { kind: 'StatefulSet'} + 
-        { apiVersion: 'apps/v1beta1' } + 
-        self.mixin.metadata.withName(name) + 
-        self.mixin.spec.withReplicas(replicas) + 
-        self.mixin.spec.template.spec.withContainers(containers) + 
-        self.mixin.spec.template.metadata.withLabels(podLabels { name: name }) +
-        (if std.length(volumeClaims)>0
-        then self.mixin.spec.withVolumeClaimTemplates(volumeClaims)
-        else {}) +
-        super.mixin.spec.updateStrategy.withType('RollingUpdate'),
+        super.new(name, replicas,containers,volumeClaims,podLabels {name: name}) +
+      super.mixin.spec.updateStrategy.withType('RollingUpdate'),
     },
   },
 

--- a/ksonnet-util/kausal.libsonnet
+++ b/ksonnet-util/kausal.libsonnet
@@ -25,11 +25,11 @@ k {
       containerPort:: $.core.v1.container.portsType {
         // Force all ports to have names.
         new(name, port)::
-          super.newNamed(name, port),
+          super.newNamed(name=name, containerPort=port),
 
         // Shortcut constructor for UDP ports.
         newUDP(name, port)::
-          super.newNamed(name, port) +
+          super.newNamed(name=name, containerPort=port) +
           super.withProtocol('UDP'),
       },
 
@@ -143,7 +143,8 @@ k {
 
     deployment+: {
       new(name, replicas, containers, podLabels={})::
-        super.new(name, replicas, containers, podLabels { name: name }) +
+        local labels = podLabels {name: name};
+        super.new(name, replicas, containers, labels) +
 
         // We want to specify a minReadySeconds on every deployment, so we get some
         // very basic canarying, for instance, with bad arguments.
@@ -151,7 +152,10 @@ k {
 
         // We want to add a sensible default for the number of old deployments
         // handing around.
-        super.mixin.spec.withRevisionHistoryLimit(10),
+        super.mixin.spec.withRevisionHistoryLimit(10) +
+
+        // required matchLabels selector
+        super.mixin.spec.selector.withMatchLabels(labels),
     },
 
     statefulSet+: {
@@ -175,6 +179,7 @@ k {
 
   apps+: {
     v1beta1+: appsExtentions,
+    v1+: appsExtentions,
   },
 
   rbac+: {

--- a/ksonnet-util/kausal.libsonnet
+++ b/ksonnet-util/kausal.libsonnet
@@ -161,7 +161,12 @@ k {
     statefulSet+: {
       new(name, replicas, containers, volumeClaims, podLabels={})::
         super.new(name, replicas,containers,volumeClaims,podLabels {name: name}) +
-      super.mixin.spec.updateStrategy.withType('RollingUpdate'),
+        super.mixin.spec.updateStrategy.withType('RollingUpdate') +
+
+        // remove volumeClaimTemplates if empty (otherwise it will create a diff all the time)
+        (if std.length(volumeClaims) == 0 then {
+          spec+: {volumeClaimTemplates:: {}}
+        })
     },
   },
 


### PR DESCRIPTION
With Kubernetes 1.16, the `extensions/v1beta1` and `apps/v1beta` have been
removed in favor of `apps/v1`.

While `ksonnet.beta.4` supports this version, our helper did not.

Most severe issues:
- by not using named arguments to `port.newNamed()` we were suffering from
a change in the API which flipped the parameters order, effectively generating
invalid yaml (port name numeric, port number being the actual name)
- `apps.v1` was not overridden with our enhancements at all, generated
deployment was lacking labels, etc.

Furthermore, the `apps/v1` group requires a `matchLabels` or similar selector,
which previous ones did not. Added this.