### PR TITLE
Update Prometheus to v2.22.0

### DIFF
--- a/prometheus-ksonnet/images.libsonnet
+++ b/prometheus-ksonnet/images.libsonnet
@@ -1,6 +1,6 @@
 {
   _images+:: {
-    prometheus: 'prom/prometheus:v2.20.0',
+    prometheus: 'prom/prometheus:v2.22.0',
     grafana: 'grafana/grafana:7.0.4',
     watch: 'weaveworks/watch:master-5fc29a9',
     kubeStateMetrics: 'gcr.io/google_containers/kube-state-metrics:v1.6.0',


### PR DESCRIPTION
The image will be released any moment. I'll only merge once it has
been published.

The RC for this release (which is identical to the final release) has
been canaried in two of our production clusters for a couple of days.