### PR TITLE
Enable AM on new installs

### DIFF
--- a/prometheus-ksonnet/lib/config.libsonnet
+++ b/prometheus-ksonnet/lib/config.libsonnet
@@ -77,6 +77,8 @@
     alertmanager_cluster_self:
       if self.cluster_name in self.alertmanager_clusters then
         self.alertmanager_clusters[self.cluster_name]
+      else if std.length(self.alertmanager_clusters) == 0 then
+        { global: true, replicas: 1 }
       else
         { global: true, replicas: 0 },
 

--- a/prometheus-ksonnet/lib/config.libsonnet
+++ b/prometheus-ksonnet/lib/config.libsonnet
@@ -78,7 +78,7 @@
       if self.cluster_name in self.alertmanager_clusters then
         self.alertmanager_clusters[self.cluster_name]
       else if std.length(self.alertmanager_clusters) == 0 then
-        { global: true, replicas: 1 }
+        { global: false, replicas: 1 }
       else
         { global: true, replicas: 0 },
 


### PR DESCRIPTION
We've done a lot of work on the Alert Manager setup, to support complex multi-cluster environments, and in the process have left behind single cluster setups. At present, deploying prometheus-ksonnet will exclude the alertmanager, because it doesn't have a named cluster listed - this is kinda excessive in terms of unnecessary configuration.

This PR simply enables a single AM instance should the list of clusters be empty (the default case).