### PR TITLE
fix(cert-manager): set calledFrom explicitly

### DIFF
--- a/cert-manager/main.libsonnet
+++ b/cert-manager/main.libsonnet
@@ -1,5 +1,4 @@
-local helm = (import 'github.com/grafana/jsonnet-libs/helm-util/helm.libsonnet').new(std.thisFile);
-
+local helm = (import 'github.com/grafana/jsonnet-libs/helm-util/helm.libsonnet');
 {
   values:: {
     installCRDs: if $._config.custom_crds then false else true,
@@ -14,6 +13,7 @@ local helm = (import 'github.com/grafana/jsonnet-libs/helm-util/helm.libsonnet')
   local generated = helm.template('cert-manager', './charts/cert-manager', {
     values: $.values,
     namespace: $._config.namespace,
+    calledFrom: std.thisFile,
   }),
 
   // manual generated lib used different labels as selectors


### PR DESCRIPTION
I was getting an error using this with tk 0.12.0-alpha3:

`evaluating jsonnet: RUNTIME ERROR: Field does not exist: new /drone/src/ksonnet/vendor/cert-manager/main.libsonnet:1:14-85`
 
This fixes it.