### PR TITLE
Percent-encode the double-quotes in silence link.

### DIFF
--- a/prometheus-ksonnet/lib/files/alertmanager_config.tmpl
+++ b/prometheus-ksonnet/lib/files/alertmanager_config.tmpl
@@ -18,8 +18,8 @@
     {{ .ExternalURL }}/#/silences/new?filter=%7B
     {{- range .CommonLabels.SortedPairs -}}
         {{- if ne .Name "alertname" -}}
-            {{- .Name }}%3D"{{- .Value -}}"%2C%20
+            {{- .Name }}%3D%22{{- .Value -}}%22%2C%20
         {{- end -}}
     {{- end -}}
-    alertname%3D"{{ .CommonLabels.alertname }}"%7D
+    alertname%3D%22{{ .CommonLabels.alertname }}%22%7D
 {{- end }}


### PR DESCRIPTION
The double-quote character is not a valid part of URL (see RFC 3986) and
thus shall be percent-encoded.