### PR TITLE
Use `default` as a picker value for datasource variable

### DIFF
--- a/grafana-builder/grafana.libsonnet
+++ b/grafana-builder/grafana.libsonnet
@@ -88,8 +88,8 @@
       list: [
         {
           current: {
-            text: 'Prometheus',
-            value: 'Prometheus',
+            text: 'default',
+            value: 'default',
           },
           hide: 0,
           label: null,


### PR DESCRIPTION
Per discussion in https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/307, this changes the selector to go for the 'default' datasource instead of the hardcoded `Prometheus`.