### PR TITLE
Ensure Grafana Dashboard Provisioner Names and Paths are Unique

### DIFF
--- a/prometheus-ksonnet/grafana/dashboards.libsonnet
+++ b/prometheus-ksonnet/grafana/dashboards.libsonnet
@@ -151,8 +151,10 @@
               path: '/grafana/dashboards-%s' % $.folderID($.mixins[mixinName].grafanaDashboardFolder),
             },
           }
-          for mixinName in std.objectFields($.mixins)
-          if $.isFolderedMixin($.mixins[mixinName])
+          for mixinName in std.set(
+            std.filter(function(n) $.isFolderedMixin($.mixins[n]), std.objectFields($.mixins)),
+            keyF=function(n) $.mixins[n].grafanaDashboardFolder
+          )
         ],
       }),
     }),


### PR DESCRIPTION
Grafana will not start if there are duplicate providers in dashboards.yml.

I came across this with [loki_mixin](https://github.com/grafana/loki/blob/f86785b68e52866259b294bcba0e6bcc1c90572b/production/loki-mixin/mixin.libsonnet#L4) and [promtail_mixin](https://github.com/grafana/loki/blob/f86785b68e52866259b294bcba0e6bcc1c90572b/production/promtail-mixin/mixin.libsonnet#L4). They both use `grafanaDashboardFolder: 'Loki'` which was resulting in duplicate providers named "dashboards-loki". Grafana fails with:

```
t=2020-04-14T22:55:06+0000 lvl=eror msg="Server shutdown" logger=server reason="Failed to create provisioner: Failed to read dashboards config: could not parse provisioning config file: dashboards.yml error: dashboard name \"dashboards-loki\" is not unique"
```