### PR TITLE
Alertmanager: Only page for PD failures

### DIFF
--- a/prometheus-ksonnet/mixins.libsonnet
+++ b/prometheus-ksonnet/mixins.libsonnet
@@ -63,6 +63,7 @@
           alertmanagerSelector: 'job="default/alertmanager"',
           alertmanagerClusterLabels: 'job, namespace',
           alertmanagerName: '{{$labels.instance}} in {{$labels.cluster}}',
+          alertmanagerCriticalIntegrationsRegEx: @'pagerduty',
         },
       },
 


### PR DESCRIPTION
Other integrations, in particular Slack, both fail more often and are
at the same time not used to deliver critical alerts. Therefore, we
don't want a failure there to trigger a page.

This requires an update of the alertmanager-mixin to the current
version.