### PR TITLE
Downgrade kube-state-metrics to 1.9.5 .

### DIFF
--- a/prometheus-ksonnet/images.libsonnet
+++ b/prometheus-ksonnet/images.libsonnet
@@ -3,7 +3,7 @@
     prometheus: 'prom/prometheus:v2.22.0',
     grafana: 'grafana/grafana:7.2.2',
     watch: 'weaveworks/watch:master-5fc29a9',
-    kubeStateMetrics: 'gcr.io/google_containers/kube-state-metrics:v1.9.7',
+    kubeStateMetrics: 'gcr.io/google_containers/kube-state-metrics:v1.9.5',
     alertmanager: 'prom/alertmanager:v0.21.0',
     nodeExporter: 'prom/node-exporter:v0.18.1',
     nginx: 'nginx:1.15.1-alpine',


### PR DESCRIPTION
Although 1.9.7 is technically released a docker image at
gcr.io/google_containers/kube-state-metrics only exists for v1.9.5 .
Let's downgrade the version for the time being.