### PR TITLE
Add __replica__ labels to prometheus-ha replicas

### DIFF
--- a/prometheus-ksonnet/lib/prometheus-ha-mixin.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus-ha-mixin.libsonnet
@@ -10,14 +10,27 @@ local configMap = k.core.v1.configMap;
     prometheus_config_file: '/etc/$(POD_NAME)/prometheus.yml',
   },
 
+  // The '__replica__' label is used by Cortex for deduplication.
   prometheus_zero+:: {
-    config+:: root.prometheus_config,
+    config+:: root.prometheus_config {
+      global+: {
+        external_labels+: {
+          __replica__: 'zero',
+        },
+      },
+    },
     alerts+:: root.prometheusAlerts,
     rules+:: root.prometheusRules,
   },
 
   prometheus_one+:: {
-    config+:: root.prometheus_config,
+    config+:: root.prometheus_config {
+      global+: {
+        external_labels+: {
+          __replica__: 'one',
+        },
+      },
+    },
     alerts+:: root.prometheusAlerts,
     rules+:: root.prometheusRules,
   },


### PR DESCRIPTION
Those labels are needed by Cortex for deduplication. In our existing
setup, we use "one" and "two" as labels. Here I have chosen "zero" and
"one", in line with the zero-based numbering within a stateful set. I
expect that this should not make any difference for Cortex. It only
matters that both label values are different.