### PR TITLE
Update weaveworks/watch to the current version

### DIFF
--- a/prometheus-ksonnet/images.libsonnet
+++ b/prometheus-ksonnet/images.libsonnet
@@ -2,7 +2,9 @@
   _images+:: {
     prometheus: 'prom/prometheus:v2.20.0',
     grafana: 'grafana/grafana:7.0.4',
-    watch: 'weaveworks/watch:master-5b2a6e5',
+    // Replace 'beorn7' with 'weaveworks' in the following line once this
+    // image has been pushed to hub.docker.io.
+    watch: 'beorn7/watch:master-f2017cf',
     kubeStateMetrics: 'gcr.io/google_containers/kube-state-metrics:v1.6.0',
     alertmanager: 'prom/alertmanager:v0.21.0',
     nodeExporter: 'prom/node-exporter:v0.18.1',


### PR DESCRIPTION
This version fixes a bug that causes misses of some updates,
especially when whole directories are being watched in the context of
K8s configmaps.

Note that the upstream weaveworks/Watch repo currently has trouble
with their CI pipeline. So I built the image from the same commit
myself and pushed it to my own Docker Hub account. Once the same image
is also on the Weaveworks account, we should switch back.

Signed-off-by: beorn7 <beorn@grafana.com>