### PR TITLE
Don't merge mixins in the global namespace anymore.

### DIFF
--- a/prometheus-ksonnet/grafana/dashboards.libsonnet
+++ b/prometheus-ksonnet/grafana/dashboards.libsonnet
@@ -29,7 +29,7 @@
     function(mixinName, acc)
       local mixin = $.mixins[mixinName] + emptyMixin;
       if std.objectHas(mixin, 'grafanaDashboardFolder')
-      then acc + {
+      then acc {
         [mixin.grafanaDashboardFolder]: mixin.grafanaDashboards,
       }
       else acc,

--- a/prometheus-ksonnet/grafana/dashboards.libsonnet
+++ b/prometheus-ksonnet/grafana/dashboards.libsonnet
@@ -10,11 +10,14 @@
   // New API: Mixins go in the mixins map.
   mixins+:: {},
 
-  // Legacy extension points for you to add your own dashboards.
+  // emptyMixin allows us to reliably do `mixin.grafanaDashboards` without
+  // having to check the field exists first. Some mixins don't declare all
+  // the fields, and thats fine.
   local emptyMixin = {
     grafanaDashboards+: {},
   },
 
+  // Legacy extension points for you to add your own dashboards.
   grafanaDashboards+:: std.foldr(
     function(mixinName, acc)
       local mixin = $.mixins[mixinName] + emptyMixin;

--- a/prometheus-ksonnet/lib/config.libsonnet
+++ b/prometheus-ksonnet/lib/config.libsonnet
@@ -81,25 +81,6 @@
     // Node exporter options.
     node_exporter_mount_root: true,
 
-    // Kubernetes mixin overrides.
-    cadvisorSelector: 'job="kube-system/cadvisor"',
-    kubeletSelector: 'job="kube-system/kubelet"',
-    kubeStateMetricsSelector: 'job="%s/kube-state-metrics"' % $._config.namespace,
-    nodeExporterSelector: 'job="%s/node-exporter"' % $._config.namespace,  // Also used by node-mixin.
-    notKubeDnsSelector: 'job!="kube-system/kube-dns"',
-    kubeSchedulerSelector: 'job="kube-system/kube-scheduler"',
-    kubeControllerManagerSelector: 'job="kube-system/kube-controller-manager"',
-    kubeApiserverSelector: 'job="kube-system/kube-apiserver"',
-    podLabel: 'instance',
-    grafanaPrefix: '/grafana',  // Also used by node-mixin.
-
-    // Prometheus mixin overrides.
-    prometheusSelector: 'job="default/prometheus"',
-    alertmanagerSelector: 'job="default/alertmanager"',
-
-    // Node mixin overrides.
-    nodeCriticalSeverity: 'warning',  // Do not page if nodes run out of disk space.
-
     // oauth2-proxy
     oauth_enabled: false,
   },

--- a/prometheus-ksonnet/lib/prometheus-config.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus-config.libsonnet
@@ -420,8 +420,8 @@
     } +
     std.foldr(
       function(mixinName, acc)
-      local mixin = $.mixins[mixinName] + emptyMixin;
-      acc + mixin.prometheusAlerts,
+        local mixin = $.mixins[mixinName] + emptyMixin;
+        acc + mixin.prometheusAlerts,
       std.objectFields($.mixins),
       {}
     ),

--- a/prometheus-ksonnet/lib/prometheus-config.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus-config.libsonnet
@@ -432,6 +432,25 @@
   },
 
   // We changes to using camelCase, but here we try and make it backwards compatible.
-  prometheusAlerts+:: $.prometheus_alerts,
-  prometheusRules+:: $.prometheus_rules,
+  prometheusAlerts+::
+    $.prometheus_alerts +
+    std.foldr(
+      function(m, acc) m + acc,
+      [
+        $.mixins[mixinName].prometheusAlerts
+        for mixinName in std.objectFields($.mixins)
+      ],
+      {}
+    ),
+
+  prometheusRules+::
+    $.prometheus_rules +
+    std.foldr(
+      function(m, acc) m + acc,
+      [
+        $.mixins[mixinName].prometheusAlerts
+        for mixinName in std.objectFields($.mixins)
+      ],
+      {}
+    ),
 }

--- a/prometheus-ksonnet/lib/prometheus-config.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus-config.libsonnet
@@ -363,94 +363,92 @@
     ],
   },
 
-  // Extension points for adding alerts, recording rules and prometheus config.
-  prometheus_alerts:: {
-    groups+: [
-      {
-        name: 'prometheus-extra',
-        rules: [
-          {
-            alert: 'PromScrapeFailed',
-            expr: |||
-              up != 1
-            |||,
-            'for': '15m',
-            labels: {
-              severity: 'warning',
-            },
-            annotations: {
-              message: 'Prometheus failed to scrape a target {{ $labels.job }} / {{ $labels.instance }}',
-            },
-          },
-          {
-            alert: 'PromScrapeFlapping',
-            expr: |||
-              avg_over_time(up[5m]) < 1
-            |||,
-            'for': '15m',
-            labels: {
-              severity: 'warning',
-            },
-            annotations: {
-              message: 'Prometheus target flapping {{ $labels.job }} / {{ $labels.instance }}',
-            },
-          },
-          {
-            alert: 'PromScrapeTooLong',
-            expr: |||
-              scrape_duration_seconds > 60
-            |||,
-            'for': '15m',
-            labels: {
-              severity: 'warning',
-            },
-            annotations: {
-              message: '{{ $labels.job }} / {{ $labels.instance }} is taking too long to scrape ({{ printf "%.1f" $value }}s)',
-            },
-          },
-        ],
-      },
-    ],
+  // Legacy Extension points for adding alerts, recording rules and prometheus config.
+  local emptyMixin = {
+    prometheusAlerts+:: {},
+    prometheusRules+:: {},
   },
 
-  prometheus_rules:: {
-    groups+: [
-      {
-        // Add mapping from namespace, pod -> node with node name as pod, as
-        // we use the node name as the node-exporter instance label.
-        name: 'instance_override',
-        rules: [
-          {
-            record: 'node_namespace_pod:kube_pod_info:',
-            expr: |||
-              max by(node, namespace, instance) (label_replace(kube_pod_info{job="default/kube-state-metrics"}, "instance", "$1", "node", "(.*)"))
-            |||,
-          },
-        ],
-      },
-    ],
-  },
-
-  // We changes to using camelCase, but here we try and make it backwards compatible.
-  prometheusAlerts+::
-    $.prometheus_alerts +
-    std.foldr(
-      function(m, acc) m + acc,
-      [
-        $.mixins[mixinName].prometheusAlerts
-        for mixinName in std.objectFields($.mixins)
+  prometheusAlerts::
+    {
+      groups+: [
+        {
+          name: 'prometheus-extra',
+          rules: [
+            {
+              alert: 'PromScrapeFailed',
+              expr: |||
+                up != 1
+              |||,
+              'for': '15m',
+              labels: {
+                severity: 'warning',
+              },
+              annotations: {
+                message: 'Prometheus failed to scrape a target {{ $labels.job }} / {{ $labels.instance }}',
+              },
+            },
+            {
+              alert: 'PromScrapeFlapping',
+              expr: |||
+                avg_over_time(up[5m]) < 1
+              |||,
+              'for': '15m',
+              labels: {
+                severity: 'warning',
+              },
+              annotations: {
+                message: 'Prometheus target flapping {{ $labels.job }} / {{ $labels.instance }}',
+              },
+            },
+            {
+              alert: 'PromScrapeTooLong',
+              expr: |||
+                scrape_duration_seconds > 60
+              |||,
+              'for': '15m',
+              labels: {
+                severity: 'warning',
+              },
+              annotations: {
+                message: '{{ $labels.job }} / {{ $labels.instance }} is taking too long to scrape ({{ printf "%.1f" $value }}s)',
+              },
+            },
+          ],
+        },
       ],
+    } +
+    std.foldr(
+      function(mixinName, acc)
+      local mixin = $.mixins[mixinName] + emptyMixin;
+      acc + mixin.prometheusAlerts,
+      std.objectFields($.mixins),
       {}
     ),
 
-  prometheusRules+::
-    $.prometheus_rules +
-    std.foldr(
-      function(m, acc) m + acc,
-      [
-        $.mixins[mixinName].prometheusAlerts
-        for mixinName in std.objectFields($.mixins)
+  prometheusRules::
+    {
+      groups+: [
+        {
+          // Add mapping from namespace, pod -> node with node name as pod, as
+          // we use the node name as the node-exporter instance label.
+          name: 'instance_override',
+          rules: [
+            {
+              record: 'node_namespace_pod:kube_pod_info:',
+              expr: |||
+                max by(node, namespace, instance) (label_replace(kube_pod_info{job="default/kube-state-metrics"}, "instance", "$1", "node", "(.*)"))
+              |||,
+            },
+          ],
+        },
       ],
-      {}
+    } +
+    std.foldr(
+      function(mixinName, acc)
+        local mixin = $.mixins[mixinName] + emptyMixin;
+        acc + mixin.prometheusRules,
+      std.objectFields($.mixins),
+      {},
     ),
 }

--- a/prometheus-ksonnet/mixins.libsonnet
+++ b/prometheus-ksonnet/mixins.libsonnet
@@ -1,0 +1,44 @@
+{
+  // Add you mixins here.
+  mixins+:: {
+    kubernetes+:
+      (import 'kubernetes-mixin/mixin.libsonnet') {
+        _config+:: {
+          cadvisorSelector: 'job="kube-system/cadvisor"',
+          kubeletSelector: 'job="kube-system/kubelet"',
+          kubeStateMetricsSelector: 'job="%s/kube-state-metrics"' % $._config.namespace,
+          nodeExporterSelector: 'job="%s/node-exporter"' % $._config.namespace,  // Also used by node-mixin.
+          notKubeDnsSelector: 'job!="kube-system/kube-dns"',
+          kubeSchedulerSelector: 'job="kube-system/kube-scheduler"',
+          kubeControllerManagerSelector: 'job="kube-system/kube-controller-manager"',
+          kubeApiserverSelector: 'job="kube-system/kube-apiserver"',
+          podLabel: 'instance',
+        },
+      },
+
+    prometheus+:
+      (import 'prometheus-mixin/mixin.libsonnet') {
+        _config+:: {
+          prometheusSelector: 'job="default/prometheus"',
+        },
+      },
+
+    alertmanager+:
+      (import 'alertmanager-mixin/mixin.libsonnet') {
+        _config+:: {
+          alertmanagerSelector: 'job="default/alertmanager"',
+        },
+      },
+
+    node_exporter+:
+      (import 'node-mixin/mixin.libsonnet') {
+        _config+:: {
+          nodeExporterSelector: 'job="%s/node-exporter"' % $._config.namespace,  // Also used by node-mixin.
+
+          // Do not page if nodes run out of disk space.
+          nodeCriticalSeverity: 'warning',
+          grafanaPrefix: '/grafana',
+        },
+      },
+  },
+}

--- a/prometheus-ksonnet/mixins.libsonnet
+++ b/prometheus-ksonnet/mixins.libsonnet
@@ -1,7 +1,7 @@
 {
   // Add you mixins here.
   mixins+:: {
-    kubernetes+:
+    kubernetes:
       (import 'kubernetes-mixin/mixin.libsonnet') {
         _config+:: {
           cadvisorSelector: 'job="kube-system/cadvisor"',
@@ -16,21 +16,21 @@
         },
       },
 
-    prometheus+:
+    prometheus:
       (import 'prometheus-mixin/mixin.libsonnet') {
         _config+:: {
           prometheusSelector: 'job="default/prometheus"',
         },
       },
 
-    alertmanager+:
+    alertmanager:
       (import 'alertmanager-mixin/mixin.libsonnet') {
         _config+:: {
           alertmanagerSelector: 'job="default/alertmanager"',
         },
       },
 
-    node_exporter+:
+    node_exporter:
       (import 'node-mixin/mixin.libsonnet') {
         _config+:: {
           nodeExporterSelector: 'job="%s/node-exporter"' % $._config.namespace,  // Also used by node-mixin.

--- a/prometheus-ksonnet/prometheus-ksonnet.libsonnet
+++ b/prometheus-ksonnet/prometheus-ksonnet.libsonnet
@@ -8,8 +8,47 @@
 (import 'lib/prometheus.libsonnet') +
 (import 'lib/prometheus-config.libsonnet') +
 (import 'lib/prometheus-configmap.libsonnet') +
-(import 'kubernetes-mixin/mixin.libsonnet') +
-(import 'prometheus-mixin/mixin.libsonnet') +
-(import 'alertmanager-mixin/mixin.libsonnet') +
-(import 'node-mixin/mixin.libsonnet') +
-(import 'lib/config.libsonnet')
+(import 'lib/config.libsonnet') +
+{
+    mixins+:: {
+        kubernetes+:
+            (import 'kubernetes-mixin/mixin.libsonnet') {
+                _config+:: {
+                    cadvisorSelector: 'job="kube-system/cadvisor"',
+                    kubeletSelector: 'job="kube-system/kubelet"',
+                    kubeStateMetricsSelector: 'job="%s/kube-state-metrics"' % $._config.namespace,
+                    nodeExporterSelector: 'job="%s/node-exporter"' % $._config.namespace,  // Also used by node-mixin.
+                    notKubeDnsSelector: 'job!="kube-system/kube-dns"',
+                    kubeSchedulerSelector: 'job="kube-system/kube-scheduler"',
+                    kubeControllerManagerSelector: 'job="kube-system/kube-controller-manager"',
+                    kubeApiserverSelector: 'job="kube-system/kube-apiserver"',
+                    podLabel: 'instance',
+                },
+            },
+
+        prometheus+:
+            (import 'prometheus-mixin/mixin.libsonnet') {
+                _config+:: {
+                    prometheusSelector: 'job="default/prometheus"',
+                },
+            },
+
+        alertmanager+:
+            (import 'alertmanager-mixin/mixin.libsonnet') {
+                _config+:: {
+                    alertmanagerSelector: 'job="default/alertmanager"',
+                },
+            },
+
+        node_exporter+:
+            (import 'node-mixin/mixin.libsonnet') {
+                _config+:: {
+                    nodeExporterSelector: 'job="%s/node-exporter"' % $._config.namespace,  // Also used by node-mixin.
+
+                    // Do not page if nodes run out of disk space.
+                    nodeCriticalSeverity: 'warning',
+                    grafanaPrefix: '/grafana',
+                },
+            },
+    },
+}

--- a/prometheus-ksonnet/prometheus-ksonnet.libsonnet
+++ b/prometheus-ksonnet/prometheus-ksonnet.libsonnet
@@ -10,45 +10,45 @@
 (import 'lib/prometheus-configmap.libsonnet') +
 (import 'lib/config.libsonnet') +
 {
-    mixins+:: {
-        kubernetes+:
-            (import 'kubernetes-mixin/mixin.libsonnet') {
-                _config+:: {
-                    cadvisorSelector: 'job="kube-system/cadvisor"',
-                    kubeletSelector: 'job="kube-system/kubelet"',
-                    kubeStateMetricsSelector: 'job="%s/kube-state-metrics"' % $._config.namespace,
-                    nodeExporterSelector: 'job="%s/node-exporter"' % $._config.namespace,  // Also used by node-mixin.
-                    notKubeDnsSelector: 'job!="kube-system/kube-dns"',
-                    kubeSchedulerSelector: 'job="kube-system/kube-scheduler"',
-                    kubeControllerManagerSelector: 'job="kube-system/kube-controller-manager"',
-                    kubeApiserverSelector: 'job="kube-system/kube-apiserver"',
-                    podLabel: 'instance',
-                },
-            },
+  mixins+:: {
+    kubernetes+:
+      (import 'kubernetes-mixin/mixin.libsonnet') {
+        _config+:: {
+          cadvisorSelector: 'job="kube-system/cadvisor"',
+          kubeletSelector: 'job="kube-system/kubelet"',
+          kubeStateMetricsSelector: 'job="%s/kube-state-metrics"' % $._config.namespace,
+          nodeExporterSelector: 'job="%s/node-exporter"' % $._config.namespace,  // Also used by node-mixin.
+          notKubeDnsSelector: 'job!="kube-system/kube-dns"',
+          kubeSchedulerSelector: 'job="kube-system/kube-scheduler"',
+          kubeControllerManagerSelector: 'job="kube-system/kube-controller-manager"',
+          kubeApiserverSelector: 'job="kube-system/kube-apiserver"',
+          podLabel: 'instance',
+        },
+      },
 
-        prometheus+:
-            (import 'prometheus-mixin/mixin.libsonnet') {
-                _config+:: {
-                    prometheusSelector: 'job="default/prometheus"',
-                },
-            },
+    prometheus+:
+      (import 'prometheus-mixin/mixin.libsonnet') {
+        _config+:: {
+          prometheusSelector: 'job="default/prometheus"',
+        },
+      },
 
-        alertmanager+:
-            (import 'alertmanager-mixin/mixin.libsonnet') {
-                _config+:: {
-                    alertmanagerSelector: 'job="default/alertmanager"',
-                },
-            },
+    alertmanager+:
+      (import 'alertmanager-mixin/mixin.libsonnet') {
+        _config+:: {
+          alertmanagerSelector: 'job="default/alertmanager"',
+        },
+      },
 
-        node_exporter+:
-            (import 'node-mixin/mixin.libsonnet') {
-                _config+:: {
-                    nodeExporterSelector: 'job="%s/node-exporter"' % $._config.namespace,  // Also used by node-mixin.
+    node_exporter+:
+      (import 'node-mixin/mixin.libsonnet') {
+        _config+:: {
+          nodeExporterSelector: 'job="%s/node-exporter"' % $._config.namespace,  // Also used by node-mixin.
 
-                    // Do not page if nodes run out of disk space.
-                    nodeCriticalSeverity: 'warning',
-                    grafanaPrefix: '/grafana',
-                },
-            },
-    },
+          // Do not page if nodes run out of disk space.
+          nodeCriticalSeverity: 'warning',
+          grafanaPrefix: '/grafana',
+        },
+      },
+  },
 }

--- a/prometheus-ksonnet/prometheus-ksonnet.libsonnet
+++ b/prometheus-ksonnet/prometheus-ksonnet.libsonnet
@@ -9,46 +9,4 @@
 (import 'lib/prometheus-config.libsonnet') +
 (import 'lib/prometheus-configmap.libsonnet') +
 (import 'lib/config.libsonnet') +
-{
-  mixins+:: {
-    kubernetes+:
-      (import 'kubernetes-mixin/mixin.libsonnet') {
-        _config+:: {
-          cadvisorSelector: 'job="kube-system/cadvisor"',
-          kubeletSelector: 'job="kube-system/kubelet"',
-          kubeStateMetricsSelector: 'job="%s/kube-state-metrics"' % $._config.namespace,
-          nodeExporterSelector: 'job="%s/node-exporter"' % $._config.namespace,  // Also used by node-mixin.
-          notKubeDnsSelector: 'job!="kube-system/kube-dns"',
-          kubeSchedulerSelector: 'job="kube-system/kube-scheduler"',
-          kubeControllerManagerSelector: 'job="kube-system/kube-controller-manager"',
-          kubeApiserverSelector: 'job="kube-system/kube-apiserver"',
-          podLabel: 'instance',
-        },
-      },
-
-    prometheus+:
-      (import 'prometheus-mixin/mixin.libsonnet') {
-        _config+:: {
-          prometheusSelector: 'job="default/prometheus"',
-        },
-      },
-
-    alertmanager+:
-      (import 'alertmanager-mixin/mixin.libsonnet') {
-        _config+:: {
-          alertmanagerSelector: 'job="default/alertmanager"',
-        },
-      },
-
-    node_exporter+:
-      (import 'node-mixin/mixin.libsonnet') {
-        _config+:: {
-          nodeExporterSelector: 'job="%s/node-exporter"' % $._config.namespace,  // Also used by node-mixin.
-
-          // Do not page if nodes run out of disk space.
-          nodeCriticalSeverity: 'warning',
-          grafanaPrefix: '/grafana',
-        },
-      },
-  },
-}
+(import 'mixins.libsonnet')


### PR DESCRIPTION
Instead, put them in the $.mixins map.

This allows for mixins to be places in specific Grafana directories, and also removes the horrible bug around playbook links.

Still support merging into the global namespace for the time being, but this will be going away.

NB this also removes the old field names (`grafana_dashboards`), I couldn't find a mixin that used this anymore.

Signed-off-by: Tom Wilkie <tom@grafana.com>