### PR TITLE
Add patchGroup and patchAll

### DIFF
--- a/promsonnet/example.jsonnet
+++ b/promsonnet/example.jsonnet
@@ -4,7 +4,7 @@ local promRuleGroup = prom.v1.ruleGroup;
 {
   prometheus_metamon::
     promRuleGroup.new('prometheus_metamon')
-    + promRuleGroup.rule.newAlert(
+    + promRuleGroup.newAlertRule(
       'PrometheusDown', {
         expr: 'up{job="prometheus"} == 0',
         'for': '5m',
@@ -15,7 +15,7 @@ local promRuleGroup = prom.v1.ruleGroup;
         },
       }
     )
-    + promRuleGroup.rule.newAlert(
+    + promRuleGroup.newAlertRule(
       'AlertManagerDown', {
         expr: 'left{job="alertmanager"} == 0',
         'for': '5m',
@@ -29,7 +29,7 @@ local promRuleGroup = prom.v1.ruleGroup;
 
   grafana_check::
     promRuleGroup.new('grafana_check')
-    + promRuleGroup.rule.newAlert(
+    + promRuleGroup.newAlertRule(
       'GrafanaDown', {
         expr: 'up{job="grafana"} == 0',
         'for': '5m',

--- a/promsonnet/example.jsonnet
+++ b/promsonnet/example.jsonnet
@@ -10,14 +10,38 @@ local promRuleGroup = prom.v1.ruleGroup;
         'for': '5m',
         labels: {
           namespace: 'prometheus',
-          severity: 'critical',
+        },
+        annotations: {
+        },
+      }
+    )
+    + promRuleGroup.rule.newAlert(
+      'AlertManagerDown', {
+        expr: 'left{job="alertmanager"} == 0',
+        'for': '5m',
+        labels: {
+          namespace: 'alertmanager',
+        },
+        annotations: {
+        },
+      },
+    ),
+
+  grafana_check::
+    promRuleGroup.new('grafana_check')
+    + promRuleGroup.rule.newAlert(
+      'GrafanaDown', {
+        expr: 'up{job="grafana"} == 0',
+        'for': '5m',
+        labels: {
+          namespace: 'grafana',
         },
         annotations: {
         },
       }
     ),
-
   prometheusAlerts+:
     promRuleGroupSet.new()
-    + promRuleGroupSet.addGroup($.prometheus_metamon),
+    + promRuleGroupSet.addGroup($.prometheus_metamon)
+    + promRuleGroupSet.addGroup($.grafana_check),
 }

--- a/promsonnet/patch.jsonnet
+++ b/promsonnet/patch.jsonnet
@@ -3,7 +3,7 @@ local prom = import 'prom.libsonnet';
 
 example {
   prometheusAlerts+: prom.v1.patchRule('prometheus_metamon', 'PrometheusDown', { 'for': '10m' })
-                     + prom.v1.patchGroup('prometheus_metamon', { annotations+: { automated: 'true' } })
-                     + prom.v1.patchAll({ labels+: { severity: 'critical' } }),
+                     + prom.v1.patchRuleGroup('prometheus_metamon', { annotations+: { automated: 'true' } })
+                     + prom.v1.patchAllRules({ labels+: { severity: 'critical' } }),
 
 }

--- a/promsonnet/patch.jsonnet
+++ b/promsonnet/patch.jsonnet
@@ -2,5 +2,8 @@ local example = import 'example.jsonnet';
 local prom = import 'prom.libsonnet';
 
 example {
-  prometheusAlerts+: prom.v1.patchRule('prometheus_metamon', 'PrometheusDown', { 'for': '10m' }),
+  prometheusAlerts+: prom.v1.patchRule('prometheus_metamon', 'PrometheusDown', { 'for': '10m' })
+                     + prom.v1.patchGroup('prometheus_metamon', { annotations+: { automated: 'true' } })
+                     + prom.v1.patchAll({ labels+: { severity: 'critical' } }),
+
 }

--- a/promsonnet/prom.libsonnet
+++ b/promsonnet/prom.libsonnet
@@ -40,19 +40,17 @@
         local rules_order = self.rules_order,
       },
 
-      rule: {
-        newAlert(name, rule):: {
-          rules_map+:: {
-            [name]: rule { alert: name },
-          },
-          rules_order+:: [name],
+      newAlertRule(name, rule):: {
+        rules_map+:: {
+          [name]: rule { alert: name },
         },
-        newRecording(name, rule):: {
-          rules_map+:: {
-            [name]: rule { record: name },
-          },
-          rules_order+:: [name],
+        rules_order+:: [name],
+      },
+      newRecordingRule(name, rule):: {
+        rules_map+:: {
+          [name]: rule { record: name },
         },
+        rules_order+:: [name],
       },
     },
 
@@ -66,7 +64,7 @@
       },
     },
 
-    patchGroup(group, patch):: {
+    patchRuleGroup(group, patch):: {
       groups_map+:: {
         [group]+: {
           patches+: [patch],
@@ -74,7 +72,7 @@
       },
     },
 
-    patchAll(patch):: {
+    patchAllRules(patch):: {
       patch_rules_all+:: [patch],
     },
   },

--- a/promsonnet/prom.libsonnet
+++ b/promsonnet/prom.libsonnet
@@ -4,9 +4,22 @@
       new():: {
         groups_map:: {},
         groups_order:: [],
+        patch_rules_all:: [],
         local groups_map = self.groups_map,
         local groups_order = self.groups_order,
-        groups: [groups_map[group] for group in groups_order],
+        local patch_rules_all = self.patch_rules_all,
+        groups: [
+          local group = groups_map[group_name];
+          {
+            name: group_name,
+            rules: [
+              local rule = group.rules_map[rule_name];
+              std.foldl(function(rule, patch) rule + patch, patch_rules_all + group.patches, rule)
+              for rule_name in group.rules_order
+            ],
+          }
+          for group_name in groups_order
+        ],
       },
 
       addGroup(group):: {
@@ -22,9 +35,9 @@
         name: name,
         rules_map:: {},
         rules_order:: [],
+        patches:: [],
         local rules_map = self.rules_map,
         local rules_order = self.rules_order,
-        rules: [rules_map[rule] for rule in rules_order],
       },
 
       rule: {
@@ -51,6 +64,18 @@
           },
         },
       },
+    },
+
+    patchGroup(group, patch):: {
+      groups_map+:: {
+        [group]+: {
+          patches+: [patch],
+        },
+      },
+    },
+
+    patchAll(patch):: {
+      patch_rules_all+:: [patch],
     },
   },
 }

--- a/promsonnet/prom.libsonnet
+++ b/promsonnet/prom.libsonnet
@@ -14,7 +14,11 @@
             name: group_name,
             rules: [
               local rule = group.rules_map[rule_name];
-              std.foldl(function(rule, patch) rule + patch, patch_rules_all + group.patches, rule)
+              std.foldl(
+                function(rule, patch) rule + patch,
+                patch_rules_all + group.patches,
+                rule,
+              )
               for rule_name in group.rules_order
             ],
           }


### PR DESCRIPTION
Adds two functions that could be useful when patching Prometheus rules.
Means that all rules within mixins can share these, rather than needing
to write their own rule manipulators, which are invariably based upon
lists and thus complex and difficult to reason about.
