### PR TITLE
Provide MinIO mixin

### DIFF
--- a/minio-mixin/alerts.libsonnet
+++ b/minio-mixin/alerts.libsonnet
@@ -1,0 +1,35 @@
+{
+  prometheusAlerts+: {
+    groups+: [{
+      name: 'minio',
+      rules: [
+        {
+          alert: 'minioDisksOffline',
+          expr: |||
+            minio_disks_offline != 0
+          |||,
+          'for': '1m',
+          labels: {
+            severity: 'critical',
+          },
+          annotations: {
+            message: "MinIO '{{ $labels.instance }}' has disks offline",
+          },
+        },
+        {
+          alert: 'minioStorageUsed',
+          expr: |||
+            disk_storage_used / disk_storage_total > 0.8
+          |||,
+          'for': '1m',
+          labels: {
+            severity: 'warning',
+          },
+          annotations: {
+            message: "MinIO disk '{{ $labels.disk }}' has more than 80% storaged used",
+          },
+        },
+      ],
+    }],
+  },
+}

--- a/minio-mixin/dashboards.libsonnet
+++ b/minio-mixin/dashboards.libsonnet
@@ -1,0 +1,6 @@
+local dashboard = import 'minio_v1.libsonnet';
+{
+  grafanaDashboards+: {
+    'minio-dashboardv1.json': dashboard,     
+  }
+}

--- a/minio-mixin/dashboards.libsonnet
+++ b/minio-mixin/dashboards.libsonnet
@@ -1,6 +1,6 @@
 local dashboard = import 'minio_v1.libsonnet';
 {
   grafanaDashboards+: {
-    'minio-dashboardv1.json': dashboard,     
-  }
+    'minio-dashboardv1.json': dashboard,
+  },
 }

--- a/minio-mixin/jsonnetfile.json
+++ b/minio-mixin/jsonnetfile.json
@@ -9,14 +9,6 @@
         }
       },
       "version": "master"
-    },
-    {
-      "source": {
-        "local": {
-          "directory": "."
-        }
-      },
-      "version": ""
     }
   ],
   "legacyImports": true

--- a/minio-mixin/jsonnetfile.json
+++ b/minio-mixin/jsonnetfile.json
@@ -1,0 +1,23 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": "grafana-builder"
+        }
+      },
+      "version": "master"
+    },
+    {
+      "source": {
+        "local": {
+          "directory": "."
+        }
+      },
+      "version": ""
+    }
+  ],
+  "legacyImports": true
+}

--- a/minio-mixin/minio_v1.libsonnet
+++ b/minio-mixin/minio_v1.libsonnet
@@ -1,0 +1,98 @@
+local g = import 'grafana-builder/grafana.libsonnet';
+
+local panel_settings_bytes = {
+    yaxes: g.yaxes('bytes')
+};
+
+local panel_settings_qps = {
+    stack: true,
+};
+
+// Add common filters
+local f(s) = s % 'instance=~"$instance", job=~"$job"';
+
+g.dashboard('MinIO distributed cluster metrics', std.md5('minio_v1'))
+.addTemplate('job', 'minio_version_info', 'job')
+.addMultiTemplate('instance', 'minio_version_info{job="$job"}', 'instance')
+.addMultiTemplate('disk', 'disk_storage_available{job="$job"}', 'disk')
+.addRow(
+    g.row('Overview')
+    .addPanel(
+        g.panel('Storage Used') + 
+        g.statPanel('sum(disk_storage_used{disk=~"$disk", job=~"$job"}) by (disk) 
+                   / sum(disk_storage_total{disk=~"$disk", job=~"$job"}) by (disk)') + 
+        {
+            type: 'gauge',
+            // The default 'percentunit' format of statPanel() doesn't seem to have an effect
+            fieldConfig: {
+                defaults: {
+                    unit: 'percentunit'
+                },
+            },
+        }
+    )
+    .addPanel(
+        g.panel('Disks Total') +
+        g.statPanel(f('sum(minio_disks_total{%s})'), 'none')
+    )
+    .addPanel(
+        g.panel('Disks Offline') +
+        g.statPanel(f('sum(minio_disks_offline{%s})'), 'none')
+    )
+    .addPanel(
+        g.panel('Errors') +
+        g.queryPanel(f('s3_errors_total{%s}'), '')
+    )
+)
+.addRow(
+    g.row('Storage')
+    .addPanel(
+        g.panel('Storage Used') +
+        g.queryPanel(f('disk_storage_used{disk=~"$disk",%s}'), '') +
+        panel_settings_bytes,
+    )
+    .addPanel(
+        g.panel('Storage Available') +
+        g.queryPanel(f('disk_storage_available{disk=~"$disk",%s}'), '') +
+        panel_settings_bytes,
+    )
+    .addPanel(
+        g.panel('Storage Total') +
+        g.queryPanel(f('disk_storage_total{disk=~"$disk",%s}'), '') +
+        panel_settings_bytes,
+    )
+)
+.addRow(
+    g.row('Requests')
+    .addPanel(
+        g.panel('Read rps') +
+        g.queryPanel(f('sum(rate(s3_requests_total{api=~"get.*|list.*|head.*",%s}[$__rate_interval])) by (api)'), '{{api}}') +
+        panel_settings_qps
+    )
+    .addPanel(
+        g.panel('Write rps') +
+        g.queryPanel(f('sum(rate(s3_requests_total{api=~"put.*",%s}[$__rate_interval])) by (api)'), '{{api}}') +
+        panel_settings_qps
+    )
+    .addPanel(
+        g.panel('Delete rps') +
+        g.queryPanel(f('sum(rate(s3_requests_total{api=~"delete.*",%s}[$__rate_interval])) by (api)'), '{{api}}')
+    )
+)
+.addRow(
+    g.row('Performance')
+    .addPanel(
+        g.panel('Read latency') +
+        g.latencyPanel('s3_ttfb_seconds', f('{api=~"get.*|list.*|head.*",%s}'))
+    )
+    .addPanel(
+        g.panel('Internode traffic') +
+        g.queryPanel([
+            f('sum(rate(internode_rx_bytes_total{%s}[$__rate_interval]))'),
+            f('sum(rate(internode_tx_bytes_total{%s}[$__rate_interval]))'),
+        ], [
+            'Inbound',
+            'Outbound'
+        ],)
+    )
+)

--- a/minio-mixin/minio_v1.libsonnet
+++ b/minio-mixin/minio_v1.libsonnet
@@ -22,8 +22,8 @@ g.dashboard('MinIO distributed cluster metrics', std.md5('minio_v1'))
     g.statPanel('sum(disk_storage_used{disk=~"$disk", job=~"$job"}) by (disk) / sum(disk_storage_total{disk=~"$disk", job=~"$job"}) by (disk)') +
     {
       type: 'gauge',
-      targets: [super.targets[0] + {
-        legendFormat: '{{disk}}'
+      targets: [super.targets[0] {
+        legendFormat: '{{disk}}',
       }],
       // The default 'percentunit' format of statPanel() doesn't seem to have an effect
       fieldConfig: {

--- a/minio-mixin/minio_v1.libsonnet
+++ b/minio-mixin/minio_v1.libsonnet
@@ -1,11 +1,11 @@
 local g = import 'grafana-builder/grafana.libsonnet';
 
 local panel_settings_bytes = {
-    yaxes: g.yaxes('bytes')
+  yaxes: g.yaxes('bytes'),
 };
 
 local panel_settings_qps = {
-    stack: true,
+  stack: true,
 };
 
 // Add common filters
@@ -16,83 +16,82 @@ g.dashboard('MinIO distributed cluster metrics', std.md5('minio_v1'))
 .addMultiTemplate('instance', 'minio_version_info{job="$job"}', 'instance')
 .addMultiTemplate('disk', 'disk_storage_available{job="$job"}', 'disk')
 .addRow(
-    g.row('Overview')
-    .addPanel(
-        g.panel('Storage Used') + 
-        g.statPanel('sum(disk_storage_used{disk=~"$disk", job=~"$job"}) by (disk) 
-                   / sum(disk_storage_total{disk=~"$disk", job=~"$job"}) by (disk)') + 
-        {
-            type: 'gauge',
-            // The default 'percentunit' format of statPanel() doesn't seem to have an effect
-            fieldConfig: {
-                defaults: {
-                    unit: 'percentunit'
-                },
-            },
-        }
-    )
-    .addPanel(
-        g.panel('Disks Total') +
-        g.statPanel(f('sum(minio_disks_total{%s})'), 'none')
-    )
-    .addPanel(
-        g.panel('Disks Offline') +
-        g.statPanel(f('sum(minio_disks_offline{%s})'), 'none')
-    )
-    .addPanel(
-        g.panel('Errors') +
-        g.queryPanel(f('s3_errors_total{%s}'), '')
-    )
+  g.row('Overview')
+  .addPanel(
+    g.panel('Storage Used') +
+    g.statPanel('sum(disk_storage_used{disk=~"$disk", job=~"$job"}) by (disk) \n                   / sum(disk_storage_total{disk=~"$disk", job=~"$job"}) by (disk)') +
+    {
+      type: 'gauge',
+      // The default 'percentunit' format of statPanel() doesn't seem to have an effect
+      fieldConfig: {
+        defaults: {
+          unit: 'percentunit',
+        },
+      },
+    }
+  )
+  .addPanel(
+    g.panel('Disks Total') +
+    g.statPanel(f('sum(minio_disks_total{%s})'), 'none')
+  )
+  .addPanel(
+    g.panel('Disks Offline') +
+    g.statPanel(f('sum(minio_disks_offline{%s})'), 'none')
+  )
+  .addPanel(
+    g.panel('Errors') +
+    g.queryPanel(f('s3_errors_total{%s}'), '')
+  )
 )
 .addRow(
-    g.row('Storage')
-    .addPanel(
-        g.panel('Storage Used') +
-        g.queryPanel(f('disk_storage_used{disk=~"$disk",%s}'), '') +
-        panel_settings_bytes,
-    )
-    .addPanel(
-        g.panel('Storage Available') +
-        g.queryPanel(f('disk_storage_available{disk=~"$disk",%s}'), '') +
-        panel_settings_bytes,
-    )
-    .addPanel(
-        g.panel('Storage Total') +
-        g.queryPanel(f('disk_storage_total{disk=~"$disk",%s}'), '') +
-        panel_settings_bytes,
-    )
+  g.row('Storage')
+  .addPanel(
+    g.panel('Storage Used') +
+    g.queryPanel(f('disk_storage_used{disk=~"$disk",%s}'), '') +
+    panel_settings_bytes,
+  )
+  .addPanel(
+    g.panel('Storage Available') +
+    g.queryPanel(f('disk_storage_available{disk=~"$disk",%s}'), '') +
+    panel_settings_bytes,
+  )
+  .addPanel(
+    g.panel('Storage Total') +
+    g.queryPanel(f('disk_storage_total{disk=~"$disk",%s}'), '') +
+    panel_settings_bytes,
+  )
 )
 .addRow(
-    g.row('Requests')
-    .addPanel(
-        g.panel('Read rps') +
-        g.queryPanel(f('sum(rate(s3_requests_total{api=~"get.*|list.*|head.*",%s}[$__rate_interval])) by (api)'), '{{api}}') +
-        panel_settings_qps
-    )
-    .addPanel(
-        g.panel('Write rps') +
-        g.queryPanel(f('sum(rate(s3_requests_total{api=~"put.*",%s}[$__rate_interval])) by (api)'), '{{api}}') +
-        panel_settings_qps
-    )
-    .addPanel(
-        g.panel('Delete rps') +
-        g.queryPanel(f('sum(rate(s3_requests_total{api=~"delete.*",%s}[$__rate_interval])) by (api)'), '{{api}}')
-    )
+  g.row('Requests')
+  .addPanel(
+    g.panel('Read rps') +
+    g.queryPanel(f('sum(rate(s3_requests_total{api=~"get.*|list.*|head.*",%s}[$__rate_interval])) by (api)'), '{{api}}') +
+    panel_settings_qps
+  )
+  .addPanel(
+    g.panel('Write rps') +
+    g.queryPanel(f('sum(rate(s3_requests_total{api=~"put.*",%s}[$__rate_interval])) by (api)'), '{{api}}') +
+    panel_settings_qps
+  )
+  .addPanel(
+    g.panel('Delete rps') +
+    g.queryPanel(f('sum(rate(s3_requests_total{api=~"delete.*",%s}[$__rate_interval])) by (api)'), '{{api}}')
+  )
 )
 .addRow(
-    g.row('Performance')
-    .addPanel(
-        g.panel('Read latency') +
-        g.latencyPanel('s3_ttfb_seconds', f('{api=~"get.*|list.*|head.*",%s}'))
-    )
-    .addPanel(
-        g.panel('Internode traffic') +
-        g.queryPanel([
-            f('sum(rate(internode_rx_bytes_total{%s}[$__rate_interval]))'),
-            f('sum(rate(internode_tx_bytes_total{%s}[$__rate_interval]))'),
-        ], [
-            'Inbound',
-            'Outbound'
-        ],)
-    )
+  g.row('Performance')
+  .addPanel(
+    g.panel('Read latency') +
+    g.latencyPanel('s3_ttfb_seconds', f('{api=~"get.*|list.*|head.*",%s}'))
+  )
+  .addPanel(
+    g.panel('Internode traffic') +
+    g.queryPanel([
+      f('sum(rate(internode_rx_bytes_total{%s}[$__rate_interval]))'),
+      f('sum(rate(internode_tx_bytes_total{%s}[$__rate_interval]))'),
+    ], [
+      'Inbound',
+      'Outbound',
+    ],)
+  )
 )

--- a/minio-mixin/minio_v1.libsonnet
+++ b/minio-mixin/minio_v1.libsonnet
@@ -19,7 +19,7 @@ g.dashboard('MinIO distributed cluster metrics', std.md5('minio_v1'))
   g.row('Overview')
   .addPanel(
     g.panel('Storage Used') +
-    g.statPanel('sum(disk_storage_used{disk=~"$disk", job=~"$job"}) by (disk) \n                   / sum(disk_storage_total{disk=~"$disk", job=~"$job"}) by (disk)') +
+    g.statPanel('sum(disk_storage_used{disk=~"$disk", job=~"$job"}) by (disk) / sum(disk_storage_total{disk=~"$disk", job=~"$job"}) by (disk)') +
     {
       type: 'gauge',
       // The default 'percentunit' format of statPanel() doesn't seem to have an effect
@@ -85,13 +85,15 @@ g.dashboard('MinIO distributed cluster metrics', std.md5('minio_v1'))
     g.latencyPanel('s3_ttfb_seconds', f('{api=~"get.*|list.*|head.*",%s}'))
   )
   .addPanel(
-    g.panel('Internode traffic') +
+    g.panel('Internode traffic') + {
+      description: 'Internode traffic for multi-node clusters. Will be zero for single node configurations.',
+    } +
     g.queryPanel([
-      f('sum(rate(internode_rx_bytes_total{%s}[$__rate_interval]))'),
-      f('sum(rate(internode_tx_bytes_total{%s}[$__rate_interval]))'),
+      f('rate(internode_rx_bytes_total{%s}[$__rate_interval])'),
+      f('rate(internode_tx_bytes_total{%s}[$__rate_interval])'),
     ], [
-      'Inbound',
-      'Outbound',
+      'Inbound-{{instance}}',
+      'Outbound-{{instance}}',
     ],)
   )
 )

--- a/minio-mixin/mixin.libsonnet
+++ b/minio-mixin/mixin.libsonnet
@@ -1,4 +1,5 @@
 (import 'dashboards.libsonnet') +
+(import 'alerts.libsonnet') +
 {
-  grafanaDashboardFolder: 'MinIO'
+  grafanaDashboardFolder: 'MinIO',
 }

--- a/minio-mixin/mixin.libsonnet
+++ b/minio-mixin/mixin.libsonnet
@@ -1,0 +1,4 @@
+(import 'dashboards.libsonnet') +
+{
+  grafanaDashboardFolder: 'MinIO'
+}


### PR DESCRIPTION
This PR provides a mixin for MinIO.  There are a couple of things to note:

* The starting point was the existing dashboard: https://grafana.com/grafana/dashboards/11568
* In local testing MinIO does not compute latency for write/delete requests, so there is only a latency graph for reads.
* In local testing the Disks Total/Offline stats are always zero, but still including because thinking this is just an artifact of local testing and the metrics do normally function.
* There are a couple alarms that seem valuable to include since they are invariant:  when free storage space is low, or disks offline is non-zero.  However, not sure of the best way to include those alarms here, so looking for some feedback.  Things to account for:
** Is there support in the jsonnet-libs for creating the alarms, or a good example?
** My understanding is that alarms require a graph panel, so the current gauge panel would have to change, or another graph panel created with somewhat duplicate information.  This was the approach I was originally going with.