### PR TITLE
memcached: Ensure container memory request is <= limit

### DIFF
--- a/memcached/memcached.libsonnet
+++ b/memcached/memcached.libsonnet
@@ -26,7 +26,12 @@ k {
     cpu_limits:: '3',
     connection_limit:: 1024,
     memory_request_bytes::
-      std.ceil((self.memory_limit_mb * self.overprovision_factor) + 100) * 1024 * 1024,
+      // Take the smaller of the memory limit and the calculated request, to
+      // ensure request <= limit
+      std.min(
+        std.ceil((self.memory_limit_mb * self.overprovision_factor) + 100) * 1024 * 1024,
+        self.memory_limits_bytes,
+      ),
     memory_limits_bytes::
       self.memory_limit_mb * 1.5 * 1024 * 1024,
 


### PR DESCRIPTION
Currently for small memory_limit_mb values, (eg 128), the container
resource request will end up larger than the limit, which is invalid.

To handle this, take the smaller of the calculated memory request
value and the memory limit as the request, ensuring even for small
values, that the request is set to the limit.