### PR TITLE
Add jsonnetfmt to the docker image.

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -9,3 +9,4 @@ RUN make -C jsonnet LDFLAGS=-static
 FROM alpine:3.7
 RUN apk --no-cache add make python git openssh-client
 COPY --from=0 jsonnet/jsonnet /usr/bin
+COPY --from=0 jsonnet/jsonnetfmt /usr/bin


### PR DESCRIPTION
The Dockerfile was originally just pulling a single jsonnet binary from
jsonnet build. We're using jsonnetfmt for linting, let's include that
one as well.