### PR TITLE
Make prometheus install for a fresh user

### DIFF
--- a/prometheus-ksonnet/lib/prometheus.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus.libsonnet
@@ -1,6 +1,6 @@
 {
-  prometheus:: {
-    name:: error 'must specify name',
+  prometheus: {
+    name:: 'prometheus',
 
     _config:: $._config,
 

--- a/prometheus-ksonnet/lib/prometheus.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus.libsonnet
@@ -1,6 +1,16 @@
 {
-  prometheus: {
-    name:: 'prometheus',
+  /*
+   * All Prometheus resources are contained within a `prometheus` node. This allows
+     multiple Prometheus instances to be created by simply cloning this node, like
+     so:
+     `other_prometheus: $.prometheus {name: "other-prometheus"},`
+
+     To remove the default Prometheus, use this code:
+     `main_prometheus: {},`
+  */
+
+  prometheus:: {
+    name:: error 'must specify name',
 
     _config:: $._config,
 
@@ -111,4 +121,6 @@
     prometheus_service:
       $.util.serviceFor(self.prometheus_statefulset),
   },
+
+  main_prometheus: $.prometheus {name: "prometheus"},
 }


### PR DESCRIPTION
Previously, a change was made to make it possible to have multiple Prometheus servers running. This involved two changes: putting everything into a `prometheus` wrapper element, and then making that element hidden.

The issue is that, for a new user, this introduces a weird behaviour. You get Grafana installed, but no Prometheus. And the reason, for a new Jsonnet user is esoteric: `::` vs `:`.

This PR keeps all Prometheus resources inside the new element - this seems like a good practice, as it allows that element to be referenced and cloned, as was the intent of the original change.

However, it makes the `prometheus` element public. That way, newcomers will get the Prometheus server they expect. More experienced users, who want to set up multiple Prometheus servers, can do `prometheus:: $.prometheus,` which will hide the prometheus node.