### PR TITLE
fix(vault): don't cluster on metrics port

### DIFF
--- a/vault/vault.libsonnet
+++ b/vault/vault.libsonnet
@@ -84,6 +84,7 @@ local kausal = import 'ksonnet-util/kausal.libsonnet';
       prometheus_listener+:: {
         tcp: {
           address: '[::]:%s' % port,
+          disable_clustering: true,
           tls_disable: true,
           telemetry: {
             unauthenticated_metrics_access: true,


### PR DESCRIPTION
Clustering on that port caused TLS errors and broke the clustering in general.

Relevant logs:
```
2020-11-11T00:59:54.669Z [ERROR] core: forward request error: error="error during forwarding RPC request"
2020-11-11T00:59:54.672Z [ERROR] core: error during forwarded RPC request: error="rpc error: code = Unavailable desc =
connection error: desc = "transport: Error while dialing remote error: tls: internal error""
```

Docs: https://www.vaultproject.io/docs/configuration#disable_clustering