### PR TITLE
Split prometheus/grafana config maps into lib

### DIFF
--- a/prometheus-ksonnet/lib/config.libsonnet
+++ b/prometheus-ksonnet/lib/config.libsonnet
@@ -110,5 +110,8 @@
     // Optionally shard dashboards into multiple config maps.
     // Set to the number of desired config maps.  0 to disable.
     dashboard_config_maps: 0,
+
+    // Optionally add labels to grafana config maps.
+    grafana_config_maps_labels: {},
   },
 }

--- a/prometheus-ksonnet/lib/config.libsonnet
+++ b/prometheus-ksonnet/lib/config.libsonnet
@@ -38,6 +38,7 @@
     prometheus_path: '/prometheus/',
     prometheus_port: 80,
     prometheus_web_route_prefix: $._config.prometheus_path,
+    prometheus_config_dir: '/etc/prometheus',
 
     // Alertmanager config options.
     alertmanager_external_hostname: 'http://alertmanager.%(namespace)s.svc.%(cluster_dns_suffix)s' % self,

--- a/prometheus-ksonnet/lib/config.libsonnet
+++ b/prometheus-ksonnet/lib/config.libsonnet
@@ -38,7 +38,6 @@
     prometheus_path: '/prometheus/',
     prometheus_port: 80,
     prometheus_web_route_prefix: $._config.prometheus_path,
-    prometheus_config_dir: '/etc/prometheus',
 
     // Alertmanager config options.
     alertmanager_external_hostname: 'http://alertmanager.%(namespace)s.svc.%(cluster_dns_suffix)s' % self,

--- a/prometheus-ksonnet/lib/config.libsonnet
+++ b/prometheus-ksonnet/lib/config.libsonnet
@@ -113,6 +113,7 @@
 
     // Optionally add labels to grafana config maps.
     grafana_dashboard_labels: {},
+    grafana_datasource_labels: {},
     grafana_notification_channel_labels: {},
   },
 }

--- a/prometheus-ksonnet/lib/config.libsonnet
+++ b/prometheus-ksonnet/lib/config.libsonnet
@@ -112,6 +112,7 @@
     dashboard_config_maps: 0,
 
     // Optionally add labels to grafana config maps.
-    grafana_config_maps_labels: {},
+    grafana_dashboard_labels: {},
+    grafana_notification_channel_labels: {},
   },
 }

--- a/prometheus-ksonnet/lib/grafana-configmaps.libsonnet
+++ b/prometheus-ksonnet/lib/grafana-configmaps.libsonnet
@@ -1,0 +1,109 @@
+{
+  local configMap = $.core.v1.configMap,
+
+  // Extension point for you to add your own dashboards.
+  dashboards+:: {},
+  grafana_dashboards+:: {},
+  grafanaDashboards+:: $.dashboards + $.grafana_dashboards,
+
+  dashboards_config_map:
+    if $._config.dashboard_config_maps > 0
+    then {}
+    else
+      configMap.new('dashboards') +
+      configMap.withDataMixin({
+        [name]: std.toString($.grafanaDashboards[name])
+        for name in std.objectFields($.grafanaDashboards)
+      }) +
+      configMap.mixin.metadata.withLabels($._config.grafana_config_maps_labels),
+
+  dashboards_config_maps: {
+    ['dashboard-%d' % shard]:
+      configMap.new('dashboards-%d' % shard) +
+      configMap.withDataMixin({
+        [name]: std.toString($.grafanaDashboards[name])
+        for name in std.objectFields($.grafanaDashboards)
+        if std.codepoint(std.md5(name)[1]) % $._config.dashboard_config_maps == shard
+      }) +
+      configMap.mixin.metadata.withLabels($._config.grafana_config_maps_labels)
+    for shard in std.range(0, $._config.dashboard_config_maps - 1)
+  },
+
+  grafana_add_datasource(name, url, default=false, method='GET')::
+    configMap.withDataMixin({
+      ['%s.yml' % name]: $.util.manifestYaml({
+        apiVersion: 1,
+        datasources: [{
+          name: name,
+          type: 'prometheus',
+          access: 'proxy',
+          url: url,
+          isDefault: default,
+          version: 1,
+          editable: false,
+          jsonData: {
+            httpMethod: method,
+          },
+        }],
+      }),
+    }),
+
+  grafana_add_datasource_with_basicauth(name, url, username, password, default=false, method='GET')::
+    configMap.withDataMixin({
+      ['%s.yml' % name]: $.util.manifestYaml({
+        apiVersion: 1,
+        datasources: [{
+          name: name,
+          type: 'prometheus',
+          access: 'proxy',
+          url: url,
+          isDefault: default,
+          version: 1,
+          editable: false,
+          basicAuth: true,
+          basicAuthUser: username,
+          basicAuthPassword: password,
+          jsonData: {
+            httpMethod: method,
+          },
+        }],
+      }),
+    }),
+
+  grafanaNotificationChannels+:: {},
+
+  /*
+    to add a notification channel:
+
+    grafanaNotificationChannels+:: {
+      'my-notification-channel.yml': grafana_add_notification_channel('my-email', 'email', 'my-email', 1, true, true, '1h', false, {addresses: 'me@example.com'}),
+    }
+    See https://grafana.com/docs/administration/provisioning/#alert-notification-channels
+  */
+
+  grafana_add_notification_channel(name, type, uid, org_id, settings, is_default=false, send_reminders=true, frequency='1h', disable_resolve_message=false)::
+    $.util.manifestYaml({
+      notifiers: [
+        {
+          name: name,
+          type: type,
+          uid: uid,
+          org_id: org_id,
+          is_default: is_default,
+          send_reminders: send_reminders,
+          frequency: frequency,
+          disable_resolve_message: disable_resolve_message,
+          settings: settings,
+        },
+      ],
+    }),
+
+  notification_channel_config_map:
+    configMap.new('grafana-notification-channels') +
+    configMap.withDataMixin({
+      [name]: std.toString($.grafanaNotificationChannels[name])
+      for name in std.objectFields($.grafanaNotificationChannels)
+    }),
+
+  grafana_plugins+:: [],
+}

--- a/prometheus-ksonnet/lib/grafana-configmaps.libsonnet
+++ b/prometheus-ksonnet/lib/grafana-configmaps.libsonnet
@@ -29,6 +29,8 @@
     for shard in std.range(0, $._config.dashboard_config_maps - 1)
   },
 
+  grafanaDatasources+:: {},
+
   grafana_add_datasource(name, url, default=false, method='GET')::
     configMap.withDataMixin({
       ['%s.yml' % name]: $.util.manifestYaml({
@@ -69,6 +71,14 @@
         }],
       }),
     }),
+
+  grafana_datasource_config_map:
+    configMap.new('grafana-datasources') +
+    configMap.withDataMixin({
+      [name]: std.toString($.grafanaDatasources[name])
+      for name in std.objectFields($.grafanaDatasources)
+    }) +
+    configMap.mixin.metadata.withLabels($._config.grafana_datasource_labels),
 
   grafanaNotificationChannels+:: {},
 

--- a/prometheus-ksonnet/lib/grafana-configmaps.libsonnet
+++ b/prometheus-ksonnet/lib/grafana-configmaps.libsonnet
@@ -15,7 +15,7 @@
         [name]: std.toString($.grafanaDashboards[name])
         for name in std.objectFields($.grafanaDashboards)
       }) +
-      configMap.mixin.metadata.withLabels($._config.grafana_config_maps_labels),
+      configMap.mixin.metadata.withLabels($._config.grafana_dashboard_labels),
 
   dashboards_config_maps: {
     ['dashboard-%d' % shard]:
@@ -25,7 +25,7 @@
         for name in std.objectFields($.grafanaDashboards)
         if std.codepoint(std.md5(name)[1]) % $._config.dashboard_config_maps == shard
       }) +
-      configMap.mixin.metadata.withLabels($._config.grafana_config_maps_labels)
+      configMap.mixin.metadata.withLabels($._config.grafana_dashboard_labels)
     for shard in std.range(0, $._config.dashboard_config_maps - 1)
   },
 
@@ -103,7 +103,8 @@
     configMap.withDataMixin({
       [name]: std.toString($.grafanaNotificationChannels[name])
       for name in std.objectFields($.grafanaNotificationChannels)
-    }),
+    }) +
+    configMap.mixin.metadata.withLabels($._config.grafana_notification_channel_labels),
 
   grafana_plugins+:: [],
 }

--- a/prometheus-ksonnet/lib/grafana.libsonnet
+++ b/prometheus-ksonnet/lib/grafana.libsonnet
@@ -27,32 +27,6 @@
     configMap.new('grafana-config') +
     configMap.withData({ 'grafana.ini': std.manifestIni($.grafana_config) }),
 
-  // Extension point for you to add your own dashboards.
-  dashboards+:: {},
-  grafana_dashboards+:: {},
-  grafanaDashboards+:: $.dashboards + $.grafana_dashboards,
-
-  dashboards_config_map:
-    if $._config.dashboard_config_maps > 0
-    then {}
-    else
-      configMap.new('dashboards') +
-      configMap.withDataMixin({
-        [name]: std.toString($.grafanaDashboards[name])
-        for name in std.objectFields($.grafanaDashboards)
-      }),
-
-  dashboards_config_maps: {
-    ['dashboard-%d' % shard]:
-      configMap.new('dashboards-%d' % shard) +
-      configMap.withDataMixin({
-        [name]: std.toString($.grafanaDashboards[name])
-        for name in std.objectFields($.grafanaDashboards)
-        if std.codepoint(std.md5(name)[1]) % $._config.dashboard_config_maps == shard
-      })
-    for shard in std.range(0, $._config.dashboard_config_maps - 1)
-  },
-
   grafana_dashboard_provisioning_config_map:
     configMap.new('grafana-dashboard-provisioning') +
     configMap.withData({
@@ -78,92 +52,14 @@
                              'http://prometheus.%(namespace)s.svc.%(cluster_dns_suffix)s%(prometheus_web_route_prefix)s' % $._config,
                              default=true),
 
-  grafana_add_datasource(name, url, default=false, method='GET')::
-    configMap.withDataMixin({
-      ['%s.yml' % name]: $.util.manifestYaml({
-        apiVersion: 1,
-        datasources: [{
-          name: name,
-          type: 'prometheus',
-          access: 'proxy',
-          url: url,
-          isDefault: default,
-          version: 1,
-          editable: false,
-          jsonData: {
-            httpMethod: method,
-          },
-        }],
-      }),
-    }),
-
-  grafana_add_datasource_with_basicauth(name, url, username, password, default=false, method='GET')::
-    configMap.withDataMixin({
-      ['%s.yml' % name]: $.util.manifestYaml({
-        apiVersion: 1,
-        datasources: [{
-          name: name,
-          type: 'prometheus',
-          access: 'proxy',
-          url: url,
-          isDefault: default,
-          version: 1,
-          editable: false,
-          basicAuth: true,
-          basicAuthUser: username,
-          basicAuthPassword: password,
-          jsonData: {
-            httpMethod: method,
-          },
-        }],
-      }),
-    }),
-
-  grafanaNotificationChannels+:: {},
-
-  /*
-    to add a notification channel:
-
-    grafanaNotificationChannels+:: {
-      'my-notification-channel.yml': grafana_add_notification_channel('my-email', 'email', 'my-email', 1, true, true, '1h', false, {addresses: 'me@example.com'}),
-    }
-    See https://grafana.com/docs/administration/provisioning/#alert-notification-channels
-  */
-
-  grafana_add_notification_channel(name, type, uid, org_id, settings, is_default=false, send_reminders=true, frequency='1h', disable_resolve_message=false)::
-    $.util.manifestYaml({
-      notifiers: [
-        {
-          name: name,
-          type: type,
-          uid: uid,
-          org_id: org_id,
-          is_default: is_default,
-          send_reminders: send_reminders,
-          frequency: frequency,
-          disable_resolve_message: disable_resolve_message,
-          settings: settings,
-        },
-      ],
-    }),
-
-  notification_channel_config_map:
-    configMap.new('grafana-notification-channels') +
-    configMap.withDataMixin({
-      [name]: std.toString($.grafanaNotificationChannels[name])
-      for name in std.objectFields($.grafanaNotificationChannels)
-    }),
-
-  grafana_plugins+:: [],
-
   local container = $.core.v1.container,
 
   grafana_container::
     container.new('grafana', $._images.grafana) +
     container.withPorts($.core.v1.containerPort.new('grafana', 80)) +
     container.withEnvMap({
-      'GF_PATHS_CONFIG': '/etc/grafana-config/grafana.ini',
-      'GF_INSTALL_PLUGINS': std.join(',', $.grafana_plugins),
+      GF_PATHS_CONFIG: '/etc/grafana-config/grafana.ini',
+      GF_INSTALL_PLUGINS: std.join(',', $.grafana_plugins),
     }) +
     $.util.resourcesRequests('10m', '40Mi'),
 

--- a/prometheus-ksonnet/lib/grafana.libsonnet
+++ b/prometheus-ksonnet/lib/grafana.libsonnet
@@ -46,8 +46,7 @@
       }),
     }),
 
-  grafana_datasource_config_map:
-    configMap.new('grafana-datasources') +
+  grafanaDatasources+::
     $.grafana_add_datasource('prometheus',
                              'http://prometheus.%(namespace)s.svc.%(cluster_dns_suffix)s%(prometheus_web_route_prefix)s' % $._config,
                              default=true),

--- a/prometheus-ksonnet/lib/prometheus-configmap.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus-configmap.libsonnet
@@ -1,0 +1,28 @@
+{
+  prometheus+:: {
+    name:: error 'must specify name',
+
+    // We bounce through various layers of indirection so user can:
+    // a) override config for all Prometheus' by merging into $.prometheus_config,
+    // b) override config for a specific Prometheus instance by merging in here.
+    prometheus_config:: $.prometheus_config,
+    prometheusAlerts:: $.prometheusAlerts,
+    prometheusRules:: $.prometheusRules,
+
+    local configMap = $.core.v1.configMap,
+
+    prometheus_config_map:
+      // Can't reference self.foo below as we're in a map context, so
+      // need to capture reference to the configs in scope here.
+      local prometheus_config = self.prometheus_config;
+      local prometheusAlerts = self.prometheusAlerts;
+      local prometheusRules = self.prometheusRules;
+
+      configMap.new('%s-config' % self.name) +
+      configMap.withData({
+        'prometheus.yml': $.util.manifestYaml(prometheus_config),
+        'alerts.rules': $.util.manifestYaml(prometheusAlerts),
+        'recording.rules': $.util.manifestYaml(prometheusRules),
+      }),
+  },
+}

--- a/prometheus-ksonnet/lib/prometheus.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus.libsonnet
@@ -50,7 +50,7 @@
       container.new('prometheus', $._images.prometheus) +
       container.withPorts($.core.v1.containerPort.new('http-metrics', 80)) +
       container.withArgs([
-        '--config.file=/etc/prometheus/prometheus.yml',
+        '--config.file=%(prometheus_config_dir)s/prometheus.yml' % _config,
         '--web.listen-address=:%s' % _config.prometheus_port,
         '--web.external-url=%(prometheus_external_hostname)s%(prometheus_path)s' % _config,
         '--web.enable-lifecycle',
@@ -68,7 +68,7 @@
       container.withArgs([
         '-v',
         '-t',
-        '-p=/etc/prometheus',
+        '-p=%(prometheus_config_dir)s' % _config,
         'curl',
         '-X',
         'POST',

--- a/prometheus-ksonnet/lib/prometheus.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus.libsonnet
@@ -4,13 +4,6 @@
 
     _config:: $._config,
 
-    // We bounce through various layers of indirection so user can:
-    // a) override config for all Prometheus' by merging into $.prometheus_config,
-    // b) override config for a specific Prometheus instance by merging in here.
-    prometheus_config:: $.prometheus_config,
-    prometheusAlerts:: $.prometheusAlerts,
-    prometheusRules:: $.prometheusRules,
-
     local policyRule = $.rbac.v1beta1.policyRule,
 
     prometheus_rbac:
@@ -24,23 +17,6 @@
         policyRule.withNonResourceUrls('/metrics') +
         policyRule.withVerbs(['get']),
       ]),
-
-
-    local configMap = $.core.v1.configMap,
-
-    prometheus_config_map:
-      // Can't reference self.foo below as we're in a map context, so
-      // need to capture reference to the configs in scope here.
-      local prometheus_config = self.prometheus_config;
-      local prometheusAlerts = self.prometheusAlerts;
-      local prometheusRules = self.prometheusRules;
-
-      configMap.new('%s-config' % self.name) +
-      configMap.withData({
-        'prometheus.yml': $.util.manifestYaml(prometheus_config),
-        'alerts.rules': $.util.manifestYaml(prometheusAlerts),
-        'recording.rules': $.util.manifestYaml(prometheusRules),
-      }),
 
     local container = $.core.v1.container,
 

--- a/prometheus-ksonnet/lib/prometheus.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus.libsonnet
@@ -26,7 +26,7 @@
       container.new('prometheus', $._images.prometheus) +
       container.withPorts($.core.v1.containerPort.new('http-metrics', 80)) +
       container.withArgs([
-        '--config.file=%(prometheus_config_dir)s/prometheus.yml' % _config,
+        '--config.file=/etc/prometheus/prometheus.yml',
         '--web.listen-address=:%s' % _config.prometheus_port,
         '--web.external-url=%(prometheus_external_hostname)s%(prometheus_path)s' % _config,
         '--web.enable-lifecycle',
@@ -44,7 +44,7 @@
       container.withArgs([
         '-v',
         '-t',
-        '-p=%(prometheus_config_dir)s' % _config,
+        '-p=/etc/prometheus',
         'curl',
         '-X',
         'POST',

--- a/prometheus-ksonnet/prometheus-ksonnet.libsonnet
+++ b/prometheus-ksonnet/prometheus-ksonnet.libsonnet
@@ -8,6 +8,7 @@
 (import 'lib/node-exporter.libsonnet') +
 (import 'lib/prometheus.libsonnet') +
 (import 'lib/prometheus-config.libsonnet') +
+(import 'lib/prometheus-configmap.libsonnet') +
 (import 'kubernetes-mixin/mixin.libsonnet') +
 (import 'prometheus-mixin/mixin.libsonnet') +
 (import 'alertmanager-mixin/mixin.libsonnet') +

--- a/prometheus-ksonnet/prometheus-ksonnet.libsonnet
+++ b/prometheus-ksonnet/prometheus-ksonnet.libsonnet
@@ -2,6 +2,7 @@
 (import 'images.libsonnet') +
 (import 'lib/alertmanager.libsonnet') +
 (import 'lib/grafana.libsonnet') +
+(import 'lib/grafana-configmaps.libsonnet') +
 (import 'lib/kube-state-metrics.libsonnet') +
 (import 'lib/nginx.libsonnet') +
 (import 'lib/node-exporter.libsonnet') +


### PR DESCRIPTION
This will allow us to import the config maps logic into another library
and provision dashboard, notification channels, alert rules and other config maps
separate from (Grafana) deployments. The config maps labels will allow us
to query the API and aggregate them later on in the process.