### PR TITLE
fix(prometheus-ksonnet): add ns/pod/container

### DIFF
--- a/prometheus-ksonnet/lib/prometheus-config.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus-config.libsonnet
@@ -364,11 +364,30 @@
           insecure_skip_verify: $._config.prometheus_insecure_skip_verify,
         },
 
-        relabel_configs: [{
-          source_labels: ['__meta_kubernetes_service_label_component'],
-          regex: 'apiserver',
-          action: 'keep',
-        }],
+        relabel_configs: [
+          {
+            source_labels: ['__meta_kubernetes_service_label_component'],
+            regex: 'apiserver',
+            action: 'keep',
+          },
+
+          // Include the namespace, container, pod as separate labels
+          {
+            source_labels: ['__meta_kubernetes_namespace'],
+            action: 'replace',
+            target_label: 'namespace',
+          },
+          {
+            source_labels: ['__meta_kubernetes_pod_name'],
+            action: 'replace',
+            target_label: 'pod',  // Not 'pod_name', which disappeared in K8s 1.16.
+          },
+          {
+            source_labels: ['__meta_kubernetes_pod_container_name'],
+            action: 'replace',
+            target_label: 'container',  // Not 'container_name', which disappeared in K8s 1.16.
+          },
+        ],
 
         // Drop some high cardinality metrics.
         metric_relabel_configs: [


### PR DESCRIPTION
This adds labels for namespace, pod and container to metrics coming from
job=default/kubernetes.

The etcd-mixin uses `grpc_server_*` to calculate some of its alerts,
these metrics originate from job=default/kubernetes and we are missing the
namespace label. In our current routing setup, we need the namespace
label to route our alerts to the right team.