### PR TITLE
refactor: remove method-use

### DIFF
--- a/k8s-node-termination-handler/handler.libsonnet
+++ b/k8s-node-termination-handler/handler.libsonnet
@@ -38,33 +38,30 @@
     daemonset:
       daemonSet.new('node-termination-handler', [self.container]) +
       daemonSet.mixin.spec.template.spec.withServiceAccount(self.service_account.metadata.name) +
-      daemonSet.mixin.spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.mixinInstance(
-        nodeSelector.withNodeSelectorTerms([
+      daemonSet.mixin.spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.withNodeSelectorTerms(
+        [
           nodeSelector.nodeSelectorTermsType.new() +
           nodeSelector.nodeSelectorTermsType.withMatchExpressions([
-            nodeSelector.nodeSelectorTermsType.matchFieldsType
-            .withKey('cloud.google.com/gke-accelerator')
-            .withOperator('Exists'),
+            nodeSelector.nodeSelectorTermsType.matchFieldsType.withKey('cloud.google.com/gke-accelerator')
+            + nodeSelector.nodeSelectorTermsType.matchFieldsType.withOperator('Exists'),
           ]),
           nodeSelector.nodeSelectorTermsType.new() +
           nodeSelector.nodeSelectorTermsType.withMatchExpressions([
-            nodeSelector.nodeSelectorTermsType.matchFieldsType
-            .withKey('cloud.google.com/gke-preemptible')
-            .withOperator('Exists'),
+            nodeSelector.nodeSelectorTermsType.matchFieldsType.withKey('cloud.google.com/gke-preemptible')
+            + nodeSelector.nodeSelectorTermsType.matchFieldsType.withOperator('Exists'),
           ]),
-        ])
+        ]
       ) +
       daemonSet.mixin.metadata.withNamespace(_config.namespace) +
       daemonSet.mixin.spec.template.spec.withHostPid(true) +
       daemonSet.mixin.spec.template.spec.withTolerations([
         tolerations.new() +
-        tolerations
-        .withOperator('Exists')
-        .withEffect('NoSchedule'),
+        tolerations.withOperator('Exists') +
+        tolerations.withEffect('NoSchedule'),
+
         tolerations.new() +
-        tolerations
-        .withOperator('Exists')
-        .withEffect('NoExecute'),
+        tolerations.withOperator('Exists') +
+        tolerations.withEffect('NoExecute'),
       ]),
 
     local serviceAccount = k.core.v1.serviceAccount,

--- a/prometheus-ksonnet/lib/prometheus.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus.libsonnet
@@ -81,7 +81,7 @@
       local _config = self._config;
 
       statefulset.new(self.name, 1, [
-        self.prometheus_container.withVolumeMountsMixin(
+        self.prometheus_container + container.withVolumeMountsMixin(
           volumeMount.new('%s-data' % self.name, '/prometheus')
         ),
         self.prometheus_watch_container,


### PR DESCRIPTION
Removes ksonnet-libs uses of the form `<instance>.withFoo` and replaces
them with `<instance> + <type>.withFoo`, as this is required for
migrating to jsonnet-libs/k8s