### PR TITLE
Let the prometheus-ha watcher watch the correct directory

### DIFF
--- a/prometheus-ksonnet/lib/config.libsonnet
+++ b/prometheus-ksonnet/lib/config.libsonnet
@@ -38,7 +38,8 @@
     prometheus_path: '/prometheus/',
     prometheus_port: 9090,
     prometheus_web_route_prefix: self.prometheus_path,
-    prometheus_config_file: '/etc/prometheus/prometheus.yml',
+    prometheus_config_dir: '/etc/prometheus',
+    prometheus_config_file: self.prometheus_config_dir + '/prometheus.yml',
 
     // Alertmanager config options.
     alertmanager_external_hostname: 'http://alertmanager.%(namespace)s.svc.%(cluster_dns_suffix)s' % self,

--- a/prometheus-ksonnet/lib/prometheus-ha-mixin.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus-ha-mixin.libsonnet
@@ -7,7 +7,7 @@ local configMap = k.core.v1.configMap;
   local root = self,
 
   _config+:: {
-    prometheus_config_file: '/etc/$(POD_NAME)/prometheus.yml',
+    prometheus_config_dir: '/etc/$(POD_NAME)',
   },
 
   // The '__replica__' label is used by Cortex for deduplication.
@@ -55,6 +55,10 @@ local configMap = k.core.v1.configMap;
   prometheus_config_mount:: {},
 
   prometheus_container+:: container.withEnv([
+    container.envType.fromFieldPath('POD_NAME', 'metadata.name'),
+  ]),
+
+  prometheus_watch_container+:: container.withEnv([
     container.envType.fromFieldPath('POD_NAME', 'metadata.name'),
   ]),
 

--- a/prometheus-ksonnet/lib/prometheus.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus.libsonnet
@@ -52,7 +52,7 @@
       container.withArgs([
         '-v',
         '-t',
-        '-p=/etc/prometheus',
+        '-p=' + _config.prometheus_config_dir,
         'curl',
         '-X',
         'POST',
@@ -75,7 +75,7 @@
     local volumeMount = $.core.v1.volumeMount,
 
     prometheus_config_mount::
-      $.util.configVolumeMount('%s-config' % self.name, '/etc/prometheus'),
+      $.util.configVolumeMount('%s-config' % self.name, _config.prometheus_config_dir),
 
     prometheus_statefulset:
       statefulset.new(self.name, 1, [


### PR DESCRIPTION
This also introduces a `prometheus_config_dir` variable to avoid
hardcoding of `/etc/prometheus` at multiple places.