### PR TITLE
Switch back to the weaveworks source of the watch docker image

### DIFF
--- a/prometheus-ksonnet/images.libsonnet
+++ b/prometheus-ksonnet/images.libsonnet
@@ -2,9 +2,7 @@
   _images+:: {
     prometheus: 'prom/prometheus:v2.20.0',
     grafana: 'grafana/grafana:7.0.4',
-    // Replace 'beorn7' with 'weaveworks' in the following line once this
-    // image has been pushed to hub.docker.io.
-    watch: 'beorn7/watch:master-f2017cf-1',
+    watch: 'weaveworks/watch:master-5fc29a9',
     kubeStateMetrics: 'gcr.io/google_containers/kube-state-metrics:v1.6.0',
     alertmanager: 'prom/alertmanager:v0.21.0',
     nodeExporter: 'prom/node-exporter:v0.18.1',


### PR DESCRIPTION
Weaveworks' CI has been fixed. Their docker image is up to date now.