### PR TITLE
Assign service account and split nodeSelectorTerms

### DIFF
--- a/k8s-node-termination-handler/handler.libsonnet
+++ b/k8s-node-termination-handler/handler.libsonnet
@@ -37,6 +37,7 @@
     local nodeSelector = nodeAffinity.requiredDuringSchedulingIgnoredDuringExecutionType,
     daemonset:
       daemonSet.new('node-termination-handler', [self.container]) +
+      daemonSet.mixin.spec.template.spec.withServiceAccount(self.service_account.metadata.name) +
       daemonSet.mixin.spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.mixinInstance(
         nodeSelector.withNodeSelectorTerms([
           nodeSelector.nodeSelectorTermsType.new() +
@@ -44,6 +45,9 @@
             nodeSelector.nodeSelectorTermsType.matchFieldsType
             .withKey('cloud.google.com/gke-accelerator')
             .withOperator('Exists'),
+          ]),
+          nodeSelector.nodeSelectorTermsType.new() +
+          nodeSelector.nodeSelectorTermsType.withMatchExpressions([
             nodeSelector.nodeSelectorTermsType.matchFieldsType
             .withKey('cloud.google.com/gke-preemptible')
             .withOperator('Exists'),


### PR DESCRIPTION
tl;dr A single MatchExpressions didn't schedule the pods.

From the docs on nodeSelectorTerms:
"All matchExpressions associated with
requiredDuringSchedulingIgnoredDuringExecution affinity and
anti-affinity must be satisfied for the pod to be scheduled onto a
node."