### PR TITLE
HA prometheus statefulset mixin

### DIFF
--- a/prometheus-ksonnet/lib/config.libsonnet
+++ b/prometheus-ksonnet/lib/config.libsonnet
@@ -38,6 +38,7 @@
     prometheus_path: '/prometheus/',
     prometheus_port: 9090,
     prometheus_web_route_prefix: $._config.prometheus_path,
+    prometheus_config_file: '/etc/prometheus/prometheus.yml',
 
     // Alertmanager config options.
     alertmanager_external_hostname: 'http://alertmanager.%(namespace)s.svc.%(cluster_dns_suffix)s' % self,

--- a/prometheus-ksonnet/lib/prometheus-ha-mixin.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus-ha-mixin.libsonnet
@@ -1,0 +1,42 @@
+{
+  prometheus_config_0: $.prometheus_config,
+  prometheus_config_1: $.prometheus_config,
+
+  prometheusAlerts_0: $.prometheusAlerts,
+  prometheusAlerts_1: $.prometheusAlerts,
+
+  prometheusRules_0: $.prometheusRules,
+  prometheusRules_1: $.prometheusRules,
+
+  prometheus+:: {
+    local configMap = $.core.v1.configMap,
+
+    prometheus_config_map:: {},
+
+    prometheus_config_maps: [{
+      configMap.new('%s-config-0' % self.name) +
+      configMap.withData({
+        'prometheus.yml': $.util.manifestYaml($.prometheus_config_0),
+        'alerts.rules': $.util.manifestYaml($.prometheusAlerts_0),
+        'recording.rules': $.util.manifestYaml($.prometheusRules_0),
+      }),
+      configMap.new('%s-config-1' % self.name) +
+      configMap.withData({
+        'prometheus.yml': $.util.manifestYaml($.prometheus_config_1),
+        'alerts.rules': $.util.manifestYaml($.prometheusAlerts_1),
+        'recording.rules': $.util.manifestYaml($.prometheusRules_1),
+      }),
+    ]},
+
+  prometheus_config_mount:: {},
+
+  prometheus_init_container::
+    container.new('prometheus-init', 'busybox') +
+    container.withCommand(["ln", "-s", "/etc/$HOSTNAME", "/etc/prometheus"]),
+
+  prometheus_statefulset:
+    $.util.configVolumeMount('%s-config-0' % self.name, '/etc/prometheus-0') +
+    $.util.configVolumeMount('%s-config-1' % self.name, '/etc/prometheus-1') +
+    statefulset.mixin.spec.template.spec.withInitContainers(self.prometheus_init_container) +
+    statefulset.mixin.spec.withReplicas(2),
+}

--- a/prometheus-ksonnet/lib/prometheus-ha-mixin.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus-ha-mixin.libsonnet
@@ -1,46 +1,47 @@
-local container = $.core.v1.container;
-local statefulset = $.apps.v1.statefulSet;
+local k = import 'ksonnet-util/kausal.libsonnet';
+local container = k.core.v1.container;
+local statefulset = k.apps.v1.statefulSet;
+local configMap = k.core.v1.configMap;
 
 {
-  prometheus_config_0: $.prometheus_config,
-  prometheus_config_1: $.prometheus_config,
+  prometheus_config_0:: self.prometheus_config,
+  prometheus_config_1:: self.prometheus_config,
 
-  prometheusAlerts_0: $.prometheusAlerts,
-  prometheusAlerts_1: $.prometheusAlerts,
+  prometheusAlerts_0:: self.prometheusAlerts,
+  prometheusAlerts_1:: self.prometheusAlerts,
 
-  prometheusRules_0: $.prometheusRules,
-  prometheusRules_1: $.prometheusRules,
+  prometheusRules_0:: self.prometheusRules,
+  prometheusRules_1:: self.prometheusRules,
 
-  prometheus+:: {
-    local configMap = $.core.v1.configMap,
+  local prom = self,
 
-    prometheus_config_map:: {},
+  prometheus_config_map:: {},
 
-    prometheus_config_maps: [{
-      configMap.new('%s-config-0' % self.name) +
-      configMap.withData({
-        'prometheus.yml': $.util.manifestYaml($.prometheus_config_0),
-        'alerts.rules': $.util.manifestYaml($.prometheusAlerts_0),
-        'recording.rules': $.util.manifestYaml($.prometheusRules_0),
-      }),
-      configMap.new('%s-config-1' % self.name) +
-      configMap.withData({
-        'prometheus.yml': $.util.manifestYaml($.prometheus_config_1),
-        'alerts.rules': $.util.manifestYaml($.prometheusAlerts_1),
-        'recording.rules': $.util.manifestYaml($.prometheusRules_1),
-      }),
-    ]},
+  prometheus_config_maps: [
+    configMap.new('%s-config-0' % self.name) +
+    configMap.withData({
+      'prometheus.yml': k.util.manifestYaml(prom.prometheus_config_0),
+      'alerts.rules': k.util.manifestYaml(prom.prometheusAlerts_0),
+      'recording.rules': k.util.manifestYaml(prom.prometheusRules_0),
+    }),
+    configMap.new('%s-config-1' % self.name) +
+    configMap.withData({
+      'prometheus.yml': k.util.manifestYaml(prom.prometheus_config_1),
+      'alerts.rules': k.util.manifestYaml(prom.prometheusAlerts_1),
+      'recording.rules': k.util.manifestYaml(prom.prometheusRules_1),
+    }),
+  ],
 
   prometheus_config_mount:: {},
 
   prometheus_config_file:: '/etc/$(POD_NAME)/prometheus.yml',
 
   prometheus_container+:: container.withEnv([
-      container.envType.fromFieldPath('POD_NAME', 'metadata.name'),
-    ]),
+    container.envType.fromFieldPath('POD_NAME', 'metadata.name'),
+  ]),
 
-  prometheus_statefulset:
-    $.util.configVolumeMount('%s-config-0' % self.name, '/etc/prometheus-0') +
-    $.util.configVolumeMount('%s-config-1' % self.name, '/etc/prometheus-1') +
+  prometheus_statefulset+:
+    k.util.configVolumeMount('%s-config-0' % self.name, '/etc/prometheus-0') +
+    k.util.configVolumeMount('%s-config-1' % self.name, '/etc/prometheus-1') +
     statefulset.mixin.spec.withReplicas(2),
 }

--- a/prometheus-ksonnet/lib/prometheus.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus.libsonnet
@@ -77,6 +77,9 @@
     local statefulset = $.apps.v1.statefulSet,
     local volumeMount = $.core.v1.volumeMount,
 
+    prometheus_config_mount::
+      $.util.configVolumeMount('%s-config' % self.name, '/etc/prometheus'),
+
     prometheus_statefulset:
       local _config = self._config;
 
@@ -86,7 +89,7 @@
         ),
         self.prometheus_watch_container,
       ], self.prometheus_pvc) +
-      $.util.configVolumeMount('%s-config' % self.name, '/etc/prometheus') +
+      self.prometheus_config_mount +
       statefulset.mixin.spec.withServiceName('prometheus') +
       statefulset.mixin.spec.template.metadata.withAnnotations({
         'prometheus.io.path': '%smetrics' % _config.prometheus_web_route_prefix,

--- a/prometheus-ksonnet/lib/prometheus.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus.libsonnet
@@ -31,22 +31,19 @@
 
     local container = $.core.v1.container,
 
-    prometheus_args:: {
-        '--config.file': _config.prometheus_config_file,
-        '--web.listen-address': _config.prometheus_port,
-        '--web.external-url': '%(prometheus_external_hostname)s%(prometheus_path)s' % _config,
-        '--web.enable-admin-api': true,
-        '--web.enable-lifecycle': true,
-        '--web.route-prefix': _config.prometheus_web_route_prefix,
-        '--storage.tsdb.path': '/prometheus/data',
-        '--storage.tsdb.wal-compression': true,
-    },
-
     prometheus_container::
-
       container.new('prometheus', $._images.prometheus) +
       container.withPorts($.core.v1.containerPort.new('http-metrics', _config.prometheus_port)) +
-      container.withArgs($.util.mapToArgs(self.prometheus_args) +
+      container.withArgs([
+        '--config.file=' + _config.prometheus_config_file,
+        '--web.listen-address=:%s' % _config.prometheus_port,
+        '--web.external-url=%(prometheus_external_hostname)s%(prometheus_path)s' % _config,
+        '--web.enable-admin-api',
+        '--web.enable-lifecycle',
+        '--web.route-prefix=%s' % _config.prometheus_web_route_prefix,
+        '--storage.tsdb.path=/prometheus/data',
+        '--storage.tsdb.wal-compression',
+      ]) +
       $.util.resourcesRequests('250m', '1536Mi') +
       $.util.resourcesLimits('500m', '2Gi'),
 

--- a/prometheus-ksonnet/lib/prometheus.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus.libsonnet
@@ -30,13 +30,15 @@
 
     local container = $.core.v1.container,
 
+    prometheus_config_file:: '/etc/prometheus/prometheus.yml',
+
     prometheus_container::
       local _config = self._config;
 
       container.new('prometheus', $._images.prometheus) +
       container.withPorts($.core.v1.containerPort.new('http-metrics', _config.prometheus_port)) +
       container.withArgs([
-        '--config.file=/etc/prometheus/prometheus.yml',
+        '--config.file=' + self.prometheus_config_file,
         '--web.listen-address=:%s' % _config.prometheus_port,
         '--web.external-url=%(prometheus_external_hostname)s%(prometheus_path)s' % _config,
         '--web.enable-admin-api',


### PR DESCRIPTION
Adds a mixin that will adapt a prometheus instance to have two replicas, and each has the ability to have its own config.

This PR is for review only - it has not yet been tried out.