### PR TITLE
Introduce operator for percona-server-mongodb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,1 @@
-.DS_Store
-vendor
-jsonnetfile.lock.json
-*.zip
+.*.sw[op]

--- a/psmdbs-operator/README.md
+++ b/psmdbs-operator/README.md
@@ -1,0 +1,65 @@
+
+# Kubernetes Operator for Percona Server MongoDB
+
+https://www.percona.com/doc/kubernetes-operator-for-psmongodb/kubernetes.html
+
+To use:
+
+```bash
+$ jb install github.com/grafana/jsonnet-libs/psmdbs-operator
+```
+
+```jsonnet
+local percona = (import 'psmdbs-operator/psmdbs-operator.libsonnet');
+{
+  percona: percona {
+    _config+:: {
+      /* Defaults
+      custom_crds: true,
+      percona_enable_default_cluster: true,
+      percona_namespace: 'psmdb',
+      percona_mongodb_backup_user: 'backup',
+      percona_mongodb_backup_password: 'backup123456',
+      percona_mongodb_cluster_admin_user: 'clusterAdmin',
+      percona_mongodb_cluster_admin_password: 'clusterAdmin123456',
+      percona_mongodb_cluster_monitor_user: 'clusterMonitor',
+      percona_mongodb_cluster_monitor_password: 'clusterMonitor123456',
+      percona_mongodb_user_admin_user: 'userAdmin',
+      percona_mongodb_user_admin_password: 'userAdmin123456',
+      percona_mongodb_pmm_server_user: 'pmm',
+      percona_mongodb_pmm_server_password: 'supa|^|pazz',
+      */
+    },
+  },
+}
+```
+
+By default this will install the default cluster as outlined in percona
+docs.
+To disable creating crds, set `custom_crds: false` in the `_config` object.
+
+To create a new custom operator, functions are provided:
+
+```jsonnet
+local percona = (import 'psmdbs-operator/psmdbs-operator.libsonnet');
+{
+  operator: percona {
+    _config+:: {
+      percona_enable_default_cluster: false,
+      // ...
+    },
+    yet_another_example: percona.percona.cluster.new('yet-another', {
+      MONGODB_BACKUP_USER: 'exbackup00',
+      MONGODB_BACKUP_PASSWORD: 'exbackup0012346',
+      MONGODB_USER_ADMIN_USER: 'exuseradmin00',
+      MONGODB_USER_ADMIN_PASSWORD: 'exuseradmin0012346',
+      MONGODB_CLUSTER_ADMIN_USER: 'exclusteradmin00',
+      MONGODB_CLUSTER_ADMIN_PASSWORD: 'exclusteradmin0012346',
+      MONGODB_CLUSTER_MONITOR_USER: 'exmonitor00',
+      MONGODB_CLUSTER_MONITOR_PASSWORD: 'exmonitor0012346',
+      PMM_SERVER_USER: 'pmmuser00',
+      PMM_SERVER_PASSWORD: 'pmuser00',
+    }),
+  },
+}
+```

--- a/psmdbs-operator/files/00-crd.yaml
+++ b/psmdbs-operator/files/00-crd.yaml
@@ -1,0 +1,123 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: perconaservermongodbs.psmdb.percona.com
+spec:
+  group: psmdb.percona.com
+  names:
+    kind: PerconaServerMongoDB
+    listKind: PerconaServerMongoDBList
+    plural: perconaservermongodbs
+    singular: perconaservermongodb
+    shortNames:
+    - psmdb
+  scope: Namespaced
+  versions:
+    - name: v1
+      storage: true
+      served: true
+    - name: v1-1-0
+      storage: false
+      served: true
+    - name: v1-2-0
+      storage: false
+      served: true
+    - name: v1-3-0
+      storage: false
+      served: true
+    - name: v1-4-0
+      storage: false
+      served: true
+    - name: v1-5-0
+      storage: false
+      served: true
+    - name: v1alpha1
+      storage: false
+      served: true
+  additionalPrinterColumns:
+    - name: Status
+      type: string
+      JSONPath: .status.state
+    - name: Age
+      type: date
+      JSONPath: .metadata.creationTimestamp
+  subresources:
+    status: {}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: perconaservermongodbbackups.psmdb.percona.com
+spec:
+  group: psmdb.percona.com
+  names:
+    kind: PerconaServerMongoDBBackup
+    listKind: PerconaServerMongoDBBackupList
+    plural: perconaservermongodbbackups
+    singular: perconaservermongodbbackup
+    shortNames:
+    - psmdb-backup
+  scope: Namespaced
+  versions:
+    - name: v1
+      storage: true
+      served: true
+  additionalPrinterColumns:
+    - name: Cluster
+      type: string
+      description: Cluster name
+      JSONPath: .spec.psmdbCluster
+    - name: Storage
+      type: string
+      description: Storage name from pxc spec
+      JSONPath: .spec.storageName
+    - name: Destination
+      type: string
+      description: Backup destination
+      JSONPath: .status.destination
+    - name: Status
+      type: string
+      description: Job status
+      JSONPath: .status.state
+    - name: Completed
+      description: Completed time
+      type: date
+      JSONPath: .status.completed
+    - name: Age
+      type: date
+      JSONPath: .metadata.creationTimestamp
+  subresources:
+    status: {}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: perconaservermongodbrestores.psmdb.percona.com
+spec:
+  group: psmdb.percona.com
+  names:
+    kind: PerconaServerMongoDBRestore
+    listKind: PerconaServerMongoDBRestoreList
+    plural: perconaservermongodbrestores
+    singular: perconaservermongodbrestore
+    shortNames:
+    - psmdb-restore
+  scope: Namespaced
+  versions:
+    - name: v1
+      storage: true
+      served: true
+  additionalPrinterColumns:
+    - name: Cluster
+      type: string
+      description: Cluster name
+      JSONPath: .spec.clusterName
+    - name: Status
+      type: string
+      description: Job status
+      JSONPath: .status.state
+    - name: Age
+      type: date
+      JSONPath: .metadata.creationTimestamp
+  subresources:
+    status: {}

--- a/psmdbs-operator/psmdbs-operator.libsonnet
+++ b/psmdbs-operator/psmdbs-operator.libsonnet
@@ -1,0 +1,460 @@
+local k = import 'ksonnet-util/kausal.libsonnet';
+k {
+  _config+:: {
+    custom_crds: true,
+    percona_enable_default_cluster: true,
+    percona_namespace: 'psmdb',
+    percona_mongodb_backup_user: 'backup',
+    percona_mongodb_backup_password: 'backup123456',
+    percona_mongodb_cluster_admin_user: 'clusterAdmin',
+    percona_mongodb_cluster_admin_password: 'clusterAdmin123456',
+    percona_mongodb_cluster_monitor_user: 'clusterMonitor',
+    percona_mongodb_cluster_monitor_password: 'clusterMonitor123456',
+    percona_mongodb_user_admin_user: 'userAdmin',
+    percona_mongodb_user_admin_password: 'userAdmin123456',
+    percona_mongodb_pmm_server_user: 'pmm',
+    percona_mongodb_pmm_server_password: 'supa|^|pazz',
+  },
+
+  local secret = $.core.v1.secret,
+
+  percona: {
+    percona_namespace: {
+      apiVersion: 'v1',
+      kind: 'Namespace',
+      metadata: {
+        name: $._config.percona_namespace,
+      },
+    },
+    cluster:: {
+      new(name, config)::
+        {
+          local secret_name = '%s-secrets' % name,
+          secret: $.percona.cluster.percona_cluster_secrets.new(secret_name, $.percona.cluster.utils.withCreds(config)),
+          server: $.percona.cluster.percona_server.new(name, secret_name),
+        },
+
+      utils: {
+        withCreds(creds):: {
+          MONGODB_BACKUP_USER: std.base64(creds.MONGODB_BACKUP_USER),
+          MONGODB_BACKUP_PASSWORD: std.base64(creds.MONGODB_BACKUP_PASSWORD),
+          MONGODB_CLUSTER_ADMIN_USER: std.base64(creds.MONGODB_CLUSTER_ADMIN_USER),
+          MONGODB_CLUSTER_ADMIN_PASSWORD: std.base64(creds.MONGODB_CLUSTER_ADMIN_PASSWORD),
+          MONGODB_CLUSTER_MONITOR_USER: std.base64(creds.MONGODB_CLUSTER_MONITOR_USER),
+          MONGODB_CLUSTER_MONITOR_PASSWORD: std.base64(creds.MONGODB_CLUSTER_MONITOR_PASSWORD),
+          MONGODB_USER_ADMIN_USER: std.base64(creds.MONGODB_USER_ADMIN_USER),
+          MONGODB_USER_ADMIN_PASSWORD: std.base64(creds.MONGODB_USER_ADMIN_PASSWORD),
+          PMM_SERVER_USER: std.base64(creds.PMM_SERVER_USER),
+          PMM_SERVER_PASSWORD: std.base64(creds.PMM_SERVER_PASSWORD),
+        },
+      },
+      percona_cluster_secrets::
+        secret.new('my-cluster-name-secrets',
+                   {
+                     MONGODB_BACKUP_USER: std.base64($._config.percona_mongodb_backup_user),
+                     MONGODB_BACKUP_PASSWORD: std.base64($._config.percona_mongodb_backup_password),
+                     MONGODB_CLUSTER_ADMIN_USER: std.base64($._config.percona_mongodb_cluster_admin_user),
+                     MONGODB_CLUSTER_ADMIN_PASSWORD: std.base64($._config.percona_mongodb_cluster_admin_password),
+                     MONGODB_CLUSTER_MONITOR_USER: std.base64($._config.percona_mongodb_cluster_monitor_user),
+                     MONGODB_CLUSTER_MONITOR_PASSWORD: std.base64($._config.percona_mongodb_cluster_monitor_password),
+                     MONGODB_USER_ADMIN_USER: std.base64($._config.percona_mongodb_user_admin_user),
+                     MONGODB_USER_ADMIN_PASSWORD: std.base64($._config.percona_mongodb_user_admin_password),
+                     PMM_SERVER_USER: std.base64($._config.percona_mongodb_pmm_server_user),
+                     PMM_SERVER_PASSWORD: std.base64($._config.percona_mongodb_pmm_server_password),
+                   }) +
+        {
+          metadata+: { namespace: $._config.percona_namespace },
+          new(name, data)::
+            super.new(name, data) +
+            { metadata+: { namespace: $._config.percona_namespace } },
+        },
+      percona_server:: {
+        new(name, secret_name)::
+          local security_key_name = '%s-mongodb-encryption-key' % name;
+          self + { metadata+: { name: name } } +
+          $.percona.cluster.percona_server.withSecret(secret_name) +
+          $.percona.cluster.percona_server.withSecurityPolicy(security_key_name),
+        withSecurityPolicy(name)::
+          { spec+: { mongod+: { security+: { encryptionKeySecret: name } } } },
+        withSecret(name)::
+          { spec+: { secrets+: { users: name } } },
+        apiVersion: 'psmdb.percona.com/v1-5-0',
+        kind: 'PerconaServerMongoDB',
+        metadata: {
+          name: 'my-cluster-name',
+          namespace: $._config.percona_namespace,
+        },
+        spec: {
+          allowUnsafeConfigurations: false,
+          backup: {
+            enabled: true,
+            image: 'percona/percona-server-mongodb-operator:1.5.0-backup',
+            restartOnFailure: true,
+            serviceAccountName: 'percona-server-mongodb-operator',
+            storages: null,
+            tasks: null,
+          },
+          image: 'percona/percona-server-mongodb:4.2.8-8',
+          imagePullPolicy: 'Always',
+          mongod: {
+            net: {
+              hostPort: 0,
+              port: 27017,
+            },
+            operationProfiling: {
+              mode: 'slowOp',
+              rateLimit: 100,
+              slowOpThresholdMs: 100,
+            },
+            security: {
+              enableEncryption: true,
+              encryptionCipherMode: 'AES256-CBC',
+              encryptionKeySecret: 'my-cluster-name-mongodb-encryption-key',
+              redactClientLogData: false,
+            },
+            setParameter: {
+              ttlMonitorSleepSecs: 60,
+              wiredTigerConcurrentReadTransactions: 128,
+              wiredTigerConcurrentWriteTransactions: 128,
+            },
+            storage: {
+              engine: 'wiredTiger',
+              inMemory: {
+                engineConfig: {
+                  inMemorySizeRatio: 0.9,
+                },
+              },
+              mmapv1: {
+                nsSize: 16,
+                smallfiles: false,
+              },
+              wiredTiger: {
+                collectionConfig: {
+                  blockCompressor: 'snappy',
+                },
+                engineConfig: {
+                  cacheSizeRatio: 0.5,
+                  directoryForIndexes: false,
+                  journalCompressor: 'snappy',
+                },
+                indexConfig: {
+                  prefixCompression: true,
+                },
+              },
+            },
+          },
+          pmm: {
+            enabled: false,
+            image: 'percona/percona-server-mongodb-operator:1.5.0-pmm',
+            serverHost: 'monitoring-service',
+          },
+          replsets: [
+            {
+              affinity: {
+                antiAffinityTopologyKey: 'kubernetes.io/hostname',
+              },
+              arbiter: {
+                affinity: {
+                  antiAffinityTopologyKey: 'kubernetes.io/hostname',
+                },
+                enabled: false,
+                size: 1,
+              },
+              expose: {
+                enabled: false,
+                exposeType: 'LoadBalancer',
+              },
+              name: 'rs0',
+              podDisruptionBudget: {
+                maxUnavailable: 1,
+              },
+              resources: {
+                limits: {
+                  cpu: '300m',
+                  memory: '0.5G',
+                },
+                requests: {
+                  cpu: '300m',
+                  memory: '0.5G',
+                },
+              },
+              size: 3,
+              volumeSpec: {
+                persistentVolumeClaim: {
+                  resources: {
+                    requests: {
+                      storage: '3Gi',
+                    },
+                  },
+                },
+              },
+            },
+          ],
+          secrets: {
+            users: $.percona.cluster.percona_cluster_secrets.metadata.name,
+          },
+          updateStrategy: 'SmartUpdate',
+          upgradeOptions: {
+            apply: 'recommended',
+            schedule: '0 2 * * *',
+            versionServiceEndpoint: 'https://check.percona.com/versions/',
+          },
+        },
+      },
+    },
+  },
+
+  crds:
+    if $._config.custom_crds
+    then std.native('parseYaml')(importstr 'files/00-crd.yaml')
+    else {},
+
+
+  rbacs: {
+    role: {
+      apiVersion: 'rbac.authorization.k8s.io/v1beta1',
+      kind: 'Role',
+      metadata: {
+        namespace: $._config.percona_namespace,
+        name: 'percona-server-mongodb-operator',
+      },
+      rules: [
+        {
+          apiGroups: [
+            'psmdb.percona.com',
+          ],
+          resources: [
+            'perconaservermongodbs',
+            'perconaservermongodbs/status',
+            'perconaservermongodbbackups',
+            'perconaservermongodbbackups/status',
+            'perconaservermongodbrestores',
+            'perconaservermongodbrestores/status',
+          ],
+          verbs: [
+            'get',
+            'list',
+            'update',
+            'watch',
+            'create',
+          ],
+        },
+        {
+          apiGroups: [
+            '',
+          ],
+          resources: [
+            'pods',
+            'pods/exec',
+            'services',
+            'persistentvolumeclaims',
+            'secrets',
+            'configmaps',
+          ],
+          verbs: [
+            'get',
+            'list',
+            'watch',
+            'create',
+            'update',
+            'patch',
+            'delete',
+          ],
+        },
+        {
+          apiGroups: [
+            'apps',
+          ],
+          resources: [
+            'deployments',
+            'replicasets',
+            'statefulsets',
+          ],
+          verbs: [
+            'get',
+            'list',
+            'watch',
+            'create',
+            'update',
+            'patch',
+            'delete',
+          ],
+        },
+        {
+          apiGroups: [
+            'batch',
+          ],
+          resources: [
+            'cronjobs',
+          ],
+          verbs: [
+            'get',
+            'list',
+            'watch',
+            'create',
+            'update',
+            'patch',
+            'delete',
+          ],
+        },
+        {
+          apiGroups: [
+            'policy',
+          ],
+          resources: [
+            'poddisruptionbudgets',
+          ],
+          verbs: [
+            'get',
+            'list',
+            'watch',
+            'create',
+            'update',
+            'patch',
+            'delete',
+          ],
+        },
+        {
+          apiGroups: [
+            'certmanager.k8s.io',
+          ],
+          resources: [
+            'issuers',
+            'certificates',
+          ],
+          verbs: [
+            'get',
+            'list',
+            'watch',
+            'create',
+            'update',
+            'patch',
+            'delete',
+            'deletecollection',
+          ],
+        },
+      ],
+    },
+    serviceaccount: {
+      apiVersion: 'v1',
+      kind: 'ServiceAccount',
+      metadata: {
+        namespace: $._config.percona_namespace,
+        name: 'percona-server-mongodb-operator',
+      },
+    },
+    role_binding: {
+      apiVersion: 'rbac.authorization.k8s.io/v1beta1',
+      kind: 'RoleBinding',
+      metadata: {
+        namespace: $._config.percona_namespace,
+        name: 'service-account-percona-server-mongodb-operator',
+      },
+      roleRef: {
+        apiGroup: 'rbac.authorization.k8s.io',
+        kind: 'Role',
+        name: 'percona-server-mongodb-operator',
+      },
+      subjects: [
+        {
+          kind: 'ServiceAccount',
+          name: 'percona-server-mongodb-operator',
+        },
+      ],
+    },
+  },
+
+  operator: {
+    apiVersion: 'apps/v1',
+    kind: 'Deployment',
+    metadata: {
+      namespace: $._config.percona_namespace,
+      name: 'percona-server-mongodb-operator',
+    },
+    spec: {
+      replicas: 1,
+      selector: {
+        matchLabels: {
+          name: 'percona-server-mongodb-operator',
+        },
+      },
+      template: {
+        metadata: {
+          labels: {
+            name: 'percona-server-mongodb-operator',
+          },
+        },
+        spec: {
+          containers: [
+            {
+              command: [
+                'percona-server-mongodb-operator',
+              ],
+              env: [
+                {
+                  name: 'WATCH_NAMESPACE',
+                  valueFrom: {
+                    fieldRef: {
+                      fieldPath: 'metadata.namespace',
+                    },
+                  },
+                },
+                {
+                  name: 'POD_NAME',
+                  valueFrom: {
+                    fieldRef: {
+                      fieldPath: 'metadata.name',
+                    },
+                  },
+                },
+                {
+                  name: 'OPERATOR_NAME',
+                  value: 'percona-server-mongodb-operator',
+                },
+                {
+                  name: 'RESYNC_PERIOD',
+                  value: '5s',
+                },
+                {
+                  name: 'LOG_VERBOSE',
+                  value: 'false',
+                },
+              ],
+              image: 'percona/percona-server-mongodb-operator:1.5.0',
+              imagePullPolicy: 'Always',
+              name: 'percona-server-mongodb-operator',
+              ports: [
+                {
+                  containerPort: 60000,
+                  name: 'metrics',
+                },
+              ],
+            },
+          ],
+          serviceAccountName: 'percona-server-mongodb-operator',
+        },
+      },
+    },
+  },
+
+  default_cluster: if $._config.percona_enable_default_cluster then {
+    secret: $.percona.cluster.percona_cluster_secrets,
+    server: $.percona.cluster.percona_server,
+  } else {},
+
+
+  /*
+  yet_another_example: $.percona.cluster.new('yet-another', {
+    MONGODB_BACKUP_USER: 'exbackup00',
+    MONGODB_BACKUP_PASSWORD: 'exbackup00',
+    MONGODB_USER_ADMIN_USER: 'exuseradmin00',
+    MONGODB_USER_ADMIN_PASSWORD: 'exuseradmin00',
+    MONGODB_CLUSTER_ADMIN_USER: 'exclusteradmin00',
+    MONGODB_CLUSTER_ADMIN_PASSWORD: 'exclusteradmin00',
+    MONGODB_CLUSTER_MONITOR_USER: 'exmonitor00',
+    MONGODB_CLUSTER_MONITOR_PASSWORD: 'exmonitor00',
+    PMM_SERVER_USER: 'pmmuser00',
+    PMM_SERVER_PASSWORD: 'pmuser00',
+  }),
+  */
+}


### PR DESCRIPTION
Here is an operator for percona server mongodb.  It includes a way to use the default cluster, a way to use the default cluster but with just the credentials changed, and an expressive way to create new mongodb clusters.
