### PR TITLE
A generic way of mapping k8s label/annotations to prom labels

### DIFF
--- a/prometheus-ksonnet/lib/prometheus-config.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus-config.libsonnet
@@ -171,7 +171,8 @@
             replacement: '__param_$1',
           },
 
-          // Generic mapping of k8s label/annotation to prometheus labels.
+          // Map all K8s labels/annotations starting with
+          // 'prometheus.io/label-' to Prometheus labels.
           {
             regex: '__meta_kubernetes_pod_label_prometheus_io_label_(.+)',
             action: 'labelmap',

--- a/prometheus-ksonnet/lib/prometheus-config.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus-config.libsonnet
@@ -171,6 +171,17 @@
             replacement: '__param_$1',
           },
 
+          // Generic mapping of k8s label/annotation to prometheus labels.
+          {
+            regex: '__meta_kubernetes_pod_label_prometheus_io_label_(.+)',
+            action: 'labelmap'
+          },
+
+          {
+            regex: '__meta_kubernetes_pod_annotation_prometheus_io_label_(.+)',
+            action: 'labelmap'
+          },
+
           // Drop pods with phase Succeeded or Failed
           {
             source_labels: ['__meta_kubernetes_pod_phase'],

--- a/prometheus-ksonnet/lib/prometheus-config.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus-config.libsonnet
@@ -174,12 +174,12 @@
           // Generic mapping of k8s label/annotation to prometheus labels.
           {
             regex: '__meta_kubernetes_pod_label_prometheus_io_label_(.+)',
-            action: 'labelmap'
+            action: 'labelmap',
           },
 
           {
             regex: '__meta_kubernetes_pod_annotation_prometheus_io_label_(.+)',
-            action: 'labelmap'
+            action: 'labelmap',
           },
 
           // Drop pods with phase Succeeded or Failed


### PR DESCRIPTION
This will allow devs to add Prometheus label by exposing k8s labels/annotations in a generic fashion rather than having unique scrape configs. 

ref https://github.com/grafana/hosted-grafana/pull/216