### PR TITLE
Allow patching by name/kind after helm.template

### DIFF
--- a/helm-util/helm.libsonnet
+++ b/helm-util/helm.libsonnet
@@ -51,7 +51,7 @@ local d = import 'github.com/sh0rez/docsonnet/doc-util/main.libsonnet';
     then
       // a Kubernetes object is characterized by having an apiVersion and Kind
       if std.objectHas(object, 'apiVersion') && std.objectHas(object, 'kind')
-         && (kind == null || object.kind == std.trace('%s: %s' % [object.kind, kind], kind)) && (name == null || object.metadata.name == name)
+         && (kind == null || object.kind == kind) && (name == null || object.metadata.name == name)
       then object + patch
       else
         std.mapWithKey(

--- a/helm-util/helm.libsonnet
+++ b/helm-util/helm.libsonnet
@@ -46,23 +46,24 @@ local d = import 'github.com/sh0rez/docsonnet/doc-util/main.libsonnet';
       d.arg('patch', d.T.object),
     ]
   ),
-  patchKubernetesObjects(object, patch)::
+  patchKubernetesObjects(object, patch, kind=null, name=null)::
     if std.isObject(object)
     then
       // a Kubernetes object is characterized by having an apiVersion and Kind
       if std.objectHas(object, 'apiVersion') && std.objectHas(object, 'kind')
+         && (kind == null || object.kind == std.trace('%s: %s' % [object.kind, kind], kind)) && (name == null || object.metadata.name == name)
       then object + patch
       else
         std.mapWithKey(
           function(key, obj)
-            this.patchKubernetesObjects(obj, patch),
+            this.patchKubernetesObjects(obj, patch, kind, name),
           object
         )
     else if std.isArray(object)
     then
       std.map(
         function(obj)
-          this.patchKubernetesObjects(obj, patch),
+          this.patchKubernetesObjects(obj, patch, kind, name),
         object
       )
     else object,


### PR DESCRIPTION
Currently, `patchKubernetesObjects` patches *all* objects. I want to add a node-selector to all StatefulSets. This PR adds an optional `kind` and `name` elements which allow us to patch specific resources rather than all of them.
