### PR TITLE
Add Light and Dark url's for Grafana to the index page

### DIFF
--- a/prometheus-ksonnet/lib/config.libsonnet
+++ b/prometheus-ksonnet/lib/config.libsonnet
@@ -9,9 +9,16 @@
     // Overrides for the nginx frontend for all these services.
     admin_services: std.prune([
       {
-        title: 'Grafana',
+        title: 'Grafana(Light)',
         path: 'grafana',
-        params: '/?search=open',
+        params: '/?search=open&theme=light',
+        url: 'http://grafana.%(namespace)s.svc.%(cluster_dns_suffix)s/' % $._config,
+        allowWebsockets: true,
+      },
+      {
+        title: 'Grafana(Dark)',
+        path: 'grafana',
+        params: '/?search=open&theme=dark',
         url: 'http://grafana.%(namespace)s.svc.%(cluster_dns_suffix)s/' % $._config,
         allowWebsockets: true,
       },

--- a/prometheus-ksonnet/lib/config.libsonnet
+++ b/prometheus-ksonnet/lib/config.libsonnet
@@ -9,14 +9,14 @@
     // Overrides for the nginx frontend for all these services.
     admin_services: std.prune([
       {
-        title: 'Grafana(Light)',
+        title: 'Grafana (Light)',
         path: 'grafana',
         params: '/?search=open&theme=light',
         url: 'http://grafana.%(namespace)s.svc.%(cluster_dns_suffix)s/' % $._config,
         allowWebsockets: true,
       },
       {
-        title: 'Grafana(Dark)',
+        title: 'Grafana (Dark)',
         path: 'grafana',
         params: '/?search=open&theme=dark',
         url: 'http://grafana.%(namespace)s.svc.%(cluster_dns_suffix)s/' % $._config,

--- a/prometheus-ksonnet/lib/nginx.libsonnet
+++ b/prometheus-ksonnet/lib/nginx.libsonnet
@@ -43,7 +43,7 @@
     local vars = {
       location_stanzas: [
         buildLocation(service)
-        for service in $._config.admin_services
+        for service in std.set($._config.admin_services, keyF=url)
       ],
       locations: std.join('\n', self.location_stanzas),
       link_stanzas: [

--- a/prometheus-ksonnet/lib/nginx.libsonnet
+++ b/prometheus-ksonnet/lib/nginx.libsonnet
@@ -43,7 +43,7 @@
     local vars = {
       location_stanzas: [
         buildLocation(service)
-        for service in std.set($._config.admin_services, keyF=url)
+        for service in std.set($._config.admin_services, function(s) s.url)
       ],
       locations: std.join('\n', self.location_stanzas),
       link_stanzas: [


### PR DESCRIPTION
As there are lot of strong personal opinions over using light or dark mode in Grafana, I suggest this as a solution to accommodate both preferences by taking advantage of the `theme=light` or `theme=dark` query params supported by Grafana.

To prevent multiple entires in the nginx config for the same url, I added a `std.Set` operator to the list of url's, be aware this changes the sort order of the resulting list. 

This shouldn't matter as it's only the sort order of the proxy paths in the nginx config but it does result in a large diff when applying the change.