### PR TITLE
Log all http requests in grafana

### DIFF
--- a/prometheus-ksonnet/grafana/config.libsonnet
+++ b/prometheus-ksonnet/grafana/config.libsonnet
@@ -26,6 +26,7 @@
       },
       server: {
         http_port: 3000,
+        router_logging: true,
         root_url: $._config.grafana_root_url,
       },
       analytics: {


### PR DESCRIPTION
If tracing is enabled in Grafana the `traceID` will be included in the request log. 

Signed-off-by: bergquist <carl.bergquist@gmail.com>