### PR TITLE
fix: kausalco/public -> grafana/jsonnet-libs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2017 Kausal Ltd.
+Copyright (c) 2020 Grafana Labs
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/consul-mixin/README.md
+++ b/consul-mixin/README.md
@@ -3,14 +3,14 @@
 <img align="right" width="200" height="129" src="dashboard.png">
 
 Grafana dashboards and Prometheus alerts for operating Consul, in the form
-of a monitoring mixin. They are easiest to use with the [prometheus-ksonnet](https://github.com/kausalco/public/tree/master/prometheus-ksonnet)
+of a monitoring mixin. They are easiest to use with the [prometheus-ksonnet](https://github.com/grafana/jsonnet-libs/tree/master/prometheus-ksonnet)
 package.
 
 To install this mixin, use [ksonnet](https://ksonnet.io/):
 
 ```sh
 $ go get github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb
-$ jb install github.com/kausalco/public/consul-mixin
+$ jb install github.com/grafana/jsonnet-libs/consul-mixin
 ```
 
 Then to use, in your environment's `main.jsonnet` file:

--- a/consul-mixin/jsonnetfile.json
+++ b/consul-mixin/jsonnetfile.json
@@ -4,7 +4,7 @@
             "name": "grafana-builder",
             "source": {
                 "git": {
-                    "remote": "https://github.com/kausalco/public",
+                    "remote": "https://github.com/grafana/jsonnet-libs",
                     "subdir": "grafana-builder"
                 }
             },

--- a/memcached-mixin/jsonnetfile.json
+++ b/memcached-mixin/jsonnetfile.json
@@ -4,7 +4,7 @@
             "name": "grafana-builder",
             "source": {
                 "git": {
-                    "remote": "https://github.com/kausalco/public",
+                    "remote": "https://github.com/grafana/jsonnet-libs",
                     "subdir": "grafana-builder"
                 }
             },

--- a/oauth2-proxy/jsonnetfile.json
+++ b/oauth2-proxy/jsonnetfile.json
@@ -4,7 +4,7 @@
             "name": "ksonnet-util",
             "source": {
                 "git": {
-                    "remote": "https://github.com/kausalco/public",
+                    "remote": "https://github.com/grafana/jsonnet-libs",
                     "subdir": "ksonnet-util"
                 }
             },


### PR DESCRIPTION
Whenever this migration was done, it was not complete, because there were still
some import paths referring to the old location.

This is actually a problem, because jsonnet-bundler thinks those are separate
packages, leading to unnoticed clashes