### PR TITLE
Enable Prometheus TSDB admin API by default

### DIFF
--- a/prometheus-ksonnet/lib/prometheus.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus.libsonnet
@@ -39,6 +39,7 @@
         '--config.file=/etc/prometheus/prometheus.yml',
         '--web.listen-address=:%s' % _config.prometheus_port,
         '--web.external-url=%(prometheus_external_hostname)s%(prometheus_path)s' % _config,
+        '--web.enable-admin-api',
         '--web.enable-lifecycle',
         '--web.route-prefix=%s' % _config.prometheus_web_route_prefix,
         '--storage.tsdb.path=/prometheus/data',


### PR DESCRIPTION
I think this is useful to have on by default. We can take snapshot if
we need to, or cleanup tombstones. We can also delete individual
series, which is at the same time the risk (if it happens
accidentally). However, since we remote-write everything to Cortex, I
think the risk is quite limited.

But perhaps there was another reason to not enable it?

Details about the API see
https://prometheus.io/docs/prometheus/latest/querying/api/#tsdb-admin-apis