### PR TITLE
Allow plugins

### DIFF
--- a/prometheus-ksonnet/lib/grafana.libsonnet
+++ b/prometheus-ksonnet/lib/grafana.libsonnet
@@ -161,10 +161,10 @@
   grafana_container::
     container.new('grafana', $._images.grafana) +
     container.withPorts($.core.v1.containerPort.new('grafana', 80)) +
-    container.withEnv([
-      container.envType.new('GF_PATHS_CONFIG', '/etc/grafana-config/grafana.ini'),
-      container.envType.new('GF_INSTALL_PLUGINS', std.join(',', $.grafana_plugins)),
-    ])+
+    container.withEnvMap({
+      'GF_PATHS_CONFIG': '/etc/grafana-config/grafana.ini',
+      'GF_INSTALL_PLUGINS': std.join(',', $.grafana_plugins),
+    }) +
     $.util.resourcesRequests('10m', '40Mi'),
 
   local deployment = $.apps.v1beta1.deployment,

--- a/prometheus-ksonnet/lib/grafana.libsonnet
+++ b/prometheus-ksonnet/lib/grafana.libsonnet
@@ -154,6 +154,8 @@
       for name in std.objectFields($.grafanaNotificationChannels)
     }),
 
+  grafana_plugins+:: [],
+
   local container = $.core.v1.container,
 
   grafana_container::
@@ -161,6 +163,7 @@
     container.withPorts($.core.v1.containerPort.new('grafana', 80)) +
     container.withEnv([
       container.envType.new('GF_PATHS_CONFIG', '/etc/grafana-config/grafana.ini'),
+      container.envType.new('GF_INSTALL_PLUGINS', std.join(',', $.grafana_plugins)),
     ])+
     $.util.resourcesRequests('10m', '40Mi'),
 

--- a/prometheus-ksonnet/lib/grafana.libsonnet
+++ b/prometheus-ksonnet/lib/grafana.libsonnet
@@ -159,11 +159,9 @@
   grafana_container::
     container.new('grafana', $._images.grafana) +
     container.withPorts($.core.v1.containerPort.new('grafana', 80)) +
-    container.withCommand([
-      '/usr/share/grafana/bin/grafana-server',
-      '--homepath=/usr/share/grafana',
-      '--config=/etc/grafana-config/grafana.ini',
-    ]) +
+    container.withEnv([
+      container.envType.new('GF_PATHS_CONFIG', '/etc/grafana-config/grafana.ini'),
+    ])+
     $.util.resourcesRequests('10m', '40Mi'),
 
   local deployment = $.apps.v1beta1.deployment,


### PR DESCRIPTION
The current Grafana cannot be configured to install plugins. The entrypoint of the Docker container, `run.sh` can do this, but we avoid it so as to set our own config file.

This change switches to running Grafana with the `run.sh` entrypoint, and passes the needed config file in as an environment variable.

It also creates a `grafana_plugins: [ ]` element, and then joins names found in this array and hands them to `run.sh` via `GF_INSTALL_PLUGINS`.

This means that we can add plugins to Grafana by adding config such as this:

```
grafana_plugins+:: ['grafana-piechart-panel'],
```
Which I think is rather cool :-)