### PR TITLE
Surface Prometheus Requests + Limits for cpu, mem

### DIFF
--- a/prometheus-ksonnet/lib/config.libsonnet
+++ b/prometheus-ksonnet/lib/config.libsonnet
@@ -27,6 +27,12 @@
     apiServerAddress: 'kubernetes.default.svc.%(cluster_dns_suffix)s:443' % self,
     insecureSkipVerify: false,
 
+    // Prometheus config basics
+    prometheus_requests_cpu: '250m',
+    prometheus_requests_memory: '1536Mi',
+    prometheus_limits_cpu: '500m',
+    prometheus_limits_memory: '2Gi',
+
     // Prometheus config options.
     prometheus_api_server_address: self.apiServerAddress,
     scrape_api_server_endpoints: true,

--- a/prometheus-ksonnet/lib/prometheus.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus.libsonnet
@@ -44,8 +44,10 @@
         '--storage.tsdb.path=/prometheus/data',
         '--storage.tsdb.wal-compression',
       ]) +
-      $.util.resourcesRequests('250m', '1536Mi') +
-      $.util.resourcesLimits('500m', '2Gi'),
+      $.util.resourcesRequests(_config.prometheus_requests_cpu,
+                               _config.prometheus_requests_memory) +
+      $.util.resourcesLimits(_config.prometheus_limits_cpu,
+                             _config.prometheus_limits_memory),
 
     prometheus_watch_container::
       container.new('watch', $._images.watch) +


### PR DESCRIPTION
Surface the basics for prometheus requests and limits in _config, vs.
requiring consumers of prometheus-ksonnet to ferret out how/where to
override.  On a modest cluster (25 nodes) the defaults yield a crashing
prometheus due to resource constraints.

This does not change defaults so should not disturb existing deploys.