### PR TITLE
Update Prometheus to 2.17.0 and Alertmanager to 0.20.0

### DIFF
--- a/prometheus-ksonnet/images.libsonnet
+++ b/prometheus-ksonnet/images.libsonnet
@@ -1,10 +1,10 @@
 {
   _images+:: {
-    prometheus: 'prom/prometheus:v2.16.0',
+    prometheus: 'prom/prometheus:v2.17.0',
     grafana: 'grafana/grafana:6.4.4',
     watch: 'weaveworks/watch:master-5b2a6e5',
     kubeStateMetrics: 'gcr.io/google_containers/kube-state-metrics:v1.6.0',
-    alertmanager: 'prom/alertmanager:v0.19.0',
+    alertmanager: 'prom/alertmanager:v0.20.0',
     nodeExporter: 'prom/node-exporter:v0.18.1',
     nginx: 'nginx:1.15.1-alpine',
   },


### PR DESCRIPTION
Both updates are low risk and should "just work".

(Also note that this will only propagate to production with a vendoring update.)