### PR TITLE
fix grafanaDatasources usage and add clearer instructions

### DIFF
--- a/prometheus-ksonnet/lib/grafana-configmaps.libsonnet
+++ b/prometheus-ksonnet/lib/grafana-configmaps.libsonnet
@@ -29,47 +29,77 @@
     for shard in std.range(0, $._config.dashboard_config_maps - 1)
   },
 
+  /*
+    to add datasources:
+
+    grafanaDatasources+:: {
+      'my-datasource': $.grafana_datasource(name, url, default, method),
+      'secure-datasource': $.grafana_datasource_with_basicauth(name, url, username, password, default, method),
+    },
+  */
   grafanaDatasources+:: {},
 
-  grafana_add_datasource(name, url, default=false, method='GET')::
-    configMap.withDataMixin({
-      ['%s.yml' % name]: $.util.manifestYaml({
-        apiVersion: 1,
-        datasources: [{
-          name: name,
-          type: 'prometheus',
-          access: 'proxy',
-          url: url,
-          isDefault: default,
-          version: 1,
-          editable: false,
-          jsonData: {
-            httpMethod: method,
-          },
-        }],
-      }),
+  // Generates yaml string containing datasource config
+  grafana_datasource(name, url, default=false, method='GET')::
+    $.util.manifestYaml({
+      apiVersion: 1,
+      datasources: [{
+        name: name,
+        type: 'prometheus',
+        access: 'proxy',
+        url: url,
+        isDefault: default,
+        version: 1,
+        editable: false,
+        jsonData: {
+          httpMethod: method,
+        },
+      }],
     }),
 
+  /*
+    helper to allow adding datasources directly to the datasource_config_map
+    eg:
+
+    grafana_datasource_config_map+:
+      $.grafana_add_datasource(name, url, default, method),
+  */
+  grafana_add_datasource(name, url, default=false, method='GET')::
+    configMap.withDataMixin({
+      ['%s.yml' % name]: $.grafana_datasource(name, url, default, method),
+    }),
+
+  // Generates yaml string containing datasource config
+  grafana_datasource_with_basicauth(name, url, username, password, default=false, method='GET')::
+    $.util.manifestYaml({
+      apiVersion: 1,
+      datasources: [{
+        name: name,
+        type: 'prometheus',
+        access: 'proxy',
+        url: url,
+        isDefault: default,
+        version: 1,
+        editable: false,
+        basicAuth: true,
+        basicAuthUser: username,
+        basicAuthPassword: password,
+        jsonData: {
+          httpMethod: method,
+        },
+      }],
+    }),
+
+  /*
+   helper to allow adding datasources directly to the datasource_config_map
+   eg:
+
+   grafana_datasource_config_map+:
+     $.grafana_add_datasource_with_basicauth(name, url, username, password, default, method),
+  */
   grafana_add_datasource_with_basicauth(name, url, username, password, default=false, method='GET')::
     configMap.withDataMixin({
-      ['%s.yml' % name]: $.util.manifestYaml({
-        apiVersion: 1,
-        datasources: [{
-          name: name,
-          type: 'prometheus',
-          access: 'proxy',
-          url: url,
-          isDefault: default,
-          version: 1,
-          editable: false,
-          basicAuth: true,
-          basicAuthUser: username,
-          basicAuthPassword: password,
-          jsonData: {
-            httpMethod: method,
-          },
-        }],
-      }),
+      ['%s.yml' % name]: $.grafana_datasource_with_basicauth(name, url, username, password, default, method),
     }),
 
   grafana_datasource_config_map:

--- a/prometheus-ksonnet/lib/grafana.libsonnet
+++ b/prometheus-ksonnet/lib/grafana.libsonnet
@@ -46,10 +46,11 @@
       }),
     }),
 
-  grafanaDatasources+::
-    $.grafana_add_datasource('prometheus',
-                             'http://prometheus.%(namespace)s.svc.%(cluster_dns_suffix)s%(prometheus_web_route_prefix)s' % $._config,
-                             default=true),
+  grafanaDatasources+:: {
+    prometheus: $.grafana_datasource('prometheus',
+                                     'http://prometheus.%(namespace)s.svc.%(cluster_dns_suffix)s%(prometheus_web_route_prefix)s' % $._config,
+                                     default=true),
+  },
 
   local container = $.core.v1.container,
 


### PR DESCRIPTION
grafanaDatasources was recently added as a way to define datasources
without having to add them to a configMap.  However, grafanaDatasources
was incorrectly being used as though it was a configMap.

This change fixes the usage of grafanaDatasources by adding 2 new helper
functions 'grafana_datasource' and 'grafana_datasource_with_basicauth'.

These functions generate the same datasource payload as
'grafana_add_datasource' and 'grafana_add_datasource_with_basicauth'
except they just return the generated yaml string instead of returning a
configmap data object.