### PR TITLE
Use upstream ksonnet-lib

### DIFF
--- a/ksonnet-util/jsonnetfile.json
+++ b/ksonnet-util/jsonnetfile.json
@@ -1,0 +1,15 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/ksonnet/ksonnet-lib",
+          "subdir": "ksonnet.beta.4"
+        }
+      },
+      "version": "master"
+    }
+  ],
+  "legacyImports": true
+}

--- a/ksonnet-util/kausal.libsonnet
+++ b/ksonnet-util/kausal.libsonnet
@@ -1,5 +1,5 @@
 // Override defaults paramters for objects in the ksonnet libs here.
-local k = import 'k.libsonnet';
+local k = import 'ksonnet.beta.4/k.libsonnet';
 
 k {
   _config+:: {

--- a/ksonnet-util/kausal.libsonnet
+++ b/ksonnet-util/kausal.libsonnet
@@ -44,6 +44,9 @@ k {
         fromSecret(name, secret)::
           super.withName(name) +
           super.mixin.secret.withSecretName(secret),
+
+        // Rename emptyDir to claimName
+        fromPersistentVolumeClaim(name='', claimName=''):: super.fromPersistentVolumeClaim(name=name, emptyDir=claimName),
       },
 
       volumeMount:: $.core.v1.container.volumeMountsType {


### PR DESCRIPTION
Internally Grafana uses a slightly adapted version of ksonnet-lib derived from ksonnet.beta.4. To use this lib, we must follow a process of tk init and manually copying over the altered version. This is cumbersome and holds us back from publicly developing against ksonnet-lib.

This PR backports the change (yes only one significant change) into ksonnet-util and then refer to upstream ksonnet-lib just like any other lib.