### PR TITLE
altered alertmanager dns naming logic for clusters, added a gossip service

### DIFF
--- a/prometheus-ksonnet/lib/alertmanager.libsonnet
+++ b/prometheus-ksonnet/lib/alertmanager.libsonnet
@@ -164,7 +164,7 @@
           ]) +
           service.spec.withSessionAffinity('ClientIP'),
       }
-    else if replicas > 0 then
+    else if replicas > 1 then
       {
         web:
           $.util.serviceFor($.alertmanager_statefulset) +


### PR DESCRIPTION
There are some opinionated changes in here.  This is driven from several points: 

1. The "cluster" name used by alertmanager to identify monitoring domains shouldn't be the same as the "cluster" that is found in the local DNS of Kubernetes. In fact, I'm pretty sure there is no way that the previous version could work without a single cluster named "cluster"
1. The service that alertmanager exposes probably shouldn't be the same one that the statefulset uses to gossip amongst itself. 

I'm not 100% clear on what we should do for the peers in the case of multiple AlertManager clusters . 
If AlertManager does actually need separate gossip pools for separate clusters, then I think we should have separate statefulsets. 

This config assumes that a single gossip pool can serve multiple AM clusters, which I thought was the case. 

/fixes #294 