### PR TITLE
Remove "mixin" from prometheus-ksonnet title

### DIFF
--- a/prometheus-ksonnet/README.md
+++ b/prometheus-ksonnet/README.md
@@ -1,4 +1,4 @@
-# Prometheus Ksonnet Mixin
+# Prometheus Ksonnet
 
 A set of extensible configs for running Prometheus on Kubernetes.
 


### PR DESCRIPTION
As per definition (https://en.wikipedia.org/wiki/Mixin), a mixin is simply spoken a piece of code that's mixed with another existing piece of code.

This does apply to monitoring mixins, because they are mixed into this very library. prometheus-ksonnet however itself is not a mixin and should thus not be titled as one.