### PR TITLE
Upgrade kube-state-metrics to latest stable version.

### DIFF
--- a/prometheus-ksonnet/images.libsonnet
+++ b/prometheus-ksonnet/images.libsonnet
@@ -3,7 +3,7 @@
     prometheus: 'prom/prometheus:v2.22.0',
     grafana: 'grafana/grafana:7.2.2',
     watch: 'weaveworks/watch:master-5fc29a9',
-    kubeStateMetrics: 'gcr.io/google_containers/kube-state-metrics:v1.6.0',
+    kubeStateMetrics: 'gcr.io/google_containers/kube-state-metrics:v1.9.7',
     alertmanager: 'prom/alertmanager:v0.21.0',
     nodeExporter: 'prom/node-exporter:v0.18.1',
     nginx: 'nginx:1.15.1-alpine',


### PR DESCRIPTION
The 1.6.0 version of kube-state metrics was using deprecated APIs that
were removed in kubernetes 1.16.

1.9.7 is latest stable version and according to the changelog at https://github.com/kubernetes/kube-state-metrics/blob/master/CHANGELOG.md#v160--2019-05-06 it doesn't
introduce breaking changes w.r.t. 1.6.0; it should be safe to upgrade.