### PR TITLE
Allow mysql_exporter credentials to be provided as secrets

### DIFF
--- a/mysql-exporter/mysql-exporter.libsonnet
+++ b/mysql-exporter/mysql-exporter.libsonnet
@@ -1,4 +1,4 @@
-local k = import 'github.com/grafana/jsonnet-libs/ksonnet-util/kausal.libsonnet';
+local k = import 'ksonnet-util/kausal.libsonnet';
 local container = k.core.v1.container;
 local service = k.core.v1.service;
 local containerPort = k.core.v1.containerPort;

--- a/mysql-exporter/mysql-exporter.libsonnet
+++ b/mysql-exporter/mysql-exporter.libsonnet
@@ -46,7 +46,7 @@ local volumeMount = k.core.v1.volumeMount;
       |||,
     ],) +
     container.withVolumeMounts([
-      volumeMount.new('init-dir', '/init-dir')
+      volumeMount.new('init-dir', '/init-dir'),
     ]),
 
   mysqld_exporter_container::
@@ -54,10 +54,10 @@ local volumeMount = k.core.v1.volumeMount;
     container.withPorts(k.core.v1.containerPort.new('http-metrics', 9104)) +
     container.withArgsMixin([
       '--collect.info_schema.innodb_metrics',
-      '--config.my-cnf=/etc/mysql/my.cnf'
+      '--config.my-cnf=/etc/mysql/my.cnf',
     ]) +
     container.withVolumeMounts([
-      volumeMount.new('init-dir', '/etc/mysql')
+      volumeMount.new('init-dir', '/etc/mysql'),
     ]),
 
   local volume = k.core.v1.volume,

--- a/mysql-exporter/mysql-exporter.libsonnet
+++ b/mysql-exporter/mysql-exporter.libsonnet
@@ -1,36 +1,70 @@
-local k = import 'ksonnet-util/kausal.libsonnet';
+local k = import 'github.com/grafana/jsonnet-libs/ksonnet-util/kausal.libsonnet';
 local container = k.core.v1.container;
 local service = k.core.v1.service;
 local containerPort = k.core.v1.containerPort;
 local deployment = k.apps.v1.deployment;
+local envVar = k.core.v1.envVar;
+local volumeMount = k.core.v1.volumeMount;
 
 {
+  image:: 'prom/mysqld-exporter:v0.12.1',
+  mysql_fqdn:: '',
+
   _config:: {
     mysql_user: error 'must specify mysql user',
     mysql_password: error 'must specify mysql password',
+    mysql_password_secret: '',
     deployment_name: error 'must specify deployment name',
     namespace: error 'must specify namespace',
   },
 
-  image:: 'prom/mysqld-exporter:v0.12.1',
-
-  mysqld_exporter_container::
-    container.new('mysqld-exporter', $.image) +
-    container.withEnvMap({
-      DATA_SOURCE_NAME: '%s:%s@tcp(%s.%s.svc.cluster.local:3306)/' % [
-        $._config.mysql_user,
-        $._config.mysql_password,
+  init_container::
+    container.new('init', 'busybox') +
+    container.withEnvMap(if std.length($.mysql_fqdn) > 0 then {
+      MYSQL_HOST: $.mysql_fqdn,
+    } else {
+      MYSQL_HOST: '%s.%s.svc.cluster.local' % [
         $._config.deployment_name,
         $._config.namespace,
       ],
     }) +
+    container.withEnvMixin([
+      { name: 'MYSQL_USER', value: $._config.mysql_user },
+      { name: 'MYSQL_PASSWORD', value: $._config.mysql_password },
+      // envVar.fromSecretRef('MYSQL_PASSWORD', $._config.mysql_password_secret, 'password'),
+    ]) +
+    container.withCommand([
+      '/bin/sh',
+      '-c',
+      |||
+        cat << EOF | tee /init-dir/my.cnf > /dev/null
+        [client]
+        user = $(MYSQL_USER)
+        password = $(MYSQL_PASSWORD)
+        host = $(MYSQL_HOST)
+        EOF
+      |||,
+    ],) +
+    container.withVolumeMounts([
+      volumeMount.new('init-dir', '/init-dir')
+    ]),
+
+  mysqld_exporter_container::
+    container.new('mysqld-exporter', $.image) +
     container.withPorts(k.core.v1.containerPort.new('http-metrics', 9104)) +
     container.withArgsMixin([
       '--collect.info_schema.innodb_metrics',
+      '--config.my-cnf=/etc/mysql/my.cnf'
+    ]) +
+    container.withVolumeMounts([
+      volumeMount.new('init-dir', '/etc/mysql')
     ]),
 
+  local volume = k.core.v1.volume,
   mysql_exporter_deployment:
-    deployment.new('%s-mysql-exporter' % $._config.deployment_name, 1, [$.mysqld_exporter_container]),
+    deployment.new('%s-mysql-exporter' % $._config.deployment_name, 1, [$.mysqld_exporter_container]) +
+    deployment.spec.template.spec.withInitContainers($.init_container) +
+    deployment.spec.template.spec.withVolumes(volume.fromEmptyDir('init-dir')),
 
   mysql_exporter_deployment_service:
     k.util.serviceFor($.mysql_exporter_deployment),

--- a/mysql-exporter/mysql-exporter.libsonnet
+++ b/mysql-exporter/mysql-exporter.libsonnet
@@ -39,7 +39,6 @@ local mysql_credential(config) =
     container.withEnvMixin(
       [
         { name: 'MYSQL_USER', value: $._config.mysql_user },
-        // use mysql_password or mysql_password_secret
       ] + mysql_credential($._config)
     ) +
     container.withCommand([


### PR DESCRIPTION
Currently the mysqld_exporter requires `DATA_SOURCE_NAME` to contain user, password & host for the mysql connection. This change allows user, password and host to be supplied as separate environment variables. This allows the password to be referenced from a kubernetes secret, for example.

This implementation uses an init container and pipes the variables into a `my.cnf` file, which is then mounted into the mysqld_exporter.

A downside of this implementation is that it does not allow any further configuration to be set via the `my.cnf` file.

TODO
- [x] Make this fallback gracefully to previous behaviour if `mysql_password_secret` is not defined
- [ ] Maybe: optionally allow more contents to the my.cnf file

