### PR TITLE
Adjust config to current version of alertmanager-mixin

### DIFF
--- a/prometheus-ksonnet/mixins.libsonnet
+++ b/prometheus-ksonnet/mixins.libsonnet
@@ -35,6 +35,8 @@
 
         _config+:: {
           alertmanagerSelector: 'job="default/alertmanager"',
+          alertmanagerClusterLabels: 'job, namespace',
+          alertmanagerName: '{{$labels.instance}} in {{$labels.cluster}}',
         },
       },
 


### PR DESCRIPTION
The actual meat to happen in grafana/deployment_tools with a vendoring update of this and the actual alertmanager-mixin.