### PR TITLE
Revert "fix(cert-manager): set calledFrom explicitly"

### DIFF
--- a/cert-manager/main.libsonnet
+++ b/cert-manager/main.libsonnet
@@ -1,4 +1,5 @@
-local helm = (import 'github.com/grafana/jsonnet-libs/helm-util/helm.libsonnet');
+local helm = (import 'github.com/grafana/jsonnet-libs/helm-util/helm.libsonnet').new(std.thisFile);
+
 {
   values:: {
     installCRDs: if $._config.custom_crds then false else true,
@@ -13,7 +14,6 @@ local helm = (import 'github.com/grafana/jsonnet-libs/helm-util/helm.libsonnet')
   local generated = helm.template('cert-manager', './charts/cert-manager', {
     values: $.values,
     namespace: $._config.namespace,
-    calledFrom: std.thisFile,
   }),
 
   // manual generated lib used different labels as selectors


### PR DESCRIPTION
This reverts commit 8d04b4834a47006016a23717a1f72fcca7196836.

The issue this commits fixes was caused by a broken dependency setup, not because of a problem with this library.

`(import "helm...").new(std.thisFile)` is the user-facing API, and our libraries should use that. `calledFrom` is an implementation detail and Tanka gives no stability guarantee on that.