### PR TITLE
A Promsonnet library for creating Prometheus Rules

### DIFF
--- a/promsonnet/README.md
+++ b/promsonnet/README.md
@@ -15,9 +15,8 @@ local promRuleGroup = prom.v1.ruleGroup;
 {
   prometheus_metamon::
     promRuleGroup.new('prometheus_metamon')
-    + promRuleGroup.rule.new(
+    + promRuleGroup.rule.newAlert(
       'PrometheusDown', {
-        alert: 'PrometheusDown',
         expr: 'up{job="prometheus"}==0',
         'for': '5m',
         labels: {

--- a/promsonnet/README.md
+++ b/promsonnet/README.md
@@ -3,8 +3,8 @@
 `PromSonnet` is intended as a very simple library for creating Prometheus
 alerts and rules. It is 'patching friendly', as in, it maintains the
 rules internally as a map, which allows users to easily patch alerts and
-recording rules after the fact. (With lists, this requires iteration, and
-is complex.
+recording rules after the fact. In contrast, lists require complex
+iteration logic.
 
 Take this example:
 

--- a/promsonnet/README.md
+++ b/promsonnet/README.md
@@ -1,0 +1,65 @@
+#PromSonnet
+
+`PromSonnet` is intended as a very simple library for creating Prometheus
+alerts and rules. It is 'patching friendly', as in, it maintains the
+rules internally as a map, which allows users to easily patch alerts and
+recording rules after the fact. (With lists, this requires iteration, and
+is complex.
+
+Take this example:
+
+```
+local prom = import 'prom.libsonnet';
+local promRuleGroupSet = prom.v1.ruleGroupSet;
+local promRuleGroup = prom.v1.ruleGroup;
+{
+  prometheus_up::
+    promRuleGroup.new('prometheus_up')
+    + promRuleGroup.rule.new(
+      'PrometheusUp', {
+        alert: 'PrometheusUp',
+        expr: 'up',
+        'for': '5m',
+        labels: {
+          namespace: 'prometheus',
+          severity: 'critical',
+        },
+        annotations: {
+        },
+      }
+    ),
+
+  prometheusAlerts+:
+    promRuleGroupSet.new()
+    + promRuleGroupSet.addGroup($.prometheus_up),
+}
+```
+
+If we wanted to change the `for` from `5m` to `10m`, we could do this
+simply with code such as:
+
+```
+{
+  prometheusAlerts+: {
+    groups_map+:: {
+      prometheus_up+:: {
+        rules+:: {
+          PrometheusUp+:: {
+            for: '10m',
+          },
+        },
+      },
+    },
+  },
+}
+```
+
+We no longer need to iterate over all alerts to do so.
+
+You can execute either of these examples in the `promsonnet` directory
+via:
+```
+$ jsonnet example.jsonnet
+$ # or:
+$ jsonnet patch.jsonnet
+```

--- a/promsonnet/README.md
+++ b/promsonnet/README.md
@@ -13,12 +13,12 @@ local prom = import 'prom.libsonnet';
 local promRuleGroupSet = prom.v1.ruleGroupSet;
 local promRuleGroup = prom.v1.ruleGroup;
 {
-  prometheus_up::
-    promRuleGroup.new('prometheus_up')
+  prometheus_metamon::
+    promRuleGroup.new('prometheus_metamon')
     + promRuleGroup.rule.new(
-      'PrometheusUp', {
-        alert: 'PrometheusUp',
-        expr: 'up',
+      'PrometheusDown', {
+        alert: 'PrometheusDown',
+        expr: 'up{job="prometheus"}==0',
         'for': '5m',
         labels: {
           namespace: 'prometheus',
@@ -31,7 +31,7 @@ local promRuleGroup = prom.v1.ruleGroup;
 
   prometheusAlerts+:
     promRuleGroupSet.new()
-    + promRuleGroupSet.addGroup($.prometheus_up),
+    + promRuleGroupSet.addGroup($.prometheus_metamon),
 }
 ```
 
@@ -42,9 +42,9 @@ simply with code such as:
 {
   prometheusAlerts+: {
     groups_map+:: {
-      prometheus_up+:: {
+      prometheus_metamon+:: {
         rules+:: {
-          PrometheusUp+:: {
+          PrometheusDown+:: {
             for: '10m',
           },
         },

--- a/promsonnet/example.jsonnet
+++ b/promsonnet/example.jsonnet
@@ -2,8 +2,8 @@ local prom = import 'prom.libsonnet';
 local promRuleGroupSet = prom.v1.ruleGroupSet;
 local promRuleGroup = prom.v1.ruleGroup;
 {
-  prometheus_down::
-    promRuleGroup.new('prometheus_down')
+  prometheus_metamon::
+    promRuleGroup.new('prometheus_metamon')
     + promRuleGroup.rule.new(
       'PrometheusDown', {
         alert: 'PrometheusDown',
@@ -20,5 +20,5 @@ local promRuleGroup = prom.v1.ruleGroup;
 
   prometheusAlerts+:
     promRuleGroupSet.new()
-    + promRuleGroupSet.addGroup($.prometheus_down),
+    + promRuleGroupSet.addGroup($.prometheus_metamon),
 }

--- a/promsonnet/example.jsonnet
+++ b/promsonnet/example.jsonnet
@@ -4,9 +4,8 @@ local promRuleGroup = prom.v1.ruleGroup;
 {
   prometheus_metamon::
     promRuleGroup.new('prometheus_metamon')
-    + promRuleGroup.rule.new(
+    + promRuleGroup.rule.newAlert(
       'PrometheusDown', {
-        alert: 'PrometheusDown',
         expr: 'up{job="prometheus"} == 0',
         'for': '5m',
         labels: {

--- a/promsonnet/example.jsonnet
+++ b/promsonnet/example.jsonnet
@@ -1,0 +1,24 @@
+local prom = import 'prom.libsonnet';
+local promRuleGroupSet = prom.v1.ruleGroupSet;
+local promRuleGroup = prom.v1.ruleGroup;
+{
+  prometheus_down::
+    promRuleGroup.new('prometheus_down')
+    + promRuleGroup.rule.new(
+      'PrometheusDown', {
+        alert: 'PrometheusDown',
+        expr: 'up{job="prometheus"} == 0',
+        'for': '5m',
+        labels: {
+          namespace: 'prometheus',
+          severity: 'critical',
+        },
+        annotations: {
+        },
+      }
+    ),
+
+  prometheusAlerts+:
+    promRuleGroupSet.new()
+    + promRuleGroupSet.addGroup($.prometheus_down),
+}

--- a/promsonnet/patch.jsonnet
+++ b/promsonnet/patch.jsonnet
@@ -3,7 +3,7 @@ local example = import 'example.jsonnet';
 example {
   prometheusAlerts+: {
     groups_map+:: {
-      prometheus_down+:: {
+      prometheus_metamon+:: {
         rules_map+:: {
           PrometheusDown+:: {
             'for': '10m',

--- a/promsonnet/patch.jsonnet
+++ b/promsonnet/patch.jsonnet
@@ -1,0 +1,15 @@
+local example = import 'example.jsonnet';
+
+example {
+  prometheusAlerts+: {
+    groups_map+:: {
+      prometheus_down+:: {
+        rules_map+:: {
+          PrometheusDown+:: {
+            'for': '10m',
+          },
+        },
+      },
+    },
+  },
+}

--- a/promsonnet/prom.libsonnet
+++ b/promsonnet/prom.libsonnet
@@ -1,0 +1,39 @@
+{
+  v1: {
+    ruleGroupSet: {
+      new():: {
+        groups_map:: {},
+        groups_order:: [],
+        local groups_map = self.groups_map,
+        local groups_order = self.groups_order,
+        groups: [groups_map[group] for group in groups_order],
+      },
+      addGroup(group):: {
+        groups_map+:: {
+          [group.name]: group,
+        },
+        groups_order+:: [group.name],
+      },
+    },
+
+    ruleGroup: {
+      new(name):: {
+        name: name,
+        rules_map:: {},
+        rules_order:: [],
+        local rules_map = self.rules_map,
+        local rules_order = self.rules_order,
+        rules: [rules_map[rule] for rule in rules_order],
+      },
+
+      rule: {
+        new(name, rule):: {
+          rules_map+:: {
+            [name]: rule,
+          },
+          rules_order+:: [name],
+        },
+      },
+    },
+  },
+}

--- a/promsonnet/prom.libsonnet
+++ b/promsonnet/prom.libsonnet
@@ -27,9 +27,15 @@
       },
 
       rule: {
-        new(name, rule):: {
+        newAlert(name, rule):: {
           rules_map+:: {
-            [name]: rule,
+            [name]: rule { alert: name },
+          },
+          rules_order+:: [name],
+        },
+        newRecording(name, rule):: {
+          rules_map+:: {
+            [name]: rule { record: name },
           },
           rules_order+:: [name],
         },


### PR DESCRIPTION
A simple library for rendering Prometheus rules. Provides a workaround for the issue that patching Prometheus alerts/recording rules is hard in Jsonnet, as individual elements in a list are not addressable. Under the bonnet, this stores rules in a map, then renders the required list late. The entries in the map can be patched, as demonstrated in the example `patch.jsonnet`.

Comments/thoughts/approvals welcome.