### PR TITLE
Add ' folder' suffix to prevent naming conflict

### DIFF
--- a/prometheus-ksonnet/grafana/dashboards.libsonnet
+++ b/prometheus-ksonnet/grafana/dashboards.libsonnet
@@ -143,7 +143,7 @@
           {
             name: 'dashboards-%s' % $.folderID($.mixins[mixinName].grafanaDashboardFolder),
             orgId: 1,
-            folder: $.mixins[mixinName].grafanaDashboardFolder,
+            folder: '%s folder' % $.mixins[mixinName].grafanaDashboardFolder,
             type: 'file',
             disableDeletion: true,
             editable: false,


### PR DESCRIPTION
Resolves:

name=dashboards-prometheus error="Dashboard name cannot be the same as folder"