### PR TITLE
Don't run Grafana as root anymore,

### DIFF
--- a/prometheus-ksonnet/grafana/config.libsonnet
+++ b/prometheus-ksonnet/grafana/config.libsonnet
@@ -6,7 +6,7 @@
         org_role: 'Admin',
       },
       server: {
-        http_port: 80,
+        http_port: 3000,
         root_url: $._config.grafana_root_url,
       },
       analytics: {

--- a/prometheus-ksonnet/grafana/deployment.libsonnet
+++ b/prometheus-ksonnet/grafana/deployment.libsonnet
@@ -86,7 +86,7 @@
     $.util.serviceFor($.grafana_deployment) +
     service.mixin.spec.withPortsMixin([
       servicePort.newNamed(
-        name="http",
+        name='http',
         port=80,
         targetPort=3000,
       ),

--- a/prometheus-ksonnet/grafana/deployment.libsonnet
+++ b/prometheus-ksonnet/grafana/deployment.libsonnet
@@ -26,7 +26,7 @@
 
   grafana_container::
     container.new('grafana', $._images.grafana) +
-    container.withPorts($.core.v1.containerPort.new('grafana-metrics', 80)) +
+    container.withPorts($.core.v1.containerPort.new('grafana-metrics', 3000)) +
     container.withEnvMap({
       GF_PATHS_CONFIG: '/etc/grafana-config/grafana.ini',
       GF_INSTALL_PLUGINS: std.join(',', $.grafana_plugins),
@@ -49,8 +49,10 @@
 
   grafana_deployment:
     deployment.new('grafana', 1, [$.grafana_container]) +
-    deployment.mixin.spec.template.spec.securityContext.withRunAsUser(0) +
-    $.util.configVolumeMount('grafana-config', '/etc/grafana-config') +
+    // Use configMapVolumeMount to automatically include the hash of the config
+    // as an annotation.  No need to use for others, Grafana will pick up
+    // changes there.
+    $.util.configMapVolumeMount($.grafana_config_map, '/etc/grafana-config') +
     $.util.configVolumeMount('grafana-dashboard-provisioning', '%(grafana_provisioning_dir)s/dashboards' % $._config) +
     $.util.configVolumeMount('grafana-datasources', '%(grafana_provisioning_dir)s/datasources' % $._config) +
     $.util.configVolumeMount('grafana-notification-channels', '%(grafana_provisioning_dir)s/notifiers' % $._config) +
@@ -77,6 +79,16 @@
     ) +
     $.util.podPriority('critical'),
 
+  local service = $.core.v1.service,
+  local servicePort = service.mixin.spec.portsType,
+
   grafana_service:
-    $.util.serviceFor($.grafana_deployment),
+    $.util.serviceFor($.grafana_deployment) +
+    service.mixin.spec.withPortsMixin([
+      servicePort.newNamed(
+        name="http",
+        port=80,
+        targetPort=3000,
+      ),
+    ]),
 }


### PR DESCRIPTION
Instead use the service to map port 80 to port 3000.

Also, include the config hash so Grafana gets restarted when the config changes.

/cc @slim-bean @cyriltovena I couldn't get the capabilities thing to work, rummaging around on github issues seems to imply is won't work with some setuid bit on the binary, and I think thats probably a little far.  Hence, I remapped port 80 to 3000 using the service instead.

Signed-off-by: Tom Wilkie <tom@grafana.com>