### PR TITLE
Copy some dashboard opinions from kubernete-mixin and apply to all dashboards.

### DIFF
--- a/prometheus-ksonnet/grafana/dashboards.libsonnet
+++ b/prometheus-ksonnet/grafana/dashboards.libsonnet
@@ -15,9 +15,9 @@
   // the fields, and thats fine.
   //
   // We also use this to add a little "opinion":
-  // - Dashboard UIDs should be the md5 hash of their filename.
-  // - Timezone should be "default" (ie local).
-  // - Tooltip should only show a single value.
+  // - Dashboard UIDs are set to the md5 hash of their filename.
+  // - Timezone are set to be "default" (ie local).
+  // - Tooltip only show a single value.
   local mixinProto = {
     grafanaDashboards+:: {},
   } + {


### PR DESCRIPTION
Previously, this would happen automatically as all mixins were merged into one.  Now we keep mixins in different namespaces, this needs to be done by out grafana jsonnet code.

Opinions are:
  // - Dashboard UIDs should be the md5 hash of their filename.
  // - Timezone should be default (ie local).
  // - Tooltip should only show a single value.

Signed-off-by: Tom Wilkie <tom@grafana.com>