### PR TITLE
refactor(etcd-cluster): use core.v1 resources

### DIFF
--- a/etcd-operator/etcd-cluster.libsonnet
+++ b/etcd-operator/etcd-cluster.libsonnet
@@ -1,5 +1,6 @@
 {
-  local podAntiAffinity = $.apps.v1.deployment.mixin.spec.template.spec.affinity.podAntiAffinity,
+  local podAntiAffinity = $.apps.v1.deployment.spec.template.spec.affinity.podAntiAffinity,
+  local podAffinityTerm = $.core.v1.podAffinityTerm,
 
   etcd_cluster(name, size=3, version='3.3.13', env=[]):: {
     apiVersion: 'etcd.database.coreos.com/v1beta2',
@@ -15,9 +16,8 @@
       version: version,
       pod:
         podAntiAffinity.withRequiredDuringSchedulingIgnoredDuringExecution([
-          podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecutionType.new() +
-          podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecutionType.mixin.labelSelector.withMatchLabels({ etcd_cluster: name }) +
-          podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecutionType.withTopologyKey('kubernetes.io/hostname'),
+          podAffinityTerm.labelSelector.withMatchLabels({ etcd_cluster: name }) +
+          podAffinityTerm.withTopologyKey('kubernetes.io/hostname'),
         ]).spec.template.spec
         {
           labels: { name: name },

--- a/etcd-operator/operator.libsonnet
+++ b/etcd-operator/operator.libsonnet
@@ -3,33 +3,29 @@
     operator: 'quay.io/coreos/etcd-operator:v0.9.4',
   },
 
-  local policyRule = $.rbac.v1beta1.policyRule,
+  local policyRule = $.rbac.v1.policyRule,
 
   operator_rbac:
     $.util.rbac('etcd-operator', [
-      policyRule.new() +
       policyRule.withApiGroups(['etcd.database.coreos.com']) +
       policyRule.withResources(['etcdclusters', 'etcdbackups', 'etcdrestores']) +
       policyRule.withVerbs(['*']),
 
-      policyRule.new() +
       policyRule.withApiGroups(['apiextensions.k8s.io']) +
       policyRule.withResources(['customresourcedefinitions']) +
       policyRule.withVerbs(['*']),
 
-      policyRule.new() +
       policyRule.withApiGroups(['']) +
       policyRule.withResources(['pods', 'services', 'endpoints', 'persistentvolumeclaims', 'events']) +
       policyRule.withVerbs(['*']),
 
-      policyRule.new() +
       policyRule.withApiGroups(['apps']) +
       policyRule.withResources(['deployments']) +
       policyRule.withVerbs(['*']),
     ]),
 
   local container = $.core.v1.container,
-  local env = container.envType,
+  local env = $.core.v1.envVar,
   operator_container::
     container.new('operator', $._images.operator) +
     container.withCommand(['etcd-operator']) +
@@ -46,5 +42,5 @@
 
   operator_deployment:
     deployment.new('etcd-operator', 1, [$.operator_container]) +
-    deployment.mixin.spec.template.spec.withServiceAccount('etcd-operator'),
+    deployment.spec.template.spec.withServiceAccount('etcd-operator'),
 }


### PR DESCRIPTION
Uses:
core.v1.podAffinityTerm
core.v1.envVar
rbac.v1.policyRule

removes .mixin

works with k8s-alpha