### PR TITLE
Don't wrap datasources in an array

### DIFF
--- a/prometheus-ksonnet/grafana/datasources.libsonnet
+++ b/prometheus-ksonnet/grafana/datasources.libsonnet
@@ -34,7 +34,10 @@
   */
   grafana_add_datasource(name, url, default=false, method='GET')::
     configMap.withDataMixin({
-      ['%s.yml' % name]: $.util.manifestYaml($.grafana_datasource(name, url, default, method)),
+      ['%s.yml' % name]: $.util.manifestYaml({
+        apiVersion: 1,
+        datasources: [$.grafana_datasource(name, url, default, method)],
+      }),
     }),
 
   // Generates yaml string containing datasource config
@@ -63,13 +66,16 @@
   */
   grafana_add_datasource_with_basicauth(name, url, username, password, default=false, method='GET')::
     configMap.withDataMixin({
-      ['%s.yml' % name]: $.util.manifestYaml($.grafana_datasource_with_basicauth(name, url, username, password, default, method)),
+      ['%s.yml' % name]: $.util.manifestYaml({
+        apiVersion: 1,
+        datasources: [$.grafana_datasource_with_basicauth(name, url, username, password, default, method)],
+      }),
     }),
 
   grafana_datasource_config_map:
     configMap.new('grafana-datasources') +
     configMap.withDataMixin({
-      [name]: (
+      [if std.endsWith(name, '.yml') then name else name + '.yml']: (
         if std.isString($.grafanaDatasources[name]) then
           $.grafanaDatasources[name]
         else

--- a/prometheus-ksonnet/grafana/datasources.libsonnet
+++ b/prometheus-ksonnet/grafana/datasources.libsonnet
@@ -12,22 +12,18 @@
   grafanaDatasources+:: {},
 
   // Generates yaml string containing datasource config
-  grafana_datasource(name, url, default=false, method='GET')::
-    {
-      apiVersion: 1,
-      datasources: [{
-        name: name,
-        type: 'prometheus',
-        access: 'proxy',
-        url: url,
-        isDefault: default,
-        version: 1,
-        editable: false,
-        jsonData: {
-          httpMethod: method,
-        },
-      }],
+  grafana_datasource(name, url, default=false, method='GET', type='prometheus'):: {
+    name: name,
+    type: type,
+    access: 'proxy',
+    url: url,
+    isDefault: default,
+    version: 1,
+    editable: false,
+    jsonData: {
+      httpMethod: method,
     },
+  },
 
   /*
     helper to allow adding datasources directly to the datasource_config_map
@@ -42,25 +38,21 @@
     }),
 
   // Generates yaml string containing datasource config
-  grafana_datasource_with_basicauth(name, url, username, password, default=false, method='GET')::
-    {
-      apiVersion: 1,
-      datasources: [{
-        name: name,
-        type: 'prometheus',
-        access: 'proxy',
-        url: url,
-        isDefault: default,
-        version: 1,
-        editable: false,
-        basicAuth: true,
-        basicAuthUser: username,
-        basicAuthPassword: password,
-        jsonData: {
-          httpMethod: method,
-        },
-      }],
+  grafana_datasource_with_basicauth(name, url, username, password, default=false, method='GET', type='prometheus'):: {
+    name: name,
+    type: type,
+    access: 'proxy',
+    url: url,
+    isDefault: default,
+    version: 1,
+    editable: false,
+    basicAuth: true,
+    basicAuthUser: username,
+    basicAuthPassword: password,
+    jsonData: {
+      httpMethod: method,
     },
+  },
 
   /*
    helper to allow adding datasources directly to the datasource_config_map
@@ -81,7 +73,10 @@
         if std.isString($.grafanaDatasources[name]) then
           $.grafanaDatasources[name]
         else
-          $.util.manifestYaml($.grafanaDatasources[name])
+          $.util.manifestYaml({
+            apiVersion: 1,
+            datasources: [$.grafanaDatasources[name]],
+          })
       )
       for name in std.objectFields($.grafanaDatasources)
     }) +


### PR DESCRIPTION
At present, we are placing datasource json into an object that pre-supposes we will use Provisioning to deploy. It puts the datasource into an array, and that means that you cannot patch the datasource (because patching arrays is tough).

This PR moves the boilerplate needed for the provisioning API to right before the JSON is rendered as YAML, meaning any datasources in `grafanaDatasources` will be patchable.

This should effectively be a no-op. It isn't long ago that everything in `grafanaDatasources` was rendered YAML strings. So the json objects in `grafanaDatasources` option that we are changing here has only been in the library for a week or so, and is thus likely unused.

This is attempting to move us to an agnostic representation of Grafana resources, such that code specifying datasources can be consumed outside of `prometheus-ksonnet`, e.g. by [Grizzly](https://github.com/grafana/grizzly) to push datasources directly to Grafana, e.g. by people not even using Kubernetes, or for people who'se Grafana instance isn't Kubernetes managed (e.g. Grafana Cloud).