### PR TITLE
Fix kube-state-metrics permissions.

### DIFF
--- a/prometheus-ksonnet/lib/kube-state-metrics.libsonnet
+++ b/prometheus-ksonnet/lib/kube-state-metrics.libsonnet
@@ -78,13 +78,13 @@
   kube_state_metrics_container::
     container.new('kube-state-metrics', $._images.kubeStateMetrics) +
     container.withArgs([
-      '--port=80',
+      '--port=8080',
       '--telemetry-host=0.0.0.0',
-      '--telemetry-port=81',
+      '--telemetry-port=8081',
     ]) +
     container.withPorts([
-      containerPort.new('http-metrics', 80),
-      containerPort.new('self-metrics', 81),
+      containerPort.new('http-metrics', 8080),
+      containerPort.new('self-metrics', 8081),
     ]) +
     $.util.resourcesRequests('50m', '50Mi') +
     $.util.resourcesLimits('250m', '150Mi'),
@@ -99,6 +99,9 @@
     // scrape config to preserve namespace etc labels.
     deployment.mixin.spec.template.metadata.withAnnotationsMixin({ 'prometheus.io.scrape': 'false' }) +
     deployment.mixin.spec.template.spec.withServiceAccount('kube-state-metrics') +
+    deployment.mixin.spec.template.spec.securityContext.withRunAsUser(65534) +
+    deployment.mixin.spec.template.spec.securityContext.withRunAsGroup(65534) +
+    deployment.mixin.spec.template.spec.securityContext.withFsGroup(0) +  // TODO: remove after kube-state-metrics binary in docker image is not owned by root
     $.util.podPriority('critical'),
 
   kube_state_metrics_service:


### PR DESCRIPTION
Originally, kube-state-metrics was ran with root permissions. Since
1.8.0 that's no longer the case and the docker image is explicitly built
with `USER nobody`. This, however, triggers several issues, notably:
- kube-state-metrics can not use ports <1024
- the kube-state-metrics binary in the container image is owned by root
  and has 0750 permissions, preventing it from running as non-root. This
  is likely an upstream bug and will be discussed separately.

Due to the latter bug, we need to use fsGroup 0 in order to get execute
privileges on the docker image.