### PR TITLE
Configure Grafana outside grafana lib

### DIFF
--- a/prometheus-ksonnet/grafana/config.libsonnet
+++ b/prometheus-ksonnet/grafana/config.libsonnet
@@ -1,4 +1,23 @@
 {
+  _config+:: {
+    admin_services+:: [
+      {
+        title: 'Grafana (Light)',
+        path: 'grafana',
+        params: '/?search=open&theme=light',
+        url: 'http://grafana.%(namespace)s.svc.%(cluster_dns_suffix)s/' % $._config,
+        allowWebsockets: true,
+      },
+      {
+        title: 'Grafana (Dark)',
+        path: 'grafana',
+        params: '/?search=open&theme=dark',
+        url: 'http://grafana.%(namespace)s.svc.%(cluster_dns_suffix)s/' % $._config,
+        allowWebsockets: true,
+      },
+    ],
+  },
+
   grafana_config:: {
     sections: {
       'auth.anonymous': {

--- a/prometheus-ksonnet/grafana/deployment.libsonnet
+++ b/prometheus-ksonnet/grafana/deployment.libsonnet
@@ -1,13 +1,7 @@
 {
-  grafanaDatasources+:: {
-    'prometheus.yml': $.grafana_datasource('prometheus',
-                                           'http://prometheus.%(namespace)s.svc.%(cluster_dns_suffix)s%(prometheus_web_route_prefix)s' % $._config,
-                                           default=true),
-  },
-
   _config+:: {
     // Grafana config options.
-    grafana_root_url: 'http://nginx.%(namespace)s.svc.%(cluster_dns_suffix)s/grafana' % self,
+    grafana_root_url: '',
     grafana_provisioning_dir: '/etc/grafana/provisioning',
 
     // Optionally shard dashboards into multiple config maps.

--- a/prometheus-ksonnet/lib/config.libsonnet
+++ b/prometheus-ksonnet/lib/config.libsonnet
@@ -6,22 +6,11 @@
     cluster_name: error 'must specify cluster name',
     namespace: error 'must specify namespace',
 
+    // Grafana config options.
+    grafana_root_url: 'http://nginx.%(namespace)s.svc.%(cluster_dns_suffix)s/grafana' % self,
+
     // Overrides for the nginx frontend for all these services.
-    admin_services: std.prune([
-      {
-        title: 'Grafana (Light)',
-        path: 'grafana',
-        params: '/?search=open&theme=light',
-        url: 'http://grafana.%(namespace)s.svc.%(cluster_dns_suffix)s/' % $._config,
-        allowWebsockets: true,
-      },
-      {
-        title: 'Grafana (Dark)',
-        path: 'grafana',
-        params: '/?search=open&theme=dark',
-        url: 'http://grafana.%(namespace)s.svc.%(cluster_dns_suffix)s/' % $._config,
-        allowWebsockets: true,
-      },
+    admin_services+: std.prune([
       {
         title: 'Prometheus',
         path: 'prometheus',

--- a/prometheus-ksonnet/lib/datasources.libsonnet
+++ b/prometheus-ksonnet/lib/datasources.libsonnet
@@ -1,0 +1,7 @@
+{
+  grafanaDatasources+:: {
+    'prometheus.yml': $.grafana_datasource('prometheus',
+                                           'http://prometheus.%(namespace)s.svc.%(cluster_dns_suffix)s%(prometheus_web_route_prefix)s' % $._config,
+                                           default=true),
+  },
+}

--- a/prometheus-ksonnet/prometheus-ksonnet.libsonnet
+++ b/prometheus-ksonnet/prometheus-ksonnet.libsonnet
@@ -1,6 +1,7 @@
 (import 'ksonnet-util/kausal.libsonnet') +
 (import 'images.libsonnet') +
 (import 'grafana/grafana.libsonnet') +
+(import 'lib/datasources.libsonnet') +
 (import 'lib/alertmanager.libsonnet') +
 (import 'lib/kube-state-metrics.libsonnet') +
 (import 'lib/nginx.libsonnet') +


### PR DESCRIPTION
We have a library here for installing Grafana that has some really neat features in it. However, this library contains a couple of things that make it specific to a Prometheus case. Therefore, to use it without Prometheus, you have to know that you have to remove things.

This PR switches those to sensible defaults for Grafana, and then moves the Prometheus specific configs into Prometheus specific locations. If you want to use Grafana on its own, you can. If you want to use Grafana with Prometheus, you can. If you want to use Prometheus without Grafana, you can.

This also can act as a precursor to moving the Grafana lib one level up, so that it isn't in the `prometheus-ksonnet` package - it no-longer needs to be there and has a more general purpose value.

This is a no-op on all the clusters I tested. This should also help @jdbaldry I believe!