### PR TITLE
feat(ksonnet-util): proper pvc `new()`

### DIFF
--- a/ksonnet-util/kausal.libsonnet
+++ b/ksonnet-util/kausal.libsonnet
@@ -56,7 +56,12 @@ k {
       },
 
       persistentVolumeClaim+:: {
-        new():: {},
+        // new() creates a new PVC with the given name (e.g. grafana)
+        // and of the given size (e.g. 300Gi)
+        new(name, size, mode="ReadWriteOnce"):: super.new()
+          + super.mixin.metadata.withName(name)
+          + super.mixin.spec.withAccessModes(mode)
+          + super.mixin.spec.resources.withRequests({ storage: size }),
       },
 
       container:: $.apps.v1.deployment.mixin.spec.template.spec.containersType {


### PR DESCRIPTION
The previous `new()` constructor for `core.v1.persistentVolumeClaim` was
pretty useless, because it returned an empty object, not even
`apiVersion` or `kind`

Thus I created a new one, that initializes all required fiels of a PVC:

- `metadata.name`
- `spec.resources.requests`: how big the PVC is going to be
- `spec.accessModes` (default `ReadWriteOnce`)