### PR TITLE
K8s style observability resources

### DIFF
--- a/grizzly/README.md
+++ b/grizzly/README.md
@@ -12,7 +12,7 @@ or associated libraries, where other resources are using Tanka, place a file
 named `grr.jsonnet` next to your `main.jsonnet`, and give it this content:
 
 ```
-local main = (import 'main.jsonnet').o11y.o11y;
+local main = (import 'main.jsonnet');
 local grizzly = (import 'grizzly/grizzly.libsonnet');
 
 grizzly.fromPrometheusKsonnet(main)

--- a/grizzly/README.md
+++ b/grizzly/README.md
@@ -1,0 +1,23 @@
+# Grizzly Library
+
+This library provides utilities for [Grizzly](https://github.com/grafana/grizzly),
+a utility for managing observability resources on Grafana and hosted Prometheus
+installations.
+
+## Kubernetes Style Observability Objects
+It provides functions to render Kubernetes style objects from Monitoring Mixins.
+
+If deploying dashboards structured to be consumed by [prometheus-ksonnet](https://github.com/grafana/jsonnet-libs/prometheus-ksonnet)
+or associated libraries, where other resources are using Tanka, place a file
+named `grr.jsonnet` next to your `main.jsonnet`, and give it this content:
+
+```
+local main = (import 'main.jsonnet').o11y.o11y;
+local grizzly = (import 'grizzly/grizzly.libsonnet');
+
+grizzly.fromPrometheusKsonnet(main)
+```
+
+Then, you can invoke this from Grizzly like so:
+
+`grr show -r environments/<my-environment>/grr.libsonnet`

--- a/grizzly/grafana.libsonnet
+++ b/grizzly/grafana.libsonnet
@@ -1,0 +1,21 @@
+local util = import 'util.libsonnet';
+
+{
+  getFolder(main):: util.get(main, 'grafanaDashboardFolder', 'General'),
+
+  fromMap(dashboards, folder):: {
+    [k]: util.makeResource('Dashboard', k, dashboards[k], { folder: folder })
+    for k in std.objectFields(dashboards)
+  },
+
+  fromMixins(mixins):: {
+    [key]:
+      local mixin = mixins[key];
+      {
+        local folder = util.get(mixin, 'grafanaDashboardFolder', 'General'),
+        [k]: util.makeResource('Dashboard', k, mixin.grafanaDashboards[k], { folder: folder })
+        for k in std.objectFieldsAll(util.get(mixin, 'grafanaDashboards', {}))
+      }
+    for key in std.objectFields(mixins)
+  },
+}

--- a/grizzly/grizzly.libsonnet
+++ b/grizzly/grizzly.libsonnet
@@ -1,0 +1,18 @@
+local grafana = import 'grafana.libsonnet';
+local prometheus = import 'prometheus.libsonnet';
+{
+  grafana: grafana,
+  prometheus: prometheus,
+
+  fromPrometheusKsonnet(main):: {
+    local dashboardFolder = grafana.getFolder(main),
+    local mixinRules = prometheus.getMixinRuleNames(main.mixins),
+
+    grafana: grafana.fromMap(main.grafanaDashboards, dashboardFolder)
+             + grafana.fromMixins(main.mixins),
+
+    prometheus: prometheus.fromMapsFiltered(main.prometheusAlerts, mixinRules)
+                + prometheus.fromMapsFiltered(main.prometheusRules, mixinRules)
+                + prometheus.fromMixins(main.mixins),
+  },
+}

--- a/grizzly/prometheus.libsonnet
+++ b/grizzly/prometheus.libsonnet
@@ -1,0 +1,27 @@
+local util = import 'util.libsonnet';
+{
+  getMixinRuleNames(mixins)::
+    local flatMixins = [mixins[key] for key in std.objectFieldsAll(mixins)];
+    local mixinRules = std.flattenArrays([mixin.prometheusRules.groups for mixin in flatMixins if std.objectHasAll(mixin, 'prometheusRules')]);
+    local mixinAlerts = std.flattenArrays([mixin.prometheusAlerts.groups for mixin in flatMixins if std.objectHasAll(mixin, 'prometheusAlerts')]);
+    [group.name for group in mixinAlerts] + [group.name for group in mixinRules],
+
+  fromMaps(rules):: { [k]: util.makeResource('PrometheusRuleGroup', k, { groups: rules }, {}) for k in std.objectFields(rules) },
+
+  fromMapsFiltered(rules, excludes):: {
+    local filterRules(rules, exclude_list) = [rule for rule in rules.groups if !std.member(exclude_list, rule.name)],
+    [k]: util.makeResource('RuleGroup', k, { groups: filterRules(rules, excludes) }, {})
+    for k in std.objectFields(rules)
+  },
+
+  fromMixins(mixins):: {
+    [if std.objectHasAll(mixins[key], 'prometheusAlerts') || std.objectHasAll(mixins[key], 'prometheusRules') then key else null]:
+      util.makeResource(
+        'PrometheusRuleGroup',
+        key,
+        (if std.objectHasAll(mixins[key], 'prometheusAlerts') then mixins[key].prometheusAlerts else {})
+        + (if std.objectHasAll(mixins[key], 'prometheusRules') then mixins[key].prometheusRules else {})
+      )
+    for key in std.objectFields(mixins)
+  },
+}

--- a/grizzly/util.libsonnet
+++ b/grizzly/util.libsonnet
@@ -1,0 +1,13 @@
+{
+  grizzlyAPI:: 'grafana.com/grizzly/v1',
+  get(obj, key, default):: if std.objectHasAll(obj, key) then obj[key] else default,
+
+  makeResource(kind, name, resource, metadata={}):: {
+    apiVersion: $.grizzlyAPI,
+    kind: kind,
+    metadata: {
+      name: name,
+    } + metadata,
+    spec: resource,
+  },
+}

--- a/grizzly/util.libsonnet
+++ b/grizzly/util.libsonnet
@@ -1,5 +1,5 @@
 {
-  grizzlyAPI:: 'grafana.com/grizzly/v1',
+  grizzlyAPI:: 'grizzly.grafana.com/v1',
   get(obj, key, default):: if std.objectHasAll(obj, key) then obj[key] else default,
 
   makeResource(kind, name, resource, metadata={}):: {


### PR DESCRIPTION
Prometheus ksonnet consumes observability resources as hidden elements to prevent them being accessible to Kubernetes. This works well when the thing that is consuming the resources is also jsonnet - i.e. it has access to those hidden elements.

However, the library can happily accept resources such as this:
```
{
  mixins:: {
    foo: {
      grafanaDashboards: {...},
    },
  },
}
```

In this example, we could invoke `(import 'main.jsonnet').mixins` to gain access to the hidden mixins element, but still, the `grafanaDashboards` element is also set to hidden, and thus won't be exported.

A cleaner way is to allow the library (and associated sub-libraries) to communicate with the outside world using kubernetes style objects (e.g. having `apiVersion`/`kind` attributes).

This PR adds functions to each relevant library that can be invoked with `grr(import 'main.jsonnet)` and will return k8s style objects for everything that would otherwise be rendered from mixins/etc.

Grizzly will shortly have the ability to consume resources in this format. In fact, it is quite possible that this could become its default method.

Note, these are designed to look like CRDs. A preliminary search for existing CRDs didn't reveal anything hugely obvious to model after, but it would be reasonable to adapt this format to match any pre-existing CRDs for Grafana or Prometheus.