### PR TITLE
Use self not $

### DIFF
--- a/prometheus-ksonnet/lib/config.libsonnet
+++ b/prometheus-ksonnet/lib/config.libsonnet
@@ -37,7 +37,7 @@
     prometheus_external_hostname: 'http://prometheus.%(namespace)s.svc.%(cluster_dns_suffix)s' % self,
     prometheus_path: '/prometheus/',
     prometheus_port: 9090,
-    prometheus_web_route_prefix: $._config.prometheus_path,
+    prometheus_web_route_prefix: self.prometheus_path,
     prometheus_config_file: '/etc/prometheus/prometheus.yml',
 
     // Alertmanager config options.


### PR DESCRIPTION
The prometheus library has been refactored so that it doesn't need to be at the root of the tree. This reference breaks that new model. Using `self` to access other config elements fixes it.