### PR TITLE
Remove RBAC helpers.

### DIFF
--- a/ksonnet-util/kausal.libsonnet
+++ b/ksonnet-util/kausal.libsonnet
@@ -194,26 +194,7 @@ k {
     v1beta1+: {
       // Shortcut to access the hidden types.
       policyRule:: $.rbac.v1beta1.clusterRole.rulesType,
-
-      subject:: $.rbac.v1beta1.clusterRoleBinding.subjectsType {
-        withKind(kind):: self + { kind: kind },
-      },
-
-      roleBinding+: {
-        mixin+: {
-          roleRef+: {
-            withKind(kind):: self.mixinInstance({ kind: kind }),
-          },
-        },
-      },
-
-      clusterRoleBinding+: {
-        mixin+: {
-          roleRef+: {
-            withKind(kind):: self.mixinInstance({ kind: kind }),
-          },
-        },
-      },
+      subject:: $.rbac.v1beta1.clusterRoleBinding.subjectsType,
     },
   },
 


### PR DESCRIPTION
These helpers are already implemented in k8s.libsonnet and have
equivalent functionality (adding a convenient `self` to the return
value, allowing to chain the `with` statements).