### PR TITLE
Migrate CI from CircleCI to Drone

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,9 +6,6 @@ defaults: &defaults
 
 workflows:
   version: 2
-  default:
-    jobs:
-    - lint
 
 jobs:
   lint:

--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -1,0 +1,10 @@
+local triggers = import 'lib/drone/triggers.libsonnet';
+local pipeline = (import 'lib/drone/drone.libsonnet').pipeline;
+local withInlineStep = (import 'lib/drone/drone.libsonnet').withInlineStep;
+
+[
+  pipeline('ci')
+  + withInlineStep('lint', ['make lint'], image='grafana/jsonnet-build:7f1cb84')
+  + triggers.master
+  + triggers.pr,
+]

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -1,0 +1,23 @@
+---
+kind: pipeline
+type: docker
+name: ci
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: lint
+  image: grafana/jsonnet-build:7f1cb84
+  commands:
+  - make lint
+
+trigger:
+  branch:
+  - master
+  event:
+  - push
+  - pull_request
+
+...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -20,4 +20,8 @@ trigger:
   - push
   - pull_request
 
+---
+kind: signature
+hmac: d6c05915444d8389944b22da34f14b8f39abaaf18d52237a1f07cf7c5c42fc5b
+
 ...

--- a/.drone/lib/drone/drone.libsonnet
+++ b/.drone/lib/drone/drone.libsonnet
@@ -1,0 +1,22 @@
+local images = import 'images.libsonnet';
+{
+  step(name, commands, image=images._images.runner, settings={}):: {
+    name: name,
+    commands: commands,
+    image: image,
+    settings: settings,
+  },
+
+  withStep(step):: {
+    steps+: [step],
+  },
+
+  withInlineStep(name, commands, image=images._images.runner, settings={}, environment={}):: $.withStep($.step(name, commands, image, settings) + environment),
+
+  pipeline(name, steps=[]):: {
+    kind: 'pipeline',
+    type: 'docker',
+    name: name,
+    steps: steps,
+  },
+}

--- a/.drone/lib/drone/images.libsonnet
+++ b/.drone/lib/drone/images.libsonnet
@@ -1,0 +1,5 @@
+{
+  _images+:: {
+    runner: 'grafana/jsonnet-build:7f1cb84',
+  },
+}

--- a/.drone/lib/drone/triggers.libsonnet
+++ b/.drone/lib/drone/triggers.libsonnet
@@ -1,0 +1,17 @@
+{
+  master:: {
+    trigger+: {
+      branch+: ['master'],
+      event+: {
+        include+: ['push'],
+      },
+    },
+  },
+  pr:: {
+    trigger+: {
+      event+: {
+        include+: ['pull_request'],
+      },
+    },
+  },
+}

--- a/Makefile
+++ b/Makefile
@@ -27,3 +27,7 @@ lint:
 				fi; \
 		done; \
 		exit $$RESULT
+
+generate_drone:
+	drone jsonnet --stream --format --source .drone/drone.jsonnet --target .drone/drone.yml
+	drone lint .drone/drone.yml

--- a/Makefile
+++ b/Makefile
@@ -31,3 +31,4 @@ lint:
 generate_drone:
 	drone jsonnet --stream --format --source .drone/drone.jsonnet --target .drone/drone.yml
 	drone lint .drone/drone.yml
+	drone sign --save grafana/jsonnet-libs .drone/drone.yml


### PR DESCRIPTION
Migrates CI for this repo from CircleCI to Drone.

Removes the CircleCI workflows, removal of the whole config will happen on a subsequent PR to avoid having failing checks.