### PR TITLE
re-add 'else' clause

### DIFF
--- a/ksonnet-util/kausal.libsonnet
+++ b/ksonnet-util/kausal.libsonnet
@@ -166,7 +166,7 @@ k {
         // remove volumeClaimTemplates if empty (otherwise it will create a diff all the time)
         (if std.length(volumeClaims) == 0 then {
           spec+: {volumeClaimTemplates:: {}}
-        })
+        } else {})
     },
   },
 


### PR DESCRIPTION
In a previous refactor, we lost the `else {}` clause that allows the creation of statefulsets without lots of weird pain! This PR re-adds it!