### PR TITLE
feat: add basicIngressFor utility function

### DIFF
--- a/ksonnet-util/kausal.libsonnet
+++ b/ksonnet-util/kausal.libsonnet
@@ -238,13 +238,8 @@ k {
 
     // basicIngressFor creates an ingress that routes all traffic for a host to a service
     // WARNING: This function only uses the first port specified in the service
-    basicIngressFor(service, host, ignored_labels=[])::
+    basicIngressFor(service, host)::
       local ingress = $.extensions.v1beta1.ingress;
-      local labels = {
-        [x]: service.metadata.labels[x]
-        for x in std.objectFields(service.metadata.labels)
-        if std.count(ignored_labels, x) == 0
-      };
 
       ingress.new() + ingress.mixin.metadata.withName(service.metadata.name)
       + ingress.mixin.metadata.withLabelsMixin({ name: service.metadata.name })

--- a/ksonnet-util/kausal.libsonnet
+++ b/ksonnet-util/kausal.libsonnet
@@ -244,14 +244,15 @@ k {
       ingress.new() + ingress.mixin.metadata.withName(service.metadata.name)
       + ingress.mixin.metadata.withLabelsMixin({ name: service.metadata.name })
       + ingress.mixin.spec.withRules([
-        { host: host, 
+        {
+          host: host,
           http: { paths: [{
-            path: "/*",
+            path: '/*',
             backend: {
               serviceName: service.metadata.name,
               servicePort: service.spec.ports[0].port,
-            }
-          }]},
+            },
+          }] },
         },
       ]),
 

--- a/ksonnet-util/kausal.libsonnet
+++ b/ksonnet-util/kausal.libsonnet
@@ -236,6 +236,30 @@ k {
       ) +
       service.mixin.metadata.withLabels({ name: deployment.metadata.name }),
 
+    // basicIngressFor creates an ingress that routes all traffic for a host to a service
+    // WARNING: This function only uses the first port specified in the service
+    basicIngressFor(service, host, ignored_labels=[])::
+      local ingress = $.extensions.v1beta1.ingress;
+      local labels = {
+        [x]: service.metadata.labels[x]
+        for x in std.objectFields(service.metadata.labels)
+        if std.count(ignored_labels, x) == 0
+      };
+
+      ingress.new() + ingress.mixin.metadata.withName(service.metadata.name)
+      + ingress.mixin.metadata.withLabelsMixin({ name: service.metadata.name })
+      + ingress.mixin.spec.withRules([
+        { host: host, 
+          http: { paths: [{
+            path: "/*",
+            backend: {
+              serviceName: service.metadata.name,
+              servicePort: service.spec.ports[0].port,
+            }
+          }]},
+        },
+      ]),
+
     // rbac creates a service account, role and role binding with the given
     // name and rules.
     rbac(name, rules)::


### PR DESCRIPTION
This adds a `basicIngressFor` function which generates an ingress resource for a given hostname and service. It routes all traffic and assumes the first port assigned to the service is the target of the ingress.

This isn't suited for some production configurations, but it is a pattern I have run into a fair amount -- especially in the development and testing phases.
