### PR TITLE
Configure securityContext for AlertManager statefulset.

### DIFF
--- a/prometheus-ksonnet/lib/alertmanager.libsonnet
+++ b/prometheus-ksonnet/lib/alertmanager.libsonnet
@@ -150,6 +150,9 @@
     ], self.alertmanager_pvc) +
     statefulset.mixin.spec.withServiceName('alertmanager') +
     statefulset.mixin.spec.template.metadata.withAnnotations({ 'prometheus.io.path': '%smetrics' % $._config.alertmanager_path }) +
+    statefulset.mixin.spec.template.spec.securityContext.withFsGroup(2000) +
+    statefulset.mixin.spec.template.spec.securityContext.withRunAsUser(1000) +
+    statefulset.mixin.spec.template.spec.securityContext.withRunAsNonRoot(true) +
     $.util.configVolumeMount('alertmanager-config', '/etc/alertmanager/config') +
     $.util.podPriority('critical')
   else {},


### PR DESCRIPTION
AlertManager became a non-root image some time ago. Since in StatefulSet
variant it writes some state to an external PV, which is usually
ext4-formatted and root-owned, this prevents AM from writing to the PV.

Prometheus had a similar issue which has been resolved by adding
`securityContext` to the StatefulSet in https://github.com/grafana/jsonnet-libs/pull/244; let's do the same for
AlertManager.