### PR TITLE
fix(ksonnet-util): prune instead of hide

### DIFF
--- a/ksonnet-util/kausal.libsonnet
+++ b/ksonnet-util/kausal.libsonnet
@@ -190,7 +190,7 @@ k {
 
         // remove volumeClaimTemplates if empty (otherwise it will create a diff all the time)
         (if std.length(volumeClaims) == 0 then {
-           spec+: { volumeClaimTemplates:: {} },
+           spec+: std.prune({ volumeClaimTemplates: {} }),
          } else {}),
     },
   },


### PR DESCRIPTION
Hiding is also affected volumeClaimTemplates that are added in a later mixin.