### PR TITLE
fix: remove broken persistentVolumeClaim that breaks the resource

### DIFF
--- a/ksonnet-util/kausal.libsonnet
+++ b/ksonnet-util/kausal.libsonnet
@@ -55,10 +55,6 @@ k {
           else {},
       },
 
-      persistentVolumeClaim+:: {
-        new():: {},
-      },
-
       container:: $.apps.v1.deployment.mixin.spec.template.spec.containersType {
         new(name, image)::
           super.new(name, image) +


### PR DESCRIPTION
The `persistentVolumeClaim+` resource in `kasual.libsonnet` does not add anything and breaks the upstream `new()` in `k8s.libsonnet`. As this did not add any features, removing this resource from the kasual library makes sense.