### PR TITLE
Wip/bewest/cert manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,1 @@
-.DS_Store
-vendor
-jsonnetfile.lock.json
-*.zip
+.*.sw[op]

--- a/cert-manager/chartfile.yaml
+++ b/cert-manager/chartfile.yaml
@@ -6,5 +6,5 @@ repositories:
   url: https://charts.jetstack.io
 requires:
 - chart: jetstack/cert-manager
-  version: 0.13.0
+  version: 0.14.3
 version: 1

--- a/cert-manager/charts/cert-manager/Chart.yaml
+++ b/cert-manager/charts/cert-manager/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: v0.13.0
+appVersion: v0.14.3
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager
 icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
@@ -14,4 +14,4 @@ maintainers:
 name: cert-manager
 sources:
 - https://github.com/jetstack/cert-manager
-version: v0.13.0
+version: v0.14.3

--- a/cert-manager/charts/cert-manager/README.md
+++ b/cert-manager/charts/cert-manager/README.md
@@ -8,28 +8,32 @@ to renew certificates at an appropriate time before expiry.
 
 ## Prerequisites
 
-- Kubernetes 1.12+
+- Kubernetes 1.11+
 
 ## Installing the Chart
 
 Full installation instructions, including details on how to configure extra
-functionality in cert-manager can be found in the [getting started docs](https://docs.cert-manager.io/en/latest/getting-started/).
+functionality in cert-manager can be found in the [installation docs](https://cert-manager.io/docs/installation/kubernetes/).
+
+Before installing the chart, you must first install the cert-manager CustomResourceDefinition resources.
+This is performed in a separate step to allow you to easily uninstall and reinstall cert-manager without deleting your installed custom resources.
+
+```bash
+# Kubernetes 1.15+
+$ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.14.2/cert-manager.crds.yaml
+
+# Kubernetes <1.15
+$ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.14.2/cert-manager-legacy.crds.yaml
+```
+
+> **Note**: If you're using a Kubernetes version below `v1.15` you will need to install the legacy version of the custom resource definitions.
+> This version does not have API version conversion enabled and only supports `cert-manager.io/v1alpha2` API resources.
 
 To install the chart with the release name `my-release`:
 
 ```console
-## IMPORTANT: you MUST install the cert-manager CRDs **before** installing the
-## cert-manager Helm chart
-$ kubectl apply --validate=false \
-    -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.13/deploy/manifests/00-crds.yaml
-
-## If you are installing on openshift :
-$ oc create \
-    -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.13/deploy/manifests/00-crds.yaml
-
 ## Add the Jetstack Helm repository
 $ helm repo add jetstack https://charts.jetstack.io
-
 
 ## Install the cert-manager helm chart
 $ helm install --name my-release --namespace cert-manager jetstack/cert-manager
@@ -39,23 +43,20 @@ In order to begin issuing certificates, you will need to set up a ClusterIssuer
 or Issuer resource (for example, by creating a 'letsencrypt-staging' issuer).
 
 More information on the different types of issuers and how to configure them
-can be found in our documentation:
-
-https://docs.cert-manager.io/en/latest/tasks/issuers/index.html
+can be found in [our documentation](https://cert-manager.io/docs/configuration/).
 
 For information on how to configure cert-manager to automatically provision
-Certificates for Ingress resources, take a look at the `ingress-shim`
-documentation:
-
-https://docs.cert-manager.io/en/latest/tasks/issuing-certificates/ingress-shim.html
+Certificates for Ingress resources, take a look at the
+[Securing Ingresses documentation](https://cert-manager.io/docs/usage/ingress/).
 
 > **Tip**: List all releases using `helm list`
 
 ## Upgrading the Chart
 
 Special considerations may be required when upgrading the Helm chart, and these
-are documented in our full [upgrading guide](https://docs.cert-manager.io/en/latest/tasks/upgrading/index.html).
-Please check here before perform upgrades!
+are documented in our full [upgrading guide](https://cert-manager.io/docs/installation/upgrading/).
+
+**Please check here before performing upgrades!**
 
 ## Uninstalling the Chart
 
@@ -66,6 +67,17 @@ $ helm delete my-release
 ```
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+If you want to completely uninstall cert-manager from your cluster, you will also need to
+delete the previously installed CustomResourceDefinition resources:
+
+```console
+# Kubernetes 1.15+
+$ kubectl delete -f https://github.com/jetstack/cert-manager/releases/download/v0.14.2/cert-manager.crds.yaml
+
+# Kubernetes <1.15
+$ kubectl delete -f https://github.com/jetstack/cert-manager/releases/download/v0.14.2/cert-manager-legacy.crds.yaml
+```
 
 ## Configuration
 
@@ -80,7 +92,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `global.podSecurityPolicy.useAppArmor` | If `true`, use Apparmor seccomp profile in PSP | `true` |
 | `global.leaderElection.namespace` | Override the namespace used to store the ConfigMap for leader election | `kube-system` |
 | `image.repository` | Image repository | `quay.io/jetstack/cert-manager-controller` |
-| `image.tag` | Image tag | `v0.13.0` |
+| `image.tag` | Image tag | `v0.14.2` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `replicaCount`  | Number of cert-manager replicas  | `1` |
 | `clusterResourceNamespace` | Override the namespace used to store DNS provider credentials etc. for ClusterIssuer resources | Same namespace as cert-manager pod |
@@ -116,8 +128,8 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `http_proxy` | Value of the `HTTP_PROXY` environment variable in the cert-manager pod | |
 | `https_proxy` | Value of the `HTTPS_PROXY` environment variable in the cert-manager pod | |
 | `no_proxy` | Value of the `NO_PROXY` environment variable in the cert-manager pod | |
-| `webhook.enabled` | Toggles whether the validating webhook component should be installed | `true` |
 | `webhook.replicaCount` | Number of cert-manager webhook replicas | `1` |
+| `webhook.serviceName` | The name of the Service resource deployed for the webhook pod | `cert-manager-webhook` |
 | `webhook.podAnnotations` | Annotations to add to the webhook pods | `{}` |
 | `webhook.deploymentAnnotations` | Annotations to add to the webhook deployment | `{}` |
 | `webhook.extraArgs` | Optional flags for cert-manager webhook component | `[]` |
@@ -126,7 +138,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `webhook.affinity` | Node affinity for webhook pod assignment | `{}` |
 | `webhook.tolerations` | Node tolerations for webhook pod assignment | `[]` |
 | `webhook.image.repository` | Webhook image repository | `quay.io/jetstack/cert-manager-webhook` |
-| `webhook.image.tag` | Webhook image tag | `v0.13.0` |
+| `webhook.image.tag` | Webhook image tag | `v0.14.2` |
 | `webhook.image.pullPolicy` | Webhook image pull policy | `IfNotPresent` |
 | `webhook.injectAPIServerCA` | if true, the apiserver's CABundle will be automatically injected into the ValidatingWebhookConfiguration resource | `true` |
 | `webhook.securePort` | The port that the webhook should listen on for requests. | `10250` |
@@ -141,7 +153,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `cainjector.affinity` | Node affinity for cainjector pod assignment | `{}` |
 | `cainjector.tolerations` | Node tolerations for cainjector pod assignment | `[]` |
 | `cainjector.image.repository` | cainjector image repository | `quay.io/jetstack/cert-manager-cainjector` |
-| `cainjector.image.tag` | cainjector image tag | `v0.13.0` |
+| `cainjector.image.tag` | cainjector image tag | `v0.14.2` |
 | `cainjector.image.pullPolicy` | cainjector image pull policy | `IfNotPresent` |
 | `cainjector.securityContext` | Security context for cainjector pod assignment | `{}` |
 

--- a/cert-manager/charts/cert-manager/templates/NOTES.txt
+++ b/cert-manager/charts/cert-manager/templates/NOTES.txt
@@ -6,10 +6,10 @@ or Issuer resource (for example, by creating a 'letsencrypt-staging' issuer).
 More information on the different types of issuers and how to configure them
 can be found in our documentation:
 
-https://docs.cert-manager.io/en/latest/reference/issuers.html
+https://cert-manager.io/docs/configuration/
 
 For information on how to configure cert-manager to automatically provision
 Certificates for Ingress resources, take a look at the `ingress-shim`
 documentation:
 
-https://docs.cert-manager.io/en/latest/reference/ingress-shim.html
+https://cert-manager.io/docs/usage/ingress/

--- a/cert-manager/charts/cert-manager/templates/cainjector-deployment.yaml
+++ b/cert-manager/charts/cert-manager/templates/cainjector-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.cainjector.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -8,6 +9,7 @@ metadata:
     app.kubernetes.io/name: {{ include "cainjector.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: "cainjector"
     helm.sh/chart: {{ include "cainjector.chart" . }}
   {{- if .Values.cainjector.deploymentAnnotations }}
   annotations:
@@ -17,10 +19,9 @@ spec:
   replicas: {{ .Values.cainjector.replicaCount }}
   selector:
     matchLabels:
-      app: {{ include "cainjector.name" . }}
       app.kubernetes.io/name: {{ include "cainjector.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
-      app.kubernetes.io/managed-by: {{ .Release.Service }}
+      app.kubernetes.io/component: "cainjector"
   {{- with .Values.cainjector.strategy }}
   strategy:
     {{- . | toYaml | nindent 4 }}
@@ -32,6 +33,7 @@ spec:
         app.kubernetes.io/name: {{ include "cainjector.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/component: "cainjector"
         helm.sh/chart: {{ include "cainjector.chart" . }}
       annotations:
       {{- if .Values.cainjector.podAnnotations }}
@@ -77,3 +79,4 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+{{- end -}}

--- a/cert-manager/charts/cert-manager/templates/cainjector-psp-clusterrole.yaml
+++ b/cert-manager/charts/cert-manager/templates/cainjector-psp-clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.cainjector.enabled -}}
 {{- if .Values.global.podSecurityPolicy.enabled }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -5,13 +6,16 @@ metadata:
   name: {{ template "cainjector.fullname" . }}-psp
   labels:
     app: {{ include "cainjector.name" . }}
-    chart: {{ include "cainjector.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "cainjector.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: "cainjector"
+    helm.sh/chart: {{ include "cainjector.chart" . }}
 rules:
 - apiGroups: ['policy']
   resources: ['podsecuritypolicies']
   verbs:     ['use']
   resourceNames:
   - {{ template "cainjector.fullname" . }}
+{{- end }}
 {{- end }}

--- a/cert-manager/charts/cert-manager/templates/cainjector-psp-clusterrolebinding.yaml
+++ b/cert-manager/charts/cert-manager/templates/cainjector-psp-clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.cainjector.enabled -}}
 {{- if .Values.global.podSecurityPolicy.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -5,9 +6,11 @@ metadata:
   name: {{ template "cainjector.fullname" . }}-psp
   labels:
     app: {{ include "cainjector.name" . }}
-    chart: {{ include "cainjector.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "cainjector.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: "cainjector"
+    helm.sh/chart: {{ include "cainjector.chart" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -16,4 +19,5 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "cainjector.fullname" . }}
     namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end }}

--- a/cert-manager/charts/cert-manager/templates/cainjector-psp.yaml
+++ b/cert-manager/charts/cert-manager/templates/cainjector-psp.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.cainjector.enabled -}}
 {{- if .Values.global.podSecurityPolicy.enabled }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
@@ -5,9 +6,11 @@ metadata:
   name: {{ template "cainjector.fullname" . }}
   labels:
     app: {{ include "cainjector.name" . }}
-    chart: {{ include "cainjector.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "cainjector.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: "cainjector"
+    helm.sh/chart: {{ include "cainjector.chart" . }}
   annotations:
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
     seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
@@ -45,4 +48,5 @@ spec:
     ranges:
     - min: 1000
       max: 1000
-{{- end }}
+{{- end -}}
+{{- end -}}

--- a/cert-manager/charts/cert-manager/templates/cainjector-rbac.yaml
+++ b/cert-manager/charts/cert-manager/templates/cainjector-rbac.yaml
@@ -1,13 +1,15 @@
+{{- if .Values.cainjector.enabled -}}
 {{- if .Values.global.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: {{ template "cainjector.fullname" . }}
   labels:
-    app: {{ template "cainjector.name" . }}
+    app: {{ include "cainjector.name" . }}
     app.kubernetes.io/name: {{ include "cainjector.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: "cainjector"
     helm.sh/chart: {{ include "cainjector.chart" . }}
 rules:
   - apiGroups: ["cert-manager.io"]
@@ -34,10 +36,11 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ template "cainjector.fullname" . }}
   labels:
-    app: {{ template "cainjector.name" . }}
+    app: {{ include "cainjector.name" . }}
     app.kubernetes.io/name: {{ include "cainjector.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: "cainjector"
     helm.sh/chart: {{ include "cainjector.chart" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -56,11 +59,12 @@ metadata:
   name: {{ template "cainjector.fullname" . }}:leaderelection
   namespace: {{ .Values.global.leaderElection.namespace }}
   labels:
-    app: {{ template "cainjector.name" . }}
-    app.kubernetes.io/name: {{ template "cainjector.name" . }}
+    app: {{ include "cainjector.name" . }}
+    app.kubernetes.io/name: {{ include "cainjector.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ template "cainjector.chart" . }}
+    app.kubernetes.io/component: "cainjector"
+    helm.sh/chart: {{ include "cainjector.chart" . }}
 rules:
   # Used for leader election by the controller
   # TODO: refine the permission to *just* the leader election configmap
@@ -82,6 +86,7 @@ metadata:
     app.kubernetes.io/name: {{ include "cainjector.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: "cainjector"
     helm.sh/chart: {{ include "cainjector.chart" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -93,4 +98,5 @@ subjects:
     namespace: {{ .Release.Namespace }}
 
 
+{{- end -}}
 {{- end -}}

--- a/cert-manager/charts/cert-manager/templates/cainjector-serviceaccount.yaml
+++ b/cert-manager/charts/cert-manager/templates/cainjector-serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.cainjector.enabled -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -8,7 +9,9 @@ metadata:
     app.kubernetes.io/name: {{ include "cainjector.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: "cainjector"
     helm.sh/chart: {{ include "cainjector.chart" . }}
 {{- if .Values.global.imagePullSecrets }}
 imagePullSecrets: {{ toYaml .Values.global.imagePullSecrets | nindent 2 }}
 {{- end }}
+{{- end -}}

--- a/cert-manager/charts/cert-manager/templates/deployment.yaml
+++ b/cert-manager/charts/cert-manager/templates/deployment.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: {{ template "cert-manager.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: "controller"
     helm.sh/chart: {{ template "cert-manager.chart" . }}
   {{- if .Values.deploymentAnnotations }}
   annotations:
@@ -17,10 +18,9 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app: {{ template "cert-manager.name" . }}
       app.kubernetes.io/name: {{ template "cert-manager.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
-      app.kubernetes.io/managed-by: {{ .Release.Service }}
+      app.kubernetes.io/component: "controller"
   {{- with .Values.strategy }}
   strategy:
     {{- . | toYaml | nindent 4 }}
@@ -31,6 +31,7 @@ spec:
         app: {{ template "cert-manager.name" . }}
         app.kubernetes.io/name: {{ template "cert-manager.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: "controller"
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         helm.sh/chart: {{ template "cert-manager.chart" . }}
 {{- if .Values.podLabels }}
@@ -54,8 +55,8 @@ spec:
       priorityClassName: {{ .Values.global.priorityClassName | quote }}
       {{- end }}
       {{- $enabledDefined := gt (len (keys (pick .Values.securityContext "enabled"))) 0 }}
-      {{- $legacyEnabledExplicitlydOff := and $enabledDefined (not .Values.securityContext.enabled) }}
-      {{- if and .Values.securityContext (not $legacyEnabledExplicitlydOff) }}
+      {{- $legacyEnabledExplicitlyOff := and $enabledDefined (not .Values.securityContext.enabled) }}
+      {{- if and .Values.securityContext (not $legacyEnabledExplicitlyOff) }}
       securityContext:
         {{- if .Values.securityContext.enabled -}}
         {{/* support legacy securityContext.enabled and its two parameters */}}
@@ -101,7 +102,7 @@ spec:
           - --webhook-namespace=$(POD_NAMESPACE)
           - --webhook-ca-secret={{ include "webhook.rootCACertificate" . }}
           - --webhook-serving-secret={{ include "webhook.servingCertificate" . }}
-          - --webhook-dns-names={{ include "webhook.fullname" . }},{{ include "webhook.fullname" . }}.{{ .Release.Namespace }},{{ include "webhook.fullname" . }}.{{ .Release.Namespace }}.svc
+          - --webhook-dns-names={{ .Values.webhook.serviceName }},{{ .Values.webhook.serviceName }}.{{ .Release.Namespace }},{{ .Values.webhook.serviceName }}.{{ .Release.Namespace }}.svc
           ports:
           - containerPort: 9402
             protocol: TCP

--- a/cert-manager/charts/cert-manager/templates/psp-clusterrole.yaml
+++ b/cert-manager/charts/cert-manager/templates/psp-clusterrole.yaml
@@ -5,9 +5,11 @@ metadata:
   name: {{ template "cert-manager.fullname" . }}-psp
   labels:
     app: {{ include "cert-manager.name" . }}
-    chart: {{ include "cert-manager.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "cert-manager.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: {{ include "cert-manager.chart" . }}
 rules:
 - apiGroups: ['policy']
   resources: ['podsecuritypolicies']

--- a/cert-manager/charts/cert-manager/templates/psp-clusterrolebinding.yaml
+++ b/cert-manager/charts/cert-manager/templates/psp-clusterrolebinding.yaml
@@ -5,9 +5,11 @@ metadata:
   name: {{ template "cert-manager.fullname" . }}-psp
   labels:
     app: {{ include "cert-manager.name" . }}
-    chart: {{ include "cert-manager.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "cert-manager.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: {{ include "cert-manager.chart" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/cert-manager/charts/cert-manager/templates/psp.yaml
+++ b/cert-manager/charts/cert-manager/templates/psp.yaml
@@ -5,9 +5,11 @@ metadata:
   name: {{ template "cert-manager.fullname" . }}
   labels:
     app: {{ include "cert-manager.name" . }}
-    chart: {{ include "cert-manager.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "cert-manager.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: {{ include "cert-manager.chart" . }}
   annotations:
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
     seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'

--- a/cert-manager/charts/cert-manager/templates/rbac.yaml
+++ b/cert-manager/charts/cert-manager/templates/rbac.yaml
@@ -6,11 +6,12 @@ metadata:
   name: {{ template "cert-manager.fullname" . }}:leaderelection
   namespace: {{ .Values.global.leaderElection.namespace }}
   labels:
-    app: {{ template "cert-manager.name" . }}
-    app.kubernetes.io/name: {{ template "cert-manager.name" . }}
+    app: {{ include "cert-manager.name" . }}
+    app.kubernetes.io/name: {{ include "cert-manager.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ template "cert-manager.chart" . }}
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: {{ include "cert-manager.chart" . }}
 rules:
   # Used for leader election by the controller
   # TODO: refine the permission to *just* the leader election configmap
@@ -32,6 +33,7 @@ metadata:
     app.kubernetes.io/name: {{ include "cert-manager.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: "controller"
     helm.sh/chart: {{ include "cert-manager.chart" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -51,11 +53,12 @@ kind: ClusterRole
 metadata:
   name: {{ template "cert-manager.fullname" . }}-controller-issuers
   labels:
-    app: {{ template "cert-manager.name" . }}
-    app.kubernetes.io/name: {{ template "cert-manager.name" . }}
+    app: {{ include "cert-manager.name" . }}
+    app.kubernetes.io/name: {{ include "cert-manager.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ template "cert-manager.chart" . }}
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: {{ include "cert-manager.chart" . }}
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["issuers", "issuers/status"]
@@ -78,11 +81,12 @@ kind: ClusterRole
 metadata:
   name: {{ template "cert-manager.fullname" . }}-controller-clusterissuers
   labels:
-    app: {{ template "cert-manager.name" . }}
-    app.kubernetes.io/name: {{ template "cert-manager.name" . }}
+    app: {{ include "cert-manager.name" . }}
+    app.kubernetes.io/name: {{ include "cert-manager.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ template "cert-manager.chart" . }}
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: {{ include "cert-manager.chart" . }}
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["clusterissuers", "clusterissuers/status"]
@@ -105,11 +109,12 @@ kind: ClusterRole
 metadata:
   name: {{ template "cert-manager.fullname" . }}-controller-certificates
   labels:
-    app: {{ template "cert-manager.name" . }}
-    app.kubernetes.io/name: {{ template "cert-manager.name" . }}
+    app: {{ include "cert-manager.name" . }}
+    app.kubernetes.io/name: {{ include "cert-manager.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ template "cert-manager.chart" . }}
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: {{ include "cert-manager.chart" . }}
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificates/status", "certificaterequests", "certificaterequests/status"]
@@ -141,11 +146,12 @@ kind: ClusterRole
 metadata:
   name: {{ template "cert-manager.fullname" . }}-controller-orders
   labels:
-    app: {{ template "cert-manager.name" . }}
-    app.kubernetes.io/name: {{ template "cert-manager.name" . }}
+    app: {{ include "cert-manager.name" . }}
+    app.kubernetes.io/name: {{ include "cert-manager.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ template "cert-manager.chart" . }}
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: {{ include "cert-manager.chart" . }}
 rules:
   - apiGroups: ["acme.cert-manager.io"]
     resources: ["orders", "orders/status"]
@@ -180,11 +186,12 @@ kind: ClusterRole
 metadata:
   name: {{ template "cert-manager.fullname" . }}-controller-challenges
   labels:
-    app: {{ template "cert-manager.name" . }}
-    app.kubernetes.io/name: {{ template "cert-manager.name" . }}
+    app: {{ include "cert-manager.name" . }}
+    app.kubernetes.io/name: {{ include "cert-manager.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ template "cert-manager.chart" . }}
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: {{ include "cert-manager.chart" . }}
 rules:
   # Use to update challenge resource status
   - apiGroups: ["acme.cert-manager.io"]
@@ -213,14 +220,12 @@ rules:
   - apiGroups: ["extensions"]
     resources: ["ingresses"]
     verbs: ["get", "list", "watch", "create", "delete", "update"]
-{{- if .Values.global.isOpenshift }}
   # We require the ability to specify a custom hostname when we are creating
   # new ingress resources.
   # See: https://github.com/openshift/origin/blob/21f191775636f9acadb44fa42beeb4f75b255532/pkg/route/apiserver/admission/ingress_admission.go#L84-L148
   - apiGroups: ["route.openshift.io"]
     resources: ["routes/custom-host"]
     verbs: ["create"]
-{{- end }}
   # We require these rules to support users with the OwnerReferencesPermissionEnforcement
   # admission controller enabled:
   # https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
@@ -240,11 +245,12 @@ kind: ClusterRole
 metadata:
   name: {{ template "cert-manager.fullname" . }}-controller-ingress-shim
   labels:
-    app: {{ template "cert-manager.name" . }}
-    app.kubernetes.io/name: {{ template "cert-manager.name" . }}
+    app: {{ include "cert-manager.name" . }}
+    app.kubernetes.io/name: {{ include "cert-manager.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ template "cert-manager.chart" . }}
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: {{ include "cert-manager.chart" . }}
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificaterequests"]
@@ -272,11 +278,12 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ template "cert-manager.fullname" . }}-controller-issuers
   labels:
-    app: {{ template "cert-manager.name" . }}
-    app.kubernetes.io/name: {{ template "cert-manager.name" . }}
+    app: {{ include "cert-manager.name" . }}
+    app.kubernetes.io/name: {{ include "cert-manager.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ template "cert-manager.chart" . }}
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: {{ include "cert-manager.chart" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -293,11 +300,12 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ template "cert-manager.fullname" . }}-controller-clusterissuers
   labels:
-    app: {{ template "cert-manager.name" . }}
-    app.kubernetes.io/name: {{ template "cert-manager.name" . }}
+    app: {{ include "cert-manager.name" . }}
+    app.kubernetes.io/name: {{ include "cert-manager.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ template "cert-manager.chart" . }}
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: {{ include "cert-manager.chart" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -314,11 +322,12 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ template "cert-manager.fullname" . }}-controller-certificates
   labels:
-    app: {{ template "cert-manager.name" . }}
-    app.kubernetes.io/name: {{ template "cert-manager.name" . }}
+    app: {{ include "cert-manager.name" . }}
+    app.kubernetes.io/name: {{ include "cert-manager.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ template "cert-manager.chart" . }}
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: {{ include "cert-manager.chart" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -335,11 +344,12 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ template "cert-manager.fullname" . }}-controller-orders
   labels:
-    app: {{ template "cert-manager.name" . }}
-    app.kubernetes.io/name: {{ template "cert-manager.name" . }}
+    app: {{ include "cert-manager.name" . }}
+    app.kubernetes.io/name: {{ include "cert-manager.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ template "cert-manager.chart" . }}
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: {{ include "cert-manager.chart" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -356,11 +366,12 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ template "cert-manager.fullname" . }}-controller-challenges
   labels:
-    app: {{ template "cert-manager.name" . }}
-    app.kubernetes.io/name: {{ template "cert-manager.name" . }}
+    app: {{ include "cert-manager.name" . }}
+    app.kubernetes.io/name: {{ include "cert-manager.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ template "cert-manager.chart" . }}
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: {{ include "cert-manager.chart" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -377,11 +388,12 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ template "cert-manager.fullname" . }}-controller-ingress-shim
   labels:
-    app: {{ template "cert-manager.name" . }}
-    app.kubernetes.io/name: {{ template "cert-manager.name" . }}
+    app: {{ include "cert-manager.name" . }}
+    app.kubernetes.io/name: {{ include "cert-manager.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ template "cert-manager.chart" . }}
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: {{ include "cert-manager.chart" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -398,11 +410,12 @@ kind: ClusterRole
 metadata:
   name: {{ template "cert-manager.fullname" . }}-view
   labels:
-    app: {{ template "cert-manager.name" . }}
-    app.kubernetes.io/name: {{ template "cert-manager.name" . }}
+    app: {{ include "cert-manager.name" . }}
+    app.kubernetes.io/name: {{ include "cert-manager.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ template "cert-manager.chart" . }}
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: {{ include "cert-manager.chart" . }}
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
@@ -418,11 +431,12 @@ kind: ClusterRole
 metadata:
   name: {{ template "cert-manager.fullname" . }}-edit
   labels:
-    app: {{ template "cert-manager.name" . }}
-    app.kubernetes.io/name: {{ template "cert-manager.name" . }}
+    app: {{ include "cert-manager.name" . }}
+    app.kubernetes.io/name: {{ include "cert-manager.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ template "cert-manager.chart" . }}
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: {{ include "cert-manager.chart" . }}
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:

--- a/cert-manager/charts/cert-manager/templates/service.yaml
+++ b/cert-manager/charts/cert-manager/templates/service.yaml
@@ -5,11 +5,12 @@ metadata:
   name: {{ template "cert-manager.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
-    app: {{ template "cert-manager.name" . }}
-    app.kubernetes.io/name: {{ template "cert-manager.name" . }}
+    app: {{ include "cert-manager.name" . }}
+    app.kubernetes.io/name: {{ include "cert-manager.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ template "cert-manager.chart" . }}
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: {{ include "cert-manager.chart" . }}
 spec:
   type: ClusterIP
   ports:
@@ -17,6 +18,7 @@ spec:
       port: 9402
       targetPort: 9402
   selector:
-    app.kubernetes.io/name: {{ template "cert-manager.name" . }}
+    app.kubernetes.io/name: {{ include "cert-manager.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: "controller"
 {{- end }}

--- a/cert-manager/charts/cert-manager/templates/serviceaccount.yaml
+++ b/cert-manager/charts/cert-manager/templates/serviceaccount.yaml
@@ -12,9 +12,10 @@ metadata:
 {{ toYaml .Values.serviceAccount.annotations | indent 4 }}
   {{- end }}
   labels:
-    app: {{ template "cert-manager.name" . }}
-    app.kubernetes.io/name: {{ template "cert-manager.name" . }}
+    app: {{ include "cert-manager.name" . }}
+    app.kubernetes.io/name: {{ include "cert-manager.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ template "cert-manager.chart" . }}
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: {{ include "cert-manager.chart" . }}
 {{- end }}

--- a/cert-manager/charts/cert-manager/templates/servicemonitor.yaml
+++ b/cert-manager/charts/cert-manager/templates/servicemonitor.yaml
@@ -9,11 +9,12 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
 {{- end }}
   labels:
-    app: {{ template "cert-manager.name" . }}
-    app.kubernetes.io/name: {{ template "cert-manager.name" . }}
+    app: {{ include "cert-manager.name" . }}
+    app.kubernetes.io/name: {{ include "cert-manager.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ template "cert-manager.chart" . }}
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: {{ include "cert-manager.chart" . }}
     prometheus: {{ .Values.prometheus.servicemonitor.prometheusInstance }}
 {{- if .Values.prometheus.servicemonitor.labels }}
 {{ toYaml .Values.prometheus.servicemonitor.labels | indent 4}}
@@ -24,6 +25,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ template "cert-manager.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: "controller"
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/cert-manager/charts/cert-manager/templates/webhook-deployment.yaml
+++ b/cert-manager/charts/cert-manager/templates/webhook-deployment.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.webhook.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -9,6 +8,7 @@ metadata:
     app.kubernetes.io/name: {{ include "webhook.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: "webhook"
     helm.sh/chart: {{ include "webhook.chart" . }}
   {{- if .Values.webhook.deploymentAnnotations }}
   annotations:
@@ -18,10 +18,9 @@ spec:
   replicas: {{ .Values.webhook.replicaCount }}
   selector:
     matchLabels:
-      app: {{ include "webhook.name" . }}
       app.kubernetes.io/name: {{ include "webhook.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
-      app.kubernetes.io/managed-by: {{ .Release.Service }}
+      app.kubernetes.io/component: "webhook"
   {{- with .Values.webhook.strategy }}
   strategy:
     {{- . | toYaml | nindent 4 }}
@@ -33,6 +32,7 @@ spec:
         app.kubernetes.io/name: {{ include "webhook.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/component: "webhook"
         helm.sh/chart: {{ include "webhook.chart" . }}
       annotations:
       {{- if .Values.webhook.podAnnotations }}
@@ -97,4 +97,4 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
-{{- end -}}
+

--- a/cert-manager/charts/cert-manager/templates/webhook-mutating-webhook.yaml
+++ b/cert-manager/charts/cert-manager/templates/webhook-mutating-webhook.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.webhook.enabled -}}
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -8,6 +7,7 @@ metadata:
     app.kubernetes.io/name: {{ include "webhook.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: "webhook"
     helm.sh/chart: {{ include "webhook.chart" . }}
   annotations:
     cert-manager.io/inject-ca-from-secret: "{{ .Release.Namespace }}/{{ include "webhook.servingCertificate" . }}"
@@ -19,16 +19,24 @@ webhooks:
           - "acme.cert-manager.io"
         apiVersions:
           - v1alpha2
+          - v1alpha3
         operations:
           - CREATE
           - UPDATE
         resources:
           - "*/*"
     failurePolicy: Fail
+{{- if (semverCompare ">=1.12-0" .Capabilities.KubeVersion.GitVersion) }}
+    # Only include 'sideEffects' field in Kubernetes 1.12+
     sideEffects: None
+{{- end }}
     clientConfig:
+{{- if (semverCompare "<=1.12-0" .Capabilities.KubeVersion.GitVersion) }}
+      # Set caBundle to empty to avoid https://github.com/kubernetes/kubernetes/pull/70138
+      # in Kubernetes 1.12 and below.
+      caBundle: ""
+{{- end }}
       service:
-        name: {{ include "webhook.fullname" . }}
+        name: {{ .Values.webhook.serviceName }}
         namespace: {{ .Release.Namespace | quote }}
         path: /mutate
-{{- end -}}

--- a/cert-manager/charts/cert-manager/templates/webhook-psp-clusterrole.yaml
+++ b/cert-manager/charts/cert-manager/templates/webhook-psp-clusterrole.yaml
@@ -5,9 +5,11 @@ metadata:
   name: {{ template "webhook.fullname" . }}-psp
   labels:
     app: {{ include "webhook.name" . }}
-    chart: {{ include "webhook.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "webhook.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: "webhook"
+    helm.sh/chart: {{ include "webhook.chart" . }}
 rules:
 - apiGroups: ['policy']
   resources: ['podsecuritypolicies']

--- a/cert-manager/charts/cert-manager/templates/webhook-psp-clusterrolebinding.yaml
+++ b/cert-manager/charts/cert-manager/templates/webhook-psp-clusterrolebinding.yaml
@@ -5,9 +5,11 @@ metadata:
   name: {{ template "webhook.fullname" . }}-psp
   labels:
     app: {{ include "webhook.name" . }}
-    chart: {{ include "webhook.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "webhook.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: "webhook"
+    helm.sh/chart: {{ include "webhook.chart" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/cert-manager/charts/cert-manager/templates/webhook-psp.yaml
+++ b/cert-manager/charts/cert-manager/templates/webhook-psp.yaml
@@ -5,9 +5,11 @@ metadata:
   name: {{ template "webhook.fullname" . }}
   labels:
     app: {{ include "webhook.name" . }}
-    chart: {{ include "webhook.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "webhook.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: "webhook"
+    helm.sh/chart: {{ include "webhook.chart" . }}
   annotations:
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
     seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'

--- a/cert-manager/charts/cert-manager/templates/webhook-service.yaml
+++ b/cert-manager/charts/cert-manager/templates/webhook-service.yaml
@@ -1,14 +1,14 @@
-{{- if .Values.webhook.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "webhook.fullname" . }}
+  name: {{ .Values.webhook.serviceName }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ include "webhook.name" . }}
     app.kubernetes.io/name: {{ include "webhook.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: "webhook"
     helm.sh/chart: {{ include "webhook.chart" . }}
 spec:
   type: ClusterIP
@@ -17,8 +17,6 @@ spec:
     port: 443
     targetPort: {{ .Values.webhook.securePort }}
   selector:
-    app: {{ include "webhook.name" . }}
     app.kubernetes.io/name: {{ include "webhook.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- end -}}
+    app.kubernetes.io/component: "webhook"

--- a/cert-manager/charts/cert-manager/templates/webhook-serviceaccount.yaml
+++ b/cert-manager/charts/cert-manager/templates/webhook-serviceaccount.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.webhook.enabled -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -9,8 +8,9 @@ metadata:
     app.kubernetes.io/name: {{ include "webhook.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: "webhook"
     helm.sh/chart: {{ include "webhook.chart" . }}
 {{- if .Values.global.imagePullSecrets }}
 imagePullSecrets: {{ toYaml .Values.global.imagePullSecrets | nindent 2 }}
 {{- end -}}
-{{- end -}}
+

--- a/cert-manager/charts/cert-manager/templates/webhook-validating-webhook.yaml
+++ b/cert-manager/charts/cert-manager/templates/webhook-validating-webhook.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.webhook.enabled -}}
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -8,6 +7,7 @@ metadata:
     app.kubernetes.io/name: {{ include "webhook.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: "webhook"
     helm.sh/chart: {{ include "webhook.chart" . }}
   annotations:
     cert-manager.io/inject-ca-from-secret: "{{ .Release.Namespace }}/{{ include "webhook.servingCertificate" . }}"
@@ -29,16 +29,24 @@ webhooks:
           - "acme.cert-manager.io"
         apiVersions:
           - v1alpha2
+          - v1alpha3
         operations:
           - CREATE
           - UPDATE
         resources:
           - "*/*"
     failurePolicy: Fail
+{{- if (semverCompare ">=1.12-0" .Capabilities.KubeVersion.GitVersion) }}
+    # Only include 'sideEffects' field in Kubernetes 1.12+
     sideEffects: None
+{{- end }}
     clientConfig:
+{{- if (semverCompare "<=1.12-0" .Capabilities.KubeVersion.GitVersion) }}
+      # Set caBundle to empty to avoid https://github.com/kubernetes/kubernetes/pull/70138
+      # in Kubernetes 1.12 and below.
+      caBundle: ""
+{{- end }}
       service:
-        name: {{ include "webhook.fullname" . }}
+        name: {{ .Values.webhook.serviceName }}
         namespace: {{ .Release.Namespace | quote }}
-        path: /mutate
-{{- end -}}
+        path: /validate

--- a/cert-manager/charts/cert-manager/values.yaml
+++ b/cert-manager/charts/cert-manager/values.yaml
@@ -1,239 +1,76 @@
-# Default values for cert-manager.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
+affinity: {}
+cainjector:
+  affinity: {}
+  deploymentAnnotations: {}
+  enabled: true
+  extraArgs: []
+  image:
+    pullPolicy: IfNotPresent
+    repository: quay.io/jetstack/cert-manager-cainjector
+  nodeSelector: {}
+  podAnnotations: {}
+  replicaCount: 1
+  resources: {}
+  securityContext: {}
+  strategy: {}
+  tolerations: []
+clusterResourceNamespace: ""
+deploymentAnnotations: {}
+extraArgs: []
+extraEnv: []
 global:
-  ## Reference to one or more secrets to be used when pulling images
-  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-  ##
   imagePullSecrets: []
-  isOpenshift: false
-  # - name: "image-pull-secret"
-
-  # Optional priority class to be used for the cert-manager pods
-  priorityClassName: ""
-  rbac:
-    create: true
-
+  leaderElection:
+    namespace: kube-system
+  logLevel: 2
   podSecurityPolicy:
     enabled: false
     useAppArmor: true
-
-  # Set the verbosity of cert-manager. Range of 0 - 6 with 6 being the most verbose.
-  logLevel: 2
-
-  leaderElection:
-    # Override the namespace used to store the ConfigMap for leader election
-    namespace: "kube-system"
-
-replicaCount: 1
-
-strategy: {}
-  # type: RollingUpdate
-  # rollingUpdate:
-  #   maxSurge: 0
-  #   maxUnavailable: 1
-
-
+  priorityClassName: ""
+  rbac:
+    create: true
 image:
-  repository: quay.io/jetstack/cert-manager-controller
-  # Override the image tag to deploy by setting this variable.
-  # If no value is set, the chart's appVersion will be used.
-  # tag: canary
   pullPolicy: IfNotPresent
-
-# Override the namespace used to store DNS provider credentials etc. for ClusterIssuer
-# resources. By default, the same namespace as cert-manager is deployed within is
-# used. This namespace will not be automatically created by the Helm chart.
-clusterResourceNamespace: ""
-
-serviceAccount:
-  # Specifies whether a service account should be created
-  create: true
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
-  name:
-  annotations: {}
-
-# Optional additional arguments
-extraArgs: []
-  # Use this flag to set a namespace that cert-manager will use to store
-  # supporting resources required for each ClusterIssuer (default is kube-system)
-  # - --cluster-resource-namespace=kube-system
-  # When this flag is enabled, secrets will be automatically removed when the certificate resource is deleted
-  # - --enable-certificate-owner-ref=true
-
-extraEnv: []
-# - name: SOME_VAR
-#   value: 'some value'
-
-resources: {}
-  # requests:
-  #   cpu: 10m
-  #   memory: 32Mi
-
-# Pod Security Context
-# ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
-securityContext: {}
-# legacy securityContext parameter format: if enabled is set to true, only fsGroup and runAsUser are supported
-# securityContext:
-#   enabled: false
-#   fsGroup: 1001
-#   runAsUser: 1001
-# to support additional securityContext parameters, omit the `enabled` parameter and simply specify the parameters
-# you want to set, e.g.
-# securityContext:
-#   fsGroup: 1000
-#   runAsUser: 1000
-#   runAsNonRoot: true
-
-volumes: []
-
-volumeMounts: []
-
-deploymentAnnotations: {}
-
-podAnnotations: {}
-
-podLabels: {}
-# Optional DNS settings, useful if you have a public and private DNS zone for
-# the same domain on Route 53. What follows is an example of ensuring
-# cert-manager can access an ingress or DNS TXT records at all times.
-# NOTE: This requires Kubernetes 1.10 or `CustomPodDNS` feature gate enabled for
-# the cluster to work.
-# podDnsPolicy: "None"
-# podDnsConfig:
-#   nameservers:
-#     - "1.1.1.1"
-#     - "8.8.8.8"
-
-nodeSelector: {}
-
+  repository: quay.io/jetstack/cert-manager-controller
 ingressShim: {}
-  # defaultIssuerName: ""
-  # defaultIssuerKind: ""
-  # defaultIssuerGroup: ""
-
+nodeSelector: {}
+podAnnotations: {}
+podLabels: {}
 prometheus:
   enabled: true
   servicemonitor:
     enabled: false
-    prometheusInstance: default
-    targetPort: 9402
-    path: /metrics
     interval: 60s
-    scrapeTimeout: 30s
     labels: {}
-
-# Use these variables to configure the HTTP_PROXY environment variables
-# http_proxy: "http://proxy:8080"
-# http_proxy: "http://proxy:8080"
-# no_proxy: 127.0.0.1,localhost
-
-# expects input structure as per specification https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core
-# for example:
-#   affinity:
-#     nodeAffinity:
-#      requiredDuringSchedulingIgnoredDuringExecution:
-#        nodeSelectorTerms:
-#        - matchExpressions:
-#          - key: foo.bar.com/role
-#            operator: In
-#            values:
-#            - master
-affinity: {}
-
-# expects input structure as per specification https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#toleration-v1-core
-# for example:
-#   tolerations:
-#   - key: foo.bar.com/role
-#     operator: Equal
-#     value: master
-#     effect: NoSchedule
+    path: /metrics
+    prometheusInstance: default
+    scrapeTimeout: 30s
+    targetPort: 9402
+replicaCount: 1
+resources: {}
+securityContext: {}
+serviceAccount:
+  annotations: {}
+  create: true
+  name: null
+strategy: {}
 tolerations: []
-
+volumeMounts: []
+volumes: []
 webhook:
-  enabled: true
-  replicaCount: 1
-
-  strategy: {}
-    # type: RollingUpdate
-    # rollingUpdate:
-    #   maxSurge: 0
-    #   maxUnavailable: 1
-
-  securityContext: {}
-
-  deploymentAnnotations: {}
-
-  podAnnotations: {}
-
-  # Optional additional arguments for webhook
-  extraArgs: []
-
-  resources: {}
-    # requests:
-    #   cpu: 10m
-    #   memory: 32Mi
-
-  nodeSelector: {}
-
   affinity: {}
-
-  tolerations: []
-
+  deploymentAnnotations: {}
+  extraArgs: []
   image:
+    pullPolicy: IfNotPresent
     repository: quay.io/jetstack/cert-manager-webhook
-    # Override the image tag to deploy by setting this variable.
-    # If no value is set, the chart's appVersion will be used.
-    # tag: canary
-    pullPolicy: IfNotPresent
-
-  # If true, the apiserver's cabundle will be automatically injected into the
-  # webhook's ValidatingWebhookConfiguration resource by the CA injector.
-  # in future this will default to false, as the apiserver can use the loopback
-  # configuration caBundle to talk to itself in kubernetes 1.11+
-  # see https://github.com/kubernetes/kubernetes/pull/62649
   injectAPIServerCA: true
-
-  # The port that the webhook should listen on for requests.
-  # In GKE private clusters, by default kubernetes apiservers are allowed to
-  # talk to the cluster nodes only on 443 and 10250. so configuring
-  # securePort: 10250, will work out of the box without needing to add firewall
-  # rules or requiring NET_BIND_SERVICE capabilities to bind port numbers <1000
-  securePort: 10250
-
-cainjector:
-  replicaCount: 1
-
-  strategy: {}
-    # type: RollingUpdate
-    # rollingUpdate:
-    #   maxSurge: 0
-    #   maxUnavailable: 1
-
-  securityContext: {}
-
-  deploymentAnnotations: {}
-
-  podAnnotations: {}
-
-  # Optional additional arguments for cainjector
-  extraArgs: []
-
-  resources: {}
-    # requests:
-    #   cpu: 10m
-    #   memory: 32Mi
-
   nodeSelector: {}
-
-  affinity: {}
-
+  podAnnotations: {}
+  replicaCount: 1
+  resources: {}
+  securePort: 10250
+  securityContext: {}
+  serviceName: cert-manager-webhook
+  strategy: {}
   tolerations: []
-
-  image:
-    repository: quay.io/jetstack/cert-manager-cainjector
-    # Override the image tag to deploy by setting this variable.
-    # If no value is set, the chart's appVersion will be used.
-    # tag: canary
-    pullPolicy: IfNotPresent

--- a/cert-manager/default_clusterissuers.libsonnet
+++ b/cert-manager/default_clusterissuers.libsonnet
@@ -23,7 +23,7 @@
   },
 
   cluster_issuer_staging: {
-    apiVersion: 'cert-manager.io/v1alpha2',
+    apiVersion: 'cert-manager.io/v1alpha3',
     kind: 'ClusterIssuer',
     metadata: {
       name: 'letsencrypt-staging',
@@ -54,7 +54,7 @@
   },
 
   cluster_issuer_prod: {
-    apiVersion: 'cert-manager.io/v1alpha2',
+    apiVersion: 'cert-manager.io/v1alpha3',
     kind: 'ClusterIssuer',
     metadata: {
       name: 'letsencrypt-prod',

--- a/cert-manager/files/00-crds.yaml
+++ b/cert-manager/files/00-crds.yaml
@@ -1,6 +1,22 @@
+# Copyright YEAR The Jetstack cert-manager contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    cert-manager.io/inject-ca-from-secret: cert-manager/cert-manager-webhook-tls
   name: certificaterequests.cert-manager.io
 spec:
   additionalPrinterColumns:
@@ -22,8 +38,14 @@ spec:
       in RFC3339 form and is in UTC.
     name: Age
     type: date
+  conversion:
+    strategy: Webhook
+    webhookClientConfig:
+      service:
+        name: cert-manager-webhook
+        namespace: cert-manager
+        path: /convert
   group: cert-manager.io
-  preserveUnknownFields: false
   names:
     kind: CertificateRequest
     listKind: CertificateRequestList
@@ -32,6 +54,7 @@ spec:
     - cr
     - crs
     singular: certificaterequest
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -39,7 +62,6 @@ spec:
     openAPIV3Schema:
       description: CertificateRequest is a type to represent a Certificate Signing
         Request
-      type: object
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
@@ -55,15 +77,11 @@ spec:
           type: object
         spec:
           description: CertificateRequestSpec defines the desired state of CertificateRequest
-          type: object
-          required:
-          - csr
-          - issuerRef
           properties:
             csr:
               description: Byte slice containing the PEM encoded CertificateSigningRequest
-              type: string
               format: byte
+              type: string
             duration:
               description: Requested certificate default Duration
               type: string
@@ -79,9 +97,6 @@ spec:
                 with the provided name will be used. The 'name' field in this stanza
                 is required at all times. The group field refers to the API group
                 of the issuer which defaults to 'cert-manager.io' if empty.
-              type: object
-              required:
-              - name
               properties:
                 group:
                   type: string
@@ -89,11 +104,13 @@ spec:
                   type: string
                 name:
                   type: string
+              required:
+              - name
+              type: object
             usages:
               description: Usages is the set of x509 actions that are enabled for
                 a given key. Defaults are ('digital signature', 'key encipherment')
                 if empty
-              type: array
               items:
                 description: 'KeyUsage specifies valid usage contexts for keys. See:
                   https://tools.ietf.org/html/rfc5280#section-4.2.1.3      https://tools.ietf.org/html/rfc5280#section-4.2.1.12
@@ -104,7 +121,6 @@ spec:
                   protection", "s/mime", "ipsec end system", "ipsec tunnel", "ipsec
                   user", "timestamping", "ocsp signing", "microsoft sgc", "netscape
                   sgc"'
-                type: string
                 enum:
                 - signing
                 - digital signature
@@ -129,36 +145,36 @@ spec:
                 - ocsp signing
                 - microsoft sgc
                 - netscape sgc
+                type: string
+              type: array
+          required:
+          - csr
+          - issuerRef
+          type: object
         status:
           description: CertificateStatus defines the observed state of CertificateRequest
             and resulting signed certificate.
-          type: object
           properties:
             ca:
               description: Byte slice containing the PEM encoded certificate authority
                 of the signed certificate.
-              type: string
               format: byte
+              type: string
             certificate:
               description: Byte slice containing a PEM encoded signed certificate
                 resulting from the given certificate signing request.
-              type: string
               format: byte
+              type: string
             conditions:
-              type: array
               items:
                 description: CertificateRequestCondition contains condition information
                   for a CertificateRequest.
-                type: object
-                required:
-                - status
-                - type
                 properties:
                   lastTransitionTime:
                     description: LastTransitionTime is the timestamp corresponding
                       to the last status change of this condition.
-                    type: string
                     format: date-time
+                    type: string
                   message:
                     description: Message is a human readable description of the details
                       of the last transition, complementing reason.
@@ -170,28 +186,39 @@ spec:
                   status:
                     description: Status of the condition, one of ('True', 'False',
                       'Unknown').
-                    type: string
                     enum:
                     - "True"
                     - "False"
                     - Unknown
-                  type:
-                    description: Type of the condition, currently ('Ready').
                     type: string
+                  type:
+                    description: Type of the condition, currently ('Ready', 'InvalidRequest').
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
             failureTime:
               description: FailureTime stores the time that this CertificateRequest
                 failed. This is used to influence garbage collection and back-off.
-              type: string
               format: date-time
-  version: v1alpha2
+              type: string
+          type: object
+      type: object
   versions:
   - name: v1alpha2
     served: true
     storage: true
+  - name: v1alpha3
+    served: true
+    storage: false
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    cert-manager.io/inject-ca-from-secret: cert-manager/cert-manager-webhook-tls
   name: certificates.cert-manager.io
 spec:
   additionalPrinterColumns:
@@ -216,8 +243,14 @@ spec:
       in RFC3339 form and is in UTC.
     name: Age
     type: date
+  conversion:
+    strategy: Webhook
+    webhookClientConfig:
+      service:
+        name: cert-manager-webhook
+        namespace: cert-manager
+        path: /convert
   group: cert-manager.io
-  preserveUnknownFields: false
   names:
     kind: Certificate
     listKind: CertificateList
@@ -226,216 +259,511 @@ spec:
     - cert
     - certs
     singular: certificate
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
-  validation:
-    openAPIV3Schema:
-      description: Certificate is a type to represent a Certificate from ACME
-      type: object
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: CertificateSpec defines the desired state of Certificate. A
-            valid Certificate requires at least one of a CommonName, DNSName, or URISAN
-            to be valid.
-          type: object
-          required:
-          - issuerRef
-          - secretName
-          properties:
-            commonName:
-              description: CommonName is a common name to be used on the Certificate.
-                The CommonName should have a length of 64 characters or fewer to avoid
-                generating invalid CSRs.
-              type: string
-            dnsNames:
-              description: DNSNames is a list of subject alt names to be used on the
-                Certificate.
-              type: array
-              items:
-                type: string
-            duration:
-              description: Certificate default Duration
-              type: string
-            ipAddresses:
-              description: IPAddresses is a list of IP addresses to be used on the
-                Certificate
-              type: array
-              items:
-                type: string
-            isCA:
-              description: IsCA will mark this Certificate as valid for signing. This
-                implies that the 'cert sign' usage is set
-              type: boolean
-            issuerRef:
-              description: IssuerRef is a reference to the issuer for this certificate.
-                If the 'kind' field is not set, or set to 'Issuer', an Issuer resource
-                with the given name in the same namespace as the Certificate will
-                be used. If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer
-                with the provided name will be used. The 'name' field in this stanza
-                is required at all times.
-              type: object
-              required:
-              - name
-              properties:
-                group:
-                  type: string
-                kind:
-                  type: string
-                name:
-                  type: string
-            keyAlgorithm:
-              description: KeyAlgorithm is the private key algorithm of the corresponding
-                private key for this certificate. If provided, allowed values are
-                either "rsa" or "ecdsa" If KeyAlgorithm is specified and KeySize is
-                not provided, key size of 256 will be used for "ecdsa" key algorithm
-                and key size of 2048 will be used for "rsa" key algorithm.
-              type: string
-              enum:
-              - rsa
-              - ecdsa
-            keyEncoding:
-              description: KeyEncoding is the private key cryptography standards (PKCS)
-                for this certificate's private key to be encoded in. If provided,
-                allowed values are "pkcs1" and "pkcs8" standing for PKCS#1 and PKCS#8,
-                respectively. If KeyEncoding is not specified, then PKCS#1 will be
-                used by default.
-              type: string
-              enum:
-              - pkcs1
-              - pkcs8
-            keySize:
-              description: KeySize is the key bit size of the corresponding private
-                key for this certificate. If provided, value must be between 2048
-                and 8192 inclusive when KeyAlgorithm is empty or is set to "rsa",
-                and value must be one of (256, 384, 521) when KeyAlgorithm is set
-                to "ecdsa".
-              type: integer
-            organization:
-              description: Organization is the organization to be used on the Certificate
-              type: array
-              items:
-                type: string
-            renewBefore:
-              description: Certificate renew before expiration duration
-              type: string
-            secretName:
-              description: SecretName is the name of the secret resource to store
-                this secret in
-              type: string
-            uriSANs:
-              description: URISANs is a list of URI Subject Alternative Names to be
-                set on this Certificate.
-              type: array
-              items:
-                type: string
-            usages:
-              description: Usages is the set of x509 actions that are enabled for
-                a given key. Defaults are ('digital signature', 'key encipherment')
-                if empty
-              type: array
-              items:
-                description: 'KeyUsage specifies valid usage contexts for keys. See:
-                  https://tools.ietf.org/html/rfc5280#section-4.2.1.3      https://tools.ietf.org/html/rfc5280#section-4.2.1.12
-                  Valid KeyUsage values are as follows: "signing", "digital signature",
-                  "content commitment", "key encipherment", "key agreement", "data
-                  encipherment", "cert sign", "crl sign", "encipher only", "decipher
-                  only", "any", "server auth", "client auth", "code signing", "email
-                  protection", "s/mime", "ipsec end system", "ipsec tunnel", "ipsec
-                  user", "timestamping", "ocsp signing", "microsoft sgc", "netscape
-                  sgc"'
-                type: string
-                enum:
-                - signing
-                - digital signature
-                - content commitment
-                - key encipherment
-                - key agreement
-                - data encipherment
-                - cert sign
-                - crl sign
-                - encipher only
-                - decipher only
-                - any
-                - server auth
-                - client auth
-                - code signing
-                - email protection
-                - s/mime
-                - ipsec end system
-                - ipsec tunnel
-                - ipsec user
-                - timestamping
-                - ocsp signing
-                - microsoft sgc
-                - netscape sgc
-        status:
-          description: CertificateStatus defines the observed state of Certificate
-          type: object
-          properties:
-            conditions:
-              type: array
-              items:
-                description: CertificateCondition contains condition information for
-                  an Certificate.
-                type: object
-                required:
-                - status
-                - type
-                properties:
-                  lastTransitionTime:
-                    description: LastTransitionTime is the timestamp corresponding
-                      to the last status change of this condition.
-                    type: string
-                    format: date-time
-                  message:
-                    description: Message is a human readable description of the details
-                      of the last transition, complementing reason.
-                    type: string
-                  reason:
-                    description: Reason is a brief machine readable explanation for
-                      the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of ('True', 'False',
-                      'Unknown').
-                    type: string
-                    enum:
-                    - "True"
-                    - "False"
-                    - Unknown
-                  type:
-                    description: Type of the condition, currently ('Ready').
-                    type: string
-            lastFailureTime:
-              type: string
-              format: date-time
-            notAfter:
-              description: The expiration time of the certificate stored in the secret
-                named by this resource in spec.secretName.
-              type: string
-              format: date-time
-  version: v1alpha2
   versions:
   - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: Certificate is a type to represent a Certificate from ACME
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CertificateSpec defines the desired state of Certificate.
+              A valid Certificate requires at least one of a CommonName, DNSName,
+              or URISAN to be valid.
+            properties:
+              commonName:
+                description: 'CommonName is a common name to be used on the Certificate.
+                  The CommonName should have a length of 64 characters or fewer to
+                  avoid generating invalid CSRs. This value is ignored by TLS clients
+                  when any subject alt name is set. This is x509 behaviour: https://tools.ietf.org/html/rfc6125#section-6.4.4'
+                type: string
+              dnsNames:
+                description: DNSNames is a list of subject alt names to be used on
+                  the Certificate.
+                items:
+                  type: string
+                type: array
+              duration:
+                description: Certificate default Duration
+                type: string
+              emailSANs:
+                description: EmailSANs is a list of Email Subject Alternative Names
+                  to be set on this Certificate.
+                items:
+                  type: string
+                type: array
+              ipAddresses:
+                description: IPAddresses is a list of IP addresses to be used on the
+                  Certificate
+                items:
+                  type: string
+                type: array
+              isCA:
+                description: IsCA will mark this Certificate as valid for signing.
+                  This implies that the 'cert sign' usage is set
+                type: boolean
+              issuerRef:
+                description: IssuerRef is a reference to the issuer for this certificate.
+                  If the 'kind' field is not set, or set to 'Issuer', an Issuer resource
+                  with the given name in the same namespace as the Certificate will
+                  be used. If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer
+                  with the provided name will be used. The 'name' field in this stanza
+                  is required at all times.
+                properties:
+                  group:
+                    type: string
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                required:
+                - name
+                type: object
+              keyAlgorithm:
+                description: KeyAlgorithm is the private key algorithm of the corresponding
+                  private key for this certificate. If provided, allowed values are
+                  either "rsa" or "ecdsa" If KeyAlgorithm is specified and KeySize
+                  is not provided, key size of 256 will be used for "ecdsa" key algorithm
+                  and key size of 2048 will be used for "rsa" key algorithm.
+                enum:
+                - rsa
+                - ecdsa
+                type: string
+              keyEncoding:
+                description: KeyEncoding is the private key cryptography standards
+                  (PKCS) for this certificate's private key to be encoded in. If provided,
+                  allowed values are "pkcs1" and "pkcs8" standing for PKCS#1 and PKCS#8,
+                  respectively. If KeyEncoding is not specified, then PKCS#1 will
+                  be used by default.
+                enum:
+                - pkcs1
+                - pkcs8
+                type: string
+              keySize:
+                description: KeySize is the key bit size of the corresponding private
+                  key for this certificate. If provided, value must be between 2048
+                  and 8192 inclusive when KeyAlgorithm is empty or is set to "rsa",
+                  and value must be one of (256, 384, 521) when KeyAlgorithm is set
+                  to "ecdsa".
+                maximum: 8192
+                minimum: 0
+                type: integer
+              organization:
+                description: Organization is the organization to be used on the Certificate
+                items:
+                  type: string
+                type: array
+              renewBefore:
+                description: Certificate renew before expiration duration
+                type: string
+              secretName:
+                description: SecretName is the name of the secret resource to store
+                  this secret in
+                type: string
+              subject:
+                description: Full X509 name specification (https://golang.org/pkg/crypto/x509/pkix/#Name).
+                properties:
+                  countries:
+                    description: Countries to be used on the Certificate.
+                    items:
+                      type: string
+                    type: array
+                  localities:
+                    description: Cities to be used on the Certificate.
+                    items:
+                      type: string
+                    type: array
+                  organizationalUnits:
+                    description: Organizational Units to be used on the Certificate.
+                    items:
+                      type: string
+                    type: array
+                  postalCodes:
+                    description: Postal codes to be used on the Certificate.
+                    items:
+                      type: string
+                    type: array
+                  provinces:
+                    description: State/Provinces to be used on the Certificate.
+                    items:
+                      type: string
+                    type: array
+                  serialNumber:
+                    description: Serial number to be used on the Certificate.
+                    type: string
+                  streetAddresses:
+                    description: Street addresses to be used on the Certificate.
+                    items:
+                      type: string
+                    type: array
+                type: object
+              uriSANs:
+                description: URISANs is a list of URI Subject Alternative Names to
+                  be set on this Certificate.
+                items:
+                  type: string
+                type: array
+              usages:
+                description: Usages is the set of x509 actions that are enabled for
+                  a given key. Defaults are ('digital signature', 'key encipherment')
+                  if empty
+                items:
+                  description: 'KeyUsage specifies valid usage contexts for keys.
+                    See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3      https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+                    Valid KeyUsage values are as follows: "signing", "digital signature",
+                    "content commitment", "key encipherment", "key agreement", "data
+                    encipherment", "cert sign", "crl sign", "encipher only", "decipher
+                    only", "any", "server auth", "client auth", "code signing", "email
+                    protection", "s/mime", "ipsec end system", "ipsec tunnel", "ipsec
+                    user", "timestamping", "ocsp signing", "microsoft sgc", "netscape
+                    sgc"'
+                  enum:
+                  - signing
+                  - digital signature
+                  - content commitment
+                  - key encipherment
+                  - key agreement
+                  - data encipherment
+                  - cert sign
+                  - crl sign
+                  - encipher only
+                  - decipher only
+                  - any
+                  - server auth
+                  - client auth
+                  - code signing
+                  - email protection
+                  - s/mime
+                  - ipsec end system
+                  - ipsec tunnel
+                  - ipsec user
+                  - timestamping
+                  - ocsp signing
+                  - microsoft sgc
+                  - netscape sgc
+                  type: string
+                type: array
+            required:
+            - issuerRef
+            - secretName
+            type: object
+          status:
+            description: CertificateStatus defines the observed state of Certificate
+            properties:
+              conditions:
+                items:
+                  description: CertificateCondition contains condition information
+                    for an Certificate.
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the timestamp corresponding
+                        to the last status change of this condition.
+                      format: date-time
+                      type: string
+                    message:
+                      description: Message is a human readable description of the
+                        details of the last transition, complementing reason.
+                      type: string
+                    reason:
+                      description: Reason is a brief machine readable explanation
+                        for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of ('True', 'False',
+                        'Unknown').
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: Type of the condition, currently ('Ready').
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastFailureTime:
+                format: date-time
+                type: string
+              notAfter:
+                description: The expiration time of the certificate stored in the
+                  secret named by this resource in spec.secretName.
+                format: date-time
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: Certificate is a type to represent a Certificate from ACME
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CertificateSpec defines the desired state of Certificate.
+              A valid Certificate requires at least one of a CommonName, DNSName,
+              or URISAN to be valid.
+            properties:
+              commonName:
+                description: 'CommonName is a common name to be used on the Certificate.
+                  The CommonName should have a length of 64 characters or fewer to
+                  avoid generating invalid CSRs. This value is ignored by TLS clients
+                  when any subject alt name is set. This is x509 behaviour: https://tools.ietf.org/html/rfc6125#section-6.4.4'
+                type: string
+              dnsNames:
+                description: DNSNames is a list of subject alt names to be used on
+                  the Certificate.
+                items:
+                  type: string
+                type: array
+              duration:
+                description: Certificate default Duration
+                type: string
+              emailSANs:
+                description: EmailSANs is a list of Email Subject Alternative Names
+                  to be set on this Certificate.
+                items:
+                  type: string
+                type: array
+              ipAddresses:
+                description: IPAddresses is a list of IP addresses to be used on the
+                  Certificate
+                items:
+                  type: string
+                type: array
+              isCA:
+                description: IsCA will mark this Certificate as valid for signing.
+                  This implies that the 'cert sign' usage is set
+                type: boolean
+              issuerRef:
+                description: IssuerRef is a reference to the issuer for this certificate.
+                  If the 'kind' field is not set, or set to 'Issuer', an Issuer resource
+                  with the given name in the same namespace as the Certificate will
+                  be used. If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer
+                  with the provided name will be used. The 'name' field in this stanza
+                  is required at all times.
+                properties:
+                  group:
+                    type: string
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                required:
+                - name
+                type: object
+              keyAlgorithm:
+                description: KeyAlgorithm is the private key algorithm of the corresponding
+                  private key for this certificate. If provided, allowed values are
+                  either "rsa" or "ecdsa" If KeyAlgorithm is specified and KeySize
+                  is not provided, key size of 256 will be used for "ecdsa" key algorithm
+                  and key size of 2048 will be used for "rsa" key algorithm.
+                enum:
+                - rsa
+                - ecdsa
+                type: string
+              keyEncoding:
+                description: KeyEncoding is the private key cryptography standards
+                  (PKCS) for this certificate's private key to be encoded in. If provided,
+                  allowed values are "pkcs1" and "pkcs8" standing for PKCS#1 and PKCS#8,
+                  respectively. If KeyEncoding is not specified, then PKCS#1 will
+                  be used by default.
+                enum:
+                - pkcs1
+                - pkcs8
+                type: string
+              keySize:
+                description: KeySize is the key bit size of the corresponding private
+                  key for this certificate. If provided, value must be between 2048
+                  and 8192 inclusive when KeyAlgorithm is empty or is set to "rsa",
+                  and value must be one of (256, 384, 521) when KeyAlgorithm is set
+                  to "ecdsa".
+                maximum: 8192
+                minimum: 0
+                type: integer
+              renewBefore:
+                description: Certificate renew before expiration duration
+                type: string
+              secretName:
+                description: SecretName is the name of the secret resource to store
+                  this secret in
+                type: string
+              subject:
+                description: Full X509 name specification (https://golang.org/pkg/crypto/x509/pkix/#Name).
+                properties:
+                  countries:
+                    description: Countries to be used on the Certificate.
+                    items:
+                      type: string
+                    type: array
+                  localities:
+                    description: Cities to be used on the Certificate.
+                    items:
+                      type: string
+                    type: array
+                  organizationalUnits:
+                    description: Organizational Units to be used on the Certificate.
+                    items:
+                      type: string
+                    type: array
+                  organizations:
+                    description: Organizations to be used on the Certificate.
+                    items:
+                      type: string
+                    type: array
+                  postalCodes:
+                    description: Postal codes to be used on the Certificate.
+                    items:
+                      type: string
+                    type: array
+                  provinces:
+                    description: State/Provinces to be used on the Certificate.
+                    items:
+                      type: string
+                    type: array
+                  serialNumber:
+                    description: Serial number to be used on the Certificate.
+                    type: string
+                  streetAddresses:
+                    description: Street addresses to be used on the Certificate.
+                    items:
+                      type: string
+                    type: array
+                type: object
+              uriSANs:
+                description: URISANs is a list of URI Subject Alternative Names to
+                  be set on this Certificate.
+                items:
+                  type: string
+                type: array
+              usages:
+                description: Usages is the set of x509 actions that are enabled for
+                  a given key. Defaults are ('digital signature', 'key encipherment')
+                  if empty
+                items:
+                  description: 'KeyUsage specifies valid usage contexts for keys.
+                    See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3      https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+                    Valid KeyUsage values are as follows: "signing", "digital signature",
+                    "content commitment", "key encipherment", "key agreement", "data
+                    encipherment", "cert sign", "crl sign", "encipher only", "decipher
+                    only", "any", "server auth", "client auth", "code signing", "email
+                    protection", "s/mime", "ipsec end system", "ipsec tunnel", "ipsec
+                    user", "timestamping", "ocsp signing", "microsoft sgc", "netscape
+                    sgc"'
+                  enum:
+                  - signing
+                  - digital signature
+                  - content commitment
+                  - key encipherment
+                  - key agreement
+                  - data encipherment
+                  - cert sign
+                  - crl sign
+                  - encipher only
+                  - decipher only
+                  - any
+                  - server auth
+                  - client auth
+                  - code signing
+                  - email protection
+                  - s/mime
+                  - ipsec end system
+                  - ipsec tunnel
+                  - ipsec user
+                  - timestamping
+                  - ocsp signing
+                  - microsoft sgc
+                  - netscape sgc
+                  type: string
+                type: array
+            required:
+            - issuerRef
+            - secretName
+            type: object
+          status:
+            description: CertificateStatus defines the observed state of Certificate
+            properties:
+              conditions:
+                items:
+                  description: CertificateCondition contains condition information
+                    for an Certificate.
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the timestamp corresponding
+                        to the last status change of this condition.
+                      format: date-time
+                      type: string
+                    message:
+                      description: Message is a human readable description of the
+                        details of the last transition, complementing reason.
+                      type: string
+                    reason:
+                      description: Reason is a brief machine readable explanation
+                        for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of ('True', 'False',
+                        'Unknown').
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: Type of the condition, currently ('Ready').
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastFailureTime:
+                format: date-time
+                type: string
+              notAfter:
+                description: The expiration time of the certificate stored in the
+                  secret named by this resource in spec.secretName.
+                format: date-time
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    cert-manager.io/inject-ca-from-secret: cert-manager/cert-manager-webhook-tls
   name: challenges.acme.cert-manager.io
 spec:
   additionalPrinterColumns:
@@ -456,13 +784,20 @@ spec:
       in RFC3339 form and is in UTC.
     name: Age
     type: date
+  conversion:
+    strategy: Webhook
+    webhookClientConfig:
+      service:
+        name: cert-manager-webhook
+        namespace: cert-manager
+        path: /convert
   group: acme.cert-manager.io
-  preserveUnknownFields: false
   names:
     kind: Challenge
     listKind: ChallengeList
     plural: challenges
     singular: challenge
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
@@ -470,9 +805,6 @@ spec:
     openAPIV3Schema:
       description: Challenge is a type to represent a Challenge request with an ACME
         server
-      type: object
-      required:
-      - metadata
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
@@ -487,15 +819,6 @@ spec:
         metadata:
           type: object
         spec:
-          type: object
-          required:
-          - authzURL
-          - dnsName
-          - issuerRef
-          - key
-          - token
-          - type
-          - url
           properties:
             authzURL:
               description: AuthzURL is the URL to the ACME Authorization resource
@@ -511,9 +834,6 @@ spec:
                 not exist, processing will be retried. If the Issuer is not an 'ACME'
                 Issuer, an error will be returned and the Challenge will be marked
                 as failed.
-              type: object
-              required:
-              - name
               properties:
                 group:
                   type: string
@@ -521,29 +841,23 @@ spec:
                   type: string
                 name:
                   type: string
+              required:
+              - name
+              type: object
             key:
               description: Key is the ACME challenge key for this challenge
               type: string
             solver:
               description: Solver contains the domain solving configuration that should
                 be used to solve this challenge resource.
-              type: object
               properties:
                 dns01:
-                  type: object
                   properties:
                     acmedns:
                       description: ACMEIssuerDNS01ProviderAcmeDNS is a structure containing
                         the configuration for ACME-DNS servers
-                      type: object
-                      required:
-                      - accountSecretRef
-                      - host
                       properties:
                         accountSecretRef:
-                          type: object
-                          required:
-                          - name
                           properties:
                             key:
                               description: The key of the secret to select from. Must
@@ -553,77 +867,74 @@ spec:
                               description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                 TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
+                          required:
+                          - name
+                          type: object
                         host:
                           type: string
+                      required:
+                      - accountSecretRef
+                      - host
+                      type: object
                     akamai:
                       description: ACMEIssuerDNS01ProviderAkamai is a structure containing
                         the DNS configuration for Akamai DNS—Zone Record Management
                         API
-                      type: object
+                      properties:
+                        accessTokenSecretRef:
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        clientSecretSecretRef:
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        clientTokenSecretRef:
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        serviceConsumerDomain:
+                          type: string
                       required:
                       - accessTokenSecretRef
                       - clientSecretSecretRef
                       - clientTokenSecretRef
                       - serviceConsumerDomain
-                      properties:
-                        accessTokenSecretRef:
-                          type: object
-                          required:
-                          - name
-                          properties:
-                            key:
-                              description: The key of the secret to select from. Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                        clientSecretSecretRef:
-                          type: object
-                          required:
-                          - name
-                          properties:
-                            key:
-                              description: The key of the secret to select from. Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                        clientTokenSecretRef:
-                          type: object
-                          required:
-                          - name
-                          properties:
-                            key:
-                              description: The key of the secret to select from. Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                        serviceConsumerDomain:
-                          type: string
+                      type: object
                     azuredns:
                       description: ACMEIssuerDNS01ProviderAzureDNS is a structure
                         containing the configuration for Azure DNS
-                      type: object
-                      required:
-                      - clientID
-                      - clientSecretSecretRef
-                      - resourceGroupName
-                      - subscriptionID
-                      - tenantID
                       properties:
                         clientID:
                           type: string
                         clientSecretSecretRef:
-                          type: object
-                          required:
-                          - name
                           properties:
                             key:
                               description: The key of the secret to select from. Must
@@ -633,13 +944,16 @@ spec:
                               description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                 TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
+                          required:
+                          - name
+                          type: object
                         environment:
-                          type: string
                           enum:
                           - AzurePublicCloud
                           - AzureChinaCloud
                           - AzureGermanCloud
                           - AzureUSGovernmentCloud
+                          type: string
                         hostedZoneName:
                           type: string
                         resourceGroupName:
@@ -648,19 +962,20 @@ spec:
                           type: string
                         tenantID:
                           type: string
+                      required:
+                      - clientID
+                      - clientSecretSecretRef
+                      - resourceGroupName
+                      - subscriptionID
+                      - tenantID
+                      type: object
                     clouddns:
                       description: ACMEIssuerDNS01ProviderCloudDNS is a structure
                         containing the DNS configuration for Google Cloud DNS
-                      type: object
-                      required:
-                      - project
                       properties:
                         project:
                           type: string
                         serviceAccountSecretRef:
-                          type: object
-                          required:
-                          - name
                           properties:
                             key:
                               description: The key of the secret to select from. Must
@@ -670,17 +985,17 @@ spec:
                               description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                 TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
+                          required:
+                          - name
+                          type: object
+                      required:
+                      - project
+                      type: object
                     cloudflare:
                       description: ACMEIssuerDNS01ProviderCloudflare is a structure
                         containing the DNS configuration for Cloudflare
-                      type: object
-                      required:
-                      - email
                       properties:
                         apiKeySecretRef:
-                          type: object
-                          required:
-                          - name
                           properties:
                             key:
                               description: The key of the secret to select from. Must
@@ -690,10 +1005,10 @@ spec:
                               description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                 TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
+                          required:
+                          - name
+                          type: object
                         apiTokenSecretRef:
-                          type: object
-                          required:
-                          - name
                           properties:
                             key:
                               description: The key of the secret to select from. Must
@@ -703,26 +1018,26 @@ spec:
                               description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                 TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
+                          required:
+                          - name
+                          type: object
                         email:
                           type: string
+                      required:
+                      - email
+                      type: object
                     cnameStrategy:
                       description: CNAMEStrategy configures how the DNS01 provider
                         should handle CNAME records when found in DNS zones.
-                      type: string
                       enum:
                       - None
                       - Follow
+                      type: string
                     digitalocean:
                       description: ACMEIssuerDNS01ProviderDigitalOcean is a structure
                         containing the DNS configuration for DigitalOcean Domains
-                      type: object
-                      required:
-                      - tokenSecretRef
                       properties:
                         tokenSecretRef:
-                          type: object
-                          required:
-                          - name
                           properties:
                             key:
                               description: The key of the secret to select from. Must
@@ -732,12 +1047,15 @@ spec:
                               description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                 TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
+                          required:
+                          - name
+                          type: object
+                      required:
+                      - tokenSecretRef
+                      type: object
                     rfc2136:
                       description: ACMEIssuerDNS01ProviderRFC2136 is a structure containing
                         the configuration for RFC2136 DNS
-                      type: object
-                      required:
-                      - nameserver
                       properties:
                         nameserver:
                           description: 'The IP address of the DNS supporting RFC2136.
@@ -757,9 +1075,6 @@ spec:
                         tsigSecretSecretRef:
                           description: The name of the secret containing the TSIG
                             value. If ``tsigKeyName`` is defined, this field is required.
-                          type: object
-                          required:
-                          - name
                           properties:
                             key:
                               description: The key of the secret to select from. Must
@@ -769,12 +1084,15 @@ spec:
                               description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                 TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
+                          required:
+                          - name
+                          type: object
+                      required:
+                      - nameserver
+                      type: object
                     route53:
                       description: ACMEIssuerDNS01ProviderRoute53 is a structure containing
                         the Route 53 configuration for AWS
-                      type: object
-                      required:
-                      - region
                       properties:
                         accessKeyID:
                           description: 'The AccessKeyID is used for authentication.
@@ -800,9 +1118,6 @@ spec:
                           description: The SecretAccessKey is used for authentication.
                             If not set we fall-back to using env vars, shared credentials
                             file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
-                          type: object
-                          required:
-                          - name
                           properties:
                             key:
                               description: The key of the secret to select from. Must
@@ -812,14 +1127,16 @@ spec:
                               description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                 TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
+                          required:
+                          - name
+                          type: object
+                      required:
+                      - region
+                      type: object
                     webhook:
                       description: ACMEIssuerDNS01ProviderWebhook specifies configuration
                         for a webhook DNS01 provider, including where to POST ChallengePayload
                         resources.
-                      type: object
-                      required:
-                      - groupName
-                      - solverName
                       properties:
                         config:
                           description: Additional configuration that should be passed
@@ -842,6 +1159,11 @@ spec:
                             the webhook provider implementation. This will typically
                             be the name of the provider, e.g. 'cloudflare'.
                           type: string
+                      required:
+                      - groupName
+                      - solverName
+                      type: object
+                  type: object
                 http01:
                   description: ACMEChallengeSolverHTTP01 contains configuration detailing
                     how to solve HTTP01 challenges within a Kubernetes cluster. Typically
@@ -849,7 +1171,6 @@ spec:
                     that configure ingress controllers to direct traffic to 'solver
                     pods', which are responsible for responding to the ACME server's
                     HTTP requests.
-                  type: object
                   properties:
                     ingress:
                       description: The ingress based HTTP01 challenge solver will
@@ -857,7 +1178,6 @@ spec:
                         in order to route requests for '/.well-known/acme-challenge/XYZ'
                         to 'challenge solver' pods that are provisioned by cert-manager
                         for each Challenge to be completed.
-                      type: object
                       properties:
                         class:
                           description: The ingress class to use when creating Ingress
@@ -875,7 +1195,6 @@ spec:
                         podTemplate:
                           description: Optional pod template used to configure the
                             ACME challenge solver pods used for HTTP01 challenges
-                          type: object
                           properties:
                             metadata:
                               description: ObjectMeta overrides for the pod used to
@@ -883,36 +1202,33 @@ spec:
                                 fields may be set. If labels or annotations overlap
                                 with in-built values, the values here will override
                                 the in-built values.
-                              type: object
                               properties:
                                 annotations:
+                                  additionalProperties:
+                                    type: string
                                   description: Annotations that should be added to
                                     the create ACME HTTP01 solver pods.
                                   type: object
+                                labels:
                                   additionalProperties:
                                     type: string
-                                labels:
                                   description: Labels that should be added to the
                                     created ACME HTTP01 solver pods.
                                   type: object
-                                  additionalProperties:
-                                    type: string
+                              type: object
                             spec:
                               description: PodSpec defines overrides for the HTTP01
                                 challenge solver pod. Only the 'nodeSelector', 'affinity'
                                 and 'tolerations' fields are supported currently.
                                 All other fields will be ignored.
-                              type: object
                               properties:
                                 affinity:
                                   description: If specified, the pod's scheduling
                                     constraints
-                                  type: object
                                   properties:
                                     nodeAffinity:
                                       description: Describes node affinity scheduling
                                         rules for the pod.
-                                      type: object
                                       properties:
                                         preferredDuringSchedulingIgnoredDuringExecution:
                                           description: The scheduler will prefer to
@@ -930,38 +1246,27 @@ spec:
                                             sum if the node matches the corresponding
                                             matchExpressions; the node(s) with the
                                             highest sum are the most preferred.
-                                          type: array
                                           items:
                                             description: An empty preferred scheduling
                                               term matches all objects with implicit
                                               weight 0 (i.e. it's a no-op). A null
                                               preferred scheduling term matches no
                                               objects (i.e. is also a no-op).
-                                            type: object
-                                            required:
-                                            - preference
-                                            - weight
                                             properties:
                                               preference:
                                                 description: A node selector term,
                                                   associated with the corresponding
                                                   weight.
-                                                type: object
                                                 properties:
                                                   matchExpressions:
                                                     description: A list of node selector
                                                       requirements by node's labels.
-                                                    type: array
                                                     items:
                                                       description: A node selector
                                                         requirement is a selector
                                                         that contains values, a key,
                                                         and an operator that relates
                                                         the key and values.
-                                                      type: object
-                                                      required:
-                                                      - key
-                                                      - operator
                                                       properties:
                                                         key:
                                                           description: The label key
@@ -992,23 +1297,23 @@ spec:
                                                             This array is replaced
                                                             during a strategic merge
                                                             patch.
-                                                          type: array
                                                           items:
                                                             type: string
+                                                          type: array
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
                                                   matchFields:
                                                     description: A list of node selector
                                                       requirements by node's fields.
-                                                    type: array
                                                     items:
                                                       description: A node selector
                                                         requirement is a selector
                                                         that contains values, a key,
                                                         and an operator that relates
                                                         the key and values.
-                                                      type: object
-                                                      required:
-                                                      - key
-                                                      - operator
                                                       properties:
                                                         key:
                                                           description: The label key
@@ -1039,15 +1344,26 @@ spec:
                                                             This array is replaced
                                                             during a strategic merge
                                                             patch.
-                                                          type: array
                                                           items:
                                                             type: string
+                                                          type: array
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                type: object
                                               weight:
                                                 description: Weight associated with
                                                   matching the corresponding nodeSelectorTerm,
                                                   in the range 1-100.
-                                                type: integer
                                                 format: int32
+                                                type: integer
+                                            required:
+                                            - preference
+                                            - weight
+                                            type: object
+                                          type: array
                                         requiredDuringSchedulingIgnoredDuringExecution:
                                           description: If the affinity requirements
                                             specified by this field are not met at
@@ -1058,36 +1374,26 @@ spec:
                                             due to an update), the system may or may
                                             not try to eventually evict the pod from
                                             its node.
-                                          type: object
-                                          required:
-                                          - nodeSelectorTerms
                                           properties:
                                             nodeSelectorTerms:
                                               description: Required. A list of node
                                                 selector terms. The terms are ORed.
-                                              type: array
                                               items:
                                                 description: A null or empty node
                                                   selector term matches no objects.
                                                   The requirements of them are ANDed.
                                                   The TopologySelectorTerm type implements
                                                   a subset of the NodeSelectorTerm.
-                                                type: object
                                                 properties:
                                                   matchExpressions:
                                                     description: A list of node selector
                                                       requirements by node's labels.
-                                                    type: array
                                                     items:
                                                       description: A node selector
                                                         requirement is a selector
                                                         that contains values, a key,
                                                         and an operator that relates
                                                         the key and values.
-                                                      type: object
-                                                      required:
-                                                      - key
-                                                      - operator
                                                       properties:
                                                         key:
                                                           description: The label key
@@ -1118,23 +1424,23 @@ spec:
                                                             This array is replaced
                                                             during a strategic merge
                                                             patch.
-                                                          type: array
                                                           items:
                                                             type: string
+                                                          type: array
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
                                                   matchFields:
                                                     description: A list of node selector
                                                       requirements by node's fields.
-                                                    type: array
                                                     items:
                                                       description: A node selector
                                                         requirement is a selector
                                                         that contains values, a key,
                                                         and an operator that relates
                                                         the key and values.
-                                                      type: object
-                                                      required:
-                                                      - key
-                                                      - operator
                                                       properties:
                                                         key:
                                                           description: The label key
@@ -1165,14 +1471,24 @@ spec:
                                                             This array is replaced
                                                             during a strategic merge
                                                             patch.
-                                                          type: array
                                                           items:
                                                             type: string
+                                                          type: array
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                type: object
+                                              type: array
+                                          required:
+                                          - nodeSelectorTerms
+                                          type: object
+                                      type: object
                                     podAffinity:
                                       description: Describes pod affinity scheduling
                                         rules (e.g. co-locate this pod in the same
                                         node, zone, etc. as some other pod(s)).
-                                      type: object
                                       properties:
                                         preferredDuringSchedulingIgnoredDuringExecution:
                                           description: The scheduler will prefer to
@@ -1191,37 +1507,27 @@ spec:
                                             the corresponding podAffinityTerm; the
                                             node(s) with the highest sum are the most
                                             preferred.
-                                          type: array
                                           items:
                                             description: The weights of all of the
                                               matched WeightedPodAffinityTerm fields
                                               are added per-node to find the most
                                               preferred node(s)
-                                            type: object
-                                            required:
-                                            - podAffinityTerm
-                                            - weight
                                             properties:
                                               podAffinityTerm:
                                                 description: Required. A pod affinity
                                                   term, associated with the corresponding
                                                   weight.
-                                                type: object
-                                                required:
-                                                - topologyKey
                                                 properties:
                                                   labelSelector:
                                                     description: A label query over
                                                       a set of resources, in this
                                                       case pods.
-                                                    type: object
                                                     properties:
                                                       matchExpressions:
                                                         description: matchExpressions
                                                           is a list of label selector
                                                           requirements. The requirements
                                                           are ANDed.
-                                                        type: array
                                                         items:
                                                           description: A label selector
                                                             requirement is a selector
@@ -1229,10 +1535,6 @@ spec:
                                                             a key, and an operator
                                                             that relates the key and
                                                             values.
-                                                          type: object
-                                                          required:
-                                                          - key
-                                                          - operator
                                                           properties:
                                                             key:
                                                               description: key is
@@ -1263,10 +1565,17 @@ spec:
                                                                 is replaced during
                                                                 a strategic merge
                                                                 patch.
-                                                              type: array
                                                               items:
                                                                 type: string
+                                                              type: array
+                                                          required:
+                                                          - key
+                                                          - operator
+                                                          type: object
+                                                        type: array
                                                       matchLabels:
+                                                        additionalProperties:
+                                                          type: string
                                                         description: matchLabels is
                                                           a map of {key,value} pairs.
                                                           A single {key,value} in
@@ -1278,17 +1587,16 @@ spec:
                                                           only "value". The requirements
                                                           are ANDed.
                                                         type: object
-                                                        additionalProperties:
-                                                          type: string
+                                                    type: object
                                                   namespaces:
                                                     description: namespaces specifies
                                                       which namespaces the labelSelector
                                                       applies to (matches against);
                                                       null or empty list means "this
                                                       pod's namespace"
-                                                    type: array
                                                     items:
                                                       type: string
+                                                    type: array
                                                   topologyKey:
                                                     description: This pod should be
                                                       co-located (affinity) or not
@@ -1303,12 +1611,20 @@ spec:
                                                       is running. Empty topologyKey
                                                       is not allowed.
                                                     type: string
+                                                required:
+                                                - topologyKey
+                                                type: object
                                               weight:
                                                 description: weight associated with
                                                   matching the corresponding podAffinityTerm,
                                                   in the range 1-100.
-                                                type: integer
                                                 format: int32
+                                                type: integer
+                                            required:
+                                            - podAffinityTerm
+                                            - weight
+                                            type: object
+                                          type: array
                                         requiredDuringSchedulingIgnoredDuringExecution:
                                           description: If the affinity requirements
                                             specified by this field are not met at
@@ -1323,7 +1639,6 @@ spec:
                                             corresponding to each podAffinityTerm
                                             are intersected, i.e. all terms must be
                                             satisfied.
-                                          type: array
                                           items:
                                             description: Defines a set of pods (namely
                                               those matching the labelSelector relative
@@ -1335,31 +1650,22 @@ spec:
                                               key <topologyKey> matches that of any
                                               node on which a pod of the set of pods
                                               is running
-                                            type: object
-                                            required:
-                                            - topologyKey
                                             properties:
                                               labelSelector:
                                                 description: A label query over a
                                                   set of resources, in this case pods.
-                                                type: object
                                                 properties:
                                                   matchExpressions:
                                                     description: matchExpressions
                                                       is a list of label selector
                                                       requirements. The requirements
                                                       are ANDed.
-                                                    type: array
                                                     items:
                                                       description: A label selector
                                                         requirement is a selector
                                                         that contains values, a key,
                                                         and an operator that relates
                                                         the key and values.
-                                                      type: object
-                                                      required:
-                                                      - key
-                                                      - operator
                                                       properties:
                                                         key:
                                                           description: key is the
@@ -1384,10 +1690,17 @@ spec:
                                                             array must be empty. This
                                                             array is replaced during
                                                             a strategic merge patch.
-                                                          type: array
                                                           items:
                                                             type: string
+                                                          type: array
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
                                                   matchLabels:
+                                                    additionalProperties:
+                                                      type: string
                                                     description: matchLabels is a
                                                       map of {key,value} pairs. A
                                                       single {key,value} in the matchLabels
@@ -1398,17 +1711,16 @@ spec:
                                                       contains only "value". The requirements
                                                       are ANDed.
                                                     type: object
-                                                    additionalProperties:
-                                                      type: string
+                                                type: object
                                               namespaces:
                                                 description: namespaces specifies
                                                   which namespaces the labelSelector
                                                   applies to (matches against); null
                                                   or empty list means "this pod's
                                                   namespace"
-                                                type: array
                                                 items:
                                                   type: string
+                                                type: array
                                               topologyKey:
                                                 description: This pod should be co-located
                                                   (affinity) or not co-located (anti-affinity)
@@ -1421,11 +1733,15 @@ spec:
                                                   selected pods is running. Empty
                                                   topologyKey is not allowed.
                                                 type: string
+                                            required:
+                                            - topologyKey
+                                            type: object
+                                          type: array
+                                      type: object
                                     podAntiAffinity:
                                       description: Describes pod anti-affinity scheduling
                                         rules (e.g. avoid putting this pod in the
                                         same node, zone, etc. as some other pod(s)).
-                                      type: object
                                       properties:
                                         preferredDuringSchedulingIgnoredDuringExecution:
                                           description: The scheduler will prefer to
@@ -1444,37 +1760,27 @@ spec:
                                             has pods which matches the corresponding
                                             podAffinityTerm; the node(s) with the
                                             highest sum are the most preferred.
-                                          type: array
                                           items:
                                             description: The weights of all of the
                                               matched WeightedPodAffinityTerm fields
                                               are added per-node to find the most
                                               preferred node(s)
-                                            type: object
-                                            required:
-                                            - podAffinityTerm
-                                            - weight
                                             properties:
                                               podAffinityTerm:
                                                 description: Required. A pod affinity
                                                   term, associated with the corresponding
                                                   weight.
-                                                type: object
-                                                required:
-                                                - topologyKey
                                                 properties:
                                                   labelSelector:
                                                     description: A label query over
                                                       a set of resources, in this
                                                       case pods.
-                                                    type: object
                                                     properties:
                                                       matchExpressions:
                                                         description: matchExpressions
                                                           is a list of label selector
                                                           requirements. The requirements
                                                           are ANDed.
-                                                        type: array
                                                         items:
                                                           description: A label selector
                                                             requirement is a selector
@@ -1482,10 +1788,6 @@ spec:
                                                             a key, and an operator
                                                             that relates the key and
                                                             values.
-                                                          type: object
-                                                          required:
-                                                          - key
-                                                          - operator
                                                           properties:
                                                             key:
                                                               description: key is
@@ -1516,10 +1818,17 @@ spec:
                                                                 is replaced during
                                                                 a strategic merge
                                                                 patch.
-                                                              type: array
                                                               items:
                                                                 type: string
+                                                              type: array
+                                                          required:
+                                                          - key
+                                                          - operator
+                                                          type: object
+                                                        type: array
                                                       matchLabels:
+                                                        additionalProperties:
+                                                          type: string
                                                         description: matchLabels is
                                                           a map of {key,value} pairs.
                                                           A single {key,value} in
@@ -1531,17 +1840,16 @@ spec:
                                                           only "value". The requirements
                                                           are ANDed.
                                                         type: object
-                                                        additionalProperties:
-                                                          type: string
+                                                    type: object
                                                   namespaces:
                                                     description: namespaces specifies
                                                       which namespaces the labelSelector
                                                       applies to (matches against);
                                                       null or empty list means "this
                                                       pod's namespace"
-                                                    type: array
                                                     items:
                                                       type: string
+                                                    type: array
                                                   topologyKey:
                                                     description: This pod should be
                                                       co-located (affinity) or not
@@ -1556,12 +1864,20 @@ spec:
                                                       is running. Empty topologyKey
                                                       is not allowed.
                                                     type: string
+                                                required:
+                                                - topologyKey
+                                                type: object
                                               weight:
                                                 description: weight associated with
                                                   matching the corresponding podAffinityTerm,
                                                   in the range 1-100.
-                                                type: integer
                                                 format: int32
+                                                type: integer
+                                            required:
+                                            - podAffinityTerm
+                                            - weight
+                                            type: object
+                                          type: array
                                         requiredDuringSchedulingIgnoredDuringExecution:
                                           description: If the anti-affinity requirements
                                             specified by this field are not met at
@@ -1576,7 +1892,6 @@ spec:
                                             corresponding to each podAffinityTerm
                                             are intersected, i.e. all terms must be
                                             satisfied.
-                                          type: array
                                           items:
                                             description: Defines a set of pods (namely
                                               those matching the labelSelector relative
@@ -1588,31 +1903,22 @@ spec:
                                               key <topologyKey> matches that of any
                                               node on which a pod of the set of pods
                                               is running
-                                            type: object
-                                            required:
-                                            - topologyKey
                                             properties:
                                               labelSelector:
                                                 description: A label query over a
                                                   set of resources, in this case pods.
-                                                type: object
                                                 properties:
                                                   matchExpressions:
                                                     description: matchExpressions
                                                       is a list of label selector
                                                       requirements. The requirements
                                                       are ANDed.
-                                                    type: array
                                                     items:
                                                       description: A label selector
                                                         requirement is a selector
                                                         that contains values, a key,
                                                         and an operator that relates
                                                         the key and values.
-                                                      type: object
-                                                      required:
-                                                      - key
-                                                      - operator
                                                       properties:
                                                         key:
                                                           description: key is the
@@ -1637,10 +1943,17 @@ spec:
                                                             array must be empty. This
                                                             array is replaced during
                                                             a strategic merge patch.
-                                                          type: array
                                                           items:
                                                             type: string
+                                                          type: array
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
                                                   matchLabels:
+                                                    additionalProperties:
+                                                      type: string
                                                     description: matchLabels is a
                                                       map of {key,value} pairs. A
                                                       single {key,value} in the matchLabels
@@ -1651,17 +1964,16 @@ spec:
                                                       contains only "value". The requirements
                                                       are ANDed.
                                                     type: object
-                                                    additionalProperties:
-                                                      type: string
+                                                type: object
                                               namespaces:
                                                 description: namespaces specifies
                                                   which namespaces the labelSelector
                                                   applies to (matches against); null
                                                   or empty list means "this pod's
                                                   namespace"
-                                                type: array
                                                 items:
                                                   type: string
+                                                type: array
                                               topologyKey:
                                                 description: This pod should be co-located
                                                   (affinity) or not co-located (anti-affinity)
@@ -1674,23 +1986,27 @@ spec:
                                                   selected pods is running. Empty
                                                   topologyKey is not allowed.
                                                 type: string
+                                            required:
+                                            - topologyKey
+                                            type: object
+                                          type: array
+                                      type: object
+                                  type: object
                                 nodeSelector:
+                                  additionalProperties:
+                                    type: string
                                   description: 'NodeSelector is a selector which must
                                     be true for the pod to fit on a node. Selector
                                     which must match a node''s labels for the pod
                                     to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                                   type: object
-                                  additionalProperties:
-                                    type: string
                                 tolerations:
                                   description: If specified, the pod's tolerations.
-                                  type: array
                                   items:
                                     description: The pod this Toleration is attached
                                       to tolerates any taint that matches the triple
                                       <key,value,effect> using the matching operator
                                       <operator>.
-                                    type: object
                                     properties:
                                       effect:
                                         description: Effect indicates the taint effect
@@ -1722,22 +2038,27 @@ spec:
                                           the taint forever (do not evict). Zero and
                                           negative values will be treated as 0 (evict
                                           immediately) by the system.
-                                        type: integer
                                         format: int64
+                                        type: integer
                                       value:
                                         description: Value is the taint value the
                                           toleration matches to. If the operator is
                                           Exists, the value should be empty, otherwise
                                           just a regular string.
                                         type: string
+                                    type: object
+                                  type: array
+                              type: object
+                          type: object
                         serviceType:
                           description: Optional service type for Kubernetes solver
                             service
                           type: string
+                      type: object
+                  type: object
                 selector:
                   description: Selector selects a set of DNSNames on the Certificate
                     resource that should be solved using this challenge solver.
-                  type: object
                   properties:
                     dnsNames:
                       description: List of DNSNames that this solver will be used
@@ -1747,9 +2068,9 @@ spec:
                         the most matching labels in matchLabels will be selected.
                         If neither has more matches, the solver defined earlier in
                         the list will be selected.
-                      type: array
                       items:
                         type: string
+                      type: array
                     dnsZones:
                       description: List of DNSZones that this solver will be used
                         to solve. The most specific DNS zone match specified here
@@ -1760,15 +2081,17 @@ spec:
                         the most matching labels in matchLabels will be selected.
                         If neither has more matches, the solver defined earlier in
                         the list will be selected.
-                      type: array
                       items:
                         type: string
+                      type: array
                     matchLabels:
+                      additionalProperties:
+                        type: string
                       description: A label selector that is used to refine the set
                         of certificate's that this challenge solver will apply to.
                       type: object
-                      additionalProperties:
-                        type: string
+                  type: object
+              type: object
             token:
               description: Token is the ACME challenge token for this challenge.
               type: string
@@ -1785,8 +2108,16 @@ spec:
               description: Wildcard will be true if this challenge is for a wildcard
                 identifier, for example '*.example.com'
               type: boolean
-        status:
+          required:
+          - authzURL
+          - dnsName
+          - issuerRef
+          - key
+          - token
+          - type
+          - url
           type: object
+        status:
           properties:
             presented:
               description: Presented will be set to true if the challenge values for
@@ -1810,7 +2141,6 @@ spec:
             state:
               description: State contains the current 'state' of the challenge. If
                 not set, the state of the challenge is unknown.
-              type: string
               enum:
               - valid
               - ready
@@ -1819,15 +2149,24 @@ spec:
               - invalid
               - expired
               - errored
-  version: v1alpha2
+              type: string
+          type: object
+      required:
+      - metadata
+      type: object
   versions:
   - name: v1alpha2
     served: true
     storage: true
+  - name: v1alpha3
+    served: true
+    storage: false
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    cert-manager.io/inject-ca-from-secret: cert-manager/cert-manager-webhook-tls
   name: clusterissuers.cert-manager.io
 spec:
   additionalPrinterColumns:
@@ -1845,19 +2184,25 @@ spec:
       in RFC3339 form and is in UTC.
     name: Age
     type: date
+  conversion:
+    strategy: Webhook
+    webhookClientConfig:
+      service:
+        name: cert-manager-webhook
+        namespace: cert-manager
+        path: /convert
   group: cert-manager.io
-  preserveUnknownFields: false
   names:
     kind: ClusterIssuer
     listKind: ClusterIssuerList
     plural: clusterissuers
     singular: clusterissuer
+  preserveUnknownFields: false
   scope: Cluster
   subresources:
     status: {}
   validation:
     openAPIV3Schema:
-      type: object
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
@@ -1874,24 +2219,58 @@ spec:
         spec:
           description: IssuerSpec is the specification of an Issuer. This includes
             any configuration required for the issuer.
-          type: object
           properties:
             acme:
               description: ACMEIssuer contains the specification for an ACME issuer
-              type: object
-              required:
-              - privateKeySecretRef
-              - server
               properties:
                 email:
                   description: Email is the email for this account
                   type: string
+                externalAccountBinding:
+                  description: ExternalAccountBinding is a reference to a CA external
+                    account of the ACME server.
+                  properties:
+                    keyAlgorithm:
+                      description: keyAlgorithm is the MAC key algorithm that the
+                        key is used for. Valid values are "HS256", "HS384" and "HS512".
+                      enum:
+                      - HS256
+                      - HS384
+                      - HS512
+                      type: string
+                    keyID:
+                      description: keyID is the ID of the CA key that the External
+                        Account is bound to.
+                      type: string
+                    keySecretRef:
+                      description: keySecretRef is a Secret Key Selector referencing
+                        a data item in a Kubernetes Secret which holds the symmetric
+                        MAC key of the External Account Binding. The `key` is the
+                        index string that is paired with the key data in the Secret
+                        and should not be confused with the key data itself, or indeed
+                        with the External Account Binding keyID above. The secret
+                        key stored in the Secret **must** be un-padded, base64 URL
+                        encoded data.
+                      properties:
+                        key:
+                          description: The key of the secret to select from. Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - keyAlgorithm
+                  - keyID
+                  - keySecretRef
+                  type: object
                 privateKeySecretRef:
                   description: PrivateKey is the name of a secret containing the private
                     key for this user account.
-                  type: object
-                  required:
-                  - name
                   properties:
                     key:
                       description: The key of the secret to select from. Must be a
@@ -1901,6 +2280,9 @@ spec:
                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                         TODO: Add other useful fields. apiVersion, kind, uid?'
                       type: string
+                  required:
+                  - name
+                  type: object
                 server:
                   description: Server is the ACME server URL
                   type: string
@@ -1910,25 +2292,15 @@ spec:
                 solvers:
                   description: Solvers is a list of challenge solvers that will be
                     used to solve ACME challenges for the matching domains.
-                  type: array
                   items:
-                    type: object
                     properties:
                       dns01:
-                        type: object
                         properties:
                           acmedns:
                             description: ACMEIssuerDNS01ProviderAcmeDNS is a structure
                               containing the configuration for ACME-DNS servers
-                            type: object
-                            required:
-                            - accountSecretRef
-                            - host
                             properties:
                               accountSecretRef:
-                                type: object
-                                required:
-                                - name
                                 properties:
                                   key:
                                     description: The key of the secret to select from.
@@ -1940,83 +2312,80 @@ spec:
                                       TODO: Add other useful fields. apiVersion, kind,
                                       uid?'
                                     type: string
+                                required:
+                                - name
+                                type: object
                               host:
                                 type: string
+                            required:
+                            - accountSecretRef
+                            - host
+                            type: object
                           akamai:
                             description: ACMEIssuerDNS01ProviderAkamai is a structure
                               containing the DNS configuration for Akamai DNS—Zone
                               Record Management API
-                            type: object
+                            properties:
+                              accessTokenSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              clientSecretSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              clientTokenSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              serviceConsumerDomain:
+                                type: string
                             required:
                             - accessTokenSecretRef
                             - clientSecretSecretRef
                             - clientTokenSecretRef
                             - serviceConsumerDomain
-                            properties:
-                              accessTokenSecretRef:
-                                type: object
-                                required:
-                                - name
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                              clientSecretSecretRef:
-                                type: object
-                                required:
-                                - name
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                              clientTokenSecretRef:
-                                type: object
-                                required:
-                                - name
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                              serviceConsumerDomain:
-                                type: string
+                            type: object
                           azuredns:
                             description: ACMEIssuerDNS01ProviderAzureDNS is a structure
                               containing the configuration for Azure DNS
-                            type: object
-                            required:
-                            - clientID
-                            - clientSecretSecretRef
-                            - resourceGroupName
-                            - subscriptionID
-                            - tenantID
                             properties:
                               clientID:
                                 type: string
                               clientSecretSecretRef:
-                                type: object
-                                required:
-                                - name
                                 properties:
                                   key:
                                     description: The key of the secret to select from.
@@ -2028,13 +2397,16 @@ spec:
                                       TODO: Add other useful fields. apiVersion, kind,
                                       uid?'
                                     type: string
+                                required:
+                                - name
+                                type: object
                               environment:
-                                type: string
                                 enum:
                                 - AzurePublicCloud
                                 - AzureChinaCloud
                                 - AzureGermanCloud
                                 - AzureUSGovernmentCloud
+                                type: string
                               hostedZoneName:
                                 type: string
                               resourceGroupName:
@@ -2043,19 +2415,20 @@ spec:
                                 type: string
                               tenantID:
                                 type: string
+                            required:
+                            - clientID
+                            - clientSecretSecretRef
+                            - resourceGroupName
+                            - subscriptionID
+                            - tenantID
+                            type: object
                           clouddns:
                             description: ACMEIssuerDNS01ProviderCloudDNS is a structure
                               containing the DNS configuration for Google Cloud DNS
-                            type: object
-                            required:
-                            - project
                             properties:
                               project:
                                 type: string
                               serviceAccountSecretRef:
-                                type: object
-                                required:
-                                - name
                                 properties:
                                   key:
                                     description: The key of the secret to select from.
@@ -2067,17 +2440,17 @@ spec:
                                       TODO: Add other useful fields. apiVersion, kind,
                                       uid?'
                                     type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - project
+                            type: object
                           cloudflare:
                             description: ACMEIssuerDNS01ProviderCloudflare is a structure
                               containing the DNS configuration for Cloudflare
-                            type: object
-                            required:
-                            - email
                             properties:
                               apiKeySecretRef:
-                                type: object
-                                required:
-                                - name
                                 properties:
                                   key:
                                     description: The key of the secret to select from.
@@ -2089,10 +2462,10 @@ spec:
                                       TODO: Add other useful fields. apiVersion, kind,
                                       uid?'
                                     type: string
+                                required:
+                                - name
+                                type: object
                               apiTokenSecretRef:
-                                type: object
-                                required:
-                                - name
                                 properties:
                                   key:
                                     description: The key of the secret to select from.
@@ -2104,27 +2477,27 @@ spec:
                                       TODO: Add other useful fields. apiVersion, kind,
                                       uid?'
                                     type: string
+                                required:
+                                - name
+                                type: object
                               email:
                                 type: string
+                            required:
+                            - email
+                            type: object
                           cnameStrategy:
                             description: CNAMEStrategy configures how the DNS01 provider
                               should handle CNAME records when found in DNS zones.
-                            type: string
                             enum:
                             - None
                             - Follow
+                            type: string
                           digitalocean:
                             description: ACMEIssuerDNS01ProviderDigitalOcean is a
                               structure containing the DNS configuration for DigitalOcean
                               Domains
-                            type: object
-                            required:
-                            - tokenSecretRef
                             properties:
                               tokenSecretRef:
-                                type: object
-                                required:
-                                - name
                                 properties:
                                   key:
                                     description: The key of the secret to select from.
@@ -2136,12 +2509,15 @@ spec:
                                       TODO: Add other useful fields. apiVersion, kind,
                                       uid?'
                                     type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - tokenSecretRef
+                            type: object
                           rfc2136:
                             description: ACMEIssuerDNS01ProviderRFC2136 is a structure
                               containing the configuration for RFC2136 DNS
-                            type: object
-                            required:
-                            - nameserver
                             properties:
                               nameserver:
                                 description: 'The IP address of the DNS supporting
@@ -2164,9 +2540,6 @@ spec:
                                 description: The name of the secret containing the
                                   TSIG value. If ``tsigKeyName`` is defined, this
                                   field is required.
-                                type: object
-                                required:
-                                - name
                                 properties:
                                   key:
                                     description: The key of the secret to select from.
@@ -2178,12 +2551,15 @@ spec:
                                       TODO: Add other useful fields. apiVersion, kind,
                                       uid?'
                                     type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - nameserver
+                            type: object
                           route53:
                             description: ACMEIssuerDNS01ProviderRoute53 is a structure
                               containing the Route 53 configuration for AWS
-                            type: object
-                            required:
-                            - region
                             properties:
                               accessKeyID:
                                 description: 'The AccessKeyID is used for authentication.
@@ -2210,9 +2586,6 @@ spec:
                                 description: The SecretAccessKey is used for authentication.
                                   If not set we fall-back to using env vars, shared
                                   credentials file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
-                                type: object
-                                required:
-                                - name
                                 properties:
                                   key:
                                     description: The key of the secret to select from.
@@ -2224,14 +2597,16 @@ spec:
                                       TODO: Add other useful fields. apiVersion, kind,
                                       uid?'
                                     type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - region
+                            type: object
                           webhook:
                             description: ACMEIssuerDNS01ProviderWebhook specifies
                               configuration for a webhook DNS01 provider, including
                               where to POST ChallengePayload resources.
-                            type: object
-                            required:
-                            - groupName
-                            - solverName
                             properties:
                               config:
                                 description: Additional configuration that should
@@ -2255,6 +2630,11 @@ spec:
                                   in the webhook provider implementation. This will
                                   typically be the name of the provider, e.g. 'cloudflare'.
                                 type: string
+                            required:
+                            - groupName
+                            - solverName
+                            type: object
+                        type: object
                       http01:
                         description: ACMEChallengeSolverHTTP01 contains configuration
                           detailing how to solve HTTP01 challenges within a Kubernetes
@@ -2262,7 +2642,6 @@ spec:
                           'routes' of some description that configure ingress controllers
                           to direct traffic to 'solver pods', which are responsible
                           for responding to the ACME server's HTTP requests.
-                        type: object
                         properties:
                           ingress:
                             description: The ingress based HTTP01 challenge solver
@@ -2270,7 +2649,6 @@ spec:
                               resources in order to route requests for '/.well-known/acme-challenge/XYZ'
                               to 'challenge solver' pods that are provisioned by cert-manager
                               for each Challenge to be completed.
-                            type: object
                             properties:
                               class:
                                 description: The ingress class to use when creating
@@ -2289,7 +2667,6 @@ spec:
                               podTemplate:
                                 description: Optional pod template used to configure
                                   the ACME challenge solver pods used for HTTP01 challenges
-                                type: object
                                 properties:
                                   metadata:
                                     description: ObjectMeta overrides for the pod
@@ -2297,36 +2674,33 @@ spec:
                                       and 'annotations' fields may be set. If labels
                                       or annotations overlap with in-built values,
                                       the values here will override the in-built values.
-                                    type: object
                                     properties:
                                       annotations:
+                                        additionalProperties:
+                                          type: string
                                         description: Annotations that should be added
                                           to the create ACME HTTP01 solver pods.
                                         type: object
+                                      labels:
                                         additionalProperties:
                                           type: string
-                                      labels:
                                         description: Labels that should be added to
                                           the created ACME HTTP01 solver pods.
                                         type: object
-                                        additionalProperties:
-                                          type: string
+                                    type: object
                                   spec:
                                     description: PodSpec defines overrides for the
                                       HTTP01 challenge solver pod. Only the 'nodeSelector',
                                       'affinity' and 'tolerations' fields are supported
                                       currently. All other fields will be ignored.
-                                    type: object
                                     properties:
                                       affinity:
                                         description: If specified, the pod's scheduling
                                           constraints
-                                        type: object
                                         properties:
                                           nodeAffinity:
                                             description: Describes node affinity scheduling
                                               rules for the pod.
-                                            type: object
                                             properties:
                                               preferredDuringSchedulingIgnoredDuringExecution:
                                                 description: The scheduler will prefer
@@ -2347,7 +2721,6 @@ spec:
                                                   corresponding matchExpressions;
                                                   the node(s) with the highest sum
                                                   are the most preferred.
-                                                type: array
                                                 items:
                                                   description: An empty preferred
                                                     scheduling term matches all objects
@@ -2355,22 +2728,16 @@ spec:
                                                     a no-op). A null preferred scheduling
                                                     term matches no objects (i.e.
                                                     is also a no-op).
-                                                  type: object
-                                                  required:
-                                                  - preference
-                                                  - weight
                                                   properties:
                                                     preference:
                                                       description: A node selector
                                                         term, associated with the
                                                         corresponding weight.
-                                                      type: object
                                                       properties:
                                                         matchExpressions:
                                                           description: A list of node
                                                             selector requirements
                                                             by node's labels.
-                                                          type: array
                                                           items:
                                                             description: A node selector
                                                               requirement is a selector
@@ -2378,10 +2745,6 @@ spec:
                                                               a key, and an operator
                                                               that relates the key
                                                               and values.
-                                                            type: object
-                                                            required:
-                                                            - key
-                                                            - operator
                                                             properties:
                                                               key:
                                                                 description: The label
@@ -2417,14 +2780,18 @@ spec:
                                                                   array is replaced
                                                                   during a strategic
                                                                   merge patch.
-                                                                type: array
                                                                 items:
                                                                   type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
                                                         matchFields:
                                                           description: A list of node
                                                             selector requirements
                                                             by node's fields.
-                                                          type: array
                                                           items:
                                                             description: A node selector
                                                               requirement is a selector
@@ -2432,10 +2799,6 @@ spec:
                                                               a key, and an operator
                                                               that relates the key
                                                               and values.
-                                                            type: object
-                                                            required:
-                                                            - key
-                                                            - operator
                                                             properties:
                                                               key:
                                                                 description: The label
@@ -2471,16 +2834,27 @@ spec:
                                                                   array is replaced
                                                                   during a strategic
                                                                   merge patch.
-                                                                type: array
                                                                 items:
                                                                   type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                      type: object
                                                     weight:
                                                       description: Weight associated
                                                         with matching the corresponding
                                                         nodeSelectorTerm, in the range
                                                         1-100.
-                                                      type: integer
                                                       format: int32
+                                                      type: integer
+                                                  required:
+                                                  - preference
+                                                  - weight
+                                                  type: object
+                                                type: array
                                               requiredDuringSchedulingIgnoredDuringExecution:
                                                 description: If the affinity requirements
                                                   specified by this field are not
@@ -2492,15 +2866,11 @@ spec:
                                                   (e.g. due to an update), the system
                                                   may or may not try to eventually
                                                   evict the pod from its node.
-                                                type: object
-                                                required:
-                                                - nodeSelectorTerms
                                                 properties:
                                                   nodeSelectorTerms:
                                                     description: Required. A list
                                                       of node selector terms. The
                                                       terms are ORed.
-                                                    type: array
                                                     items:
                                                       description: A null or empty
                                                         node selector term matches
@@ -2508,13 +2878,11 @@ spec:
                                                         of them are ANDed. The TopologySelectorTerm
                                                         type implements a subset of
                                                         the NodeSelectorTerm.
-                                                      type: object
                                                       properties:
                                                         matchExpressions:
                                                           description: A list of node
                                                             selector requirements
                                                             by node's labels.
-                                                          type: array
                                                           items:
                                                             description: A node selector
                                                               requirement is a selector
@@ -2522,10 +2890,6 @@ spec:
                                                               a key, and an operator
                                                               that relates the key
                                                               and values.
-                                                            type: object
-                                                            required:
-                                                            - key
-                                                            - operator
                                                             properties:
                                                               key:
                                                                 description: The label
@@ -2561,14 +2925,18 @@ spec:
                                                                   array is replaced
                                                                   during a strategic
                                                                   merge patch.
-                                                                type: array
                                                                 items:
                                                                   type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
                                                         matchFields:
                                                           description: A list of node
                                                             selector requirements
                                                             by node's fields.
-                                                          type: array
                                                           items:
                                                             description: A node selector
                                                               requirement is a selector
@@ -2576,10 +2944,6 @@ spec:
                                                               a key, and an operator
                                                               that relates the key
                                                               and values.
-                                                            type: object
-                                                            required:
-                                                            - key
-                                                            - operator
                                                             properties:
                                                               key:
                                                                 description: The label
@@ -2615,15 +2979,25 @@ spec:
                                                                   array is replaced
                                                                   during a strategic
                                                                   merge patch.
-                                                                type: array
                                                                 items:
                                                                   type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                      type: object
+                                                    type: array
+                                                required:
+                                                - nodeSelectorTerms
+                                                type: object
+                                            type: object
                                           podAffinity:
                                             description: Describes pod affinity scheduling
                                               rules (e.g. co-locate this pod in the
                                               same node, zone, etc. as some other
                                               pod(s)).
-                                            type: object
                                             properties:
                                               preferredDuringSchedulingIgnoredDuringExecution:
                                                 description: The scheduler will prefer
@@ -2644,30 +3018,21 @@ spec:
                                                   which matches the corresponding
                                                   podAffinityTerm; the node(s) with
                                                   the highest sum are the most preferred.
-                                                type: array
                                                 items:
                                                   description: The weights of all
                                                     of the matched WeightedPodAffinityTerm
                                                     fields are added per-node to find
                                                     the most preferred node(s)
-                                                  type: object
-                                                  required:
-                                                  - podAffinityTerm
-                                                  - weight
                                                   properties:
                                                     podAffinityTerm:
                                                       description: Required. A pod
                                                         affinity term, associated
                                                         with the corresponding weight.
-                                                      type: object
-                                                      required:
-                                                      - topologyKey
                                                       properties:
                                                         labelSelector:
                                                           description: A label query
                                                             over a set of resources,
                                                             in this case pods.
-                                                          type: object
                                                           properties:
                                                             matchExpressions:
                                                               description: matchExpressions
@@ -2675,7 +3040,6 @@ spec:
                                                                 selector requirements.
                                                                 The requirements are
                                                                 ANDed.
-                                                              type: array
                                                               items:
                                                                 description: A label
                                                                   selector requirement
@@ -2684,10 +3048,6 @@ spec:
                                                                   a key, and an operator
                                                                   that relates the
                                                                   key and values.
-                                                                type: object
-                                                                required:
-                                                                - key
-                                                                - operator
                                                                 properties:
                                                                   key:
                                                                     description: key
@@ -2723,10 +3083,17 @@ spec:
                                                                       replaced during
                                                                       a strategic
                                                                       merge patch.
-                                                                    type: array
                                                                     items:
                                                                       type: string
+                                                                    type: array
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                type: object
+                                                              type: array
                                                             matchLabels:
+                                                              additionalProperties:
+                                                                type: string
                                                               description: matchLabels
                                                                 is a map of {key,value}
                                                                 pairs. A single {key,value}
@@ -2740,8 +3107,7 @@ spec:
                                                                 "value". The requirements
                                                                 are ANDed.
                                                               type: object
-                                                              additionalProperties:
-                                                                type: string
+                                                          type: object
                                                         namespaces:
                                                           description: namespaces
                                                             specifies which namespaces
@@ -2749,9 +3115,9 @@ spec:
                                                             to (matches against);
                                                             null or empty list means
                                                             "this pod's namespace"
-                                                          type: array
                                                           items:
                                                             type: string
+                                                          type: array
                                                         topologyKey:
                                                           description: This pod should
                                                             be co-located (affinity)
@@ -2768,13 +3134,21 @@ spec:
                                                             is running. Empty topologyKey
                                                             is not allowed.
                                                           type: string
+                                                      required:
+                                                      - topologyKey
+                                                      type: object
                                                     weight:
                                                       description: weight associated
                                                         with matching the corresponding
                                                         podAffinityTerm, in the range
                                                         1-100.
-                                                      type: integer
                                                       format: int32
+                                                      type: integer
+                                                  required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                  type: object
+                                                type: array
                                               requiredDuringSchedulingIgnoredDuringExecution:
                                                 description: If the affinity requirements
                                                   specified by this field are not
@@ -2790,7 +3164,6 @@ spec:
                                                   the lists of nodes corresponding
                                                   to each podAffinityTerm are intersected,
                                                   i.e. all terms must be satisfied.
-                                                type: array
                                                 items:
                                                   description: Defines a set of pods
                                                     (namely those matching the labelSelector
@@ -2802,22 +3175,17 @@ spec:
                                                     of the label with key <topologyKey>
                                                     matches that of any node on which
                                                     a pod of the set of pods is running
-                                                  type: object
-                                                  required:
-                                                  - topologyKey
                                                   properties:
                                                     labelSelector:
                                                       description: A label query over
                                                         a set of resources, in this
                                                         case pods.
-                                                      type: object
                                                       properties:
                                                         matchExpressions:
                                                           description: matchExpressions
                                                             is a list of label selector
                                                             requirements. The requirements
                                                             are ANDed.
-                                                          type: array
                                                           items:
                                                             description: A label selector
                                                               requirement is a selector
@@ -2825,10 +3193,6 @@ spec:
                                                               a key, and an operator
                                                               that relates the key
                                                               and values.
-                                                            type: object
-                                                            required:
-                                                            - key
-                                                            - operator
                                                             properties:
                                                               key:
                                                                 description: key is
@@ -2859,10 +3223,17 @@ spec:
                                                                   array is replaced
                                                                   during a strategic
                                                                   merge patch.
-                                                                type: array
                                                                 items:
                                                                   type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
                                                         matchLabels:
+                                                          additionalProperties:
+                                                            type: string
                                                           description: matchLabels
                                                             is a map of {key,value}
                                                             pairs. A single {key,value}
@@ -2875,17 +3246,16 @@ spec:
                                                             only "value". The requirements
                                                             are ANDed.
                                                           type: object
-                                                          additionalProperties:
-                                                            type: string
+                                                      type: object
                                                     namespaces:
                                                       description: namespaces specifies
                                                         which namespaces the labelSelector
                                                         applies to (matches against);
                                                         null or empty list means "this
                                                         pod's namespace"
-                                                      type: array
                                                       items:
                                                         type: string
+                                                      type: array
                                                     topologyKey:
                                                       description: This pod should
                                                         be co-located (affinity) or
@@ -2901,12 +3271,16 @@ spec:
                                                         running. Empty topologyKey
                                                         is not allowed.
                                                       type: string
+                                                  required:
+                                                  - topologyKey
+                                                  type: object
+                                                type: array
+                                            type: object
                                           podAntiAffinity:
                                             description: Describes pod anti-affinity
                                               scheduling rules (e.g. avoid putting
                                               this pod in the same node, zone, etc.
                                               as some other pod(s)).
-                                            type: object
                                             properties:
                                               preferredDuringSchedulingIgnoredDuringExecution:
                                                 description: The scheduler will prefer
@@ -2927,30 +3301,21 @@ spec:
                                                   has pods which matches the corresponding
                                                   podAffinityTerm; the node(s) with
                                                   the highest sum are the most preferred.
-                                                type: array
                                                 items:
                                                   description: The weights of all
                                                     of the matched WeightedPodAffinityTerm
                                                     fields are added per-node to find
                                                     the most preferred node(s)
-                                                  type: object
-                                                  required:
-                                                  - podAffinityTerm
-                                                  - weight
                                                   properties:
                                                     podAffinityTerm:
                                                       description: Required. A pod
                                                         affinity term, associated
                                                         with the corresponding weight.
-                                                      type: object
-                                                      required:
-                                                      - topologyKey
                                                       properties:
                                                         labelSelector:
                                                           description: A label query
                                                             over a set of resources,
                                                             in this case pods.
-                                                          type: object
                                                           properties:
                                                             matchExpressions:
                                                               description: matchExpressions
@@ -2958,7 +3323,6 @@ spec:
                                                                 selector requirements.
                                                                 The requirements are
                                                                 ANDed.
-                                                              type: array
                                                               items:
                                                                 description: A label
                                                                   selector requirement
@@ -2967,10 +3331,6 @@ spec:
                                                                   a key, and an operator
                                                                   that relates the
                                                                   key and values.
-                                                                type: object
-                                                                required:
-                                                                - key
-                                                                - operator
                                                                 properties:
                                                                   key:
                                                                     description: key
@@ -3006,10 +3366,17 @@ spec:
                                                                       replaced during
                                                                       a strategic
                                                                       merge patch.
-                                                                    type: array
                                                                     items:
                                                                       type: string
+                                                                    type: array
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                type: object
+                                                              type: array
                                                             matchLabels:
+                                                              additionalProperties:
+                                                                type: string
                                                               description: matchLabels
                                                                 is a map of {key,value}
                                                                 pairs. A single {key,value}
@@ -3023,8 +3390,7 @@ spec:
                                                                 "value". The requirements
                                                                 are ANDed.
                                                               type: object
-                                                              additionalProperties:
-                                                                type: string
+                                                          type: object
                                                         namespaces:
                                                           description: namespaces
                                                             specifies which namespaces
@@ -3032,9 +3398,9 @@ spec:
                                                             to (matches against);
                                                             null or empty list means
                                                             "this pod's namespace"
-                                                          type: array
                                                           items:
                                                             type: string
+                                                          type: array
                                                         topologyKey:
                                                           description: This pod should
                                                             be co-located (affinity)
@@ -3051,13 +3417,21 @@ spec:
                                                             is running. Empty topologyKey
                                                             is not allowed.
                                                           type: string
+                                                      required:
+                                                      - topologyKey
+                                                      type: object
                                                     weight:
                                                       description: weight associated
                                                         with matching the corresponding
                                                         podAffinityTerm, in the range
                                                         1-100.
-                                                      type: integer
                                                       format: int32
+                                                      type: integer
+                                                  required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                  type: object
+                                                type: array
                                               requiredDuringSchedulingIgnoredDuringExecution:
                                                 description: If the anti-affinity
                                                   requirements specified by this field
@@ -3073,7 +3447,6 @@ spec:
                                                   elements, the lists of nodes corresponding
                                                   to each podAffinityTerm are intersected,
                                                   i.e. all terms must be satisfied.
-                                                type: array
                                                 items:
                                                   description: Defines a set of pods
                                                     (namely those matching the labelSelector
@@ -3085,22 +3458,17 @@ spec:
                                                     of the label with key <topologyKey>
                                                     matches that of any node on which
                                                     a pod of the set of pods is running
-                                                  type: object
-                                                  required:
-                                                  - topologyKey
                                                   properties:
                                                     labelSelector:
                                                       description: A label query over
                                                         a set of resources, in this
                                                         case pods.
-                                                      type: object
                                                       properties:
                                                         matchExpressions:
                                                           description: matchExpressions
                                                             is a list of label selector
                                                             requirements. The requirements
                                                             are ANDed.
-                                                          type: array
                                                           items:
                                                             description: A label selector
                                                               requirement is a selector
@@ -3108,10 +3476,6 @@ spec:
                                                               a key, and an operator
                                                               that relates the key
                                                               and values.
-                                                            type: object
-                                                            required:
-                                                            - key
-                                                            - operator
                                                             properties:
                                                               key:
                                                                 description: key is
@@ -3142,10 +3506,17 @@ spec:
                                                                   array is replaced
                                                                   during a strategic
                                                                   merge patch.
-                                                                type: array
                                                                 items:
                                                                   type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
                                                         matchLabels:
+                                                          additionalProperties:
+                                                            type: string
                                                           description: matchLabels
                                                             is a map of {key,value}
                                                             pairs. A single {key,value}
@@ -3158,17 +3529,16 @@ spec:
                                                             only "value". The requirements
                                                             are ANDed.
                                                           type: object
-                                                          additionalProperties:
-                                                            type: string
+                                                      type: object
                                                     namespaces:
                                                       description: namespaces specifies
                                                         which namespaces the labelSelector
                                                         applies to (matches against);
                                                         null or empty list means "this
                                                         pod's namespace"
-                                                      type: array
                                                       items:
                                                         type: string
+                                                      type: array
                                                     topologyKey:
                                                       description: This pod should
                                                         be co-located (affinity) or
@@ -3184,24 +3554,28 @@ spec:
                                                         running. Empty topologyKey
                                                         is not allowed.
                                                       type: string
+                                                  required:
+                                                  - topologyKey
+                                                  type: object
+                                                type: array
+                                            type: object
+                                        type: object
                                       nodeSelector:
+                                        additionalProperties:
+                                          type: string
                                         description: 'NodeSelector is a selector which
                                           must be true for the pod to fit on a node.
                                           Selector which must match a node''s labels
                                           for the pod to be scheduled on that node.
                                           More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                                         type: object
-                                        additionalProperties:
-                                          type: string
                                       tolerations:
                                         description: If specified, the pod's tolerations.
-                                        type: array
                                         items:
                                           description: The pod this Toleration is
                                             attached to tolerates any taint that matches
                                             the triple <key,value,effect> using the
                                             matching operator <operator>.
-                                          type: object
                                           properties:
                                             effect:
                                               description: Effect indicates the taint
@@ -3236,8 +3610,8 @@ spec:
                                                 (do not evict). Zero and negative
                                                 values will be treated as 0 (evict
                                                 immediately) by the system.
-                                              type: integer
                                               format: int64
+                                              type: integer
                                             value:
                                               description: Value is the taint value
                                                 the toleration matches to. If the
@@ -3245,14 +3619,19 @@ spec:
                                                 be empty, otherwise just a regular
                                                 string.
                                               type: string
+                                          type: object
+                                        type: array
+                                    type: object
+                                type: object
                               serviceType:
                                 description: Optional service type for Kubernetes
                                   solver service
                                 type: string
+                            type: object
+                        type: object
                       selector:
                         description: Selector selects a set of DNSNames on the Certificate
                           resource that should be solved using this challenge solver.
-                        type: object
                         properties:
                           dnsNames:
                             description: List of DNSNames that this solver will be
@@ -3262,9 +3641,9 @@ spec:
                               value, the solver with the most matching labels in matchLabels
                               will be selected. If neither has more matches, the solver
                               defined earlier in the list will be selected.
-                            type: array
                             items:
                               type: string
+                            type: array
                           dnsZones:
                             description: List of DNSZones that this solver will be
                               used to solve. The most specific DNS zone match specified
@@ -3275,45 +3654,41 @@ spec:
                               the solver with the most matching labels in matchLabels
                               will be selected. If neither has more matches, the solver
                               defined earlier in the list will be selected.
-                            type: array
                             items:
                               type: string
+                            type: array
                           matchLabels:
+                            additionalProperties:
+                              type: string
                             description: A label selector that is used to refine the
                               set of certificate's that this challenge solver will
                               apply to.
                             type: object
-                            additionalProperties:
-                              type: string
-            ca:
-              type: object
+                        type: object
+                    type: object
+                  type: array
               required:
-              - secretName
+              - privateKeySecretRef
+              - server
+              type: object
+            ca:
               properties:
                 secretName:
                   description: SecretName is the name of the secret used to sign Certificates
                     issued by this Issuer.
                   type: string
+              required:
+              - secretName
+              type: object
             selfSigned:
               type: object
             vault:
-              type: object
-              required:
-              - auth
-              - path
-              - server
               properties:
                 auth:
                   description: Vault authentication
-                  type: object
                   properties:
                     appRole:
                       description: This Secret contains a AppRole and Secret
-                      type: object
-                      required:
-                      - path
-                      - roleId
-                      - secretRef
                       properties:
                         path:
                           description: Where the authentication path is mounted in
@@ -3322,9 +3697,6 @@ spec:
                         roleId:
                           type: string
                         secretRef:
-                          type: object
-                          required:
-                          - name
                           properties:
                             key:
                               description: The key of the secret to select from. Must
@@ -3334,13 +3706,17 @@ spec:
                               description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                 TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
+                          required:
+                          - name
+                          type: object
+                      required:
+                      - path
+                      - roleId
+                      - secretRef
+                      type: object
                     kubernetes:
                       description: This contains a Role and Secret with a ServiceAccount
                         token to authenticate with vault.
-                      type: object
-                      required:
-                      - role
-                      - secretRef
                       properties:
                         mountPath:
                           description: The Vault mountPath here is the mount path
@@ -3358,9 +3734,6 @@ spec:
                           description: The required Secret field containing a Kubernetes
                             ServiceAccount JWT used for authenticating with Vault.
                             Use of 'ambient credentials' is not supported.
-                          type: object
-                          required:
-                          - name
                           properties:
                             key:
                               description: The key of the secret to select from. Must
@@ -3370,11 +3743,15 @@ spec:
                               description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                 TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
+                          required:
+                          - name
+                          type: object
+                      required:
+                      - role
+                      - secretRef
+                      type: object
                     tokenSecretRef:
                       description: This Secret contains the Vault token key
-                      type: object
-                      required:
-                      - name
                       properties:
                         key:
                           description: The key of the secret to select from. Must
@@ -3384,40 +3761,39 @@ spec:
                           description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                             TODO: Add other useful fields. apiVersion, kind, uid?'
                           type: string
+                      required:
+                      - name
+                      type: object
+                  type: object
                 caBundle:
                   description: Base64 encoded CA bundle to validate Vault server certificate.
                     Only used if the Server URL is using HTTPS protocol. This parameter
                     is ignored for plain HTTP protocol connection. If not set the
                     system root certificates are used to validate the TLS connection.
-                  type: string
                   format: byte
+                  type: string
                 path:
                   description: Vault URL path to the certificate role
                   type: string
                 server:
                   description: Server is the vault connection address
                   type: string
+              required:
+              - auth
+              - path
+              - server
+              type: object
             venafi:
               description: VenafiIssuer describes issuer configuration details for
                 Venafi Cloud.
-              type: object
-              required:
-              - zone
               properties:
                 cloud:
                   description: Cloud specifies the Venafi cloud configuration settings.
                     Only one of TPP or Cloud may be specified.
-                  type: object
-                  required:
-                  - apiTokenSecretRef
-                  - url
                   properties:
                     apiTokenSecretRef:
                       description: APITokenSecretRef is a secret key selector for
                         the Venafi Cloud API token.
-                      type: object
-                      required:
-                      - name
                       properties:
                         key:
                           description: The key of the secret to select from. Must
@@ -3427,52 +3803,60 @@ spec:
                           description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                             TODO: Add other useful fields. apiVersion, kind, uid?'
                           type: string
+                      required:
+                      - name
+                      type: object
                     url:
                       description: URL is the base URL for Venafi Cloud
                       type: string
+                  required:
+                  - apiTokenSecretRef
+                  type: object
                 tpp:
                   description: TPP specifies Trust Protection Platform configuration
                     settings. Only one of TPP or Cloud may be specified.
-                  type: object
-                  required:
-                  - credentialsRef
-                  - url
                   properties:
                     caBundle:
-                      description: CABundle is a PEM encoded TLS certifiate to use
+                      description: CABundle is a PEM encoded TLS certificate to use
                         to verify connections to the TPP instance. If specified, system
                         roots will not be used and the issuing CA for the TPP instance
                         must be verifiable using the provided root. If not specified,
                         the connection will be verified using the cert-manager system
                         root certificates.
-                      type: string
                       format: byte
+                      type: string
                     credentialsRef:
                       description: CredentialsRef is a reference to a Secret containing
                         the username and password for the TPP server. The secret must
                         contain two keys, 'username' and 'password'.
-                      type: object
-                      required:
-                      - name
                       properties:
                         name:
                           description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                             TODO: Add other useful fields. apiVersion, kind, uid?'
                           type: string
+                      required:
+                      - name
+                      type: object
                     url:
                       description: URL is the base URL for the Venafi TPP instance
                       type: string
+                  required:
+                  - credentialsRef
+                  - url
+                  type: object
                 zone:
                   description: Zone is the Venafi Policy Zone to use for this issuer.
                     All requests made to the Venafi platform will be restricted by
                     the named zone policy. This field is required.
                   type: string
+              required:
+              - zone
+              type: object
+          type: object
         status:
           description: IssuerStatus contains status information about an Issuer
-          type: object
           properties:
             acme:
-              type: object
               properties:
                 lastRegisteredEmail:
                   description: LastRegisteredEmail is the email associated with the
@@ -3483,21 +3867,17 @@ spec:
                   description: URI is the unique account identifier, which can also
                     be used to retrieve account details from the CA
                   type: string
+              type: object
             conditions:
-              type: array
               items:
                 description: IssuerCondition contains condition information for an
                   Issuer.
-                type: object
-                required:
-                - status
-                - type
                 properties:
                   lastTransitionTime:
                     description: LastTransitionTime is the timestamp corresponding
                       to the last status change of this condition.
-                    type: string
                     format: date-time
+                    type: string
                   message:
                     description: Message is a human readable description of the details
                       of the last transition, complementing reason.
@@ -3509,23 +3889,34 @@ spec:
                   status:
                     description: Status of the condition, one of ('True', 'False',
                       'Unknown').
-                    type: string
                     enum:
                     - "True"
                     - "False"
                     - Unknown
+                    type: string
                   type:
                     description: Type of the condition, currently ('Ready').
                     type: string
-  version: v1alpha2
+                required:
+                - status
+                - type
+                type: object
+              type: array
+          type: object
+      type: object
   versions:
   - name: v1alpha2
     served: true
     storage: true
+  - name: v1alpha3
+    served: true
+    storage: false
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    cert-manager.io/inject-ca-from-secret: cert-manager/cert-manager-webhook-tls
   name: issuers.cert-manager.io
 spec:
   additionalPrinterColumns:
@@ -3543,19 +3934,25 @@ spec:
       in RFC3339 form and is in UTC.
     name: Age
     type: date
+  conversion:
+    strategy: Webhook
+    webhookClientConfig:
+      service:
+        name: cert-manager-webhook
+        namespace: cert-manager
+        path: /convert
   group: cert-manager.io
-  preserveUnknownFields: false
   names:
     kind: Issuer
     listKind: IssuerList
     plural: issuers
     singular: issuer
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
   validation:
     openAPIV3Schema:
-      type: object
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
@@ -3572,24 +3969,58 @@ spec:
         spec:
           description: IssuerSpec is the specification of an Issuer. This includes
             any configuration required for the issuer.
-          type: object
           properties:
             acme:
               description: ACMEIssuer contains the specification for an ACME issuer
-              type: object
-              required:
-              - privateKeySecretRef
-              - server
               properties:
                 email:
                   description: Email is the email for this account
                   type: string
+                externalAccountBinding:
+                  description: ExternalAccountBinding is a reference to a CA external
+                    account of the ACME server.
+                  properties:
+                    keyAlgorithm:
+                      description: keyAlgorithm is the MAC key algorithm that the
+                        key is used for. Valid values are "HS256", "HS384" and "HS512".
+                      enum:
+                      - HS256
+                      - HS384
+                      - HS512
+                      type: string
+                    keyID:
+                      description: keyID is the ID of the CA key that the External
+                        Account is bound to.
+                      type: string
+                    keySecretRef:
+                      description: keySecretRef is a Secret Key Selector referencing
+                        a data item in a Kubernetes Secret which holds the symmetric
+                        MAC key of the External Account Binding. The `key` is the
+                        index string that is paired with the key data in the Secret
+                        and should not be confused with the key data itself, or indeed
+                        with the External Account Binding keyID above. The secret
+                        key stored in the Secret **must** be un-padded, base64 URL
+                        encoded data.
+                      properties:
+                        key:
+                          description: The key of the secret to select from. Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - keyAlgorithm
+                  - keyID
+                  - keySecretRef
+                  type: object
                 privateKeySecretRef:
                   description: PrivateKey is the name of a secret containing the private
                     key for this user account.
-                  type: object
-                  required:
-                  - name
                   properties:
                     key:
                       description: The key of the secret to select from. Must be a
@@ -3599,6 +4030,9 @@ spec:
                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                         TODO: Add other useful fields. apiVersion, kind, uid?'
                       type: string
+                  required:
+                  - name
+                  type: object
                 server:
                   description: Server is the ACME server URL
                   type: string
@@ -3608,25 +4042,15 @@ spec:
                 solvers:
                   description: Solvers is a list of challenge solvers that will be
                     used to solve ACME challenges for the matching domains.
-                  type: array
                   items:
-                    type: object
                     properties:
                       dns01:
-                        type: object
                         properties:
                           acmedns:
                             description: ACMEIssuerDNS01ProviderAcmeDNS is a structure
                               containing the configuration for ACME-DNS servers
-                            type: object
-                            required:
-                            - accountSecretRef
-                            - host
                             properties:
                               accountSecretRef:
-                                type: object
-                                required:
-                                - name
                                 properties:
                                   key:
                                     description: The key of the secret to select from.
@@ -3638,83 +4062,80 @@ spec:
                                       TODO: Add other useful fields. apiVersion, kind,
                                       uid?'
                                     type: string
+                                required:
+                                - name
+                                type: object
                               host:
                                 type: string
+                            required:
+                            - accountSecretRef
+                            - host
+                            type: object
                           akamai:
                             description: ACMEIssuerDNS01ProviderAkamai is a structure
                               containing the DNS configuration for Akamai DNS—Zone
                               Record Management API
-                            type: object
+                            properties:
+                              accessTokenSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              clientSecretSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              clientTokenSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              serviceConsumerDomain:
+                                type: string
                             required:
                             - accessTokenSecretRef
                             - clientSecretSecretRef
                             - clientTokenSecretRef
                             - serviceConsumerDomain
-                            properties:
-                              accessTokenSecretRef:
-                                type: object
-                                required:
-                                - name
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                              clientSecretSecretRef:
-                                type: object
-                                required:
-                                - name
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                              clientTokenSecretRef:
-                                type: object
-                                required:
-                                - name
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                              serviceConsumerDomain:
-                                type: string
+                            type: object
                           azuredns:
                             description: ACMEIssuerDNS01ProviderAzureDNS is a structure
                               containing the configuration for Azure DNS
-                            type: object
-                            required:
-                            - clientID
-                            - clientSecretSecretRef
-                            - resourceGroupName
-                            - subscriptionID
-                            - tenantID
                             properties:
                               clientID:
                                 type: string
                               clientSecretSecretRef:
-                                type: object
-                                required:
-                                - name
                                 properties:
                                   key:
                                     description: The key of the secret to select from.
@@ -3726,13 +4147,16 @@ spec:
                                       TODO: Add other useful fields. apiVersion, kind,
                                       uid?'
                                     type: string
+                                required:
+                                - name
+                                type: object
                               environment:
-                                type: string
                                 enum:
                                 - AzurePublicCloud
                                 - AzureChinaCloud
                                 - AzureGermanCloud
                                 - AzureUSGovernmentCloud
+                                type: string
                               hostedZoneName:
                                 type: string
                               resourceGroupName:
@@ -3741,19 +4165,20 @@ spec:
                                 type: string
                               tenantID:
                                 type: string
+                            required:
+                            - clientID
+                            - clientSecretSecretRef
+                            - resourceGroupName
+                            - subscriptionID
+                            - tenantID
+                            type: object
                           clouddns:
                             description: ACMEIssuerDNS01ProviderCloudDNS is a structure
                               containing the DNS configuration for Google Cloud DNS
-                            type: object
-                            required:
-                            - project
                             properties:
                               project:
                                 type: string
                               serviceAccountSecretRef:
-                                type: object
-                                required:
-                                - name
                                 properties:
                                   key:
                                     description: The key of the secret to select from.
@@ -3765,17 +4190,17 @@ spec:
                                       TODO: Add other useful fields. apiVersion, kind,
                                       uid?'
                                     type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - project
+                            type: object
                           cloudflare:
                             description: ACMEIssuerDNS01ProviderCloudflare is a structure
                               containing the DNS configuration for Cloudflare
-                            type: object
-                            required:
-                            - email
                             properties:
                               apiKeySecretRef:
-                                type: object
-                                required:
-                                - name
                                 properties:
                                   key:
                                     description: The key of the secret to select from.
@@ -3787,10 +4212,10 @@ spec:
                                       TODO: Add other useful fields. apiVersion, kind,
                                       uid?'
                                     type: string
+                                required:
+                                - name
+                                type: object
                               apiTokenSecretRef:
-                                type: object
-                                required:
-                                - name
                                 properties:
                                   key:
                                     description: The key of the secret to select from.
@@ -3802,27 +4227,27 @@ spec:
                                       TODO: Add other useful fields. apiVersion, kind,
                                       uid?'
                                     type: string
+                                required:
+                                - name
+                                type: object
                               email:
                                 type: string
+                            required:
+                            - email
+                            type: object
                           cnameStrategy:
                             description: CNAMEStrategy configures how the DNS01 provider
                               should handle CNAME records when found in DNS zones.
-                            type: string
                             enum:
                             - None
                             - Follow
+                            type: string
                           digitalocean:
                             description: ACMEIssuerDNS01ProviderDigitalOcean is a
                               structure containing the DNS configuration for DigitalOcean
                               Domains
-                            type: object
-                            required:
-                            - tokenSecretRef
                             properties:
                               tokenSecretRef:
-                                type: object
-                                required:
-                                - name
                                 properties:
                                   key:
                                     description: The key of the secret to select from.
@@ -3834,12 +4259,15 @@ spec:
                                       TODO: Add other useful fields. apiVersion, kind,
                                       uid?'
                                     type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - tokenSecretRef
+                            type: object
                           rfc2136:
                             description: ACMEIssuerDNS01ProviderRFC2136 is a structure
                               containing the configuration for RFC2136 DNS
-                            type: object
-                            required:
-                            - nameserver
                             properties:
                               nameserver:
                                 description: 'The IP address of the DNS supporting
@@ -3862,9 +4290,6 @@ spec:
                                 description: The name of the secret containing the
                                   TSIG value. If ``tsigKeyName`` is defined, this
                                   field is required.
-                                type: object
-                                required:
-                                - name
                                 properties:
                                   key:
                                     description: The key of the secret to select from.
@@ -3876,12 +4301,15 @@ spec:
                                       TODO: Add other useful fields. apiVersion, kind,
                                       uid?'
                                     type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - nameserver
+                            type: object
                           route53:
                             description: ACMEIssuerDNS01ProviderRoute53 is a structure
                               containing the Route 53 configuration for AWS
-                            type: object
-                            required:
-                            - region
                             properties:
                               accessKeyID:
                                 description: 'The AccessKeyID is used for authentication.
@@ -3908,9 +4336,6 @@ spec:
                                 description: The SecretAccessKey is used for authentication.
                                   If not set we fall-back to using env vars, shared
                                   credentials file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
-                                type: object
-                                required:
-                                - name
                                 properties:
                                   key:
                                     description: The key of the secret to select from.
@@ -3922,14 +4347,16 @@ spec:
                                       TODO: Add other useful fields. apiVersion, kind,
                                       uid?'
                                     type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - region
+                            type: object
                           webhook:
                             description: ACMEIssuerDNS01ProviderWebhook specifies
                               configuration for a webhook DNS01 provider, including
                               where to POST ChallengePayload resources.
-                            type: object
-                            required:
-                            - groupName
-                            - solverName
                             properties:
                               config:
                                 description: Additional configuration that should
@@ -3953,6 +4380,11 @@ spec:
                                   in the webhook provider implementation. This will
                                   typically be the name of the provider, e.g. 'cloudflare'.
                                 type: string
+                            required:
+                            - groupName
+                            - solverName
+                            type: object
+                        type: object
                       http01:
                         description: ACMEChallengeSolverHTTP01 contains configuration
                           detailing how to solve HTTP01 challenges within a Kubernetes
@@ -3960,7 +4392,6 @@ spec:
                           'routes' of some description that configure ingress controllers
                           to direct traffic to 'solver pods', which are responsible
                           for responding to the ACME server's HTTP requests.
-                        type: object
                         properties:
                           ingress:
                             description: The ingress based HTTP01 challenge solver
@@ -3968,7 +4399,6 @@ spec:
                               resources in order to route requests for '/.well-known/acme-challenge/XYZ'
                               to 'challenge solver' pods that are provisioned by cert-manager
                               for each Challenge to be completed.
-                            type: object
                             properties:
                               class:
                                 description: The ingress class to use when creating
@@ -3987,7 +4417,6 @@ spec:
                               podTemplate:
                                 description: Optional pod template used to configure
                                   the ACME challenge solver pods used for HTTP01 challenges
-                                type: object
                                 properties:
                                   metadata:
                                     description: ObjectMeta overrides for the pod
@@ -3995,36 +4424,33 @@ spec:
                                       and 'annotations' fields may be set. If labels
                                       or annotations overlap with in-built values,
                                       the values here will override the in-built values.
-                                    type: object
                                     properties:
                                       annotations:
+                                        additionalProperties:
+                                          type: string
                                         description: Annotations that should be added
                                           to the create ACME HTTP01 solver pods.
                                         type: object
+                                      labels:
                                         additionalProperties:
                                           type: string
-                                      labels:
                                         description: Labels that should be added to
                                           the created ACME HTTP01 solver pods.
                                         type: object
-                                        additionalProperties:
-                                          type: string
+                                    type: object
                                   spec:
                                     description: PodSpec defines overrides for the
                                       HTTP01 challenge solver pod. Only the 'nodeSelector',
                                       'affinity' and 'tolerations' fields are supported
                                       currently. All other fields will be ignored.
-                                    type: object
                                     properties:
                                       affinity:
                                         description: If specified, the pod's scheduling
                                           constraints
-                                        type: object
                                         properties:
                                           nodeAffinity:
                                             description: Describes node affinity scheduling
                                               rules for the pod.
-                                            type: object
                                             properties:
                                               preferredDuringSchedulingIgnoredDuringExecution:
                                                 description: The scheduler will prefer
@@ -4045,7 +4471,6 @@ spec:
                                                   corresponding matchExpressions;
                                                   the node(s) with the highest sum
                                                   are the most preferred.
-                                                type: array
                                                 items:
                                                   description: An empty preferred
                                                     scheduling term matches all objects
@@ -4053,22 +4478,16 @@ spec:
                                                     a no-op). A null preferred scheduling
                                                     term matches no objects (i.e.
                                                     is also a no-op).
-                                                  type: object
-                                                  required:
-                                                  - preference
-                                                  - weight
                                                   properties:
                                                     preference:
                                                       description: A node selector
                                                         term, associated with the
                                                         corresponding weight.
-                                                      type: object
                                                       properties:
                                                         matchExpressions:
                                                           description: A list of node
                                                             selector requirements
                                                             by node's labels.
-                                                          type: array
                                                           items:
                                                             description: A node selector
                                                               requirement is a selector
@@ -4076,10 +4495,6 @@ spec:
                                                               a key, and an operator
                                                               that relates the key
                                                               and values.
-                                                            type: object
-                                                            required:
-                                                            - key
-                                                            - operator
                                                             properties:
                                                               key:
                                                                 description: The label
@@ -4115,14 +4530,18 @@ spec:
                                                                   array is replaced
                                                                   during a strategic
                                                                   merge patch.
-                                                                type: array
                                                                 items:
                                                                   type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
                                                         matchFields:
                                                           description: A list of node
                                                             selector requirements
                                                             by node's fields.
-                                                          type: array
                                                           items:
                                                             description: A node selector
                                                               requirement is a selector
@@ -4130,10 +4549,6 @@ spec:
                                                               a key, and an operator
                                                               that relates the key
                                                               and values.
-                                                            type: object
-                                                            required:
-                                                            - key
-                                                            - operator
                                                             properties:
                                                               key:
                                                                 description: The label
@@ -4169,16 +4584,27 @@ spec:
                                                                   array is replaced
                                                                   during a strategic
                                                                   merge patch.
-                                                                type: array
                                                                 items:
                                                                   type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                      type: object
                                                     weight:
                                                       description: Weight associated
                                                         with matching the corresponding
                                                         nodeSelectorTerm, in the range
                                                         1-100.
-                                                      type: integer
                                                       format: int32
+                                                      type: integer
+                                                  required:
+                                                  - preference
+                                                  - weight
+                                                  type: object
+                                                type: array
                                               requiredDuringSchedulingIgnoredDuringExecution:
                                                 description: If the affinity requirements
                                                   specified by this field are not
@@ -4190,15 +4616,11 @@ spec:
                                                   (e.g. due to an update), the system
                                                   may or may not try to eventually
                                                   evict the pod from its node.
-                                                type: object
-                                                required:
-                                                - nodeSelectorTerms
                                                 properties:
                                                   nodeSelectorTerms:
                                                     description: Required. A list
                                                       of node selector terms. The
                                                       terms are ORed.
-                                                    type: array
                                                     items:
                                                       description: A null or empty
                                                         node selector term matches
@@ -4206,13 +4628,11 @@ spec:
                                                         of them are ANDed. The TopologySelectorTerm
                                                         type implements a subset of
                                                         the NodeSelectorTerm.
-                                                      type: object
                                                       properties:
                                                         matchExpressions:
                                                           description: A list of node
                                                             selector requirements
                                                             by node's labels.
-                                                          type: array
                                                           items:
                                                             description: A node selector
                                                               requirement is a selector
@@ -4220,10 +4640,6 @@ spec:
                                                               a key, and an operator
                                                               that relates the key
                                                               and values.
-                                                            type: object
-                                                            required:
-                                                            - key
-                                                            - operator
                                                             properties:
                                                               key:
                                                                 description: The label
@@ -4259,14 +4675,18 @@ spec:
                                                                   array is replaced
                                                                   during a strategic
                                                                   merge patch.
-                                                                type: array
                                                                 items:
                                                                   type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
                                                         matchFields:
                                                           description: A list of node
                                                             selector requirements
                                                             by node's fields.
-                                                          type: array
                                                           items:
                                                             description: A node selector
                                                               requirement is a selector
@@ -4274,10 +4694,6 @@ spec:
                                                               a key, and an operator
                                                               that relates the key
                                                               and values.
-                                                            type: object
-                                                            required:
-                                                            - key
-                                                            - operator
                                                             properties:
                                                               key:
                                                                 description: The label
@@ -4313,15 +4729,25 @@ spec:
                                                                   array is replaced
                                                                   during a strategic
                                                                   merge patch.
-                                                                type: array
                                                                 items:
                                                                   type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                      type: object
+                                                    type: array
+                                                required:
+                                                - nodeSelectorTerms
+                                                type: object
+                                            type: object
                                           podAffinity:
                                             description: Describes pod affinity scheduling
                                               rules (e.g. co-locate this pod in the
                                               same node, zone, etc. as some other
                                               pod(s)).
-                                            type: object
                                             properties:
                                               preferredDuringSchedulingIgnoredDuringExecution:
                                                 description: The scheduler will prefer
@@ -4342,30 +4768,21 @@ spec:
                                                   which matches the corresponding
                                                   podAffinityTerm; the node(s) with
                                                   the highest sum are the most preferred.
-                                                type: array
                                                 items:
                                                   description: The weights of all
                                                     of the matched WeightedPodAffinityTerm
                                                     fields are added per-node to find
                                                     the most preferred node(s)
-                                                  type: object
-                                                  required:
-                                                  - podAffinityTerm
-                                                  - weight
                                                   properties:
                                                     podAffinityTerm:
                                                       description: Required. A pod
                                                         affinity term, associated
                                                         with the corresponding weight.
-                                                      type: object
-                                                      required:
-                                                      - topologyKey
                                                       properties:
                                                         labelSelector:
                                                           description: A label query
                                                             over a set of resources,
                                                             in this case pods.
-                                                          type: object
                                                           properties:
                                                             matchExpressions:
                                                               description: matchExpressions
@@ -4373,7 +4790,6 @@ spec:
                                                                 selector requirements.
                                                                 The requirements are
                                                                 ANDed.
-                                                              type: array
                                                               items:
                                                                 description: A label
                                                                   selector requirement
@@ -4382,10 +4798,6 @@ spec:
                                                                   a key, and an operator
                                                                   that relates the
                                                                   key and values.
-                                                                type: object
-                                                                required:
-                                                                - key
-                                                                - operator
                                                                 properties:
                                                                   key:
                                                                     description: key
@@ -4421,10 +4833,17 @@ spec:
                                                                       replaced during
                                                                       a strategic
                                                                       merge patch.
-                                                                    type: array
                                                                     items:
                                                                       type: string
+                                                                    type: array
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                type: object
+                                                              type: array
                                                             matchLabels:
+                                                              additionalProperties:
+                                                                type: string
                                                               description: matchLabels
                                                                 is a map of {key,value}
                                                                 pairs. A single {key,value}
@@ -4438,8 +4857,7 @@ spec:
                                                                 "value". The requirements
                                                                 are ANDed.
                                                               type: object
-                                                              additionalProperties:
-                                                                type: string
+                                                          type: object
                                                         namespaces:
                                                           description: namespaces
                                                             specifies which namespaces
@@ -4447,9 +4865,9 @@ spec:
                                                             to (matches against);
                                                             null or empty list means
                                                             "this pod's namespace"
-                                                          type: array
                                                           items:
                                                             type: string
+                                                          type: array
                                                         topologyKey:
                                                           description: This pod should
                                                             be co-located (affinity)
@@ -4466,13 +4884,21 @@ spec:
                                                             is running. Empty topologyKey
                                                             is not allowed.
                                                           type: string
+                                                      required:
+                                                      - topologyKey
+                                                      type: object
                                                     weight:
                                                       description: weight associated
                                                         with matching the corresponding
                                                         podAffinityTerm, in the range
                                                         1-100.
-                                                      type: integer
                                                       format: int32
+                                                      type: integer
+                                                  required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                  type: object
+                                                type: array
                                               requiredDuringSchedulingIgnoredDuringExecution:
                                                 description: If the affinity requirements
                                                   specified by this field are not
@@ -4488,7 +4914,6 @@ spec:
                                                   the lists of nodes corresponding
                                                   to each podAffinityTerm are intersected,
                                                   i.e. all terms must be satisfied.
-                                                type: array
                                                 items:
                                                   description: Defines a set of pods
                                                     (namely those matching the labelSelector
@@ -4500,22 +4925,17 @@ spec:
                                                     of the label with key <topologyKey>
                                                     matches that of any node on which
                                                     a pod of the set of pods is running
-                                                  type: object
-                                                  required:
-                                                  - topologyKey
                                                   properties:
                                                     labelSelector:
                                                       description: A label query over
                                                         a set of resources, in this
                                                         case pods.
-                                                      type: object
                                                       properties:
                                                         matchExpressions:
                                                           description: matchExpressions
                                                             is a list of label selector
                                                             requirements. The requirements
                                                             are ANDed.
-                                                          type: array
                                                           items:
                                                             description: A label selector
                                                               requirement is a selector
@@ -4523,10 +4943,6 @@ spec:
                                                               a key, and an operator
                                                               that relates the key
                                                               and values.
-                                                            type: object
-                                                            required:
-                                                            - key
-                                                            - operator
                                                             properties:
                                                               key:
                                                                 description: key is
@@ -4557,10 +4973,17 @@ spec:
                                                                   array is replaced
                                                                   during a strategic
                                                                   merge patch.
-                                                                type: array
                                                                 items:
                                                                   type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
                                                         matchLabels:
+                                                          additionalProperties:
+                                                            type: string
                                                           description: matchLabels
                                                             is a map of {key,value}
                                                             pairs. A single {key,value}
@@ -4573,17 +4996,16 @@ spec:
                                                             only "value". The requirements
                                                             are ANDed.
                                                           type: object
-                                                          additionalProperties:
-                                                            type: string
+                                                      type: object
                                                     namespaces:
                                                       description: namespaces specifies
                                                         which namespaces the labelSelector
                                                         applies to (matches against);
                                                         null or empty list means "this
                                                         pod's namespace"
-                                                      type: array
                                                       items:
                                                         type: string
+                                                      type: array
                                                     topologyKey:
                                                       description: This pod should
                                                         be co-located (affinity) or
@@ -4599,12 +5021,16 @@ spec:
                                                         running. Empty topologyKey
                                                         is not allowed.
                                                       type: string
+                                                  required:
+                                                  - topologyKey
+                                                  type: object
+                                                type: array
+                                            type: object
                                           podAntiAffinity:
                                             description: Describes pod anti-affinity
                                               scheduling rules (e.g. avoid putting
                                               this pod in the same node, zone, etc.
                                               as some other pod(s)).
-                                            type: object
                                             properties:
                                               preferredDuringSchedulingIgnoredDuringExecution:
                                                 description: The scheduler will prefer
@@ -4625,30 +5051,21 @@ spec:
                                                   has pods which matches the corresponding
                                                   podAffinityTerm; the node(s) with
                                                   the highest sum are the most preferred.
-                                                type: array
                                                 items:
                                                   description: The weights of all
                                                     of the matched WeightedPodAffinityTerm
                                                     fields are added per-node to find
                                                     the most preferred node(s)
-                                                  type: object
-                                                  required:
-                                                  - podAffinityTerm
-                                                  - weight
                                                   properties:
                                                     podAffinityTerm:
                                                       description: Required. A pod
                                                         affinity term, associated
                                                         with the corresponding weight.
-                                                      type: object
-                                                      required:
-                                                      - topologyKey
                                                       properties:
                                                         labelSelector:
                                                           description: A label query
                                                             over a set of resources,
                                                             in this case pods.
-                                                          type: object
                                                           properties:
                                                             matchExpressions:
                                                               description: matchExpressions
@@ -4656,7 +5073,6 @@ spec:
                                                                 selector requirements.
                                                                 The requirements are
                                                                 ANDed.
-                                                              type: array
                                                               items:
                                                                 description: A label
                                                                   selector requirement
@@ -4665,10 +5081,6 @@ spec:
                                                                   a key, and an operator
                                                                   that relates the
                                                                   key and values.
-                                                                type: object
-                                                                required:
-                                                                - key
-                                                                - operator
                                                                 properties:
                                                                   key:
                                                                     description: key
@@ -4704,10 +5116,17 @@ spec:
                                                                       replaced during
                                                                       a strategic
                                                                       merge patch.
-                                                                    type: array
                                                                     items:
                                                                       type: string
+                                                                    type: array
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                type: object
+                                                              type: array
                                                             matchLabels:
+                                                              additionalProperties:
+                                                                type: string
                                                               description: matchLabels
                                                                 is a map of {key,value}
                                                                 pairs. A single {key,value}
@@ -4721,8 +5140,7 @@ spec:
                                                                 "value". The requirements
                                                                 are ANDed.
                                                               type: object
-                                                              additionalProperties:
-                                                                type: string
+                                                          type: object
                                                         namespaces:
                                                           description: namespaces
                                                             specifies which namespaces
@@ -4730,9 +5148,9 @@ spec:
                                                             to (matches against);
                                                             null or empty list means
                                                             "this pod's namespace"
-                                                          type: array
                                                           items:
                                                             type: string
+                                                          type: array
                                                         topologyKey:
                                                           description: This pod should
                                                             be co-located (affinity)
@@ -4749,13 +5167,21 @@ spec:
                                                             is running. Empty topologyKey
                                                             is not allowed.
                                                           type: string
+                                                      required:
+                                                      - topologyKey
+                                                      type: object
                                                     weight:
                                                       description: weight associated
                                                         with matching the corresponding
                                                         podAffinityTerm, in the range
                                                         1-100.
-                                                      type: integer
                                                       format: int32
+                                                      type: integer
+                                                  required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                  type: object
+                                                type: array
                                               requiredDuringSchedulingIgnoredDuringExecution:
                                                 description: If the anti-affinity
                                                   requirements specified by this field
@@ -4771,7 +5197,6 @@ spec:
                                                   elements, the lists of nodes corresponding
                                                   to each podAffinityTerm are intersected,
                                                   i.e. all terms must be satisfied.
-                                                type: array
                                                 items:
                                                   description: Defines a set of pods
                                                     (namely those matching the labelSelector
@@ -4783,22 +5208,17 @@ spec:
                                                     of the label with key <topologyKey>
                                                     matches that of any node on which
                                                     a pod of the set of pods is running
-                                                  type: object
-                                                  required:
-                                                  - topologyKey
                                                   properties:
                                                     labelSelector:
                                                       description: A label query over
                                                         a set of resources, in this
                                                         case pods.
-                                                      type: object
                                                       properties:
                                                         matchExpressions:
                                                           description: matchExpressions
                                                             is a list of label selector
                                                             requirements. The requirements
                                                             are ANDed.
-                                                          type: array
                                                           items:
                                                             description: A label selector
                                                               requirement is a selector
@@ -4806,10 +5226,6 @@ spec:
                                                               a key, and an operator
                                                               that relates the key
                                                               and values.
-                                                            type: object
-                                                            required:
-                                                            - key
-                                                            - operator
                                                             properties:
                                                               key:
                                                                 description: key is
@@ -4840,10 +5256,17 @@ spec:
                                                                   array is replaced
                                                                   during a strategic
                                                                   merge patch.
-                                                                type: array
                                                                 items:
                                                                   type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
                                                         matchLabels:
+                                                          additionalProperties:
+                                                            type: string
                                                           description: matchLabels
                                                             is a map of {key,value}
                                                             pairs. A single {key,value}
@@ -4856,17 +5279,16 @@ spec:
                                                             only "value". The requirements
                                                             are ANDed.
                                                           type: object
-                                                          additionalProperties:
-                                                            type: string
+                                                      type: object
                                                     namespaces:
                                                       description: namespaces specifies
                                                         which namespaces the labelSelector
                                                         applies to (matches against);
                                                         null or empty list means "this
                                                         pod's namespace"
-                                                      type: array
                                                       items:
                                                         type: string
+                                                      type: array
                                                     topologyKey:
                                                       description: This pod should
                                                         be co-located (affinity) or
@@ -4882,24 +5304,28 @@ spec:
                                                         running. Empty topologyKey
                                                         is not allowed.
                                                       type: string
+                                                  required:
+                                                  - topologyKey
+                                                  type: object
+                                                type: array
+                                            type: object
+                                        type: object
                                       nodeSelector:
+                                        additionalProperties:
+                                          type: string
                                         description: 'NodeSelector is a selector which
                                           must be true for the pod to fit on a node.
                                           Selector which must match a node''s labels
                                           for the pod to be scheduled on that node.
                                           More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                                         type: object
-                                        additionalProperties:
-                                          type: string
                                       tolerations:
                                         description: If specified, the pod's tolerations.
-                                        type: array
                                         items:
                                           description: The pod this Toleration is
                                             attached to tolerates any taint that matches
                                             the triple <key,value,effect> using the
                                             matching operator <operator>.
-                                          type: object
                                           properties:
                                             effect:
                                               description: Effect indicates the taint
@@ -4934,8 +5360,8 @@ spec:
                                                 (do not evict). Zero and negative
                                                 values will be treated as 0 (evict
                                                 immediately) by the system.
-                                              type: integer
                                               format: int64
+                                              type: integer
                                             value:
                                               description: Value is the taint value
                                                 the toleration matches to. If the
@@ -4943,14 +5369,19 @@ spec:
                                                 be empty, otherwise just a regular
                                                 string.
                                               type: string
+                                          type: object
+                                        type: array
+                                    type: object
+                                type: object
                               serviceType:
                                 description: Optional service type for Kubernetes
                                   solver service
                                 type: string
+                            type: object
+                        type: object
                       selector:
                         description: Selector selects a set of DNSNames on the Certificate
                           resource that should be solved using this challenge solver.
-                        type: object
                         properties:
                           dnsNames:
                             description: List of DNSNames that this solver will be
@@ -4960,9 +5391,9 @@ spec:
                               value, the solver with the most matching labels in matchLabels
                               will be selected. If neither has more matches, the solver
                               defined earlier in the list will be selected.
-                            type: array
                             items:
                               type: string
+                            type: array
                           dnsZones:
                             description: List of DNSZones that this solver will be
                               used to solve. The most specific DNS zone match specified
@@ -4973,45 +5404,41 @@ spec:
                               the solver with the most matching labels in matchLabels
                               will be selected. If neither has more matches, the solver
                               defined earlier in the list will be selected.
-                            type: array
                             items:
                               type: string
+                            type: array
                           matchLabels:
+                            additionalProperties:
+                              type: string
                             description: A label selector that is used to refine the
                               set of certificate's that this challenge solver will
                               apply to.
                             type: object
-                            additionalProperties:
-                              type: string
-            ca:
-              type: object
+                        type: object
+                    type: object
+                  type: array
               required:
-              - secretName
+              - privateKeySecretRef
+              - server
+              type: object
+            ca:
               properties:
                 secretName:
                   description: SecretName is the name of the secret used to sign Certificates
                     issued by this Issuer.
                   type: string
+              required:
+              - secretName
+              type: object
             selfSigned:
               type: object
             vault:
-              type: object
-              required:
-              - auth
-              - path
-              - server
               properties:
                 auth:
                   description: Vault authentication
-                  type: object
                   properties:
                     appRole:
                       description: This Secret contains a AppRole and Secret
-                      type: object
-                      required:
-                      - path
-                      - roleId
-                      - secretRef
                       properties:
                         path:
                           description: Where the authentication path is mounted in
@@ -5020,9 +5447,6 @@ spec:
                         roleId:
                           type: string
                         secretRef:
-                          type: object
-                          required:
-                          - name
                           properties:
                             key:
                               description: The key of the secret to select from. Must
@@ -5032,13 +5456,17 @@ spec:
                               description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                 TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
+                          required:
+                          - name
+                          type: object
+                      required:
+                      - path
+                      - roleId
+                      - secretRef
+                      type: object
                     kubernetes:
                       description: This contains a Role and Secret with a ServiceAccount
                         token to authenticate with vault.
-                      type: object
-                      required:
-                      - role
-                      - secretRef
                       properties:
                         mountPath:
                           description: The Vault mountPath here is the mount path
@@ -5056,9 +5484,6 @@ spec:
                           description: The required Secret field containing a Kubernetes
                             ServiceAccount JWT used for authenticating with Vault.
                             Use of 'ambient credentials' is not supported.
-                          type: object
-                          required:
-                          - name
                           properties:
                             key:
                               description: The key of the secret to select from. Must
@@ -5068,11 +5493,15 @@ spec:
                               description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                 TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
+                          required:
+                          - name
+                          type: object
+                      required:
+                      - role
+                      - secretRef
+                      type: object
                     tokenSecretRef:
                       description: This Secret contains the Vault token key
-                      type: object
-                      required:
-                      - name
                       properties:
                         key:
                           description: The key of the secret to select from. Must
@@ -5082,40 +5511,39 @@ spec:
                           description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                             TODO: Add other useful fields. apiVersion, kind, uid?'
                           type: string
+                      required:
+                      - name
+                      type: object
+                  type: object
                 caBundle:
                   description: Base64 encoded CA bundle to validate Vault server certificate.
                     Only used if the Server URL is using HTTPS protocol. This parameter
                     is ignored for plain HTTP protocol connection. If not set the
                     system root certificates are used to validate the TLS connection.
-                  type: string
                   format: byte
+                  type: string
                 path:
                   description: Vault URL path to the certificate role
                   type: string
                 server:
                   description: Server is the vault connection address
                   type: string
+              required:
+              - auth
+              - path
+              - server
+              type: object
             venafi:
               description: VenafiIssuer describes issuer configuration details for
                 Venafi Cloud.
-              type: object
-              required:
-              - zone
               properties:
                 cloud:
                   description: Cloud specifies the Venafi cloud configuration settings.
                     Only one of TPP or Cloud may be specified.
-                  type: object
-                  required:
-                  - apiTokenSecretRef
-                  - url
                   properties:
                     apiTokenSecretRef:
                       description: APITokenSecretRef is a secret key selector for
                         the Venafi Cloud API token.
-                      type: object
-                      required:
-                      - name
                       properties:
                         key:
                           description: The key of the secret to select from. Must
@@ -5125,52 +5553,60 @@ spec:
                           description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                             TODO: Add other useful fields. apiVersion, kind, uid?'
                           type: string
+                      required:
+                      - name
+                      type: object
                     url:
                       description: URL is the base URL for Venafi Cloud
                       type: string
+                  required:
+                  - apiTokenSecretRef
+                  type: object
                 tpp:
                   description: TPP specifies Trust Protection Platform configuration
                     settings. Only one of TPP or Cloud may be specified.
-                  type: object
-                  required:
-                  - credentialsRef
-                  - url
                   properties:
                     caBundle:
-                      description: CABundle is a PEM encoded TLS certifiate to use
+                      description: CABundle is a PEM encoded TLS certificate to use
                         to verify connections to the TPP instance. If specified, system
                         roots will not be used and the issuing CA for the TPP instance
                         must be verifiable using the provided root. If not specified,
                         the connection will be verified using the cert-manager system
                         root certificates.
-                      type: string
                       format: byte
+                      type: string
                     credentialsRef:
                       description: CredentialsRef is a reference to a Secret containing
                         the username and password for the TPP server. The secret must
                         contain two keys, 'username' and 'password'.
-                      type: object
-                      required:
-                      - name
                       properties:
                         name:
                           description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                             TODO: Add other useful fields. apiVersion, kind, uid?'
                           type: string
+                      required:
+                      - name
+                      type: object
                     url:
                       description: URL is the base URL for the Venafi TPP instance
                       type: string
+                  required:
+                  - credentialsRef
+                  - url
+                  type: object
                 zone:
                   description: Zone is the Venafi Policy Zone to use for this issuer.
                     All requests made to the Venafi platform will be restricted by
                     the named zone policy. This field is required.
                   type: string
+              required:
+              - zone
+              type: object
+          type: object
         status:
           description: IssuerStatus contains status information about an Issuer
-          type: object
           properties:
             acme:
-              type: object
               properties:
                 lastRegisteredEmail:
                   description: LastRegisteredEmail is the email associated with the
@@ -5181,21 +5617,17 @@ spec:
                   description: URI is the unique account identifier, which can also
                     be used to retrieve account details from the CA
                   type: string
+              type: object
             conditions:
-              type: array
               items:
                 description: IssuerCondition contains condition information for an
                   Issuer.
-                type: object
-                required:
-                - status
-                - type
                 properties:
                   lastTransitionTime:
                     description: LastTransitionTime is the timestamp corresponding
                       to the last status change of this condition.
-                    type: string
                     format: date-time
+                    type: string
                   message:
                     description: Message is a human readable description of the details
                       of the last transition, complementing reason.
@@ -5207,23 +5639,34 @@ spec:
                   status:
                     description: Status of the condition, one of ('True', 'False',
                       'Unknown').
-                    type: string
                     enum:
                     - "True"
                     - "False"
                     - Unknown
+                    type: string
                   type:
                     description: Type of the condition, currently ('Ready').
                     type: string
-  version: v1alpha2
+                required:
+                - status
+                - type
+                type: object
+              type: array
+          type: object
+      type: object
   versions:
   - name: v1alpha2
     served: true
     storage: true
+  - name: v1alpha3
+    served: true
+    storage: false
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    cert-manager.io/inject-ca-from-secret: cert-manager/cert-manager-webhook-tls
   name: orders.acme.cert-manager.io
 spec:
   additionalPrinterColumns:
@@ -5245,22 +5688,26 @@ spec:
       in RFC3339 form and is in UTC.
     name: Age
     type: date
+  conversion:
+    strategy: Webhook
+    webhookClientConfig:
+      service:
+        name: cert-manager-webhook
+        namespace: cert-manager
+        path: /convert
   group: acme.cert-manager.io
-  preserveUnknownFields: false
   names:
     kind: Order
     listKind: OrderList
     plural: orders
     singular: order
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}
   validation:
     openAPIV3Schema:
       description: Order is a type to represent an Order with an ACME server
-      type: object
-      required:
-      - metadata
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
@@ -5275,10 +5722,6 @@ spec:
         metadata:
           type: object
         spec:
-          type: object
-          required:
-          - csr
-          - issuerRef
           properties:
             commonName:
               description: CommonName is the common name as specified on the DER encoded
@@ -5291,26 +5734,23 @@ spec:
               description: Certificate signing request bytes in DER encoding. This
                 will be used when finalizing the order. This field must be set on
                 the order.
-              type: string
               format: byte
+              type: string
             dnsNames:
               description: DNSNames is a list of DNS names that should be included
                 as part of the Order validation process. If CommonName is not specified,
                 the first DNSName specified will be used as the CommonName. At least
                 one of CommonName or a DNSNames must be set. This field must match
                 the corresponding field on the DER encoded CSR.
-              type: array
               items:
                 type: string
+              type: array
             issuerRef:
               description: IssuerRef references a properly configured ACME-type Issuer
                 which should be used to create this Order. If the Issuer does not
                 exist, processing will be retried. If the Issuer is not an 'ACME'
                 Issuer, an error will be returned and the Order will be marked as
                 failed.
-              type: object
-              required:
-              - name
               properties:
                 group:
                   type: string
@@ -5318,37 +5758,33 @@ spec:
                   type: string
                 name:
                   type: string
-        status:
+              required:
+              - name
+              type: object
+          required:
+          - csr
+          - issuerRef
           type: object
+        status:
           properties:
             authorizations:
               description: Authorizations contains data returned from the ACME server
-                on what authoriations must be completed in order to validate the DNS
-                names specified on the Order.
-              type: array
+                on what authorizations must be completed in order to validate the
+                DNS names specified on the Order.
               items:
                 description: ACMEAuthorization contains data returned from the ACME
                   server on an authorization that must be completed in order validate
                   a DNS name on an ACME Order resource.
-                type: object
-                required:
-                - url
                 properties:
                   challenges:
                     description: Challenges specifies the challenge types offered
                       by the ACME server. One of these challenge types will be selected
                       when validating the DNS name and an appropriate Challenge resource
                       will be created to perform the ACME challenge process.
-                    type: array
                     items:
                       description: Challenge specifies a challenge offered by the
                         ACME server for an Order. An appropriate Challenge resource
                         can be created to perform the ACME challenge process.
-                      type: object
-                      required:
-                      - token
-                      - type
-                      - url
                       properties:
                         token:
                           description: Token is the token that must be presented for
@@ -5364,6 +5800,12 @@ spec:
                             used to retrieve additional metadata about the Challenge
                             from the ACME server.
                           type: string
+                      required:
+                      - token
+                      - type
+                      - url
+                      type: object
+                    type: array
                   identifier:
                     description: Identifier is the DNS name to be validated as part
                       of this authorization
@@ -5379,18 +5821,22 @@ spec:
                       '*.example.com' is the DNS name being validated, this field
                       will be 'true' and the 'identifier' field will be 'example.com'.
                     type: boolean
+                required:
+                - url
+                type: object
+              type: array
             certificate:
               description: Certificate is a copy of the PEM encoded certificate for
                 this Order. This field will be populated after the order has been
                 successfully finalized with the ACME server, and the order has transitioned
                 to the 'valid' state.
-              type: string
               format: byte
+              type: string
             failureTime:
               description: FailureTime stores the time that this order failed. This
                 is used to influence garbage collection and back-off.
-              type: string
               format: date-time
+              type: string
             finalizeURL:
               description: FinalizeURL of the Order. This is used to obtain certificates
                 for this order once it has been completed.
@@ -5402,7 +5848,6 @@ spec:
             state:
               description: State contains the current state of this Order resource.
                 States 'success' and 'expired' are 'final'
-              type: string
               enum:
               - valid
               - ready
@@ -5411,14 +5856,22 @@ spec:
               - invalid
               - expired
               - errored
+              type: string
             url:
               description: URL of the Order. This will initially be empty when the
                 resource is first created. The Order controller will populate this
                 field when the Order is first processed. This field will be immutable
                 after it is initially set.
               type: string
-  version: v1alpha2
+          type: object
+      required:
+      - metadata
+      type: object
   versions:
   - name: v1alpha2
     served: true
     storage: true
+  - name: v1alpha3
+    served: true
+    storage: false
+

--- a/psmdbs-operator/README.md
+++ b/psmdbs-operator/README.md
@@ -1,0 +1,65 @@
+
+# Kubernetes Operator for Percona Server MongoDB
+
+https://www.percona.com/doc/kubernetes-operator-for-psmongodb/kubernetes.html
+
+To use:
+
+```bash
+$ jb install github.com/grafana/jsonnet-libs/psmdbs-operator
+```
+
+```jsonnet
+local percona = (import 'psmdbs-operator/psmdbs-operator.libsonnet');
+{
+  percona: percona {
+    _config+:: {
+      /* Defaults
+      custom_crds: true,
+      percona_enable_default_cluster: true,
+      percona_namespace: 'psmdb',
+      percona_mongodb_backup_user: 'backup',
+      percona_mongodb_backup_password: 'backup123456',
+      percona_mongodb_cluster_admin_user: 'clusterAdmin',
+      percona_mongodb_cluster_admin_password: 'clusterAdmin123456',
+      percona_mongodb_cluster_monitor_user: 'clusterMonitor',
+      percona_mongodb_cluster_monitor_password: 'clusterMonitor123456',
+      percona_mongodb_user_admin_user: 'userAdmin',
+      percona_mongodb_user_admin_password: 'userAdmin123456',
+      percona_mongodb_pmm_server_user: 'pmm',
+      percona_mongodb_pmm_server_password: 'supa|^|pazz',
+      */
+    },
+  },
+}
+```
+
+By default this will install the default cluster as outlined in percona
+docs.
+To disable creating crds, set `custom_crds: false` in the `_config` object.
+
+To create a new custom operator, functions are provided:
+
+```jsonnet
+local percona = (import 'psmdbs-operator/psmdbs-operator.libsonnet');
+{
+  operator: percona {
+    _config+:: {
+      percona_enable_default_cluster: false,
+      // ...
+    },
+    yet_another_example: percona.percona.cluster.new('yet-another', {
+      MONGODB_BACKUP_USER: 'exbackup00',
+      MONGODB_BACKUP_PASSWORD: 'exbackup0012346',
+      MONGODB_USER_ADMIN_USER: 'exuseradmin00',
+      MONGODB_USER_ADMIN_PASSWORD: 'exuseradmin0012346',
+      MONGODB_CLUSTER_ADMIN_USER: 'exclusteradmin00',
+      MONGODB_CLUSTER_ADMIN_PASSWORD: 'exclusteradmin0012346',
+      MONGODB_CLUSTER_MONITOR_USER: 'exmonitor00',
+      MONGODB_CLUSTER_MONITOR_PASSWORD: 'exmonitor0012346',
+      PMM_SERVER_USER: 'pmmuser00',
+      PMM_SERVER_PASSWORD: 'pmuser00',
+    }),
+  },
+}
+```

--- a/psmdbs-operator/files/00-crd.yaml
+++ b/psmdbs-operator/files/00-crd.yaml
@@ -1,0 +1,123 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: perconaservermongodbs.psmdb.percona.com
+spec:
+  group: psmdb.percona.com
+  names:
+    kind: PerconaServerMongoDB
+    listKind: PerconaServerMongoDBList
+    plural: perconaservermongodbs
+    singular: perconaservermongodb
+    shortNames:
+    - psmdb
+  scope: Namespaced
+  versions:
+    - name: v1
+      storage: true
+      served: true
+    - name: v1-1-0
+      storage: false
+      served: true
+    - name: v1-2-0
+      storage: false
+      served: true
+    - name: v1-3-0
+      storage: false
+      served: true
+    - name: v1-4-0
+      storage: false
+      served: true
+    - name: v1-5-0
+      storage: false
+      served: true
+    - name: v1alpha1
+      storage: false
+      served: true
+  additionalPrinterColumns:
+    - name: Status
+      type: string
+      JSONPath: .status.state
+    - name: Age
+      type: date
+      JSONPath: .metadata.creationTimestamp
+  subresources:
+    status: {}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: perconaservermongodbbackups.psmdb.percona.com
+spec:
+  group: psmdb.percona.com
+  names:
+    kind: PerconaServerMongoDBBackup
+    listKind: PerconaServerMongoDBBackupList
+    plural: perconaservermongodbbackups
+    singular: perconaservermongodbbackup
+    shortNames:
+    - psmdb-backup
+  scope: Namespaced
+  versions:
+    - name: v1
+      storage: true
+      served: true
+  additionalPrinterColumns:
+    - name: Cluster
+      type: string
+      description: Cluster name
+      JSONPath: .spec.psmdbCluster
+    - name: Storage
+      type: string
+      description: Storage name from pxc spec
+      JSONPath: .spec.storageName
+    - name: Destination
+      type: string
+      description: Backup destination
+      JSONPath: .status.destination
+    - name: Status
+      type: string
+      description: Job status
+      JSONPath: .status.state
+    - name: Completed
+      description: Completed time
+      type: date
+      JSONPath: .status.completed
+    - name: Age
+      type: date
+      JSONPath: .metadata.creationTimestamp
+  subresources:
+    status: {}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: perconaservermongodbrestores.psmdb.percona.com
+spec:
+  group: psmdb.percona.com
+  names:
+    kind: PerconaServerMongoDBRestore
+    listKind: PerconaServerMongoDBRestoreList
+    plural: perconaservermongodbrestores
+    singular: perconaservermongodbrestore
+    shortNames:
+    - psmdb-restore
+  scope: Namespaced
+  versions:
+    - name: v1
+      storage: true
+      served: true
+  additionalPrinterColumns:
+    - name: Cluster
+      type: string
+      description: Cluster name
+      JSONPath: .spec.clusterName
+    - name: Status
+      type: string
+      description: Job status
+      JSONPath: .status.state
+    - name: Age
+      type: date
+      JSONPath: .metadata.creationTimestamp
+  subresources:
+    status: {}

--- a/psmdbs-operator/psmdbs-operator.libsonnet
+++ b/psmdbs-operator/psmdbs-operator.libsonnet
@@ -1,0 +1,460 @@
+local k = import 'ksonnet-util/kausal.libsonnet';
+k {
+  _config+:: {
+    custom_crds: true,
+    percona_enable_default_cluster: true,
+    percona_namespace: 'psmdb',
+    percona_mongodb_backup_user: 'backup',
+    percona_mongodb_backup_password: 'backup123456',
+    percona_mongodb_cluster_admin_user: 'clusterAdmin',
+    percona_mongodb_cluster_admin_password: 'clusterAdmin123456',
+    percona_mongodb_cluster_monitor_user: 'clusterMonitor',
+    percona_mongodb_cluster_monitor_password: 'clusterMonitor123456',
+    percona_mongodb_user_admin_user: 'userAdmin',
+    percona_mongodb_user_admin_password: 'userAdmin123456',
+    percona_mongodb_pmm_server_user: 'pmm',
+    percona_mongodb_pmm_server_password: 'supa|^|pazz',
+  },
+
+  local secret = $.core.v1.secret,
+
+  percona: {
+    percona_namespace: {
+      apiVersion: 'v1',
+      kind: 'Namespace',
+      metadata: {
+        name: $._config.percona_namespace,
+      },
+    },
+    cluster:: {
+      new(name, config)::
+        {
+          local secret_name = '%s-secrets' % name,
+          secret: $.percona.cluster.percona_cluster_secrets.new(secret_name, $.percona.cluster.utils.withCreds(config)),
+          server: $.percona.cluster.percona_server.new(name, secret_name),
+        },
+
+      utils: {
+        withCreds(creds):: {
+          MONGODB_BACKUP_USER: std.base64(creds.MONGODB_BACKUP_USER),
+          MONGODB_BACKUP_PASSWORD: std.base64(creds.MONGODB_BACKUP_PASSWORD),
+          MONGODB_CLUSTER_ADMIN_USER: std.base64(creds.MONGODB_CLUSTER_ADMIN_USER),
+          MONGODB_CLUSTER_ADMIN_PASSWORD: std.base64(creds.MONGODB_CLUSTER_ADMIN_PASSWORD),
+          MONGODB_CLUSTER_MONITOR_USER: std.base64(creds.MONGODB_CLUSTER_MONITOR_USER),
+          MONGODB_CLUSTER_MONITOR_PASSWORD: std.base64(creds.MONGODB_CLUSTER_MONITOR_PASSWORD),
+          MONGODB_USER_ADMIN_USER: std.base64(creds.MONGODB_USER_ADMIN_USER),
+          MONGODB_USER_ADMIN_PASSWORD: std.base64(creds.MONGODB_USER_ADMIN_PASSWORD),
+          PMM_SERVER_USER: std.base64(creds.PMM_SERVER_USER),
+          PMM_SERVER_PASSWORD: std.base64(creds.PMM_SERVER_PASSWORD),
+        },
+      },
+      percona_cluster_secrets::
+        secret.new('my-cluster-name-secrets',
+                   {
+                     MONGODB_BACKUP_USER: std.base64($._config.percona_mongodb_backup_user),
+                     MONGODB_BACKUP_PASSWORD: std.base64($._config.percona_mongodb_backup_password),
+                     MONGODB_CLUSTER_ADMIN_USER: std.base64($._config.percona_mongodb_cluster_admin_user),
+                     MONGODB_CLUSTER_ADMIN_PASSWORD: std.base64($._config.percona_mongodb_cluster_admin_password),
+                     MONGODB_CLUSTER_MONITOR_USER: std.base64($._config.percona_mongodb_cluster_monitor_user),
+                     MONGODB_CLUSTER_MONITOR_PASSWORD: std.base64($._config.percona_mongodb_cluster_monitor_password),
+                     MONGODB_USER_ADMIN_USER: std.base64($._config.percona_mongodb_user_admin_user),
+                     MONGODB_USER_ADMIN_PASSWORD: std.base64($._config.percona_mongodb_user_admin_password),
+                     PMM_SERVER_USER: std.base64($._config.percona_mongodb_pmm_server_user),
+                     PMM_SERVER_PASSWORD: std.base64($._config.percona_mongodb_pmm_server_password),
+                   }) +
+        {
+          metadata+: { namespace: $._config.percona_namespace },
+          new(name, data)::
+            super.new(name, data) +
+            { metadata+: { namespace: $._config.percona_namespace } },
+        },
+      percona_server:: {
+        new(name, secret_name)::
+          local security_key_name = '%s-mongodb-encryption-key' % name;
+          self + { metadata+: { name: name } } +
+          $.percona.cluster.percona_server.withSecret(secret_name) +
+          $.percona.cluster.percona_server.withSecurityPolicy(security_key_name),
+        withSecurityPolicy(name)::
+          { spec+: { mongod+: { security+: { encryptionKeySecret: name } } } },
+        withSecret(name)::
+          { spec+: { secrets+: { users: name } } },
+        apiVersion: 'psmdb.percona.com/v1-5-0',
+        kind: 'PerconaServerMongoDB',
+        metadata: {
+          name: 'my-cluster-name',
+          namespace: $._config.percona_namespace,
+        },
+        spec: {
+          allowUnsafeConfigurations: false,
+          backup: {
+            enabled: true,
+            image: 'percona/percona-server-mongodb-operator:1.5.0-backup',
+            restartOnFailure: true,
+            serviceAccountName: 'percona-server-mongodb-operator',
+            storages: null,
+            tasks: null,
+          },
+          image: 'percona/percona-server-mongodb:4.2.8-8',
+          imagePullPolicy: 'Always',
+          mongod: {
+            net: {
+              hostPort: 0,
+              port: 27017,
+            },
+            operationProfiling: {
+              mode: 'slowOp',
+              rateLimit: 100,
+              slowOpThresholdMs: 100,
+            },
+            security: {
+              enableEncryption: true,
+              encryptionCipherMode: 'AES256-CBC',
+              encryptionKeySecret: 'my-cluster-name-mongodb-encryption-key',
+              redactClientLogData: false,
+            },
+            setParameter: {
+              ttlMonitorSleepSecs: 60,
+              wiredTigerConcurrentReadTransactions: 128,
+              wiredTigerConcurrentWriteTransactions: 128,
+            },
+            storage: {
+              engine: 'wiredTiger',
+              inMemory: {
+                engineConfig: {
+                  inMemorySizeRatio: 0.9,
+                },
+              },
+              mmapv1: {
+                nsSize: 16,
+                smallfiles: false,
+              },
+              wiredTiger: {
+                collectionConfig: {
+                  blockCompressor: 'snappy',
+                },
+                engineConfig: {
+                  cacheSizeRatio: 0.5,
+                  directoryForIndexes: false,
+                  journalCompressor: 'snappy',
+                },
+                indexConfig: {
+                  prefixCompression: true,
+                },
+              },
+            },
+          },
+          pmm: {
+            enabled: false,
+            image: 'percona/percona-server-mongodb-operator:1.5.0-pmm',
+            serverHost: 'monitoring-service',
+          },
+          replsets: [
+            {
+              affinity: {
+                antiAffinityTopologyKey: 'kubernetes.io/hostname',
+              },
+              arbiter: {
+                affinity: {
+                  antiAffinityTopologyKey: 'kubernetes.io/hostname',
+                },
+                enabled: false,
+                size: 1,
+              },
+              expose: {
+                enabled: false,
+                exposeType: 'LoadBalancer',
+              },
+              name: 'rs0',
+              podDisruptionBudget: {
+                maxUnavailable: 1,
+              },
+              resources: {
+                limits: {
+                  cpu: '300m',
+                  memory: '0.5G',
+                },
+                requests: {
+                  cpu: '300m',
+                  memory: '0.5G',
+                },
+              },
+              size: 3,
+              volumeSpec: {
+                persistentVolumeClaim: {
+                  resources: {
+                    requests: {
+                      storage: '3Gi',
+                    },
+                  },
+                },
+              },
+            },
+          ],
+          secrets: {
+            users: $.percona.cluster.percona_cluster_secrets.metadata.name,
+          },
+          updateStrategy: 'SmartUpdate',
+          upgradeOptions: {
+            apply: 'recommended',
+            schedule: '0 2 * * *',
+            versionServiceEndpoint: 'https://check.percona.com/versions/',
+          },
+        },
+      },
+    },
+  },
+
+  crds:
+    if $._config.custom_crds
+    then std.native('parseYaml')(importstr 'files/00-crd.yaml')
+    else {},
+
+
+  rbacs: {
+    role: {
+      apiVersion: 'rbac.authorization.k8s.io/v1beta1',
+      kind: 'Role',
+      metadata: {
+        namespace: $._config.percona_namespace,
+        name: 'percona-server-mongodb-operator',
+      },
+      rules: [
+        {
+          apiGroups: [
+            'psmdb.percona.com',
+          ],
+          resources: [
+            'perconaservermongodbs',
+            'perconaservermongodbs/status',
+            'perconaservermongodbbackups',
+            'perconaservermongodbbackups/status',
+            'perconaservermongodbrestores',
+            'perconaservermongodbrestores/status',
+          ],
+          verbs: [
+            'get',
+            'list',
+            'update',
+            'watch',
+            'create',
+          ],
+        },
+        {
+          apiGroups: [
+            '',
+          ],
+          resources: [
+            'pods',
+            'pods/exec',
+            'services',
+            'persistentvolumeclaims',
+            'secrets',
+            'configmaps',
+          ],
+          verbs: [
+            'get',
+            'list',
+            'watch',
+            'create',
+            'update',
+            'patch',
+            'delete',
+          ],
+        },
+        {
+          apiGroups: [
+            'apps',
+          ],
+          resources: [
+            'deployments',
+            'replicasets',
+            'statefulsets',
+          ],
+          verbs: [
+            'get',
+            'list',
+            'watch',
+            'create',
+            'update',
+            'patch',
+            'delete',
+          ],
+        },
+        {
+          apiGroups: [
+            'batch',
+          ],
+          resources: [
+            'cronjobs',
+          ],
+          verbs: [
+            'get',
+            'list',
+            'watch',
+            'create',
+            'update',
+            'patch',
+            'delete',
+          ],
+        },
+        {
+          apiGroups: [
+            'policy',
+          ],
+          resources: [
+            'poddisruptionbudgets',
+          ],
+          verbs: [
+            'get',
+            'list',
+            'watch',
+            'create',
+            'update',
+            'patch',
+            'delete',
+          ],
+        },
+        {
+          apiGroups: [
+            'certmanager.k8s.io',
+          ],
+          resources: [
+            'issuers',
+            'certificates',
+          ],
+          verbs: [
+            'get',
+            'list',
+            'watch',
+            'create',
+            'update',
+            'patch',
+            'delete',
+            'deletecollection',
+          ],
+        },
+      ],
+    },
+    serviceaccount: {
+      apiVersion: 'v1',
+      kind: 'ServiceAccount',
+      metadata: {
+        namespace: $._config.percona_namespace,
+        name: 'percona-server-mongodb-operator',
+      },
+    },
+    role_binding: {
+      apiVersion: 'rbac.authorization.k8s.io/v1beta1',
+      kind: 'RoleBinding',
+      metadata: {
+        namespace: $._config.percona_namespace,
+        name: 'service-account-percona-server-mongodb-operator',
+      },
+      roleRef: {
+        apiGroup: 'rbac.authorization.k8s.io',
+        kind: 'Role',
+        name: 'percona-server-mongodb-operator',
+      },
+      subjects: [
+        {
+          kind: 'ServiceAccount',
+          name: 'percona-server-mongodb-operator',
+        },
+      ],
+    },
+  },
+
+  operator: {
+    apiVersion: 'apps/v1',
+    kind: 'Deployment',
+    metadata: {
+      namespace: $._config.percona_namespace,
+      name: 'percona-server-mongodb-operator',
+    },
+    spec: {
+      replicas: 1,
+      selector: {
+        matchLabels: {
+          name: 'percona-server-mongodb-operator',
+        },
+      },
+      template: {
+        metadata: {
+          labels: {
+            name: 'percona-server-mongodb-operator',
+          },
+        },
+        spec: {
+          containers: [
+            {
+              command: [
+                'percona-server-mongodb-operator',
+              ],
+              env: [
+                {
+                  name: 'WATCH_NAMESPACE',
+                  valueFrom: {
+                    fieldRef: {
+                      fieldPath: 'metadata.namespace',
+                    },
+                  },
+                },
+                {
+                  name: 'POD_NAME',
+                  valueFrom: {
+                    fieldRef: {
+                      fieldPath: 'metadata.name',
+                    },
+                  },
+                },
+                {
+                  name: 'OPERATOR_NAME',
+                  value: 'percona-server-mongodb-operator',
+                },
+                {
+                  name: 'RESYNC_PERIOD',
+                  value: '5s',
+                },
+                {
+                  name: 'LOG_VERBOSE',
+                  value: 'false',
+                },
+              ],
+              image: 'percona/percona-server-mongodb-operator:1.5.0',
+              imagePullPolicy: 'Always',
+              name: 'percona-server-mongodb-operator',
+              ports: [
+                {
+                  containerPort: 60000,
+                  name: 'metrics',
+                },
+              ],
+            },
+          ],
+          serviceAccountName: 'percona-server-mongodb-operator',
+        },
+      },
+    },
+  },
+
+  default_cluster: if $._config.percona_enable_default_cluster then {
+    secret: $.percona.cluster.percona_cluster_secrets,
+    server: $.percona.cluster.percona_server,
+  } else {},
+
+
+  /*
+  yet_another_example: $.percona.cluster.new('yet-another', {
+    MONGODB_BACKUP_USER: 'exbackup00',
+    MONGODB_BACKUP_PASSWORD: 'exbackup00',
+    MONGODB_USER_ADMIN_USER: 'exuseradmin00',
+    MONGODB_USER_ADMIN_PASSWORD: 'exuseradmin00',
+    MONGODB_CLUSTER_ADMIN_USER: 'exclusteradmin00',
+    MONGODB_CLUSTER_ADMIN_PASSWORD: 'exclusteradmin00',
+    MONGODB_CLUSTER_MONITOR_USER: 'exmonitor00',
+    MONGODB_CLUSTER_MONITOR_PASSWORD: 'exmonitor00',
+    PMM_SERVER_USER: 'pmmuser00',
+    PMM_SERVER_PASSWORD: 'pmuser00',
+  }),
+  */
+}


### PR DESCRIPTION
This adds to https://github.com/grafana/jsonnet-libs/pull/354 in order to make v1alpha3 cert-manager resource available to the cluster.   Update vendored chart to 0.14.3 and downloaded matching CRD file from the github releases.