### PR TITLE
Enable to write a panel description

### DIFF
--- a/grafana-builder/grafana.libsonnet
+++ b/grafana-builder/grafana.libsonnet
@@ -161,12 +161,13 @@
     titleSize: 'h6',
   },
 
-  panel(title):: {
+  panel(title, description=""):: {
     aliasColors: {},
     bars: false,
     dashLength: 10,
     dashes: false,
     datasource: '$datasource',
+    description: description,
     fill: 1,
     legend: {
       avg: false,

--- a/grafana-builder/grafana.libsonnet
+++ b/grafana-builder/grafana.libsonnet
@@ -161,7 +161,7 @@
     titleSize: 'h6',
   },
 
-  panel(title, description=""):: {
+  panel(title, description=''):: {
     aliasColors: {},
     bars: false,
     dashLength: 10,


### PR DESCRIPTION
This change enables to add a description to a panel.
If no description is provided, it will add an empty description which
corresponds to no description in the Grafana panel.