### PR TITLE
Revert "Add namespace to service."

### DIFF
--- a/ksonnet-util/kausal.libsonnet
+++ b/ksonnet-util/kausal.libsonnet
@@ -248,8 +248,7 @@ k {
         labels,  // selector
         ports,
       ) +
-      service.mixin.metadata.withLabels({ name: deployment.metadata.name }) +
-      service.mixin.metadata.withNamespace($._config.namespace),
+      service.mixin.metadata.withLabels({ name: deployment.metadata.name }),
 
     // rbac creates a service account, role and role binding with the given
     // name and rules.


### PR DESCRIPTION
This reverts commit 3e0083b7bb06ee9b618b71220b3fc31ba29faf5f.

Unfortunately adding namespace to the service made it difficult to use `serviceFor` without importing kausal.libsonnet into the root object, which not everybody does.