### PR TITLE
Split prom configmap into three

### DIFF
--- a/prometheus-ksonnet/lib/prometheus-config.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus-config.libsonnet
@@ -5,8 +5,8 @@
     },
 
     rule_files: [
-      'alerts.rules',
-      'recording.rules',
+      'alerts/rules',
+      'recording/rules',
     ],
 
     alerting: {

--- a/prometheus-ksonnet/lib/prometheus-config.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus-config.libsonnet
@@ -5,8 +5,8 @@
     },
 
     rule_files: [
-      'alerts/rules',
-      'recording/rules',
+      'alerts/alerts.rules',
+      'recording/recording.rules',
     ],
 
     alerting: {

--- a/prometheus-ksonnet/lib/prometheus-configmap.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus-configmap.libsonnet
@@ -28,7 +28,7 @@
           'alerts.rules': $.util.manifestYaml(prometheusAlerts),
         }),
 
-        configMap.new('%s-rules' % self.name) +
+        configMap.new('%s-recording' % self.name) +
         configMap.withData({
           'recording.rules': $.util.manifestYaml(prometheusRules),
         }),

--- a/prometheus-ksonnet/lib/prometheus-configmap.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus-configmap.libsonnet
@@ -11,18 +11,27 @@
 
     local configMap = $.core.v1.configMap,
 
-    prometheus_config_map:
+    prometheus_config_maps:
       // Can't reference self.foo below as we're in a map context, so
       // need to capture reference to the configs in scope here.
       local prometheus_config = self.prometheus_config;
       local prometheusAlerts = self.prometheusAlerts;
       local prometheusRules = self.prometheusRules;
+      [
+        configMap.new('%s-config' % self.name) +
+        configMap.withData({
+          'prometheus.yml': $.util.manifestYaml(prometheus_config),
+        }),
 
-      configMap.new('%s-config' % self.name) +
-      configMap.withData({
-        'prometheus.yml': $.util.manifestYaml(prometheus_config),
-        'alerts.rules': $.util.manifestYaml(prometheusAlerts),
-        'recording.rules': $.util.manifestYaml(prometheusRules),
-      }),
+        configMap.new('%s-alerts' % self.name) +
+        configMap.withData({
+          'alerts.rules': $.util.manifestYaml(prometheusAlerts),
+        }),
+
+        configMap.new('%s-rules' % self.name) +
+        configMap.withData({
+          'recording.rules': $.util.manifestYaml(prometheusRules),
+        }),
+      ],
   },
 }

--- a/prometheus-ksonnet/lib/prometheus-ha-mixin.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus-ha-mixin.libsonnet
@@ -50,40 +50,40 @@ local configMap = k.core.v1.configMap;
   },
 
   prometheus_config_maps: [
-    configMap.new('%s-config-0' % self.name) +
+    configMap.new('%s-0-config' % self.name) +
     configMap.withData({
       'prometheus.yml': k.util.manifestYaml(root.prometheus_zero.config),
     }),
-    configMap.new('%s-alerts-0' % self.name) +
+    configMap.new('%s-0-alerts' % self.name) +
     configMap.withData({
       'alerts.rules': k.util.manifestYaml(root.prometheus_zero.alerts),
     }),
-    configMap.new('%s-recording-0' % self.name) +
+    configMap.new('%s-0-recording' % self.name) +
     configMap.withData({
       'recording.rules': k.util.manifestYaml(root.prometheus_zero.rules),
     }),
 
-    configMap.new('%s-config-1' % self.name) +
+    configMap.new('%s-1-config' % self.name) +
     configMap.withData({
       'prometheus.yml': k.util.manifestYaml(root.prometheus_one.config),
     }),
-    configMap.new('%s-alerts-1' % self.name) +
+    configMap.new('%s-1-alerts' % self.name) +
     configMap.withData({
       'alerts.rules': k.util.manifestYaml(root.prometheus_one.alerts),
     }),
-    configMap.new('%s-recording-1' % self.name) +
+    configMap.new('%s-1-recording' % self.name) +
     configMap.withData({
       'recording.rules': k.util.manifestYaml(root.prometheus_one.rules),
     }),
   ],
 
   prometheus_config_mount::
-    k.util.configVolumeMount('%s-config-0' % self.name, '/etc/prometheus-0')
-    + k.util.configVolumeMount('%s-alerts-0' % self.name, '/etc/prometheus-0/alerts')
-    + k.util.configVolumeMount('%s-recording-0' % self.name, '/etc/prometheus-0/recording')
-    + k.util.configVolumeMount('%s-config-1' % self.name, '/etc/prometheus-1')
-    + k.util.configVolumeMount('%s-alerts-1' % self.name, '/etc/prometheus-1/alerts')
-    + k.util.configVolumeMount('%s-recording-1' % self.name, '/etc/prometheus-1/recording')
+    k.util.configVolumeMount('%s-0-config' % self.name, '/etc/prometheus-0')
+    + k.util.configVolumeMount('%s-0-alerts' % self.name, '/etc/prometheus-0/alerts')
+    + k.util.configVolumeMount('%s-0-recording' % self.name, '/etc/prometheus-0/recording')
+    + k.util.configVolumeMount('%s-1-config' % self.name, '/etc/prometheus-1')
+    + k.util.configVolumeMount('%s-1-alerts' % self.name, '/etc/prometheus-1/alerts')
+    + k.util.configVolumeMount('%s-1-recording' % self.name, '/etc/prometheus-1/recording')
   ,
 
   prometheus_container+:: container.withEnv([

--- a/prometheus-ksonnet/lib/prometheus-ha-mixin.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus-ha-mixin.libsonnet
@@ -29,7 +29,7 @@ local configMap = k.core.v1.configMap;
     config+:: root.prometheus_config {
       global+: {
         external_labels+: {
-          __replica__: 'zero',
+          __replica__: 'prometheus-0',
         },
       },
     },
@@ -41,7 +41,7 @@ local configMap = k.core.v1.configMap;
     config+:: root.prometheus_config {
       global+: {
         external_labels+: {
-          __replica__: 'one',
+          __replica__: 'prometheus-1',
         },
       },
     },

--- a/prometheus-ksonnet/lib/prometheus-ha-mixin.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus-ha-mixin.libsonnet
@@ -58,7 +58,7 @@ local configMap = k.core.v1.configMap;
     configMap.withData({
       'alerts.rules': k.util.manifestYaml(root.prometheus_zero.alerts),
     }),
-    configMap.new('%s-rules-0' % self.name) +
+    configMap.new('%s-recording-0' % self.name) +
     configMap.withData({
       'recording.rules': k.util.manifestYaml(root.prometheus_zero.rules),
     }),
@@ -71,7 +71,7 @@ local configMap = k.core.v1.configMap;
     configMap.withData({
       'alerts.rules': k.util.manifestYaml(root.prometheus_one.alerts),
     }),
-    configMap.new('%s-rules-1' % self.name) +
+    configMap.new('%s-recording-1' % self.name) +
     configMap.withData({
       'recording.rules': k.util.manifestYaml(root.prometheus_one.rules),
     }),
@@ -80,10 +80,10 @@ local configMap = k.core.v1.configMap;
   prometheus_config_mount::
     k.util.configVolumeMount('%s-config-0' % self.name, '/etc/prometheus-0')
     + k.util.configVolumeMount('%s-alerts-0' % self.name, '/etc/prometheus-0/alerts')
-    + k.util.configVolumeMount('%s-rules-0' % self.name, '/etc/prometheus-0/rules')
+    + k.util.configVolumeMount('%s-recording-0' % self.name, '/etc/prometheus-0/recording')
     + k.util.configVolumeMount('%s-config-1' % self.name, '/etc/prometheus-1')
     + k.util.configVolumeMount('%s-alerts-1' % self.name, '/etc/prometheus-1/alerts')
-    + k.util.configVolumeMount('%s-rules-1' % self.name, '/etc/prometheus-1/rules')
+    + k.util.configVolumeMount('%s-recording-1' % self.name, '/etc/prometheus-1/recording')
   ,
 
   prometheus_container+:: container.withEnv([

--- a/prometheus-ksonnet/lib/prometheus.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus.libsonnet
@@ -75,7 +75,10 @@
     local volumeMount = $.core.v1.volumeMount,
 
     prometheus_config_mount::
-      $.util.configVolumeMount('%s-config' % self.name, _config.prometheus_config_dir),
+      $.util.configVolumeMount('%s-config' % self.name, _config.prometheus_config_dir)
+      + $.util.configVolumeMount('%s-alerts' % self.name, _config.prometheus_config_dir + '/alerts')
+      + $.util.configVolumeMount('%s-rules' % self.name, _config.prometheus_config_dir + '/recording')
+    ,
 
     prometheus_statefulset:
       statefulset.new(self.name, 1, [

--- a/prometheus-ksonnet/lib/prometheus.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus.libsonnet
@@ -77,7 +77,7 @@
     prometheus_config_mount::
       $.util.configVolumeMount('%s-config' % self.name, _config.prometheus_config_dir)
       + $.util.configVolumeMount('%s-alerts' % self.name, _config.prometheus_config_dir + '/alerts')
-      + $.util.configVolumeMount('%s-rules' % self.name, _config.prometheus_config_dir + '/recording')
+      + $.util.configVolumeMount('%s-rules' % self.name, _config.prometheus_config_dir + '/rules')
     ,
 
     prometheus_statefulset:

--- a/prometheus-ksonnet/lib/prometheus.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus.libsonnet
@@ -77,7 +77,7 @@
     prometheus_config_mount::
       $.util.configVolumeMount('%s-config' % self.name, _config.prometheus_config_dir)
       + $.util.configVolumeMount('%s-alerts' % self.name, _config.prometheus_config_dir + '/alerts')
-      + $.util.configVolumeMount('%s-rules' % self.name, _config.prometheus_config_dir + '/rules')
+      + $.util.configVolumeMount('%s-recording' % self.name, _config.prometheus_config_dir + '/recording')
     ,
 
     prometheus_statefulset:


### PR DESCRIPTION
This patch puts prometheus.yml, alerts.rules and recording.rules into their own configmaps.

My previous attempt (#317) at fixing the config-map full issue for Prometheus was great in theory, but our config consuming it was too complicated for me to roll this out in short order.

Therefore, this is a much simpler version. It does not buy us as much time, but it allows for a doubling of the size of our configs, which is worth having.

This has been tested to the point of `tk show` looking correct, so far.