### PR TITLE
Allow override of target address by using fqdn

### DIFF
--- a/mysql-exporter/mysql-exporter.libsonnet
+++ b/mysql-exporter/mysql-exporter.libsonnet
@@ -10,13 +10,20 @@ local deployment = k.apps.v1.deployment;
     mysql_password: error 'must specify mysql password',
     deployment_name: error 'must specify deployment name',
     namespace: error 'must specify namespace',
+    fqdn: '',
   },
 
   image:: 'prom/mysqld-exporter:v0.12.1',
 
   mysqld_exporter_container::
     container.new('mysqld-exporter', $.image) +
-    container.withEnvMap({
+    container.withEnvMap(if std.length($._config.fqdn) > 0 then {
+      DATA_SOURCE_NAME: '%s:%s@tcp(%s:3306)/' % [
+        $._config.mysql_user,
+        $._config.mysql_password,
+        $._config.fqdn,
+      ],
+    } else {
       DATA_SOURCE_NAME: '%s:%s@tcp(%s.%s.svc.cluster.local:3306)/' % [
         $._config.mysql_user,
         $._config.mysql_password,

--- a/mysql-exporter/mysql-exporter.libsonnet
+++ b/mysql-exporter/mysql-exporter.libsonnet
@@ -10,18 +10,18 @@ local deployment = k.apps.v1.deployment;
     mysql_password: error 'must specify mysql password',
     deployment_name: error 'must specify deployment name',
     namespace: error 'must specify namespace',
-    fqdn: '',
+    mysql_fqdn: '',
   },
 
   image:: 'prom/mysqld-exporter:v0.12.1',
 
   mysqld_exporter_container::
     container.new('mysqld-exporter', $.image) +
-    container.withEnvMap(if std.length($._config.fqdn) > 0 then {
+    container.withEnvMap(if std.length($._config.mysql_fqdn) > 0 then {
       DATA_SOURCE_NAME: '%s:%s@tcp(%s:3306)/' % [
         $._config.mysql_user,
         $._config.mysql_password,
-        $._config.fqdn,
+        $._config.mysql_fqdn,
       ],
     } else {
       DATA_SOURCE_NAME: '%s:%s@tcp(%s.%s.svc.cluster.local:3306)/' % [

--- a/mysql-exporter/mysql-exporter.libsonnet
+++ b/mysql-exporter/mysql-exporter.libsonnet
@@ -10,18 +10,18 @@ local deployment = k.apps.v1.deployment;
     mysql_password: error 'must specify mysql password',
     deployment_name: error 'must specify deployment name',
     namespace: error 'must specify namespace',
-    mysql_fqdn: '',
   },
 
   image:: 'prom/mysqld-exporter:v0.12.1',
+  mysql_fqdn:: '',
 
   mysqld_exporter_container::
     container.new('mysqld-exporter', $.image) +
-    container.withEnvMap(if std.length($._config.mysql_fqdn) > 0 then {
+    container.withEnvMap(if std.length($.mysql_fqdn) > 0 then {
       DATA_SOURCE_NAME: '%s:%s@tcp(%s:3306)/' % [
         $._config.mysql_user,
         $._config.mysql_password,
-        $._config.mysql_fqdn,
+        $.mysql_fqdn,
       ],
     } else {
       DATA_SOURCE_NAME: '%s:%s@tcp(%s.%s.svc.cluster.local:3306)/' % [


### PR DESCRIPTION
this backwards-compatible change allows us to use a fqdn instead of deployment name / namespace for choosing the mysql target. This makes it cleaner to use this library when the target mysql instance is another container in the same pod.

You can see an example of how we intend on using this change [here](https://github.com/grafana/deployment_tools/pull/6136).