### PR TITLE
serviceFor() port naming breaks Istio enabled services

### DIFF
--- a/ksonnet-util/kausal.libsonnet
+++ b/ksonnet-util/kausal.libsonnet
@@ -231,7 +231,7 @@ k {
       local service = $.core.v1.service;
       local servicePort = service.mixin.spec.portsType;
       local ports = [
-        servicePort.newNamed(c.name + '-' + port.name, port.containerPort, port.containerPort) +
+        servicePort.newNamed(port.name + '-' + c.name, port.containerPort, port.containerPort) +
         if std.objectHas(port, 'protocol')
         then servicePort.withProtocol(port.protocol)
         else {}


### PR DESCRIPTION
# Description 
For Istio to work, port name in Services need to be formed with `<protocol>[-<suffix>]`
https://istio.io/docs/ops/configuration/traffic-management/protocol-selection/

When using `util.serviceFor()`, the ports are named with the container name first : 
```
servicePort.newNamed(c.name + '-' + port.name, port.containerPort, port.containerPort) +
```

# Solution
I propose to change the naming to the other way around:
```
servicePort.newNamed(port.name + '-' + c.name, port.containerPort, port.containerPort) +
```

As far as I know, nothing else is dependent on this naming beside Istio...