### PR TITLE
Prevent conflicts with grafanaDashboardFolder naming

### DIFF
--- a/prometheus-ksonnet/grafana/dashboards.libsonnet
+++ b/prometheus-ksonnet/grafana/dashboards.libsonnet
@@ -143,7 +143,7 @@
           {
             name: 'dashboards-%s' % $.folderID(mixinName),
             orgId: 1,
-            folder: $.mixins[mixinName].grafanaDashboardFolder,
+            folder: '%s folder' % $.mixins[mixinName].grafanaDashboardFolder,
             type: 'file',
             disableDeletion: true,
             editable: false,

--- a/prometheus-ksonnet/grafana/dashboards.libsonnet
+++ b/prometheus-ksonnet/grafana/dashboards.libsonnet
@@ -141,7 +141,7 @@
           },
         ] + [
           {
-            name: 'dashboards-%s' % $.folderID($.mixins[mixinName].grafanaDashboardFolder),
+            name: 'dashboards-%s' % $.folderID(mixinName),
             orgId: 1,
             folder: $.mixins[mixinName].grafanaDashboardFolder,
             type: 'file',


### PR DESCRIPTION
`name` should be a unique key in dashboards.yaml, this made Grafana crash (after update).

`folder` should not conflict with Dashboard names (`title`), this throws an error and prevents conflicting dashboard from being loaded.