### PR TITLE
add `interval` to panel

### DIFF
--- a/grafana-builder/grafana.libsonnet
+++ b/grafana-builder/grafana.libsonnet
@@ -168,6 +168,7 @@
     dashes: false,
     datasource: '$datasource',
     fill: 1,
+    interval: null,
     legend: {
       avg: false,
       current: false,


### PR DESCRIPTION
Not needed for https://github.com/kubernetes-monitoring/kubernetes-mixin/issues/429 but it would be nice to have it documented so that `interval` is visible.