### PR TITLE
Enable (optional) sharding of dashboard folder config maps too.

### DIFF
--- a/consul-mixin/dashboards.libsonnet
+++ b/consul-mixin/dashboards.libsonnet
@@ -13,8 +13,8 @@ local panel_settings = {
 
 {
   grafanaDashboards+:: {
-    'consul.json':
-      g.dashboard('Consul')
+    'consul-overview.json':
+      g.dashboard('Consul Overview')
       .addTemplate('job', 'consul_up', 'job')
       .addMultiTemplate('instance', 'consul_up{job="$job"}', 'instance')
       .addRow(

--- a/memcached-mixin/dashboards.libsonnet
+++ b/memcached-mixin/dashboards.libsonnet
@@ -2,8 +2,8 @@ local g = (import 'grafana-builder/grafana.libsonnet');
 
 {
   grafanaDashboards+: {
-    'memcached.json':
-      g.dashboard('Memcached')
+    'memcached-overview.json':
+      g.dashboard('Memcached Overview')
       .addMultiTemplate('cluster', 'memcached_commands_total', 'cluster')
       .addMultiTemplate('job', 'memcached_commands_total{cluster=~"$cluster"}', 'job')
       .addMultiTemplate('instance', 'memcached_commands_total{cluster=~"$cluster",job=~"$job"}', 'instance')

--- a/prometheus-ksonnet/grafana/dashboards.libsonnet
+++ b/prometheus-ksonnet/grafana/dashboards.libsonnet
@@ -52,7 +52,7 @@
   grafanaDashboards+:: std.foldr(
     function(mixinName, acc)
       local mixin = $.mixins[mixinName] + mixinProto;
-      if !std.objectHas(mixin, 'grafanaDashboardFolder')
+      if !$.isFolderedMixin(mixin)
       then acc + mixin.grafanaDashboards
       else acc,
     std.objectFields($.mixins),
@@ -66,6 +66,12 @@
     local underscore = std.strReplace(lower, '_', '-');
     local space = std.strReplace(underscore, ' ', '-');
     space,
+
+  // Helper to decide is a mixin should go in a folder or not.
+  isFolderedMixin(m)::
+    local mixin = m + mixinProto;
+    std.objectHas(mixin, 'grafanaDashboardFolder') &&
+    std.length(mixin.grafanaDashboards) > 0,
 
   // Its super common for a single mixin's worth of dashboards to not even fit
   // in a single config map.  So we split each mixin's dashboards up over
@@ -96,7 +102,7 @@
   dashboard_folders_config_maps: std.foldr(
     function(mixinName, acc)
       local mixin = $.mixins[mixinName] + mixinProto;
-      if !std.objectHas(mixin, 'grafanaDashboardFolder')
+      if !$.isFolderedMixin(mixin)
       then acc
       else
         local config_map_name = 'dashboards-%s' % $.folderID(mixin.grafanaDashboardFolder);
@@ -146,7 +152,7 @@
             },
           }
           for mixinName in std.objectFields($.mixins)
-          if std.objectHas($.mixins[mixinName], 'grafanaDashboardFolder')
+          if $.isFolderedMixin($.mixins[mixinName])
         ],
       }),
     }),

--- a/prometheus-ksonnet/grafana/deployment.libsonnet
+++ b/prometheus-ksonnet/grafana/deployment.libsonnet
@@ -62,7 +62,7 @@
       std.foldr(
         function(mixinName, acc)
           local mixin = $.mixins[mixinName];
-          if !std.objectHas(mixin, 'grafanaDashboardFolder')
+          if !$.isFolderedMixin(mixin)
           then acc
           else
             local config_map_name = 'dashboards-%s' % $.folderID(mixin.grafanaDashboardFolder);

--- a/prometheus-ksonnet/mixins.libsonnet
+++ b/prometheus-ksonnet/mixins.libsonnet
@@ -4,6 +4,7 @@
     kubernetes:
       (import 'kubernetes-mixin/mixin.libsonnet') {
         grafanaDashboardFolder: 'Kubernetes',
+        grafanaDashboardShards: 8,
 
         _config+:: {
           cadvisorSelector: 'job="kube-system/cadvisor"',


### PR DESCRIPTION
Mixins can now specify `grafanaDashboardShards` number to control the number of config maps they will be rendered into.

Also:
- add some more handling for special characters in folder names.
- don't add folders for mixins without dashboards.
- rename some dashboards as they can't be called the same as folders.

Signed-off-by: Tom Wilkie <tom@grafana.com>