### PR TITLE
refactor: *Type, .mixin and cert-manager

### DIFF
--- a/cert-manager/cainjector_deployment.libsonnet
+++ b/cert-manager/cainjector_deployment.libsonnet
@@ -2,21 +2,22 @@
   local deployment = $.apps.v1.deployment,
   local container = $.core.v1.container,
 
-  cainjector_container:: container.new('cainjector', $._images.cert_manager_cainjector)
-                         .withImagePullPolicy('IfNotPresent')
-                         .withArgs([
-    '--v=2',  // loglevel
-    '--leader-election-namespace=kube-system',  // optionally customizable
-  ])
-                         .withEnv([
-    container.envType.fromFieldPath('POD_NAMESPACE', 'metadata.namespace'),
-  ]),
+  cainjector_container::
+    container.new('cainjector', $._images.cert_manager_cainjector) +
+    container.withImagePullPolicy('IfNotPresent') +
+    container.withArgs([
+      '--v=2',  // loglevel
+      '--leader-election-namespace=kube-system',  // optionally customizable
+    ]) +
+    container.withEnv([
+      $.core.v1.envVar.fromFieldPath('POD_NAMESPACE', 'metadata.namespace'),
+    ]),
 
-  cainjector_deployment: deployment.new(name='cert-manager-cainjector', replicas=1, containers=[$.cainjector_container], podLabels={
-                           /* TODO: labels */
-                           app: 'cainjector',
-                         },) +
-                         deployment.mixin.spec.template.spec
-                         .withServiceAccountName('cert-manager-cainjector') +
-                         deployment.mixin.metadata.withLabels({ app: 'cainjector' },),
+  cainjector_deployment:
+    deployment.new(name='cert-manager-cainjector', replicas=1, containers=[$.cainjector_container], podLabels={
+      /* TODO: labels */
+      app: 'cainjector',
+    }) +
+    deployment.spec.template.spec.withServiceAccountName('cert-manager-cainjector') +
+    deployment.metadata.withLabels({ app: 'cainjector' }),
 }

--- a/cert-manager/cainjector_psp.libsonnet
+++ b/cert-manager/cainjector_psp.libsonnet
@@ -1,13 +1,11 @@
 {
   local podSecurityPolicy = $.policy.v1beta1.podSecurityPolicy,
-  local ranges = podSecurityPolicy.mixin.spec.runAsUser.rangesType,
+  local idRange = $.policy.v1beta1.idRange,
 
   cainjector_psp:
-    podSecurityPolicy.new() +
-    podSecurityPolicy.mixin.metadata
-    .withName('cert-manager-cainjector')
-    .withLabels({}/* TODO: labels */,)
-    .withAnnotations({
+    podSecurityPolicy.new('cert-manager-cainjector') +
+    podSecurityPolicy.metadata.withLabels({}/* TODO: labels */,) +
+    podSecurityPolicy.metadata.withAnnotations({
       'seccomp.security.alpha.kubernetes.io/allowedProfileNames': 'docker/default',
       'seccomp.security.alpha.kubernetes.io/defaultProfileName': 'docker/default',
 
@@ -17,28 +15,24 @@
       apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default',
       */
     },) +
-    podSecurityPolicy.mixin.spec
-    .withPrivileged(false)
-    .withAllowPrivilegeEscalation(false)
-    .withAllowedCapabilities([])
-    .withVolumes([
+    podSecurityPolicy.spec.withPrivileged(false) +
+    podSecurityPolicy.spec.withAllowPrivilegeEscalation(false) +
+    podSecurityPolicy.spec.withAllowedCapabilities([]) +
+    podSecurityPolicy.spec.withVolumes([
       'configMap',
       'emptyDir',
       'projected',
       'secret',
       'downwardAPI',
-    ],)
-    .withHostNetwork(false)
-    .withHostIpc(false)
-    .withHostPid(false) +
-    podSecurityPolicy.mixin.spec.runAsUser
-    .withRule('MustRunAs')
-    .withRanges(ranges.new() + ranges.withMin(1000) + ranges.withMax(1000)) +
-    podSecurityPolicy.mixin.spec.seLinux.withRule('RunAsAny') +
-    podSecurityPolicy.mixin.spec.supplementalGroups
-    .withRule('MustRunAs')
-    .withRanges(ranges.new() + ranges.withMin(1000) + ranges.withMax(1000)) +
-    podSecurityPolicy.mixin.spec.fsGroup
-    .withRule('MustRunAs')
-    .withRanges(ranges.new() + ranges.withMin(1000) + ranges.withMax(1000)),
+    ],) +
+    podSecurityPolicy.spec.withHostNetwork(false) +
+    podSecurityPolicy.spec.withHostIpc(false) +
+    podSecurityPolicy.spec.withHostPid(false) +
+    podSecurityPolicy.spec.runAsUser.withRule('MustRunAs') +
+    podSecurityPolicy.spec.runAsUser.withRanges(idRange.withMin(1000) + idRange.withMax(1000)) +
+    podSecurityPolicy.spec.seLinux.withRule('RunAsAny') +
+    podSecurityPolicy.spec.supplementalGroups.withRule('MustRunAs') +
+    podSecurityPolicy.spec.supplementalGroups.withRanges(idRange.withMin(1000) + idRange.withMax(1000)) +
+    podSecurityPolicy.spec.fsGroup.withRule('MustRunAs') +
+    podSecurityPolicy.spec.fsGroup.withRanges(idRange.withMin(1000) + idRange.withMax(1000)),
 }

--- a/cert-manager/cainjector_psp.libsonnet
+++ b/cert-manager/cainjector_psp.libsonnet
@@ -26,8 +26,8 @@
       'downwardAPI',
     ],) +
     podSecurityPolicy.spec.withHostNetwork(false) +
-    podSecurityPolicy.spec.withHostIpc(false) +
-    podSecurityPolicy.spec.withHostPid(false) +
+    podSecurityPolicy.spec.withHostIPC(false) +
+    podSecurityPolicy.spec.withHostPID(false) +
     podSecurityPolicy.spec.runAsUser.withRule('MustRunAs') +
     podSecurityPolicy.spec.runAsUser.withRanges(idRange.withMin(1000) + idRange.withMax(1000)) +
     podSecurityPolicy.spec.seLinux.withRule('RunAsAny') +

--- a/cert-manager/cainjector_psp_clusterrole.libsonnet
+++ b/cert-manager/cainjector_psp_clusterrole.libsonnet
@@ -3,7 +3,7 @@
   local policyRule = $.rbac.v1.policyRule,
 
   cainjector_psp_clusterrole:
-    clusterRule.new('cert-manager-cainjector-psp') +
+    clusterRole.new('cert-manager-cainjector-psp') +
     clusterRole.metadata.withLabels({},/* TODO: labels */) +
     clusterRole.withRules(
       policyRule.withApiGroups('policy') +

--- a/cert-manager/cainjector_psp_clusterrole.libsonnet
+++ b/cert-manager/cainjector_psp_clusterrole.libsonnet
@@ -1,18 +1,14 @@
 {
   local clusterRole = $.rbac.v1.clusterRole,
-  local rules = clusterRole.rulesType,
+  local policyRule = $.rbac.v1.policyRule,
 
   cainjector_psp_clusterrole:
-    clusterRole.new() +
-    clusterRole.mixin.metadata
-    .withName('cert-manager-cainjector-psp')
-    .withLabels({},/* TODO: labels */) +
+    clusterRule.new('cert-manager-cainjector-psp') +
+    clusterRole.metadata.withLabels({},/* TODO: labels */) +
     clusterRole.withRules(
-      rules.new() +
-      rules
-      .withApiGroups('policy')
-      .withResources(['podsecuritypolicies'])
-      .withVerbs(['use'])
-      .withResourceNames(['cert-manager-cainjector'])
+      policyRule.withApiGroups('policy') +
+      policyRule.withResources(['podsecuritypolicies']) +
+      policyRule.withVerbs(['use']) +
+      policyRule.withResourceNames(['cert-manager-cainjector'])
     ),
 }

--- a/cert-manager/cainjector_psp_clusterrolebinding.libsonnet
+++ b/cert-manager/cainjector_psp_clusterrolebinding.libsonnet
@@ -1,22 +1,17 @@
 {
   local clusterRoleBinding = $.rbac.v1.clusterRoleBinding,
-  local roleRef = clusterRoleBinding.roleRefType,
-  local subjects = clusterRoleBinding.subjectsType,
+  local subject = $.rbac.v1.subject,
 
   cainjector_psp_clusterrolebinding:
-    clusterRoleBinding.new() +
-    clusterRoleBinding.mixin.metadata
-    .withName('cert-manager-cainjector-psp')
-    .withLabels({}/* TODO: labels */,) +
-    clusterRoleBinding.mixin.roleRef
-    .withApiGroup('rbac.authorization.k8s.io')
-    .withKind('ClusterRole')
-    .withName('cert-manager-cainjector-psp') +
-    clusterRoleBinding.withSubjects(
-      subjects.new() + subjects
-                       .withKind('ServiceAccount')
-                       .withName('cert-manager-cainjector')
-                       .withNamespace($._config.namespace)
-    ),
+    clusterRoleBinding.new('cert-manager-cainjector-psp') +
+    clusterRoleBinding.metadata.withLabels({}/* TODO: labels */,) +
+    clusterRoleBinding.roleRef.withApiGroup('rbac.authorization.k8s.io') +
+    clusterRoleBinding.roleRef.withKind('ClusterRole') +
+    clusterRoleBinding.roleRef.withName('cert-manager-cainjector-psp') +
+    clusterRoleBinding.withSubjects([
+      subject.withKind('ServiceAccount') +
+      subject.withName('cert-manager-cainjector') +
+      subject.withNamespace($._config.namespace),
+    ]),
 
 }

--- a/cert-manager/cainjector_rbac.libsonnet
+++ b/cert-manager/cainjector_rbac.libsonnet
@@ -1,91 +1,82 @@
 {
-  local clusterRole = $.rbac.v1beta1.clusterRole,
-  local rules = clusterRole.rulesType,
+  local clusterRole = $.rbac.v1.clusterRole,
+  local policyRule = $.rbac.v1.policyRule,
 
   cainjector_clusterrole:
-    clusterRole.new() +
-    clusterRole.mixin.metadata
-    .withName('cert-manager-cainjector')
-    .withNamespace('kube-system')
-    .withLabels({}/* TODO:labels */) +
+    clusterRole.new('cert-manager-cainjector') +
+    clusterRole.metadata.withNamespace('kube-system') +
+    clusterRole.metadata.withLabels({}/* TODO:labels */) +
     clusterRole.withRules(
       [
-        rules.withApiGroups('cert-manager.io')
-        .withResources(['certificates'])
-        .withVerbs(['get', 'list', 'watch']),
-        rules.withApiGroups('')
-        .withResources(['secrets'])
-        .withVerbs(['get', 'list', 'watch']),
-        rules.withApiGroups('')
-        .withResources(['events'],)
-        .withVerbs(['get', 'create', 'update', 'patch']),
-        rules.withApiGroups('admissionregistration.k8s.io')
-        .withResources(['validatingwebhookconfigurations', 'mutatingwebhookconfigurations'],)
-        .withVerbs(['get', 'list', 'watch', 'update']),
-        rules.withApiGroups(['apiregistration.k8s.io'])
-        .withResources(['apiservices'])
-        .withVerbs(['get', 'list', 'watch', 'update']),
-        rules.withApiGroups(['apiextensions.k8s.io'])
-        .withResources(['customresourcedefinitions'],)
-        .withVerbs(['get', 'list', 'watch', 'update'],),
+        policyRule.withApiGroups('cert-manager.io') +
+        policyRule.withResources(['certificates']) +
+        policyRule.withVerbs(['get', 'list', 'watch']),
+
+        policyRule.withApiGroups('') +
+        policyRule.withResources(['secrets']) +
+        policyRule.withVerbs(['get', 'list', 'watch']),
+
+        policyRule.withApiGroups('') +
+        policyRule.withResources(['events']) +
+        policyRule.withVerbs(['get', 'create', 'update', 'patch']),
+
+        policyRule.withApiGroups('admissionregistration.k8s.io') +
+        policyRule.withResources(['validatingwebhookconfigurations', 'mutatingwebhookconfigurations']) +
+        policyRule.withVerbs(['get', 'list', 'watch', 'update']),
+
+        policyRule.withApiGroups(['apiregistration.k8s.io']) +
+        policyRule.withResources(['apiservices']) +
+        policyRule.withVerbs(['get', 'list', 'watch', 'update']),
+
+        policyRule.withApiGroups(['apiextensions.k8s.io']) +
+        policyRule.withResources(['customresourcedefinitions']) +
+        policyRule.withVerbs(['get', 'list', 'watch', 'update']),
       ]
     ),
 
-  local clusterRoleBinding = $.rbac.v1beta1.clusterRoleBinding,
-  local roleRef = clusterRoleBinding.roleRefType,
-  local subjects = clusterRoleBinding.subjectsType,
+  local clusterRoleBinding = $.rbac.v1.clusterRoleBinding,
+  local subject = $.rbac.v1.subject,
 
   cainjector_clusterrolebinding:
-    clusterRoleBinding.new() +
-    clusterRoleBinding.mixin.metadata
-    .withName('cert-manager-cainjector')
-    .withNamespace('kube-system')
-    .withLabels({}/* TODO: labels */) +
-    clusterRoleBinding.mixin.roleRef
-    .withName('cert-manager-cainjector')
-    .withKind('ClusterRole')
-    .withApiGroup('rbac.authorization.k8s.io') +
-    clusterRoleBinding.withSubjects(
-      subjects.withKind('ServiceAccount')
-      .withName('cert-manager-cainjector')
-      .withNamespace($._config.namespace)
-    ),
+    clusterRoleBinding.new('cert-manager-cainjector') +
+    clusterRoleBinding.metadata.withNamespace('kube-system') +
+    clusterRoleBinding.metadata.withLabels({}/* TODO: labels */) +
+    clusterRoleBinding.roleRef.withName('cert-manager-cainjector') +
+    clusterRoleBinding.roleRef.withKind('ClusterRole') +
+    clusterRoleBinding.roleRef.withApiGroup('rbac.authorization.k8s.io') +
+    clusterRoleBinding.withSubjects([
+      subject.withKind('ServiceAccount') +
+      subject.withName('cert-manager-cainjector') +
+      subject.withNamespace($._config.namespace),
+    ]),
 
-  local role = $.rbac.v1beta1.role,
+  local role = $.rbac.v1.role,
 
   cainjector_leaderelection_role:
-    role.new() +
-    role.mixin.metadata
-    .withName('cert-manager-cainjector:leaderelection')
-    .withNamespace('kube-system')
-    .withLabels({}/* TODO: labels */) +
+    role.new('cert-manager-cainjector:leaderelection') +
+    role.metadata.withNamespace('kube-system') +
+    role.metadata.withLabels({}/* TODO: labels */) +
     role.withRules(
       [
-        role.rulesType.new() +
-        role.rulesType
-        .withApiGroups('')
-        .withResources(['configmaps'],)
-        .withVerbs(['get', 'create', 'update', 'patch']),
+        policyRule.withApiGroups('') +
+        policyRule.withResources(['configmaps']) +
+        policyRule.withVerbs(['get', 'create', 'update', 'patch']),
       ],
     ),
 
-  local roleBinding = $.rbac.v1beta1.roleBinding,
+  local roleBinding = $.rbac.v1.roleBinding,
 
   cainjector_leaderelection_rolebinding:
-    roleBinding.new() +
-    roleBinding.mixin.metadata
-    .withName('cert-manager-cainjector:leaderelection')
-    .withNamespace('kube-system')
-    .withLabels({}/* TODO: labels */) +
-    roleBinding.mixin.roleRef
-    .withApiGroup('rbac.authorization.k8s.io')
-    .withKind('Role')
-    .withName('cert-manager-cainjector:leaderelection') +
-    roleBinding.withSubjects(
-      subjects
-      .withKind('ServiceAccount')
-      .withName('cert-manager-cainjector')
-      .withNamespace($._config.namespace)
-    ),
+    roleBinding.new('cert-manager-cainjector:leaderelection') +
+    roleBinding.metadata.withNamespace('kube-system') +
+    roleBinding.metadata.withLabels({}/* TODO: labels */) +
+    roleBinding.roleRef.withApiGroup('rbac.authorization.k8s.io') +
+    roleBinding.roleRef.withKind('Role') +
+    roleBinding.roleRef.withName('cert-manager-cainjector:leaderelection') +
+    roleBinding.withSubjects([
+      subject.withKind('ServiceAccount') +
+      subject.withName('cert-manager-cainjector') +
+      subject.withNamespace($._config.namespace),
+    ]),
 
 }

--- a/cert-manager/cainjector_serviceaccount.libsonnet
+++ b/cert-manager/cainjector_serviceaccount.libsonnet
@@ -2,7 +2,6 @@
   local serviceAccount = $.core.v1.serviceAccount,
   cainjector_serviceaccount:
     serviceAccount.new('cert-manager-cainjector') +
-    serviceAccount.mixin.metadata
-    .withLabels({}/* TODO: labels */)
-    .withNamespace($._config.namespace),
+    serviceAccount.metadata.withLabels({}/* TODO: labels */) +
+    serviceAccount.metadata.withNamespace($._config.namespace),
 }

--- a/cert-manager/deployment.libsonnet
+++ b/cert-manager/deployment.libsonnet
@@ -4,28 +4,29 @@
   local containerPort = $.core.v1.containerPort,
 
   cert_manager_container::
-    container.new('cert-manager', $._images.cert_manager)
-    .withPorts(containerPort.new(name='cert-manager', port=9402).withProtocol('TCP'))
-    .withImagePullPolicy('IfNotPresent')
-    .withArgs([
-                '--v=2',  // loglevel
-                '--cluster-resource-namespace=$(POD_NAMESPACE)',  // optionally customizable
-                '--leader-election-namespace=kube-system',  // optionally customizable
-                //'--default-issuer-name=', // unset by default
-                //'--default-issuer-kind=', // unset by default
-                //'--default-issuer-group=', // unset by default
-                '--webhook-namespace=$(POD_NAMESPACE)',
-                '--webhook-ca-secret=cert-manager-webhook-ca',
-                '--webhook-serving-secret=cert-manager-webhook-tls',
-                std.format('--webhook-dns-names=cert-manager-webhook,cert-manager-webhook.%(ns)s,cert-manager-webhook.%(ns)s.svc', { ns: $._config.namespace }),
-                '--default-issuer-kind=ClusterIssuer',
-              ] +
-              (if $._config.default_issuer != null then ['--default-issuer-name=' + $._config.default_issuer] else []) +
-              (if $._config.default_issuer_group != null then ['--default-issuer-group=' + $._config.default_issuer_group] else [])
-              ,)
+    container.new('cert-manager', $._images.cert_manager) +
+    container.withPorts(containerPort.new(name='cert-manager', port=9402)) +
+    container.withImagePullPolicy('IfNotPresent') +
+    container.withArgs(
+      [
+        '--v=2',  // loglevel
+        '--cluster-resource-namespace=$(POD_NAMESPACE)',  // optionally customizable
+        '--leader-election-namespace=kube-system',  // optionally customizable
+        //'--default-issuer-name=', // unset by default
+        //'--default-issuer-kind=', // unset by default
+        //'--default-issuer-group=', // unset by default
+        '--webhook-namespace=$(POD_NAMESPACE)',
+        '--webhook-ca-secret=cert-manager-webhook-ca',
+        '--webhook-serving-secret=cert-manager-webhook-tls',
+        std.format('--webhook-dns-names=cert-manager-webhook,cert-manager-webhook.%(ns)s,cert-manager-webhook.%(ns)s.svc', { ns: $._config.namespace }),
+        '--default-issuer-kind=ClusterIssuer',
+      ] +
+      (if $._config.default_issuer != null then ['--default-issuer-name=' + $._config.default_issuer] else []) +
+      (if $._config.default_issuer_group != null then ['--default-issuer-group=' + $._config.default_issuer_group] else [])
+    ) +
 
-    .withEnv([
-      container.envType.fromFieldPath('POD_NAMESPACE', 'metadata.namespace'),
+    container.withEnv([
+      $.core.v1.envVar.fromFieldPath('POD_NAMESPACE', 'metadata.namespace'),
     ]),
 
   deployment:
@@ -33,6 +34,5 @@
       app: 'controller',
       /* TODO: labels */
     },) +
-    deployment.mixin.spec.template.spec
-    .withServiceAccountName('cert-manager'),
+    deployment.spec.template.spec.withServiceAccountName('cert-manager'),
 }

--- a/cert-manager/psp.libsonnet
+++ b/cert-manager/psp.libsonnet
@@ -4,8 +4,8 @@
 
   psp:
     podSecurityPolicy.new('cert-manager') +
-    podSecurityPolicty.metadata.withLabels({}/* TODO: labels */) +
-    podSecurityPolicty.metadata.withAnnotations(
+    podSecurityPolicy.metadata.withLabels({}/* TODO: labels */) +
+    podSecurityPolicy.metadata.withAnnotations(
       {
         'seccomp.security.alpha.kubernetes.io/allowedProfileNames': 'docker/default',
         'seccomp.security.alpha.kubernetes.io/defaultProfileName': 'docker/default',
@@ -28,8 +28,8 @@
       'downwardAPI',
     ],) +
     podSecurityPolicy.spec.withHostNetwork(false) +
-    podSecurityPolicy.spec.withHostIpc(false) +
-    podSecurityPolicy.spec.withHostPid(false) +
+    podSecurityPolicy.spec.withHostIPC(false) +
+    podSecurityPolicy.spec.withHostPID(false) +
     podSecurityPolicy.spec.runAsUser.withRule('MustRunAs') +
     podSecurityPolicy.spec.runAsUser.withRanges(idRange.withMin(1000) + idRange.withMax(1000)) +
     podSecurityPolicy.spec.seLinux.withRule('RunAsAny') +

--- a/cert-manager/psp.libsonnet
+++ b/cert-manager/psp.libsonnet
@@ -1,13 +1,11 @@
 {
   local podSecurityPolicy = $.policy.v1beta1.podSecurityPolicy,
-  local ranges = podSecurityPolicy.mixin.spec.runAsUser.rangesType,
+  local idRange = $.policy.v1beta1.idRange,
 
   psp:
-    podSecurityPolicy.new() +
-    podSecurityPolicy.mixin.metadata
-    .withName('cert-manager')
-    .withLabels({}/* TODO: labels */)
-    .withAnnotations(
+    podSecurityPolicy.new('cert-manager') +
+    podSecurityPolicty.metadata.withLabels({}/* TODO: labels */) +
+    podSecurityPolicty.metadata.withAnnotations(
       {
         'seccomp.security.alpha.kubernetes.io/allowedProfileNames': 'docker/default',
         'seccomp.security.alpha.kubernetes.io/defaultProfileName': 'docker/default',
@@ -19,29 +17,25 @@
         */
       },
     ) +
-    podSecurityPolicy.mixin.spec
-    .withPrivileged(false)
-    .withAllowPrivilegeEscalation(false)
-    .withAllowedCapabilities([])
-    .withVolumes([
+    podSecurityPolicy.spec.withPrivileged(false) +
+    podSecurityPolicy.spec.withAllowPrivilegeEscalation(false) +
+    podSecurityPolicy.spec.withAllowedCapabilities([]) +
+    podSecurityPolicy.spec.withVolumes([
       'configMap',
       'emptyDir',
       'projected',
       'secret',
       'downwardAPI',
-    ],)
-    .withHostNetwork(false)
-    .withHostIpc(false)
-    .withHostPid(false) +
-    podSecurityPolicy.mixin.spec.runAsUser
-    .withRule('MustRunAs')
-    .withRanges(ranges.new() + ranges.withMin(1000) + ranges.withMax(1000)) +
-    podSecurityPolicy.mixin.spec.seLinux.withRule('RunAsAny') +
-    podSecurityPolicy.mixin.spec.supplementalGroups
-    .withRule('MustRunAs')
-    .withRanges(ranges.new() + ranges.withMin(1000) + ranges.withMax(1000)) +
-    podSecurityPolicy.mixin.spec.fsGroup
-    .withRule('MustRunAs')
-    .withRanges(ranges.new() + ranges.withMin(1000) + ranges.withMax(1000)),
+    ],) +
+    podSecurityPolicy.spec.withHostNetwork(false) +
+    podSecurityPolicy.spec.withHostIpc(false) +
+    podSecurityPolicy.spec.withHostPid(false) +
+    podSecurityPolicy.spec.runAsUser.withRule('MustRunAs') +
+    podSecurityPolicy.spec.runAsUser.withRanges(idRange.withMin(1000) + idRange.withMax(1000)) +
+    podSecurityPolicy.spec.seLinux.withRule('RunAsAny') +
+    podSecurityPolicy.spec.supplementalGroups.withRule('MustRunAs') +
+    podSecurityPolicy.spec.supplementalGroups.withRanges(idRange.withMin(1000) + idRange.withMax(1000)) +
+    podSecurityPolicy.spec.fsGroup.withRule('MustRunAs') +
+    podSecurityPolicy.spec.fsGroup.withRanges(idRange.withMin(1000) + idRange.withMax(1000)),
 
 }

--- a/cert-manager/psp_clusterrole.libsonnet
+++ b/cert-manager/psp_clusterrole.libsonnet
@@ -1,18 +1,14 @@
 {
   local clusterRole = $.rbac.v1.clusterRole,
-  local rules = clusterRole.rulesType,
+  local policyRule = $.rbac.v1.policyRule,
 
   psp_clusterrole:
-    clusterRole.new() +
-    clusterRole.mixin.metadata
-    .withName('cert-manager-psp')
-    .withLabels({},/* TODO: labels */) +
-    clusterRole.withRules(
-      rules.new() +
-      rules
-      .withApiGroups('policy')
-      .withResources(['podsecuritypolicies'])
-      .withVerbs(['use'])
-      .withResourceNames(['cert-manager'])
-    ),
+    clusterRole.new('cert-manager-psp') +
+    clusterRule.metadata.withLabels({},/* TODO: labels */) +
+    clusterRole.withRules([
+      polictyRule.withApiGroups('policy') +
+      polictyRule.withResources(['podsecuritypolicies']) +
+      polictyRule.withVerbs(['use']) +
+      polictyRule.withResourceNames(['cert-manager']),
+    ]),
 }

--- a/cert-manager/psp_clusterrole.libsonnet
+++ b/cert-manager/psp_clusterrole.libsonnet
@@ -4,11 +4,11 @@
 
   psp_clusterrole:
     clusterRole.new('cert-manager-psp') +
-    clusterRule.metadata.withLabels({},/* TODO: labels */) +
+    clusterRole.metadata.withLabels({},/* TODO: labels */) +
     clusterRole.withRules([
-      polictyRule.withApiGroups('policy') +
-      polictyRule.withResources(['podsecuritypolicies']) +
-      polictyRule.withVerbs(['use']) +
-      polictyRule.withResourceNames(['cert-manager']),
+      policyRule.withApiGroups('policy') +
+      policyRule.withResources(['podsecuritypolicies']) +
+      policyRule.withVerbs(['use']) +
+      policyRule.withResourceNames(['cert-manager']),
     ]),
 }

--- a/cert-manager/psp_clusterrolebinding.libsonnet
+++ b/cert-manager/psp_clusterrolebinding.libsonnet
@@ -1,22 +1,17 @@
 {
   local clusterRoleBinding = $.rbac.v1.clusterRoleBinding,
-  local roleRef = clusterRoleBinding.roleRefType,
-  local subjects = clusterRoleBinding.subjectsType,
+  local subject = $.rbac.v1.subject,
 
   psp_clusterrolebinding:
-    clusterRoleBinding.new() +
-    clusterRoleBinding.mixin.metadata
-    .withName('cert-manager-psp')
-    .withLabels({}/* TODO: labels */,) +
-    clusterRoleBinding.mixin.roleRef
-    .withApiGroup('rbac.authorization.k8s.io')
-    .withKind('ClusterRole')
-    .withName('cert-manager-psp') +
-    clusterRoleBinding.withSubjects(
-      subjects.new() + subjects
-                       .withKind('ServiceAccount')
-                       .withName('cert-manager')
-                       .withNamespace($._config.namespace)
-    ),
+    clusterRoleBinding.new('cert-manager-psp') +
+    clusterRoleBinding.metadata.withLabels({}/* TODO: labels */,) +
+    clusterRoleBinding.roleRef.withApiGroup('rbac.authorization.k8s.io') +
+    clusterRoleBinding.roleRef.withKind('ClusterRole') +
+    clusterRoleBinding.roleRef.withName('cert-manager-psp') +
+    clusterRoleBinding.withSubjects([
+      subject.withKind('ServiceAccount') +
+      subject.withName('cert-manager') +
+      subject.withNamespace($._config.namespace),
+    ]),
 
 }

--- a/cert-manager/rbac.libsonnet
+++ b/cert-manager/rbac.libsonnet
@@ -1,402 +1,273 @@
 {
-  local clusterRole = $.rbac.v1beta1.clusterRole,
-  local clusterRoleBinding = $.rbac.v1beta1.clusterRoleBinding,
+  local clusterRole = $.rbac.v1.clusterRole,
+  local clusterRoleBinding = $.rbac.v1.clusterRoleBinding,
 
+  local role = $.rbac.v1.role,
+  local roleBinding = $.rbac.v1.roleBinding,
 
-  local role = $.rbac.v1beta1.role,
-  local roleBinding = $.rbac.v1beta1.roleBinding,
+  local policyRule = $.rbac.v1.policyRule,
+  local subject = $.rbac.v1.subject,
 
   leaderelection_role:
-    role.new() +
-    role.mixin.metadata
-    .withName('cert-manager:leaderelection')
-    .withNamespace('kube-system')
-    .withLabels({}/* TODO: labels */) +
+    role.new('cert-manager:leaderelection') +
+    role.metadata.withNamespace('kube-system') +
+    role.metadata.withLabels({}/* TODO: labels */) +
     role.withRules([
-      role.rulesType.new() +
-      role.rulesType
-      .withApiGroups('')
-      .withResources(['configmaps'])
-      .withVerbs(['get', 'create', 'update', 'patch'],),
-    ],),
+      policyRule.withApiGroups('') +
+      policyRule.withResources(['configmaps']) +
+      policyRule.withVerbs(['get', 'create', 'update', 'patch']),
+    ]),
   leaderelection_rolebinding:
-    roleBinding.new() +
-    roleBinding.mixin.metadata
-    .withName('cert-manager:leaderelection')
-    .withNamespace('kube-system')
-    .withLabels({}/* TODO: labels */) +
-    roleBinding.mixin.roleRef
-    .withApiGroup('rbac.authorization.k8s.io')
-    .withKind('Role')
-    .withName('cert-manager:leaderelection') +
+    roleBinding.new('cert-manager:leaderelection') +
+    roleBinding.metadata.withNamespace('kube-system') +
+    roleBinding.metadata.withLabels({}/* TODO: labels */) +
+    roleBinding.roleRef.withApiGroup('rbac.authorization.k8s.io') +
+    roleBinding.roleRef.withKind('Role') +
+    roleBinding.roleRef.withName('cert-manager:leaderelection') +
     roleBinding.withSubjects([
-      roleBinding.subjectsType.new() +
-      roleBinding.subjectsType
-      .withApiGroup('')
-      .withKind('ServiceAccount')
-      .withName('cert-manager')
-      .withNamespace($._config.namespace),
-
-    ],),
+      subject.withApiGroup('') +
+      subject.withKind('ServiceAccount') +
+      subject.withName('cert-manager') +
+      subject.withNamespace($._config.namespace),
+    ]),
 
   cert_manager_controller_issuers_clusterrole:
-    clusterRole.new() +
-    clusterRole.mixin.metadata
-    .withName('cert-manager-controller-issuers')
-    .withLabels({}/* TODO namespace */) +
+    clusterRole.new('cert-manager-controller-issuers') +
+    clusterRole.metadata.withLabels({}/* TODO namespace */) +
     clusterRole.withRules([
-      clusterRole.rulesType.new() +
-      clusterRole.rulesType
-      .withApiGroups('cert-manager.io')
-      .withResources(['issuers', 'issuers/status'])
-      .withVerbs(['update']),
-      clusterRole.rulesType.new() +
-      clusterRole.rulesType
-      .withApiGroups('cert-manager.io')
-      .withResources(['issuers'])
-      .withVerbs(['get', 'list', 'watch']),
-      clusterRole.rulesType.new() +
-      clusterRole.rulesType
-      .withApiGroups('')
-      .withResources(['secrets'])
-      .withVerbs(['get', 'list', 'watch', 'create', 'update', 'delete']),
-      clusterRole.rulesType.new() +
-      clusterRole.rulesType
-      .withApiGroups('')
-      .withResources(['events'])
-      .withVerbs(['create', 'patch']),
-    ],),
+      policyRule.withApiGroups('cert-manager.io') +
+      policyRule.withResources(['issuers', 'issuers/status']) +
+      policyRule.withVerbs(['update']),
+      policyRule.withApiGroups('cert-manager.io') +
+      policyRule.withResources(['issuers']) +
+      policyRule.withVerbs(['get', 'list', 'watch']),
+      policyRule.withApiGroups('') +
+      policyRule.withResources(['secrets']) +
+      policyRule.withVerbs(['get', 'list', 'watch', 'create', 'update', 'delete']),
+      policyRule.withApiGroups('') +
+      policyRule.withResources(['events']) +
+      policyRule.withVerbs(['create', 'patch']),
+    ]),
 
   cert_manager_controller_clusterissuers_clusterrole:
-    clusterRole.new() +
-    clusterRole.mixin.metadata
-    .withName('cert-manager-controller-clusterissuers')
-    .withLabels({}/* TODO namespace */) +
+    clusterRole.new('cert-manager-controller-clusterissuers') +
+    clusterRole.metadata.withLabels({}/* TODO namespace */) +
     clusterRole.withRules([
-      clusterRole.rulesType.new() +
-      clusterRole.rulesType
-      .withApiGroups('cert-manager.io')
-      .withResources(['clusterissuers', 'clusterissuers/status'])
-      .withVerbs(['update']),
-      clusterRole.rulesType.new() +
-      clusterRole.rulesType
-      .withApiGroups('cert-manager.io')
-      .withResources(['clusterissuers'])
-      .withVerbs(['get', 'list', 'watch']),
-      clusterRole.rulesType.new() +
-      clusterRole.rulesType
-      .withApiGroups('')
-      .withResources(['secrets'])
-      .withVerbs(['get', 'list', 'watch', 'create', 'update', 'delete']),
-      clusterRole.rulesType.new() +
-      clusterRole.rulesType
-      .withApiGroups('')
-      .withResources(['events'])
-      .withVerbs(['create', 'patch']),
-    ],),
+      policyRule.withApiGroups('cert-manager.io') +
+      policyRule.withResources(['clusterissuers', 'clusterissuers/status']) +
+      policyRule.withVerbs(['update']),
+      policyRule.withApiGroups('cert-manager.io') +
+      policyRule.withResources(['clusterissuers']) +
+      policyRule.withVerbs(['get', 'list', 'watch']),
+      policyRule.withApiGroups('') +
+      policyRule.withResources(['secrets']) +
+      policyRule.withVerbs(['get', 'list', 'watch', 'create', 'update', 'delete']),
+      policyRule.withApiGroups('') +
+      policyRule.withResources(['events']) +
+      policyRule.withVerbs(['create', 'patch']),
+    ]),
   cert_manager_controller_certificates_clusterrole:
-    clusterRole.new() +
-    clusterRole.mixin.metadata
-    .withName('cert-manager-controller-certificates')
-    .withLabels({}/* TODO namespace */) +
+    clusterRole.new('cert-manager-controller-certificates') +
+    clusterRole.metadata.withLabels({}/* TODO namespace */) +
     clusterRole.withRules([
-      clusterRole.rulesType.new() +
-      clusterRole.rulesType
-      .withApiGroups('cert-manager.io')
-      .withResources(['certificates', 'certificates/status', 'certificaterequests', 'certificaterequests/status'])
-      .withVerbs(['update']),
-      clusterRole.rulesType.new() +
-      clusterRole.rulesType
-      .withApiGroups('cert-manager.io')
-      .withResources(['certificates', 'certificaterequests', 'clusterissuers', 'issuers'])
-      .withVerbs(['get', 'list', 'watch']),
-      clusterRole.rulesType.new() +
-      clusterRole.rulesType
-      .withApiGroups('cert-manager.io')
-      .withResources(['certificates/finalizers', 'certificaterequests/finalizers'])
-      .withVerbs(['update']),
-      clusterRole.rulesType.new() +
-      clusterRole.rulesType
-      .withApiGroups('acme.cert-manager.io')
-      .withResources(['orders'])
-      .withVerbs(['create', 'delete', 'get', 'list', 'watch']),
-      clusterRole.rulesType.new() +
-      clusterRole.rulesType
-      .withApiGroups('')
-      .withResources(['secrets'])
-      .withVerbs(['get', 'list', 'watch', 'create', 'update', 'delete']),
-      clusterRole.rulesType.new() +
-      clusterRole.rulesType
-      .withApiGroups('')
-      .withResources(['events'])
-      .withVerbs(['create', 'patch']),
-    ],),
+      policyRule.withApiGroups('cert-manager.io') +
+      policyRule.withResources(['certificates', 'certificates/status', 'certificaterequests', 'certificaterequests/status']) +
+      policyRule.withVerbs(['update']),
+      policyRule.withApiGroups('cert-manager.io') +
+      policyRule.withResources(['certificates', 'certificaterequests', 'clusterissuers', 'issuers']) +
+      policyRule.withVerbs(['get', 'list', 'watch']),
+      policyRule.withApiGroups('cert-manager.io') +
+      policyRule.withResources(['certificates/finalizers', 'certificaterequests/finalizers']) +
+      policyRule.withVerbs(['update']),
+      policyRule.withApiGroups('acme.cert-manager.io') +
+      policyRule.withResources(['orders']) +
+      policyRule.withVerbs(['create', 'delete', 'get', 'list', 'watch']),
+      policyRule.withApiGroups('') +
+      policyRule.withResources(['secrets']) +
+      policyRule.withVerbs(['get', 'list', 'watch', 'create', 'update', 'delete']),
+      policyRule.withApiGroups('') +
+      policyRule.withResources(['events']) +
+      policyRule.withVerbs(['create', 'patch']),
+    ]),
   cert_manager_controller_orders_clusterrole:
-    clusterRole.new() +
-    clusterRole.mixin.metadata
-    .withName('cert-manager-controller-orders')
-    .withLabels({}/* TODO namespace */) +
+    clusterRole.new('cert-manager-controller-orders') +
+    clusterRole.metadata.withLabels({}/* TODO namespace */) +
     clusterRole.withRules([
-      clusterRole.rulesType.new() +
-      clusterRole.rulesType
-      .withApiGroups('acme.cert-manager.io')
-      .withResources(['orders', 'orders/status'])
-      .withVerbs(['update']),
-      clusterRole.rulesType.new() +
-      clusterRole.rulesType
-      .withApiGroups('acme.cert-manager.io')
-      .withResources(['orders', 'challenges'])
-      .withVerbs(['get', 'list', 'watch']),
-      clusterRole.rulesType.new() +
-      clusterRole.rulesType
-      .withApiGroups('cert-manager.io')
-      .withResources(['clusterissuers', 'issuers'])
-      .withVerbs(['get', 'list', 'watch']),
-      clusterRole.rulesType.new() +
-      clusterRole.rulesType
-      .withApiGroups('acme.cert-manager.io')
-      .withResources(['challenges'])
-      .withVerbs(['create', 'delete']),
-      clusterRole.rulesType.new() +
-      clusterRole.rulesType
-      .withApiGroups('acme.cert-manager.io')
-      .withResources(['orders/finalizers'])
-      .withVerbs(['update']),
-      clusterRole.rulesType.new() +
-      clusterRole.rulesType
-      .withApiGroups('')
-      .withResources(['secrets'])
-      .withVerbs(['get', 'list', 'watch']),
-      clusterRole.rulesType.new() +
-      clusterRole.rulesType
-      .withApiGroups('')
-      .withResources(['events'])
-      .withVerbs(['create', 'patch']),
-    ],),
+      policyRule.withApiGroups('acme.cert-manager.io') +
+      policyRule.withResources(['orders', 'orders/status']) +
+      policyRule.withVerbs(['update']),
+      policyRule.withApiGroups('acme.cert-manager.io') +
+      policyRule.withResources(['orders', 'challenges']) +
+      policyRule.withVerbs(['get', 'list', 'watch']),
+      policyRule.withApiGroups('cert-manager.io') +
+      policyRule.withResources(['clusterissuers', 'issuers']) +
+      policyRule.withVerbs(['get', 'list', 'watch']),
+      policyRule.withApiGroups('acme.cert-manager.io') +
+      policyRule.withResources(['challenges']) +
+      policyRule.withVerbs(['create', 'delete']),
+      policyRule.withApiGroups('acme.cert-manager.io') +
+      policyRule.withResources(['orders/finalizers']) +
+      policyRule.withVerbs(['update']),
+      policyRule.withApiGroups('') +
+      policyRule.withResources(['secrets']) +
+      policyRule.withVerbs(['get', 'list', 'watch']),
+      policyRule.withApiGroups('') +
+      policyRule.withResources(['events']) +
+      policyRule.withVerbs(['create', 'patch']),
+    ]),
 
   cert_manager_controller_challenges_clusterrole:
-    clusterRole.new() +
-    clusterRole.mixin.metadata
-    .withName('cert-manager-controller-challenges')
-    .withLabels({}/* TODO namespace */) +
+    clusterRole.new('cert-manager-controller-challenges') +
+    clusterRole.metadata.withLabels({}/* TODO namespace */) +
     clusterRole.withRules([
-      clusterRole.rulesType.new() +
-      clusterRole.rulesType
-      .withApiGroups('acme.cert-manager.io')
-      .withResources(['challenges', 'challenges/status'])
-      .withVerbs(['update']),
-      clusterRole.rulesType.new() +
-      clusterRole.rulesType
-      .withApiGroups('acme.cert-manager.io')
-      .withResources(['challenges'])
-      .withVerbs(['get', 'list', 'watch']),
-      clusterRole.rulesType.new() +
-      clusterRole.rulesType
-      .withApiGroups('cert-manager.io')
-      .withResources(['issuers', 'clusterissuers'])
-      .withVerbs(['get', 'list', 'watch']),
-      clusterRole.rulesType.new() +
-      clusterRole.rulesType
-      .withApiGroups('')
-      .withResources(['secrets'])
-      .withVerbs(['get', 'list', 'watch']),
-      clusterRole.rulesType.new() +
-      clusterRole.rulesType
-      .withApiGroups('')
-      .withResources(['events'])
-      .withVerbs(['create', 'patch']),
+      policyRule.withApiGroups('acme.cert-manager.io') +
+      policyRule.withResources(['challenges', 'challenges/status']) +
+      policyRule.withVerbs(['update']),
+      policyRule.withApiGroups('acme.cert-manager.io') +
+      policyRule.withResources(['challenges']) +
+      policyRule.withVerbs(['get', 'list', 'watch']),
+      policyRule.withApiGroups('cert-manager.io') +
+      policyRule.withResources(['issuers', 'clusterissuers']) +
+      policyRule.withVerbs(['get', 'list', 'watch']),
+      policyRule.withApiGroups('') +
+      policyRule.withResources(['secrets']) +
+      policyRule.withVerbs(['get', 'list', 'watch']),
+      policyRule.withApiGroups('') +
+      policyRule.withResources(['events']) +
+      policyRule.withVerbs(['create', 'patch']),
       // HTTP01 rules
-      clusterRole.rulesType.new() +
-      clusterRole.rulesType
-      .withApiGroups('')
-      .withResources(['pods', 'services'])
-      .withVerbs(['get', 'list', 'watch', 'create', 'delete']),
-      clusterRole.rulesType.new() +
-      clusterRole.rulesType
-      .withApiGroups('extensions')
-      .withResources(['ingresses'])
-      .withVerbs(['get', 'list', 'watch', 'create', 'delete', 'update']),
-      clusterRole.rulesType.new() +
-      clusterRole.rulesType
-      .withApiGroups(['acme.cert-manager.io'])
-      .withResources(['challenges/finalizers'])
-      .withVerbs(['update']),
-      // DNS01 rules (duplicated above)
-      clusterRole.rulesType.new() +
-      clusterRole.rulesType
-      .withApiGroups('')
-      .withResources(['secrets'])
-      .withVerbs(['get', 'list', 'watch']),
-
-    ],),
+      policyRule.withApiGroups('') +
+      policyRule.withResources(['pods', 'services']) +
+      policyRule.withVerbs(['get', 'list', 'watch', 'create', 'delete']),
+      policyRule.withApiGroups('extensions') +
+      policyRule.withResources(['ingresses']) +
+      policyRule.withVerbs(['get', 'list', 'watch', 'create', 'delete', 'update']),
+      policyRule.withApiGroups(['acme.cert-manager.io']) +
+      policyRule.withResources(['challenges/finalizers']) +
+      policyRule.withVerbs(['update']),
+      // DNS01 rules (duplicated above)+
+      policyRule.withApiGroups('') +
+      policyRule.withResources(['secrets']) +
+      policyRule.withVerbs(['get', 'list', 'watch']),
+    ]),
   cert_manager_controller_ingress_shim_clusterrole:
-    clusterRole.new() +
-    clusterRole.mixin.metadata
-    .withName('cert-manager-controller-ingress-shim')
-    .withLabels({}/* TODO namespace */) +
+    clusterRole.new('cert-manager-controller-ingress-shim') +
+    clusterRole.metadata.withLabels({}/* TODO namespace */) +
     clusterRole.withRules([
-      clusterRole.rulesType.new() +
-      clusterRole.rulesType
-      .withApiGroups('cert-manager.io')
-      .withResources(['certificates', 'certificaterequests'])
-      .withVerbs(['create', 'update', 'delete']),
-      clusterRole.rulesType.new() +
-      clusterRole.rulesType
-      .withApiGroups('cert-manager.io')
-      .withResources(['certificates', 'certificaterequests', 'issuers', 'clusterissuers'])
-      .withVerbs(['get', 'list', 'watch']),
-      clusterRole.rulesType.new() +
-      clusterRole.rulesType
-      .withApiGroups('extensions')
-      .withResources(['ingresses'])
-      .withVerbs(['get', 'list', 'watch']),
-      clusterRole.rulesType.new() +
-      clusterRole.rulesType
-      .withApiGroups('extensions')
-      .withResources(['ingresses/finalizers'])
-      .withVerbs(['update']),
-      clusterRole.rulesType.new() +
-      clusterRole.rulesType
-      .withApiGroups('')
-      .withResources(['events'])
-      .withVerbs(['create', 'patch']),
-    ],),
+      policyRule.withApiGroups('cert-manager.io') +
+      policyRule.withResources(['certificates', 'certificaterequests']) +
+      policyRule.withVerbs(['create', 'update', 'delete']),
+      policyRule.withApiGroups('cert-manager.io') +
+      policyRule.withResources(['certificates', 'certificaterequests', 'issuers', 'clusterissuers']) +
+      policyRule.withVerbs(['get', 'list', 'watch']),
+      policyRule.withApiGroups('extensions') +
+      policyRule.withResources(['ingresses']) +
+      policyRule.withVerbs(['get', 'list', 'watch']),
+      policyRule.withApiGroups('extensions') +
+      policyRule.withResources(['ingresses/finalizers']) +
+      policyRule.withVerbs(['update']),
+      policyRule.withApiGroups('') +
+      policyRule.withResources(['events']) +
+      policyRule.withVerbs(['create', 'patch']),
+    ]),
 
   cert_manager_controller_issuers_clusterrolebinding:
-    clusterRoleBinding.new() +
-    clusterRoleBinding.mixin.metadata
-    .withName('cert-manager-controller-issuers')
-    .withLabels({}/* TODO: labels */) +
-    clusterRoleBinding.mixin.roleRef
-    .withApiGroup('rbac.authorization.k8s.io')
-    .withKind('ClusterRole')
-    .withName('cert-manager-controller-issuers') +
-    clusterRoleBinding.withSubjects(
-      clusterRoleBinding.subjectsType.new() +
-      clusterRoleBinding.subjectsType
-      .withKind('ServiceAccount')
-      .withName('cert-manager')
-      .withNamespace($._config.namespace)
-    ),
+    clusterRoleBinding.new('cert-manager-controller-issuers') +
+    clusterRoleBinding.metadata.withLabels({}/* TODO: labels */) +
+    clusterRoleBinding.roleRef.withApiGroup('rbac.authorization.k8s.io') +
+    clusterRoleBinding.roleRef.withKind('ClusterRole') +
+    clusterRoleBinding.roleRef.withName('cert-manager-controller-issuers') +
+    clusterRoleBinding.withSubjects([
+      subject.withKind('ServiceAccount') +
+      subject.withName('cert-manager') +
+      subject.withNamespace($._config.namespace),
+    ]),
 
   cert_manager_controller_clusterissuers_clusterrolebinding:
-    clusterRoleBinding.new() +
-    clusterRoleBinding.mixin.metadata
-    .withName('cert-manager-controller-clusterissuers')
-    .withLabels({}/* TODO: labels */) +
-    clusterRoleBinding.mixin.roleRef
-    .withApiGroup('rbac.authorization.k8s.io')
-    .withKind('ClusterRole')
-    .withName('cert-manager-controller-clusterissuers') +
-    clusterRoleBinding.withSubjects(
-      clusterRoleBinding.subjectsType.new() +
-      clusterRoleBinding.subjectsType
-      .withKind('ServiceAccount')
-      .withName('cert-manager')
-      .withNamespace($._config.namespace)
-    ),
+    clusterRoleBinding.new('cert-manager-controller-clusterissuers') +
+    clusterRoleBinding.metadata.withLabels({}/* TODO: labels */) +
+    clusterRoleBinding.roleRef.withApiGroup('rbac.authorization.k8s.io') +
+    clusterRoleBinding.roleRef.withKind('ClusterRole') +
+    clusterRoleBinding.roleRef.withName('cert-manager-controller-clusterissuers') +
+    clusterRoleBinding.withSubjects([
+      subject.withKind('ServiceAccount') +
+      subject.withName('cert-manager') +
+      subject.withNamespace($._config.namespace),
+    ]),
 
   cert_manager_controller_certificates_clusterrolebinding:
-    clusterRoleBinding.new() +
-    clusterRoleBinding.mixin.metadata
-    .withName('cert-manager-controller-certificates')
-    .withLabels({}/* TODO: labels */) +
-    clusterRoleBinding.mixin.roleRef
-    .withApiGroup('rbac.authorization.k8s.io')
-    .withKind('ClusterRole')
-    .withName('cert-manager-controller-certificates') +
-    clusterRoleBinding.withSubjects(
-      clusterRoleBinding.subjectsType.new() +
-      clusterRoleBinding.subjectsType
-      .withKind('ServiceAccount')
-      .withName('cert-manager')
-      .withNamespace($._config.namespace)
-    ),
+    clusterRoleBinding.new('cert-manager-controller-certificates') +
+    clusterRoleBinding.metadata.withLabels({}/* TODO: labels */) +
+    clusterRoleBinding.roleRef.withApiGroup('rbac.authorization.k8s.io') +
+    clusterRoleBinding.roleRef.withKind('ClusterRole') +
+    clusterRoleBinding.roleRef.withName('cert-manager-controller-certificates') +
+    clusterRoleBinding.withSubjects([
+      subject.withKind('ServiceAccount') +
+      subject.withName('cert-manager') +
+      subject.withNamespace($._config.namespace),
+    ]),
 
   cert_manager_controller_orders_clusterrolebinding:
-    clusterRoleBinding.new() +
-    clusterRoleBinding.mixin.metadata
-    .withName('cert-manager-controller-orders')
-    .withLabels({}/* TODO: labels */) +
-    clusterRoleBinding.mixin.roleRef
-    .withApiGroup('rbac.authorization.k8s.io')
-    .withKind('ClusterRole')
-    .withName('cert-manager-controller-orders') +
-    clusterRoleBinding.withSubjects(
-      clusterRoleBinding.subjectsType.new() +
-      clusterRoleBinding.subjectsType
-      .withKind('ServiceAccount')
-      .withName('cert-manager')
-      .withNamespace($._config.namespace)
-    ),
+    clusterRoleBinding.new('cert-manager-controller-orders') +
+    clusterRoleBinding.metadata.withLabels({}/* TODO: labels */) +
+    clusterRoleBinding.roleRef.withApiGroup('rbac.authorization.k8s.io') +
+    clusterRoleBinding.roleRef.withKind('ClusterRole') +
+    clusterRoleBinding.roleRef.withName('cert-manager-controller-orders') +
+    clusterRoleBinding.withSubjects([
+      subject.withKind('ServiceAccount') +
+      subject.withName('cert-manager') +
+      subject.withNamespace($._config.namespace),
+    ]),
 
   cert_manager_controller_challenges_clusterrolebinding:
-    clusterRoleBinding.new() +
-    clusterRoleBinding.mixin.metadata
-    .withName('cert-manager-controller-challenges')
-    .withLabels({}/* TODO: labels */) +
-    clusterRoleBinding.mixin.roleRef
-    .withApiGroup('rbac.authorization.k8s.io')
-    .withKind('ClusterRole')
-    .withName('cert-manager-controller-challenges') +
-    clusterRoleBinding.withSubjects(
-      clusterRoleBinding.subjectsType.new() +
-      clusterRoleBinding.subjectsType
-      .withKind('ServiceAccount')
-      .withName('cert-manager')
-      .withNamespace($._config.namespace)
-    ),
+    clusterRoleBinding.new('cert-manager-controller-challenges') +
+    clusterRoleBinding.metadata.withLabels({}/* TODO: labels */) +
+    clusterRoleBinding.roleRef.withApiGroup('rbac.authorization.k8s.io') +
+    clusterRoleBinding.roleRef.withKind('ClusterRole') +
+    clusterRoleBinding.roleRef.withName('cert-manager-controller-challenges') +
+    clusterRoleBinding.withSubjects([
+      subject.withKind('ServiceAccount') +
+      subject.withName('cert-manager') +
+      subject.withNamespace($._config.namespace),
+    ]),
 
   cert_manager_controller_ingress_shim_clusterrolebinding:
-    clusterRoleBinding.new() +
-    clusterRoleBinding.mixin.metadata
-    .withName('cert-manager-controller-ingress-shim')
-    .withLabels({}/* TODO: labels */) +
-    clusterRoleBinding.mixin.roleRef
-    .withApiGroup('rbac.authorization.k8s.io')
-    .withKind('ClusterRole')
-    .withName('cert-manager-controller-ingress-shim') +
-    clusterRoleBinding.withSubjects(
-      clusterRoleBinding.subjectsType.new() +
-      clusterRoleBinding.subjectsType
-      .withKind('ServiceAccount')
-      .withName('cert-manager')
-      .withNamespace($._config.namespace)
-    ),
+    clusterRoleBinding.new('cert-manager-controller-ingress-shim') +
+    clusterRoleBinding.metadata.withLabels({}/* TODO: labels */) +
+    clusterRoleBinding.roleRef.withApiGroup('rbac.authorization.k8s.io') +
+    clusterRoleBinding.roleRef.withKind('ClusterRole') +
+    clusterRoleBinding.roleRef.withName('cert-manager-controller-ingress-shim') +
+    clusterRoleBinding.withSubjects([
+      subject.withKind('ServiceAccount') +
+      subject.withName('cert-manager') +
+      subject.withNamespace($._config.namespace),
+    ]),
 
   cert_manager_view_clusterrole:
-    clusterRole.new() +
-    clusterRole.mixin.metadata
-    .withName('cert-manager-view')
-    .withLabels({
+    clusterRole.new('cert-manager-view') +
+    clusterRole.metadata.withLabels({
       'rbac.authorization.k8s.io/aggregate-to-view': 'true',
       'rbac.authorization.k8s.io/aggregate-to-edit': 'true',
       'rbac.authorization.k8s.io/aggregate-to-admin': 'true',
-    })
-    .withLabelsMixin({}/* TODO labels */) +
+    }) +
+    clusterRole.metadata.withLabelsMixin({}/* TODO labels */) +
     clusterRole.withRules([
-      clusterRole.rulesType.new() +
-      clusterRole.rulesType
-      .withApiGroups('cert-manager.io')
-      .withResources(['certificates', 'certificaterequests', 'issuers'])
-      .withVerbs(['get', 'list', 'watch']),
-    ],),
+      policyRule.withApiGroups('cert-manager.io') +
+      policyRule.withResources(['certificates', 'certificaterequests', 'issuers']) +
+      policyRule.withVerbs(['get', 'list', 'watch']),
+    ]),
 
   cert_manager_edit_clusterrole:
-    clusterRole.new() +
-    clusterRole.mixin.metadata
-    .withName('cert-manager-edit')
-    .withLabels({
+    clusterRole.new('cert-manager-edit') +
+    clusterRole.metadata.withLabels({
       'rbac.authorization.k8s.io/aggregate-to-edit': 'true',
       'rbac.authorization.k8s.io/aggregate-to-admin': 'true',
-    })
-    .withLabelsMixin({}/* TODO labels */) +
+    }) +
+    clusterRole.metadata.withLabelsMixin({}/* TODO labels */) +
     clusterRole.withRules([
-      clusterRole.rulesType.new() +
-      clusterRole.rulesType
-      .withApiGroups('cert-manager.io')
-      .withResources(['certificates', 'certificaterequests', 'issuers'])
-      .withVerbs(['create', 'delete', 'deletecollection', 'patch', 'update']),
-    ],),
+      policyRule.withApiGroups('cert-manager.io') +
+      policyRule.withResources(['certificates', 'certificaterequests', 'issuers']) +
+      policyRule.withVerbs(['create', 'delete', 'deletecollection', 'patch', 'update']),
+    ]),
 
 }

--- a/cert-manager/serviceaccount.libsonnet
+++ b/cert-manager/serviceaccount.libsonnet
@@ -2,5 +2,5 @@
   local serviceAccount = $.core.v1.serviceAccount,
   serviceaccount:
     serviceAccount.new('cert-manager') +
-    serviceAccount.mixin.metadata.withNamespace($._config.namespace),
+    serviceAccount.metadata.withNamespace($._config.namespace),
 }

--- a/cert-manager/webhook_deployment.libsonnet
+++ b/cert-manager/webhook_deployment.libsonnet
@@ -16,7 +16,7 @@
       $.core.v1.envVar.fromFieldPath('POD_NAMESPACE', 'metadata.namespace'),
     ]) +
     container.withVolumeMounts([
-      $.core.v1.Volume.new(name='certs', mountPath='/certs'),
+      $.core.v1.volumeMount.new(name='certs', mountPath='/certs'),
     ]) +
     container.livenessProbe.httpGet.withPath('/livez') +
     container.livenessProbe.httpGet.withPort(6080) +

--- a/cert-manager/webhook_psp.libsonnet
+++ b/cert-manager/webhook_psp.libsonnet
@@ -4,8 +4,8 @@
 
   webhook_psp:
     podSecurityPolicy.new('cert-manager-webhook') +
-    podSecurityPolicty.metadata.withLabels({}/* TODO: labels */) +
-    podSecurityPolicty.metadata.withAnnotations(
+    podSecurityPolicy.metadata.withLabels({}/* TODO: labels */) +
+    podSecurityPolicy.metadata.withAnnotations(
       {
         'seccomp.security.alpha.kubernetes.io/allowedProfileNames': 'docker/default',
         'seccomp.security.alpha.kubernetes.io/defaultProfileName': 'docker/default',
@@ -28,8 +28,8 @@
       'downwardAPI',
     ],) +
     podSecurityPolicy.spec.withHostNetwork(false) +
-    podSecurityPolicy.spec.withHostIpc(false) +
-    podSecurityPolicy.spec.withHostPid(false) +
+    podSecurityPolicy.spec.withHostIPC(false) +
+    podSecurityPolicy.spec.withHostPID(false) +
     podSecurityPolicy.spec.runAsUser.withRule('MustRunAs') +
     podSecurityPolicy.spec.runAsUser.withRanges(idRange.withMin(1000) + idRange.withMax(1000)) +
     podSecurityPolicy.spec.seLinux.withRule('RunAsAny') +

--- a/cert-manager/webhook_psp.libsonnet
+++ b/cert-manager/webhook_psp.libsonnet
@@ -1,13 +1,11 @@
 {
   local podSecurityPolicy = $.policy.v1beta1.podSecurityPolicy,
-  local ranges = podSecurityPolicy.mixin.spec.runAsUser.rangesType,
+  local idRange = $.policy.v1beta1.idRange,
 
   webhook_psp:
-    podSecurityPolicy.new() +
-    podSecurityPolicy.mixin.metadata
-    .withName('cert-manager-webhook')
-    .withLabels({}/* TODO: labels */)
-    .withAnnotations(
+    podSecurityPolicy.new('cert-manager-webhook') +
+    podSecurityPolicty.metadata.withLabels({}/* TODO: labels */) +
+    podSecurityPolicty.metadata.withAnnotations(
       {
         'seccomp.security.alpha.kubernetes.io/allowedProfileNames': 'docker/default',
         'seccomp.security.alpha.kubernetes.io/defaultProfileName': 'docker/default',
@@ -19,29 +17,25 @@
         */
       },
     ) +
-    podSecurityPolicy.mixin.spec
-    .withPrivileged(false)
-    .withAllowPrivilegeEscalation(false)
-    .withAllowedCapabilities([])
-    .withVolumes([
+    podSecurityPolicy.spec.withPrivileged(false) +
+    podSecurityPolicy.spec.withAllowPrivilegeEscalation(false) +
+    podSecurityPolicy.spec.withAllowedCapabilities([]) +
+    podSecurityPolicy.spec.withVolumes([
       'configMap',
       'emptyDir',
       'projected',
       'secret',
       'downwardAPI',
-    ],)
-    .withHostNetwork(false)
-    .withHostIpc(false)
-    .withHostPid(false) +
-    podSecurityPolicy.mixin.spec.runAsUser
-    .withRule('MustRunAs')
-    .withRanges(ranges.new() + ranges.withMin(1000) + ranges.withMax(1000)) +
-    podSecurityPolicy.mixin.spec.seLinux.withRule('RunAsAny') +
-    podSecurityPolicy.mixin.spec.supplementalGroups
-    .withRule('MustRunAs')
-    .withRanges(ranges.new() + ranges.withMin(1000) + ranges.withMax(1000)) +
-    podSecurityPolicy.mixin.spec.fsGroup
-    .withRule('MustRunAs')
-    .withRanges(ranges.new() + ranges.withMin(1000) + ranges.withMax(1000)),
+    ],) +
+    podSecurityPolicy.spec.withHostNetwork(false) +
+    podSecurityPolicy.spec.withHostIpc(false) +
+    podSecurityPolicy.spec.withHostPid(false) +
+    podSecurityPolicy.spec.runAsUser.withRule('MustRunAs') +
+    podSecurityPolicy.spec.runAsUser.withRanges(idRange.withMin(1000) + idRange.withMax(1000)) +
+    podSecurityPolicy.spec.seLinux.withRule('RunAsAny') +
+    podSecurityPolicy.spec.supplementalGroups.withRule('MustRunAs') +
+    podSecurityPolicy.spec.supplementalGroups.withRanges(idRange.withMin(1000) + idRange.withMax(1000)) +
+    podSecurityPolicy.spec.fsGroup.withRule('MustRunAs') +
+    podSecurityPolicy.spec.fsGroup.withRanges(idRange.withMin(1000) + idRange.withMax(1000)),
 
 }

--- a/cert-manager/webhook_psp_clusterrole.libsonnet
+++ b/cert-manager/webhook_psp_clusterrole.libsonnet
@@ -4,7 +4,7 @@
 
   webhook_psp_clusterrole:
     clusterRole.new('cert-manager-webhook-psp') +
-    clusterRole.metadat.withLabels({},/* TODO: labels */) +
+    clusterRole.metadata.withLabels({},/* TODO: labels */) +
     clusterRole.withRules([
       policyRule.withApiGroups('policy') +
       policyRule.withResourceNames(['cert-manager-webhook']) +

--- a/cert-manager/webhook_psp_clusterrole.libsonnet
+++ b/cert-manager/webhook_psp_clusterrole.libsonnet
@@ -1,18 +1,14 @@
 {
   local clusterRole = $.rbac.v1.clusterRole,
-  local rules = clusterRole.rulesType,
+  local policyRule = $.rbac.v1.policyRule,
 
   webhook_psp_clusterrole:
-    clusterRole.new() +
-    clusterRole.mixin.metadata
-    .withName('cert-manager-webhook-psp')
-    .withLabels({},/* TODO: labels */) +
-    clusterRole.withRules(
-      rules.new() +
-      rules
-      .withApiGroups('policy')
-      .withResourceNames(['cert-manager-webhook'])
-      .withResources(['podsecuritypolicies'])
-      .withVerbs(['use'])
-    ),
+    clusterRole.new('cert-manager-webhook-psp') +
+    clusterRole.metadat.withLabels({},/* TODO: labels */) +
+    clusterRole.withRules([
+      policyRule.withApiGroups('policy') +
+      policyRule.withResourceNames(['cert-manager-webhook']) +
+      policyRule.withResources(['podsecuritypolicies']) +
+      policyRule.withVerbs(['use']),
+    ]),
 }

--- a/cert-manager/webhook_psp_clusterrolebinding.libsonnet
+++ b/cert-manager/webhook_psp_clusterrolebinding.libsonnet
@@ -1,22 +1,17 @@
 {
   local clusterRoleBinding = $.rbac.v1.clusterRoleBinding,
-  local roleRef = clusterRoleBinding.roleRefType,
-  local subjects = clusterRoleBinding.subjectsType,
+  local subject = $.rbac.v1.subject,
 
   webhook_psp_clusterrolebinding:
-    clusterRoleBinding.new() +
-    clusterRoleBinding.mixin.metadata
-    .withName('cert-manager-webhook-psp')
-    .withLabels({}/* TODO: labels */,) +
-    clusterRoleBinding.mixin.roleRef
-    .withApiGroup('rbac.authorization.k8s.io')
-    .withKind('ClusterRole')
-    .withName('cert-manager-webhook-psp') +
-    clusterRoleBinding.withSubjects(
-      subjects.new() + subjects
-                       .withKind('ServiceAccount')
-                       .withName('cert-manager-webhook')
-                       .withNamespace($._config.namespace)
-    ),
+    clusterRoleBinding.new('cert-manager-webhook-psp') +
+    clusterRoleBinding.metadata.withLabels({}/* TODO: labels */,) +
+    clusterRoleBinding.roleRef.withApiGroup('rbac.authorization.k8s.io') +
+    clusterRoleBinding.roleRef.withKind('ClusterRole') +
+    clusterRoleBinding.roleRef.withName('cert-manager-webhook-psp') +
+    clusterRoleBinding.withSubjects([
+      subject.withKind('ServiceAccount') +
+      subject.withName('cert-manager-webhook') +
+      subject.withNamespace($._config.namespace),
+    ]),
 
 }

--- a/cert-manager/webhook_rbac.libsonnet
+++ b/cert-manager/webhook_rbac.libsonnet
@@ -1,60 +1,45 @@
 {
   local clusterRoleBinding = $.rbac.v1.clusterRoleBinding,
-  local roleRef = clusterRoleBinding.roleRefType,
-  local subjects = clusterRoleBinding.subjectsType,
+  local subject = $.rbac.v1.subject,
   local clusterRole = $.rbac.v1.clusterRole,
-  local rules = clusterRole.rulesType,
+  local policyRule = $.rbac.v1.policyRule,
 
   webhook_clusterrolebinding:
-    clusterRoleBinding.new() +
-    clusterRoleBinding.mixin.metadata
-    .withName('cert-manager-webhook:auth-delegator')
-    .withLabels({}/* TODO: labels */) +
-    clusterRoleBinding.mixin.roleRef
-    .withApiGroup('rbac.authorization.k8s.io')
-    .withKind('ClusterRole')
-    .withName('system:auth-delegator') +
-    clusterRoleBinding.withSubjects(
-      subjects.new() +
-      subjects
-      .withApiGroup('')
-      .withKind('ServiceAccount')
-      .withName('cert-manager-webhook')
-      .withNamespace($._config.namespace)
-    ),
+    clusterRoleBinding.new('cert-manager-webhook:auth-delegator') +
+    clusterRoleBinding.metadata.withLabels({}/* TODO: labels */) +
+    clusterRoleBinding.roleRef.withApiGroup('rbac.authorization.k8s.io') +
+    clusterRoleBinding.roleRef.withKind('ClusterRole') +
+    clusterRoleBinding.roleRef.withName('system:auth-delegator') +
+    clusterRoleBinding.withSubjects([
+      subject.withApiGroup('') +
+      subject.withKind('ServiceAccount') +
+      subject.withName('cert-manager-webhook') +
+      subject.withNamespace($._config.namespace),
+    ]),
 
-  local roleBinding = $.rbac.v1beta1.roleBinding,
+  local roleBinding = $.rbac.v1.roleBinding,
 
   webhook_rolebinding:
-    roleBinding.new() +
-    roleBinding.mixin.metadata
-    .withName('cert-manager-webhook:webhook-authentication-reader')
-    .withNamespace('kube-system')
-    .withLabels({}/* TODO: labels */) +
-    roleBinding.mixin.roleRef
-    .withApiGroup('rbac.authorization.k8s.io')
-    .withKind('Role')
-    .withName('extension-apiserver-authentication-reader') +
-    roleBinding.withSubjects(
-      subjects.new() +
-      subjects
-      .withApiGroup('')
-      .withKind('ServiceAccount')
-      .withName('cert-manager-webhook')
-      .withNamespace($._config.namespace)
-    ),
+    roleBinding.new('cert-manager-webhook:webhook-authentication-reader') +
+    roleBinding.metadata.withNamespace('kube-system') +
+    roleBinding.metadata.withLabels({}/* TODO: labels */) +
+    roleBinding.roleRef.withApiGroup('rbac.authorization.k8s.io') +
+    roleBinding.roleRef.withKind('Role') +
+    roleBinding.roleRef.withName('extension-apiserver-authentication-reader') +
+    roleBinding.withSubjects([
+      subject.withApiGroup('') +
+      subject.withKind('ServiceAccount') +
+      subject.withName('cert-manager-webhook') +
+      subject.withNamespace($._config.namespace),
+    ]),
 
   webhook_clusterrole:
-    clusterRole.new() +
-    clusterRole.mixin.metadata
-    .withName('cert-manager-webhook:webhook-requester')
-    .withLabels({}/* TODO: labels */) +
-    clusterRole.withRules(
-      rules.new() +
-      rules
-      .withApiGroups('admission.cert-manager.io')
-      .withResources(['certificates', 'certificaterequests', 'issuers', 'clusterissuers'])
-      .withVerbs(['create'])
-    ),
+    clusterRole.new('cert-manager-webhook:webhook-requester') +
+    clusterRole.metadata.withLabels({}/* TODO: labels */) +
+    clusterRole.withRules([
+      policyRule.withApiGroups('admission.cert-manager.io') +
+      policyRule.withResources(['certificates', 'certificaterequests', 'issuers', 'clusterissuers']) +
+      policyRule.withVerbs(['create']),
+    ]),
 
 }

--- a/cert-manager/webhook_service.libsonnet
+++ b/cert-manager/webhook_service.libsonnet
@@ -8,7 +8,7 @@
       { app: 'webhook' /* TODO:selector */ },
       [servicePort.newNamed(name='https', port=443, targetPort=10250)]
     ) +
-    service.withType('ClusterIP') +
-    service.withNamespace($._config.namespace) +
+    service.spec.withType('ClusterIP') +
+    service.metadata.withNamespace($._config.namespace) +
     service.metadata.withLabelsMixin({ app: 'webhook' }),
 }

--- a/cert-manager/webhook_service.libsonnet
+++ b/cert-manager/webhook_service.libsonnet
@@ -1,17 +1,14 @@
 {
   local service = $.core.v1.service,
-  local servicePort = $.core.v1.service.mixin.spec.portsType,
+  local servicePort = $.core.v1.servicePort,
 
   webhook_service:
     service.new(
       'cert-manager-webhook',
-      {
-        app: 'webhook',  // TODO:selector
-      },
-      [
-        servicePort.new(port=443, targetPort=10250).withName('https'),
-      ],
-    ).withType('ClusterIP')
-    .withNamespace($._config.namespace)
-    + service.mixin.metadata.withLabelsMixin({ app: 'webhook' }),
+      { app: 'webhook' /* TODO:selector */ },
+      [servicePort.newNamed(name='https', port=443, targetPort=10250)]
+    ) +
+    service.withType('ClusterIP') +
+    service.withNamespace($._config.namespace) +
+    service.metadata.withLabelsMixin({ app: 'webhook' }),
 }

--- a/cert-manager/webhook_serviceaccount.libsonnet
+++ b/cert-manager/webhook_serviceaccount.libsonnet
@@ -2,5 +2,5 @@
   local serviceAccount = $.core.v1.serviceAccount,
   webhook_serviceaccount:
     serviceAccount.new('cert-manager-webhook') +
-    serviceAccount.mixin.metadata.withNamespace($._config.namespace),
+    serviceAccount.metadata.withNamespace($._config.namespace),
 }

--- a/consul/consul.libsonnet
+++ b/consul/consul.libsonnet
@@ -302,7 +302,7 @@ k {
       $.consul_statsd_exporter,
       $.consul_exporter,
     ]) +
-    deployment.mixin.spec.template.spec.withServiceAccount('consul-sidekick') +
+    deployment.spec.template.spec.withServiceAccount('consul-sidekick') +
     $.util.configMapVolumeMount($.consul_config_map, '/etc/config') +
     $.util.antiAffinity,
 

--- a/consul/consul.libsonnet
+++ b/consul/consul.libsonnet
@@ -256,11 +256,10 @@ k {
     ]) +
     $.util.resourcesRequests('100m', '500Mi'),
 
-  local policyRule = $.rbac.v1beta1.policyRule,
+  local policyRule = $.rbac.v1.policyRule,
 
   consul_sidekick_rbac:
     $.util.namespacedRBAC('consul-sidekick', [
-      policyRule.new() +
       policyRule.withApiGroups(['', 'extensions', 'apps']) +
       policyRule.withResources(['pods', 'replicasets']) +
       policyRule.withVerbs(['get', 'list', 'watch']),
@@ -273,8 +272,8 @@ k {
       '--pod-name=$(POD_NAME)',
     ]) +
     container.withEnv([
-      container.envType.fromFieldPath('POD_NAMESPACE', 'metadata.namespace'),
-      container.envType.fromFieldPath('POD_NAME', 'metadata.name'),
+      $.core.v1.envVar.fromFieldPath('POD_NAMESPACE', 'metadata.namespace'),
+      $.core.v1.envVar.fromFieldPath('POD_NAME', 'metadata.name'),
     ]),
 
   consul_statsd_exporter::

--- a/etcd-operator/etcd-cluster.libsonnet
+++ b/etcd-operator/etcd-cluster.libsonnet
@@ -1,5 +1,5 @@
 {
-  local podAntiAffinity = $.apps.v1.deployment.mixin.spec.template.spec.affinity.podAntiAffinity,
+  local podAntiAffinity = $.apps.v1.deployment.spec.template.spec.affinity.podAntiAffinity,
   local podAffinityTerm = $.core.v1.podAffinityTerm,
 
   etcd_cluster(name, size=3, version='3.3.13', env=[]):: {

--- a/etcd-operator/etcd-cluster.libsonnet
+++ b/etcd-operator/etcd-cluster.libsonnet
@@ -1,5 +1,6 @@
 {
   local podAntiAffinity = $.apps.v1.deployment.mixin.spec.template.spec.affinity.podAntiAffinity,
+  local podAffinityTerm = $.core.v1.podAffinityTerm,
 
   etcd_cluster(name, size=3, version='3.3.13', env=[]):: {
     apiVersion: 'etcd.database.coreos.com/v1beta2',
@@ -15,9 +16,8 @@
       version: version,
       pod:
         podAntiAffinity.withRequiredDuringSchedulingIgnoredDuringExecution([
-          podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecutionType.new() +
-          podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecutionType.mixin.labelSelector.withMatchLabels({ etcd_cluster: name }) +
-          podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecutionType.withTopologyKey('kubernetes.io/hostname'),
+          podAffinityTerm.labelSelector.withMatchLabels({ etcd_cluster: name }) +
+          podAffinityTerm.withTopologyKey('kubernetes.io/hostname'),
         ]).spec.template.spec
         {
           labels: { name: name },

--- a/etcd-operator/operator.libsonnet
+++ b/etcd-operator/operator.libsonnet
@@ -42,5 +42,5 @@
 
   operator_deployment:
     deployment.new('etcd-operator', 1, [$.operator_container]) +
-    deployment.mixin.spec.template.spec.withServiceAccount('etcd-operator'),
+    deployment.spec.template.spec.withServiceAccount('etcd-operator'),
 }

--- a/etcd-operator/operator.libsonnet
+++ b/etcd-operator/operator.libsonnet
@@ -3,33 +3,29 @@
     operator: 'quay.io/coreos/etcd-operator:v0.9.4',
   },
 
-  local policyRule = $.rbac.v1beta1.policyRule,
+  local policyRule = $.rbac.v1.policyRule,
 
   operator_rbac:
     $.util.rbac('etcd-operator', [
-      policyRule.new() +
       policyRule.withApiGroups(['etcd.database.coreos.com']) +
       policyRule.withResources(['etcdclusters', 'etcdbackups', 'etcdrestores']) +
       policyRule.withVerbs(['*']),
 
-      policyRule.new() +
       policyRule.withApiGroups(['apiextensions.k8s.io']) +
       policyRule.withResources(['customresourcedefinitions']) +
       policyRule.withVerbs(['*']),
 
-      policyRule.new() +
       policyRule.withApiGroups(['']) +
       policyRule.withResources(['pods', 'services', 'endpoints', 'persistentvolumeclaims', 'events']) +
       policyRule.withVerbs(['*']),
 
-      policyRule.new() +
       policyRule.withApiGroups(['apps']) +
       policyRule.withResources(['deployments']) +
       policyRule.withVerbs(['*']),
     ]),
 
   local container = $.core.v1.container,
-  local env = container.envType,
+  local env = $.core.v1.envVar,
   operator_container::
     container.new('operator', $._images.operator) +
     container.withCommand(['etcd-operator']) +

--- a/jaeger-agent-mixin/jaeger.libsonnet
+++ b/jaeger-agent-mixin/jaeger.libsonnet
@@ -12,8 +12,8 @@
     then {}
     else
       container.withEnvMixin([
-        container.envType.new('JAEGER_AGENT_HOST', $._config.jaeger_agent_host),
-        container.envType.new('JAEGER_TAGS', 'namespace=%s,cluster=%s' % [$._config.namespace, $._config.cluster]),
-        container.envType.new('JAEGER_SAMPLER_MANAGER_HOST_PORT', 'http://%s:5778/sampling' % $._config.jaeger_agent_host),
+        $.core.v1.envVar.new('JAEGER_AGENT_HOST', $._config.jaeger_agent_host),
+        $.core.v1.envVar.new('JAEGER_TAGS', 'namespace=%s,cluster=%s' % [$._config.namespace, $._config.cluster]),
+        $.core.v1.envVar.new('JAEGER_SAMPLER_MANAGER_HOST_PORT', 'http://%s:5778/sampling' % $._config.jaeger_agent_host),
       ]),
 }

--- a/memcached/memcached.libsonnet
+++ b/memcached/memcached.libsonnet
@@ -60,13 +60,13 @@ k {
         self.memcached_container,
         self.memcached_exporter,
       ], []) +
-      statefulSet.mixin.spec.withServiceName(self.name) +
+      statefulSet.spec.withServiceName(self.name) +
       $.util.antiAffinity,
 
     local service = $.core.v1.service,
 
     service:
       $.util.serviceFor(self.statefulSet) +
-      service.mixin.spec.withClusterIp('None'),
+      service.spec.withClusterIp('None'),
   },
 }

--- a/oauth2-proxy/oauth2-proxy.libsonnet
+++ b/oauth2-proxy/oauth2-proxy.libsonnet
@@ -25,7 +25,7 @@ k {
     }),
 
   local container = $.core.v1.container,
-  local envFrom = container.envFromType,
+  local envFrom = $.core.v1.envFromSource,
 
   oauth2_proxy_container::
     container.new('oauth2-proxy', $._images.oauth2_proxy) +
@@ -38,8 +38,7 @@ k {
       '-pass-basic-auth=%s' % $._config.oauth_pass_basic_auth,
     ]) +
     container.withEnvFrom(
-      envFrom.new() +
-      envFrom.mixin.secretRef.withName('oauth2-proxy'),
+      envFrom.secretRef.withName('oauth2-proxy'),
     ),
 
   local deployment = $.apps.v1.deployment,

--- a/prometheus-ksonnet/grafana/dashboards.libsonnet
+++ b/prometheus-ksonnet/grafana/dashboards.libsonnet
@@ -84,7 +84,7 @@
         for name in std.objectFields(dashboards)
         if std.codepoint(std.md5(name)[1]) % shards == shard
       }) +
-      configMap.mixin.metadata.withLabels($._config.grafana_dashboard_labels)
+      configMap.metadata.withLabels($._config.grafana_dashboard_labels)
     for shard in std.range(0, shards - 1)
   },
 

--- a/prometheus-ksonnet/grafana/datasources.libsonnet
+++ b/prometheus-ksonnet/grafana/datasources.libsonnet
@@ -80,5 +80,5 @@
       [name]: std.toString($.grafanaDatasources[name])
       for name in std.objectFields($.grafanaDatasources)
     }) +
-    configMap.mixin.metadata.withLabels($._config.grafana_datasource_labels),
+    configMap.metadata.withLabels($._config.grafana_datasource_labels),
 }

--- a/prometheus-ksonnet/grafana/deployment.libsonnet
+++ b/prometheus-ksonnet/grafana/deployment.libsonnet
@@ -96,7 +96,7 @@
 
   grafana_service:
     $.util.serviceFor($.grafana_deployment) +
-    service.mixin.spec.withPortsMixin([
+    service.spec.withPortsMixin([
       servicePort.newNamed(
         name='http',
         port=80,

--- a/prometheus-ksonnet/grafana/deployment.libsonnet
+++ b/prometheus-ksonnet/grafana/deployment.libsonnet
@@ -92,7 +92,7 @@
     $.util.podPriority('critical'),
 
   local service = $.core.v1.service,
-  local servicePort = service.mixin.spec.portsType,
+  local servicePort = $.core.v1.servicePort,
 
   grafana_service:
     $.util.serviceFor($.grafana_deployment) +

--- a/prometheus-ksonnet/grafana/notifications.libsonnet
+++ b/prometheus-ksonnet/grafana/notifications.libsonnet
@@ -34,5 +34,5 @@
       [name]: std.toString($.grafanaNotificationChannels[name])
       for name in std.objectFields($.grafanaNotificationChannels)
     }) +
-    configMap.mixin.metadata.withLabels($._config.grafana_notification_channel_labels),
+    configMap.metadata.withLabels($._config.grafana_notification_channel_labels),
 }

--- a/prometheus-ksonnet/lib/alertmanager.libsonnet
+++ b/prometheus-ksonnet/lib/alertmanager.libsonnet
@@ -108,7 +108,7 @@
     container.withVolumeMountsMixin(
       volumeMount.new('alertmanager-data', '/alertmanager')
     ) +
-    container.mixin.resources.withRequests({
+    container.resources.withRequests({
       cpu: '10m',
       memory: '40Mi',
     }),
@@ -128,7 +128,7 @@
       '-sS',
       'http://localhost:%s%s-/reload' % [$._config.alertmanager_port, $._config.alertmanager_path],
     ]) +
-    container.mixin.resources.withRequests({
+    container.resources.withRequests({
       cpu: '10m',
       memory: '20Mi',
     }),
@@ -137,9 +137,9 @@
 
   alertmanager_pvc::
     pvc.new() +
-    pvc.mixin.metadata.withName('alertmanager-data') +
-    pvc.mixin.spec.withAccessModes('ReadWriteOnce') +
-    pvc.mixin.spec.resources.withRequests({ storage: '5Gi' }),
+    pvc.metadata.withName('alertmanager-data') +
+    pvc.spec.withAccessModes('ReadWriteOnce') +
+    pvc.spec.resources.withRequests({ storage: '5Gi' }),
 
   local statefulset = $.apps.v1.statefulSet,
 
@@ -149,8 +149,8 @@
       $.alertmanager_container,
       $.alertmanager_watch_container,
     ], self.alertmanager_pvc) +
-    statefulset.mixin.spec.withServiceName('alertmanager') +
-    statefulset.mixin.spec.template.metadata.withAnnotations({ 'prometheus.io.path': '%smetrics' % $._config.alertmanager_path }) +
+    statefulset.spec.withServiceName('alertmanager') +
+    statefulset.spec.template.metadata.withAnnotations({ 'prometheus.io.path': '%smetrics' % $._config.alertmanager_path }) +
     $.util.configVolumeMount('alertmanager-config', '/etc/alertmanager/config') +
     $.util.podPriority('critical')
   else {},
@@ -164,7 +164,7 @@
     then {}
     else
       $.util.serviceFor($.alertmanager_statefulset) +
-      service.mixin.spec.withPortsMixin([
+      service.spec.withPortsMixin([
         servicePort.newNamed(
           name='http',
           port=80,

--- a/prometheus-ksonnet/lib/alertmanager.libsonnet
+++ b/prometheus-ksonnet/lib/alertmanager.libsonnet
@@ -73,6 +73,7 @@
   else {},
 
   local container = $.core.v1.container,
+  local envVar = $.core.v1.envVar,
   local volumeMount = $.core.v1.volumeMount,
 
   alertmanager_container::
@@ -102,7 +103,7 @@
         []
     ) +
     container.withEnvMixin([
-      container.envType.fromFieldPath('POD_IP', 'status.podIP'),
+      envVar.fromFieldPath('POD_IP', 'status.podIP'),
     ]) +
     container.withVolumeMountsMixin(
       volumeMount.new('alertmanager-data', '/alertmanager')
@@ -155,7 +156,7 @@
   else {},
 
   local service = $.core.v1.service,
-  local servicePort = service.mixin.spec.portsType,
+  local servicePort = $.core.v1.servicePort,
 
   // Do not create service in clusters without any alertmanagers.
   alertmanager_service:

--- a/prometheus-ksonnet/lib/kube-state-metrics.libsonnet
+++ b/prometheus-ksonnet/lib/kube-state-metrics.libsonnet
@@ -97,8 +97,8 @@
     ]) +
     // Stop the default pod discovery scraping this pod - we use a special
     // scrape config to preserve namespace etc labels.
-    deployment.mixin.spec.template.metadata.withAnnotationsMixin({ 'prometheus.io.scrape': 'false' }) +
-    deployment.mixin.spec.template.spec.withServiceAccount('kube-state-metrics') +
+    deployment.spec.template.metadata.withAnnotationsMixin({ 'prometheus.io.scrape': 'false' }) +
+    deployment.spec.template.spec.withServiceAccount('kube-state-metrics') +
     $.util.podPriority('critical'),
 
   kube_state_metrics_service:

--- a/prometheus-ksonnet/lib/node-exporter.libsonnet
+++ b/prometheus-ksonnet/lib/node-exporter.libsonnet
@@ -15,8 +15,8 @@
       '--collector.filesystem.ignored-fs-types=^(tmpfs|autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$',
       '--collector.filesystem.ignored-mount-points=^/(rootfs/)?(dev|proc|sys|var/lib/docker/.+)($|/)',
     ]) +
-    container.mixin.securityContext.withPrivileged(true) +
-    container.mixin.securityContext.withRunAsUser(0) +
+    container.securityContext.withPrivileged(true) +
+    container.securityContext.withRunAsUser(0) +
     $.util.resourcesRequests('50m', '30Mi') +
     $.util.resourcesLimits('200m', '75Mi'),
 
@@ -24,9 +24,9 @@
 
   node_exporter_daemonset:
     daemonSet.new('node-exporter', [$.node_exporter_container]) +
-    daemonSet.mixin.spec.template.spec.withHostPid(true) +
-    daemonSet.mixin.spec.template.spec.withHostNetwork(true) +
-    daemonSet.mixin.spec.template.metadata.withAnnotationsMixin({ 'prometheus.io.scrape': 'false' }) +
+    daemonSet.spec.template.spec.withHostPid(true) +
+    daemonSet.spec.template.spec.withHostNetwork(true) +
+    daemonSet.spec.template.metadata.withAnnotationsMixin({ 'prometheus.io.scrape': 'false' }) +
     $.util.hostVolumeMount('proc', '/proc', '/host/proc') +
     $.util.hostVolumeMount('sys', '/sys', '/host/sys') +
     (if $._config.node_exporter_mount_root

--- a/prometheus-ksonnet/lib/prometheus-ha-mixin.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus-ha-mixin.libsonnet
@@ -66,5 +66,5 @@ local configMap = k.core.v1.configMap;
   prometheus_statefulset+:
     k.util.configVolumeMount('%s-config-0' % self.name, '/etc/prometheus-0') +
     k.util.configVolumeMount('%s-config-1' % self.name, '/etc/prometheus-1') +
-    statefulset.mixin.spec.withReplicas(2),
+    statefulset.spec.withReplicas(2),
 }

--- a/prometheus-ksonnet/lib/prometheus-ha-mixin.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus-ha-mixin.libsonnet
@@ -1,5 +1,6 @@
 local k = import 'ksonnet-util/kausal.libsonnet';
 local container = k.core.v1.container;
+local envVar = k.core.v1.envVarservice;
 local statefulset = k.apps.v1.statefulSet;
 local configMap = k.core.v1.configMap;
 
@@ -55,11 +56,11 @@ local configMap = k.core.v1.configMap;
   prometheus_config_mount:: {},
 
   prometheus_container+:: container.withEnv([
-    container.envType.fromFieldPath('POD_NAME', 'metadata.name'),
+    envVar.fromFieldPath('POD_NAME', 'metadata.name'),
   ]),
 
   prometheus_watch_container+:: container.withEnv([
-    container.envType.fromFieldPath('POD_NAME', 'metadata.name'),
+    envVar.fromFieldPath('POD_NAME', 'metadata.name'),
   ]),
 
   prometheus_statefulset+:

--- a/prometheus-ksonnet/lib/prometheus.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus.libsonnet
@@ -96,7 +96,7 @@
       $.util.podPriority('critical'),
 
     local service = $.core.v1.service,
-    local servicePort = service.mixin.spec.portsType,
+    local servicePort = $.core.v1.servicePort,
 
     prometheus_service:
       $.util.serviceFor(self.prometheus_statefulset) +

--- a/prometheus-ksonnet/lib/prometheus.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus.libsonnet
@@ -67,9 +67,9 @@
 
     prometheus_pvc::
       pvc.new() +
-      pvc.mixin.metadata.withName('%s-data' % (self.name)) +
-      pvc.mixin.spec.withAccessModes('ReadWriteOnce') +
-      pvc.mixin.spec.resources.withRequests({ storage: '300Gi' }),
+      pvc.metadata.withName('%s-data' % (self.name)) +
+      pvc.spec.withAccessModes('ReadWriteOnce') +
+      pvc.spec.resources.withRequests({ storage: '300Gi' }),
 
     local statefulset = $.apps.v1.statefulSet,
     local volumeMount = $.core.v1.volumeMount,
@@ -85,14 +85,14 @@
         self.prometheus_watch_container,
       ], self.prometheus_pvc) +
       self.prometheus_config_mount +
-      statefulset.mixin.spec.withServiceName('prometheus') +
-      statefulset.mixin.spec.template.metadata.withAnnotations({
+      statefulset.spec.withServiceName('prometheus') +
+      statefulset.spec.template.metadata.withAnnotations({
         'prometheus.io.path': '%smetrics' % _config.prometheus_web_route_prefix,
       }) +
-      statefulset.mixin.spec.template.spec.withServiceAccount(self.name) +
-      statefulset.mixin.spec.template.spec.securityContext.withFsGroup(2000) +
-      statefulset.mixin.spec.template.spec.securityContext.withRunAsUser(1000) +
-      statefulset.mixin.spec.template.spec.securityContext.withRunAsNonRoot(true) +
+      statefulset.spec.template.spec.withServiceAccount(self.name) +
+      statefulset.spec.template.spec.securityContext.withFsGroup(2000) +
+      statefulset.spec.template.spec.securityContext.withRunAsUser(1000) +
+      statefulset.spec.template.spec.securityContext.withRunAsNonRoot(true) +
       $.util.podPriority('critical'),
 
     local service = $.core.v1.service,
@@ -100,7 +100,7 @@
 
     prometheus_service:
       $.util.serviceFor(self.prometheus_statefulset) +
-      service.mixin.spec.withPortsMixin([
+      service.spec.withPortsMixin([
         servicePort.newNamed(
           name='http',
           port=80,


### PR DESCRIPTION
k8s-alpha currently depens on a shim for backwards compat, this refactors a bunch so it is not necessary anymore for
these libs.

* eradicate *Type usage
* refactored cert-manager along the way
* remove superfluous '.mixin.'

Ignored ksonnet-utils (see #290)
Ignored k8s-termination-handler (see #286)