### PR TITLE
fix(prometheus-ksonnet): kube-dns is now prefixed

### DIFF
--- a/prometheus-ksonnet/mixins.libsonnet
+++ b/prometheus-ksonnet/mixins.libsonnet
@@ -16,6 +16,7 @@
           kubeControllerManagerSelector: 'job="kube-system/kube-controller-manager"',
           kubeApiserverSelector: 'job="kube-system/kube-apiserver"',
           podLabel: 'instance',
+          notKubeDnsCoreDnsSelector: 'job!~"kube-system/kube-dns|coredns"',
         },
       },
 


### PR DESCRIPTION
The scrape config was changed (#344), this makes sure the
KubeVersionMismatch warning stops firing.