### PR TITLE
fix(ksonnet-util): allow overriding root level k import

### DIFF
--- a/ksonnet-util/kausal.libsonnet
+++ b/ksonnet-util/kausal.libsonnet
@@ -11,7 +11,7 @@
   },
 
   util+::
-    (import 'util.libsonnet')(this)
+    (import 'util.libsonnet').withK(this)
     + {
       rbac(name, rules)::
         if $._config.enable_rbac

--- a/ksonnet-util/kausal.libsonnet
+++ b/ksonnet-util/kausal.libsonnet
@@ -3,6 +3,7 @@
 
 (import 'grafana.libsonnet')
 + {
+  local this = self,
   _config+:: {
     enable_rbac: true,
     enable_pod_priorities: false,
@@ -10,7 +11,7 @@
   },
 
   util+::
-    (import 'util.libsonnet')
+    (import 'util.libsonnet')(this)
     + {
       rbac(name, rules)::
         if $._config.enable_rbac

--- a/ksonnet-util/util.libsonnet
+++ b/ksonnet-util/util.libsonnet
@@ -1,6 +1,6 @@
 // util.libsonnet provides a number of useful (opinionated) shortcuts to replace boilerplate code
 
-function(k=(import 'grafana.libsonnet')) {
+local util(k) = {
   // mapToFlags converts a map to a set of golang-style command line flags.
   mapToFlags(map, prefix='-'): [
     '%s%s=%s' % [prefix, key, map[key]]
@@ -242,4 +242,8 @@ function(k=(import 'grafana.libsonnet')) {
   local deployment = k.apps.v1.deployment,
   podPriority(p):
     deployment.mixin.spec.template.spec.withPriorityClassName(p),
+};
+
+util((import 'grafana.libsonnet')) + {
+  withK(k):: util(k),
 }

--- a/ksonnet-util/util.libsonnet
+++ b/ksonnet-util/util.libsonnet
@@ -1,7 +1,6 @@
 // util.libsonnet provides a number of useful (opinionated) shortcuts to replace boilerplate code
-local k = import 'grafana.libsonnet';
 
-{
+function(k=(import 'grafana.libsonnet')) {
   // mapToFlags converts a map to a set of golang-style command line flags.
   mapToFlags(map, prefix='-'): [
     '%s%s=%s' % [prefix, key, map[key]]


### PR DESCRIPTION
If someone wants to extend kausal.libsonnet on the root level, the imported util.libsonnet wouldn't take this change
into account into its subsequent functions.

This change recovers that feature while retaining the ability to use util.libsonnet as a separate library.

Minimal reproducible usecase:

```
(import 'ksonnet-util/kausal.libsonnet')
{
  core+: {
    v1+: {
      // Extend service
      service+: {
        new(name, selector={}, ports=[])::
          super.new(name, selector, ports)
          + {
            dns: std.trace('a', '%s.%s.svc.cluster.local' % [self.metadata.name, $._config.namespace]),
          },
      },
    },
  },
}
+
{
  _config+:: {
    namespace: 'test',
  },

  sts:
    $.apps.v1.statefulSet.new('name', 1, [], volumeClaims=[], podLabels={})
    + $.util.antiAffinity,

  svc: $.util.serviceFor(
    self.sts,
  ),
}
```
