### PR TITLE
prometheus-ksonnet README fixes

### DIFF
--- a/prometheus-ksonnet/README.md
+++ b/prometheus-ksonnet/README.md
@@ -17,7 +17,7 @@ $ GO111MODULE=on go get github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb
 $ tk init
 
 # point at cluster
-$ export CONTEXT=$(kubectl current-context)
+$ export CONTEXT=$(kubectl config current-context)
 $ tk env set environments/default  --server-from-context=$CONTEXT
 ```
 

--- a/prometheus-ksonnet/README.md
+++ b/prometheus-ksonnet/README.md
@@ -3,10 +3,12 @@
 A set of extensible configs for running Prometheus on Kubernetes.
 
 Usage:
-- Make sure you have [Tanka](https://tanka.dev/install) installed:
+- Make sure you have [Tanka](https://tanka.dev/install) and
+  [jsonnet-bundler](https://github.com/jsonnet-bundler/jsonnet-bundler) installed:
 
 ```bash
 $ GO111MODULE=on go get github.com/grafana/tanka/cmd/tk
+$ GO111MODULE=on go get github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb
 ```
 
 - In your config repo, init Tanka and point it at your Kubernetes cluster:
@@ -19,10 +21,9 @@ $ export CONTEXT=$(kubectl current-context)
 $ tk env set environments/default  --server-from-context=$CONTEXT
 ```
 
-- Vendor this package using [jsonnet-bundler](https://github.com/jsonnet-bundler/jsonnet-bundler)
+- Vendor this package using jsonnet-bundler:
 
 ```bash
-$ GO111MODULE=on go get github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb
 $ jb install github.com/grafana/jsonnet-libs/prometheus-ksonnet
 ```
 


### PR DESCRIPTION
- Without jsonnet-bundler installed, the `tk init` step fails trying
to install k.libsonnet.
- The way to get the current context seems to use the `kubectl config` command.