### PR TITLE
Point the watcher for the Prometheus config file to its directory

### DIFF
--- a/prometheus-ksonnet/lib/prometheus-ha-mixin.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus-ha-mixin.libsonnet
@@ -58,6 +58,10 @@ local configMap = k.core.v1.configMap;
     container.envType.fromFieldPath('POD_NAME', 'metadata.name'),
   ]),
 
+  prometheus_watch_container+:: container.withEnv([
+    container.envType.fromFieldPath('POD_NAME', 'metadata.name'),
+  ]),
+
   prometheus_statefulset+:
     k.util.configVolumeMount('%s-config-0' % self.name, '/etc/prometheus-0') +
     k.util.configVolumeMount('%s-config-1' % self.name, '/etc/prometheus-1') +

--- a/prometheus-ksonnet/lib/prometheus.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus.libsonnet
@@ -52,7 +52,8 @@
       container.withArgs([
         '-v',
         '-t',
-        '-p=/etc/prometheus',
+        // Watch the directory in which the Prometheus config file is located.
+        '-p=' + std.substr(_config.prometheus_config_file, 0, std.reverse(std.findSubstr('/', _config.prometheus_config_file))[0]),
         'curl',
         '-X',
         'POST',


### PR DESCRIPTION
With the hardcoding of `/etc/prometheus`, any changes to the location
of the Prometheus config file would make it unwatched. This is
essentially applying `dirname` to the Prometheus config file and
therefore watches the directory in which the config file is located.

Please let me know if there is a less horrible way of doing `dirname`.

Another way would be to to a more invasive refactoring and define a `_config.prometheus_dir` variable and refer to it everywhere instead of hardcoding `/etc/prometheus`. But I first wanted to know your opinion before doing that more invasive refactoring.