### PR TITLE
fix(helm-util): correctly refer to defaultLabels

### DIFF
--- a/helm-util/helm.libsonnet
+++ b/helm-util/helm.libsonnet
@@ -30,7 +30,7 @@ local d = import 'github.com/sh0rez/docsonnet/doc-util/main.libsonnet';
   template(name, chart, conf={})::
     this.patchLabels(
       std.native('helmTemplate')(name, chart, conf),
-      defaultLabels
+      this.defaultLabels
     ),
 
   '#patchKubernetesObjects':: d.fn(


### PR DESCRIPTION
Current impl assumes it's a local, which it is not. Renders the package unusable at the moment