### PR TITLE
Support forms in subfilter

### DIFF
--- a/prometheus-ksonnet/lib/nginx.libsonnet
+++ b/prometheus-ksonnet/lib/nginx.libsonnet
@@ -18,6 +18,7 @@
     ||| else '' + if subfilter then |||
       sub_filter 'href="/' 'href="/%(path)s/';
       sub_filter 'src="/' 'src="/%(path)s/';
+      sub_filter 'action="/' 'action="/%(path)s/';
       sub_filter 'endpoint:"/' 'endpoint:"/%(path)s/';  # for XHRs.
       sub_filter 'href:"/v1/' 'href:"/%(path)s/v1/';
       sub_filter_once off;


### PR DESCRIPTION
This allows pages that include `action="/....."` in a form to have their URL paths corrected by subfilter.