### PR TITLE
Fix moved dependency for alertmanager mixin

### DIFF
--- a/prometheus-ksonnet/jsonnetfile.json
+++ b/prometheus-ksonnet/jsonnetfile.json
@@ -45,7 +45,7 @@
           "subdir": "doc/alertmanager-mixin"
         }
       },
-      "version": "mixin"
+      "version": "master"
     },
     {
       "source": {


### PR DESCRIPTION
Reference to upstream PR here: https://github.com/prometheus/alertmanager/pull/1629

Signed-off-by: Matthias Riegler <matthias.riegler@taotesting.com>