### PR TITLE
feat(cert-manager): add aks-mixin

### DIFF
--- a/cert-manager/README.md
+++ b/cert-manager/README.md
@@ -3,3 +3,13 @@
 This jsonnet lib renders the cert-manager Helm chart with a few Grafana specific overrides.
 
 It depends on the helmraiser functionality available in tanka>=0.12.0-alpha1.
+
+## AKS
+
+`aks-mixin.libsonnet` is a mixin which adds a namespaceSelector to exclude control-plane namespaces. This selector gets
+added automatically by AKS after applying, by using this mixin, we can prevent a diff.
+
+References:
+
+* https://github.com/Azure/AKS/issues/1771
+* https://docs.microsoft.com/en-us/azure/aks/faq#can-i-use-admission-controller-webhooks-on-aks

--- a/cert-manager/aks-mixin.libsonnet
+++ b/cert-manager/aks-mixin.libsonnet
@@ -1,0 +1,23 @@
+{
+  // This is a mixin which adds a namespaceSelector to exclude control-plane namespaces.
+  // Ref: https://docs.microsoft.com/en-us/azure/aks/faq#can-i-use-admission-controller-webhooks-on-aks
+  // This selector gets added automatically by AKS after applying, by using this mixin, we can prevent a diff.
+  local webhooks = super.labeled.validating_webhook_configuration_cert_manager_webhook.webhooks,
+  labeled+: {
+    validating_webhook_configuration_cert_manager_webhook+: {
+      webhooks: [
+        webhook {
+          namespaceSelector+: {
+            matchExpressions+: [
+              {
+                key: 'control-plane',
+                operator: 'DoesNotExist',
+              },
+            ],
+          },
+        }
+        for webhook in webhooks
+      ],
+    },
+  },
+}


### PR DESCRIPTION
`aks-mixin.libsonnet` is a mixin which adds a namespaceSelector to exclude control-plane namespaces. This selector gets
added automatically by AKS after applying, by using this mixin, we can prevent a diff.

References:

* https://github.com/Azure/AKS/issues/1771
* https://docs.microsoft.com/en-us/azure/aks/faq#can-i-use-admission-controller-webhooks-on-aks