### PR TITLE
Update jsonnet verstion to v0.15.0

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -3,7 +3,7 @@
 FROM alpine:3.7
 RUN apk --no-cache add alpine-sdk git
 RUN git clone https://github.com/google/jsonnet
-RUN git  -C jsonnet checkout v0.10.0
+RUN git  -C jsonnet checkout v0.15.0
 RUN make -C jsonnet LDFLAGS=-static
 
 FROM alpine:3.7


### PR DESCRIPTION
This is a first PR en route to fix https://github.com/grafana/jsonnet-libs/issues/224 . This image is not yet used anywhere, but a follow-up PR will switch circleci to use this image instead of kausal one.