### PR TITLE
fix(ksonnet-util): allow naming pvc with new(name)

### DIFF
--- a/ksonnet-util/kausal.libsonnet
+++ b/ksonnet-util/kausal.libsonnet
@@ -63,7 +63,14 @@ k {
       },
 
       persistentVolumeClaim+:: {
-        new():: {},
+        new(name='')::
+          if 'new' in super
+          then super.new(name)
+          else
+            if name != '' then
+              {} + super.mixin.metadata.withName(name)
+            else
+              {},
       },
 
       container:: $.apps.v1.deployment.mixin.spec.template.spec.containersType {


### PR DESCRIPTION
Makes it forward compatible with k8s-alpha.