### PR TITLE
Fix pvc creation

### DIFF
--- a/ksonnet-util/kausal.libsonnet
+++ b/ksonnet-util/kausal.libsonnet
@@ -66,7 +66,7 @@ k {
         new(name='')::
           if name != '' then
             if 'new' in super
-            then super.new(name)
+            then super.new() + super.mixin.metadata.withName(name)
             else
               {} + super.mixin.metadata.withName(name)
           else


### PR DESCRIPTION
On a clean tanka project persistentVolumeClaim.new('name') is broken because parent implementation takes no parameters.

```
evaluating jsonnet: RUNTIME ERROR: function expected 0 positional argument(s), but got 1
```
