### PR TITLE
Change Grafana URL to automatically pull up the search page (and show dashboard folders)

### DIFF
--- a/prometheus-ksonnet/lib/config.libsonnet
+++ b/prometheus-ksonnet/lib/config.libsonnet
@@ -11,7 +11,7 @@
       {
         title: 'Grafana',
         path: 'grafana',
-        params: '?search=open',
+        params: '/?search=open',
         url: 'http://grafana.%(namespace)s.svc.%(cluster_dns_suffix)s/' % $._config,
         allowWebsockets: true,
       },

--- a/prometheus-ksonnet/lib/config.libsonnet
+++ b/prometheus-ksonnet/lib/config.libsonnet
@@ -11,6 +11,7 @@
       {
         title: 'Grafana',
         path: 'grafana',
+        params: '?search=open',
         url: 'http://grafana.%(namespace)s.svc.%(cluster_dns_suffix)s/' % $._config,
         allowWebsockets: true,
       },

--- a/prometheus-ksonnet/lib/nginx.libsonnet
+++ b/prometheus-ksonnet/lib/nginx.libsonnet
@@ -48,7 +48,7 @@
       locations: std.join('\n', self.location_stanzas),
       link_stanzas: [
         |||
-          <li><a href="/%(path)s">%(title)s</a></li>
+          <li><a href="/%(path)s/%s(params)s">%(title)s</a></li>
         ||| % service
         for service in $._config.admin_services
       ],

--- a/prometheus-ksonnet/lib/nginx.libsonnet
+++ b/prometheus-ksonnet/lib/nginx.libsonnet
@@ -48,8 +48,8 @@
       locations: std.join('\n', self.location_stanzas),
       link_stanzas: [
         |||
-          <li><a href="/%(path)s/%s(params)s">%(title)s</a></li>
-        ||| % service
+          <li><a href="/%(path)s%(params)s">%(title)s</a></li>
+        ||| % ({ params: '' } + service)
         for service in $._config.admin_services
       ],
       links: std.join('\n', self.link_stanzas),


### PR DESCRIPTION
Fixes #300 

After some discussion in a call yesterday it was agreed we would like this to be the default.