### PR TITLE
add ServiceAccount annotations & pull secrets

### DIFF
--- a/ksonnet-util/kausal.libsonnet
+++ b/ksonnet-util/kausal.libsonnet
@@ -252,7 +252,7 @@ k {
 
     // rbac creates a service account, role and role binding with the given
     // name and rules.
-    rbac(name, rules)::
+    rbac(name, rules, pullSecrets={}, annotations={})::
       if $._config.enable_rbac
       then {
         local clusterRole = $.rbac.v1beta1.clusterRole,
@@ -261,7 +261,14 @@ k {
         local serviceAccount = $.core.v1.serviceAccount,
 
         service_account:
-          serviceAccount.new(name),
+          serviceAccount.new(name)
+          + (
+            if (pullSecrets == {}) then {}
+            else serviceAccount.withImagePullSecrets(pullSecrets)
+          ) + (
+            if (annotations == {}) then {}
+            else serviceAccount.metadata.withAnnotationsMixin(annotations)
+          ),
 
         cluster_role:
           clusterRole.new() +
@@ -283,7 +290,7 @@ k {
       }
       else {},
 
-    namespacedRBAC(name, rules)::
+    namespacedRBAC(name, rules, pullSecrets={}, annotations={})::
       if $._config.enable_rbac
       then {
         local role = $.rbac.v1beta1.role,
@@ -293,7 +300,14 @@ k {
 
         service_account:
           serviceAccount.new(name) +
-          serviceAccount.mixin.metadata.withNamespace($._config.namespace),
+          serviceAccount.mixin.metadata.withNamespace($._config.namespace)
+          + (
+            if (pullSecrets == {}) then {}
+            else serviceAccount.withImagePullSecrets(pullSecrets)
+          ) + (
+            if (annotations == {}) then {}
+            else serviceAccount.metadata.withAnnotationsMixin(annotations)
+          ),
 
         role:
           role.new() +


### PR DESCRIPTION
Optionally add imagePullSecrets and ServiceAccount Annotations to helper
functions `rbac()` and `namespacedRBAC` - both essential for production
deployments.

Image Pull Secrets are used to allow for pulling images from a private
repository or from a public repository requiring authenticated pulls.

https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry

Service Account (SA) annotations are typically used by public cloud
providers such as AWS to annotate SA's with a role to be assumed.

In the case of Cortex, Loki, or Tempo this is typically a role allowing
for access to S3.

For example:

https://docs.aws.amazon.com/eks/latest/userguide/specify-service-account-role.html

These are (in the EKS use case):

```
eks.amazonaws.com/role-arn: arn:aws:iam::<AWS_ACCOUNT_ID>:role/<IAM_ROLE_NAME>
```

An example of a Service Account generated with this patch, passing both
inputs follows.  Existing consumers of the 2 modified functions are not
impacted.

```
apiVersion: v1
imagePullSecrets:
- name: dockerhub
kind: ServiceAccount
metadata:
  annotations:
    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/loki-ingester=loki1-east1-us-prod
  name: ingester
  namespace: loki
```

Signed-off-by: Matt Young <halcyondude@gmail.com>