### PR TITLE
Typo?  I suspect this works with more modern k.libsonnet.

### DIFF
--- a/prometheus-ksonnet/lib/alertmanager.libsonnet
+++ b/prometheus-ksonnet/lib/alertmanager.libsonnet
@@ -173,5 +173,5 @@
           targetPort=$._config.alertmanager_port,
         ),
       ]) +
-      service.spec.withSessionAffinity('ClientIP'),
+      service.mixin.spec.withSessionAffinity('ClientIP'),
 }


### PR DESCRIPTION
Without this I get:

```
% tk diff environments/default
evaluating jsonnet: RUNTIME ERROR: Field does not exist: spec
	/Users/twilkie/Documents/repos/home/tanka/vendor/prometheus-ksonnet/lib/alertmanager.libsonnet:176:7-19	
	During manifestation	
```