### PR TITLE
Add link to dashboard_url if present

### DIFF
--- a/prometheus-ksonnet/lib/alertmanager.libsonnet
+++ b/prometheus-ksonnet/lib/alertmanager.libsonnet
@@ -42,6 +42,11 @@
             text: 'Silence :no_bell:',
             url: '{{ template "__alert_silence_link" . }}',
           },
+          {
+            type: 'button',
+            text: 'Dashboard :grafana:',
+            url: '{{ (index .Alerts 0).Annotations.dashboard_url }}',
+          },
         ],
       }],
     },


### PR DESCRIPTION
This adds a dashboard link button to slack alerts.

The next step is to build add an util for building dashboard URLs. 