### PR TITLE
Allow configuring read and send timeout in Nginx

### DIFF
--- a/prometheus-ksonnet/lib/config.libsonnet
+++ b/prometheus-ksonnet/lib/config.libsonnet
@@ -87,9 +87,9 @@
     // oauth2-proxy
     oauth_enabled: false,
 
-    // Nginx proxy_read_timeout (in seconds)
-    nginx_proxy_read_timeout: "60",
-    // Nginx proxy_send_timeout (in seconds)
-    nginx_proxy_send_timeout: "60",
+    // Nginx proxy_read_timeout (in seconds) 60s is the nginx default
+    nginx_proxy_read_timeout: '60',
+    // Nginx proxy_send_timeout (in seconds) 60s is the nginx default
+    nginx_proxy_send_timeout: '60',
   },
 }

--- a/prometheus-ksonnet/lib/config.libsonnet
+++ b/prometheus-ksonnet/lib/config.libsonnet
@@ -86,5 +86,10 @@
 
     // oauth2-proxy
     oauth_enabled: false,
+
+    // Nginx proxy_read_timeout (in seconds)
+    nginx_proxy_read_timeout: "60",
+    // Nginx proxy_send_timeout (in seconds)
+    nginx_proxy_send_timeout: "60",
   },
 }

--- a/prometheus-ksonnet/lib/nginx.libsonnet
+++ b/prometheus-ksonnet/lib/nginx.libsonnet
@@ -9,7 +9,9 @@
       proxy_set_header    X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header    X-Forwarded-Proto $scheme;
       proxy_set_header    X-Forwarded-Host $http_host;
-    ||| % service + if allowWebsockets then |||
+      proxy_read_timeout  %(nginx_proxy_read_timeout)s;
+      proxy_send_timeout  %(nginx_proxy_send_timeout)s;
+    ||| % (service + $._config) + if allowWebsockets then |||
       # Allow websocket connections https://www.nginx.com/blog/websocket-nginx/
       proxy_set_header    Upgrade $http_upgrade;
       proxy_set_header    Connection "Upgrade";


### PR DESCRIPTION
Queries can take longer than the default 60s (especially Loki queries) however nginx will close the connection if it hasn't received any traffic within the `proxy_read_timeout`

This PR allows configuring these values in your deployment.

They are set to the nginx default of 60s if not overridden.