### PR TITLE
mysql-exporter: allow credentials from env vars

### DIFF
--- a/mysql-exporter/mysql-exporter.libsonnet
+++ b/mysql-exporter/mysql-exporter.libsonnet
@@ -1,4 +1,4 @@
-local k = import 'github.com/grafana/jsonnet-libs/ksonnet-util/kausal.libsonnet';
+local k = import 'ksonnet-util/kausal.libsonnet';
 local container = k.core.v1.container;
 local service = k.core.v1.service;
 local containerPort = k.core.v1.containerPort;

--- a/mysql-exporter/mysql-exporter.libsonnet
+++ b/mysql-exporter/mysql-exporter.libsonnet
@@ -13,7 +13,7 @@ local mysql_credential(config) =
     error 'must define one of _config.mysql_password or _config.mysql_password_secret.'
   else if std.length(config.mysql_password) > 0 then
     [{ name: 'MYSQL_PASSWORD', value: config.mysql_password }]
-  else [envVar.fromSecretRef('MYSQL_PASSWORD', config.mysql_password_secret, 'password')];
+  else [envVar.fromSecretRef('MYSQL_PASSWORD', config.mysql_password_secret, config.mysql_password_secret_key)];
 
 
 local mysql_host(config, fqdn) =
@@ -30,6 +30,7 @@ local mysql_host(config, fqdn) =
     mysql_user: error 'must specify mysql user',
     mysql_password: '',
     mysql_password_secret: '',
+    mysql_password_secret_key: 'password',
     deployment_name: error 'must specify deployment name',
     namespace: error 'must specify namespace',
   },

--- a/mysql-exporter/mysql-exporter.libsonnet
+++ b/mysql-exporter/mysql-exporter.libsonnet
@@ -24,7 +24,6 @@ secrets {
     MYSQL_USER: $._config.mysql_user,
     MYSQL_PASSWORD: $._config.mysql_password,
     MYSQL_HOST: $._config.mysql_fqdn,
-    DATA_SOURCE_NAME: '$(MYSQL_USER):$(MYSQL_PASSWORD)@tcp($(MYSQL_HOST):3306)/',
   },
 
   mysqld_exporter_container::
@@ -33,8 +32,11 @@ secrets {
     container.withArgsMixin([
       '--collect.info_schema.innodb_metrics',
     ]) +
-    container.withEnvMap($.mysqld_exporter_env),
-
+    container.withEnvMap($.mysqld_exporter_env) +
+    // Force DATA_SOURCE_NAME to be declared after the variables it references
+    container.withEnvMap({
+      DATA_SOURCE_NAME: '$(MYSQL_USER):$(MYSQL_PASSWORD)@tcp($(MYSQL_HOST):3306)/',
+    }),
 
   mysql_exporter_deployment:
     deployment.new('%s-mysql-exporter' % $._config.deployment_name, 1, [$.mysqld_exporter_container]),

--- a/mysql-exporter/mysql-exporter.libsonnet
+++ b/mysql-exporter/mysql-exporter.libsonnet
@@ -1,17 +1,24 @@
-local k = import 'ksonnet-util/kausal.libsonnet';
+local k = import 'github.com/grafana/jsonnet-libs/ksonnet-util/kausal.libsonnet';
 local container = k.core.v1.container;
 local service = k.core.v1.service;
 local containerPort = k.core.v1.containerPort;
 local deployment = k.apps.v1.deployment;
+local envVar = k.core.v1.envVar;
+local volumeMount = k.core.v1.volumeMount;
 
 {
+  image:: 'prom/mysqld-exporter:v0.12.1',
+  mysql_fqdn:: '',
+
   _config:: {
     mysql_user: error 'must specify mysql user',
     mysql_password: error 'must specify mysql password',
+    mysql_password_secret: '',
     deployment_name: error 'must specify deployment name',
     namespace: error 'must specify namespace',
   },
 
+<<<<<<< HEAD
   image:: 'prom/mysqld-exporter:v0.12.1',
   mysql_fqdn:: '',
 
@@ -27,17 +34,55 @@ local deployment = k.apps.v1.deployment;
       DATA_SOURCE_NAME: '%s:%s@tcp(%s.%s.svc.cluster.local:3306)/' % [
         $._config.mysql_user,
         $._config.mysql_password,
+=======
+  init_container::
+    container.new('init', 'busybox') +
+    container.withEnvMap(if std.length($.mysql_fqdn) > 0 then {
+      MYSQL_HOST: $.mysql_fqdn,
+    } else {
+      MYSQL_HOST: '%s.%s.svc.cluster.local' % [
+>>>>>>> Add init container which creates my.cnf
         $._config.deployment_name,
         $._config.namespace,
       ],
     }) +
+    container.withEnvMixin([
+      { name: 'MYSQL_USER', value: $._config.mysql_user },
+      { name: 'MYSQL_PASSWORD', value: $._config.mysql_password },
+      // envVar.fromSecretRef('MYSQL_PASSWORD', $._config.mysql_password_secret, 'password'),
+    ]) +
+    container.withCommand([
+      '/bin/sh',
+      '-c',
+      |||
+        cat << EOF | tee /init-dir/my.cnf > /dev/null
+        [client]
+        user = $(MYSQL_USER)
+        password = $(MYSQL_PASSWORD)
+        host = $(MYSQL_HOST)
+        EOF
+      |||,
+    ],) +
+    container.withVolumeMounts([
+      volumeMount.new('init-dir', '/init-dir')
+    ]),
+
+  mysqld_exporter_container::
+    container.new('mysqld-exporter', $.image) +
     container.withPorts(k.core.v1.containerPort.new('http-metrics', 9104)) +
     container.withArgsMixin([
       '--collect.info_schema.innodb_metrics',
+      '--config.my-cnf=/etc/mysql/my.cnf'
+    ]) +
+    container.withVolumeMounts([
+      volumeMount.new('init-dir', '/etc/mysql')
     ]),
 
+  local volume = k.core.v1.volume,
   mysql_exporter_deployment:
-    deployment.new('%s-mysql-exporter' % $._config.deployment_name, 1, [$.mysqld_exporter_container]),
+    deployment.new('%s-mysql-exporter' % $._config.deployment_name, 1, [$.mysqld_exporter_container]) +
+    deployment.spec.template.spec.withInitContainers($.init_container) +
+    deployment.spec.template.spec.withVolumes(volume.fromEmptyDir('init-dir')),
 
   mysql_exporter_deployment_service:
     k.util.serviceFor($.mysql_exporter_deployment),

--- a/mysql-exporter/mysql-exporter.libsonnet
+++ b/mysql-exporter/mysql-exporter.libsonnet
@@ -6,6 +6,15 @@ local deployment = k.apps.v1.deployment;
 local envVar = k.core.v1.envVar;
 local volumeMount = k.core.v1.volumeMount;
 
+local mysql_credential(config) =
+  if std.length(config.mysql_password) > 0 && std.length(config.mysql_password_secret) > 0 then
+    error 'only one of _config.mysql_password or _config.mysql_password_secret must be defined.'
+  else if std.length(config.mysql_password) == 0 && std.length(config.mysql_password_secret) == 0 then
+    error 'must define one of _config.mysql_password or _config.mysql_password_secret.'
+  else if std.length(config.mysql_password) > 0 then
+    [{ name: 'MYSQL_PASSWORD', value: config.mysql_password }]
+  else [envVar.fromSecretRef('MYSQL_PASSWORD', config.mysql_password_secret, 'password')];
+
 {
   image:: 'prom/mysqld-exporter:v0.12.1',
   mysql_fqdn:: '',
@@ -18,7 +27,6 @@ local volumeMount = k.core.v1.volumeMount;
     namespace: error 'must specify namespace',
   },
 
-<<<<<<< HEAD
   image:: 'prom/mysqld-exporter:v0.12.1',
   mysql_fqdn:: '',
 
@@ -34,43 +42,10 @@ local volumeMount = k.core.v1.volumeMount;
       DATA_SOURCE_NAME: '%s:%s@tcp(%s.%s.svc.cluster.local:3306)/' % [
         $._config.mysql_user,
         $._config.mysql_password,
-=======
-  init_container::
-    container.new('init', 'busybox') +
-    container.withEnvMap(if std.length($.mysql_fqdn) > 0 then {
-      MYSQL_HOST: $.mysql_fqdn,
-    } else {
-      MYSQL_HOST: '%s.%s.svc.cluster.local' % [
->>>>>>> Add init container which creates my.cnf
         $._config.deployment_name,
         $._config.namespace,
-      ],
-    }) +
-    container.withEnvMixin(
-      [
-        { name: 'MYSQL_USER', value: $._config.mysql_user },
-        // use mysql_password or mysql_password_secret
-      ] + if std.length($._config.mysql_password) > 0 then [
-        { name: 'MYSQL_PASSWORD', value: $._config.mysql_password },
-      ] else if std.length($._config.mysql_password_secret) > 0 then [
-        envVar.fromSecretRef('MYSQL_PASSWORD', $._config.mysql_password_secret, 'password'),
-      ] else error 'must define either _config.mysql_password or _config.mysql_password_secret'
-    ) +
-    container.withCommand([
-      '/bin/sh',
-      '-c',
-      |||
-        cat << EOF | tee /init-dir/my.cnf > /dev/null
-        [client]
-        user = $(MYSQL_USER)
-        password = $(MYSQL_PASSWORD)
-        host = $(MYSQL_HOST)
-        EOF
-      |||,
-    ],) +
-    container.withVolumeMounts([
-      volumeMount.new('init-dir', '/init-dir'),
-    ]),
+    }
+
 
   mysqld_exporter_container::
     container.new('mysqld-exporter', $.image) +
@@ -78,16 +53,12 @@ local volumeMount = k.core.v1.volumeMount;
     container.withArgsMixin([
       '--collect.info_schema.innodb_metrics',
       '--config.my-cnf=/etc/mysql/my.cnf',
-    ]) +
-    container.withVolumeMounts([
-      volumeMount.new('init-dir', '/etc/mysql'),
-    ]),
+    ])
 
   local volume = k.core.v1.volume,
   mysql_exporter_deployment:
     deployment.new('%s-mysql-exporter' % $._config.deployment_name, 1, [$.mysqld_exporter_container]) +
     deployment.spec.template.spec.withInitContainers($.init_container) +
-    deployment.spec.template.spec.withVolumes(volume.fromEmptyDir('init-dir')),
 
   mysql_exporter_deployment_service:
     k.util.serviceFor($.mysql_exporter_deployment),

--- a/mysql-exporter/mysql-exporter.libsonnet
+++ b/mysql-exporter/mysql-exporter.libsonnet
@@ -49,7 +49,6 @@ local mysql_host(config, fqdn) =
     container.withPorts(k.core.v1.containerPort.new('http-metrics', 9104)) +
     container.withArgsMixin([
       '--collect.info_schema.innodb_metrics',
-      '--config.my-cnf=/etc/mysql/my.cnf',
     ]) +
     container.withEnvMixin(
       mysql_credential($._config) +
@@ -57,11 +56,8 @@ local mysql_host(config, fqdn) =
         { name: 'MYSQL_USER', value: $._config.mysql_user },
         { name: 'DATA_SOURCE_NAME', value: '$(MYSQL_USER):$(MYSQL_PASSWORD)@tcp(%s:3306)/' % mysql_host($._config, $.mysql_fqdn) },
       ]
-    ) +
-    container.withPorts(k.core.v1.containerPort.new('http-metrics', 9104)) +
-    container.withArgsMixin([
-      '--collect.info_schema.innodb_metrics',
-    ]),
+    ),
+
 
   mysql_exporter_deployment:
     deployment.new('%s-mysql-exporter' % $._config.deployment_name, 1, [$.mysqld_exporter_container]),

--- a/mysql-exporter/mysql-exporter.libsonnet
+++ b/mysql-exporter/mysql-exporter.libsonnet
@@ -32,7 +32,7 @@ secrets {
     container.withArgsMixin([
       '--collect.info_schema.innodb_metrics',
     ]) +
-    container.withEnvMap($.mysqld_exporter_env) + 
+    container.withEnvMap($.mysqld_exporter_env) +
     // Force DATA_SOURCE_NAME to be declared after the variables it references
     container.withEnvMap({
       DATA_SOURCE_NAME: '$(MYSQL_USER):$(MYSQL_PASSWORD)@tcp($(MYSQL_HOST):3306)/',

--- a/mysql-exporter/mysql-exporter.libsonnet
+++ b/mysql-exporter/mysql-exporter.libsonnet
@@ -46,7 +46,6 @@ local mysql_credential(config) =
         $._config.namespace,
     }
 
-
   mysqld_exporter_container::
     container.new('mysqld-exporter', $.image) +
     container.withPorts(k.core.v1.containerPort.new('http-metrics', 9104)) +

--- a/mysql-exporter/mysql-exporter.libsonnet
+++ b/mysql-exporter/mysql-exporter.libsonnet
@@ -7,19 +7,13 @@ local envVar = k.core.v1.envVar;
 
 
 local mysql_credential(config) =
-  if std.length(config.mysql_password) > 0 && std.length(config.mysql_password_secret) > 0 then
-    error 'only one of _config.mysql_password or _config.mysql_password_secret must be defined.'
-  else if std.length(config.mysql_password) == 0 && std.length(config.mysql_password_secret) == 0 then
-    error 'must define one of _config.mysql_password or _config.mysql_password_secret.'
-  else if std.length(config.mysql_password) > 0 then
+  if std.length(config.mysql_password) > 0 then
     [{ name: 'MYSQL_PASSWORD', value: config.mysql_password }]
   else [envVar.fromSecretRef('MYSQL_PASSWORD', config.mysql_password_secret, config.mysql_password_secret_key)];
 
 
 local mysql_host(config, fqdn) =
-  if std.length(fqdn) == 0 && (std.length(config.deployment_name) == 0 || std.length(config.namespace) == 0) then
-    error 'must specify _config.deployment_name and _config.namespace unless fqdn is specified.'
-  else if std.length(fqdn) > 0 then
+  if std.length(fqdn) > 0 then
     '%s' % fqdn
   else
     '%s.%s.svc.cluster.local' % [
@@ -28,6 +22,9 @@ local mysql_host(config, fqdn) =
     ];
 
 {
+  image:: 'prom/mysqld-exporter:v0.12.1',
+  mysql_fqdn:: '',
+
   _config:: {
     mysql_user: error 'must specify mysql user',
     mysql_password: '',
@@ -37,8 +34,15 @@ local mysql_host(config, fqdn) =
     namespace: '',
   },
 
-  image:: 'prom/mysqld-exporter:v0.12.1',
-  mysql_fqdn:: '',
+  assert (
+    !(std.length($._config.mysql_password) == 0 && std.length($._config.mysql_password_secret) == 0) &&
+    !(std.length($._config.mysql_password) > 0 && std.length($._config.mysql_password_secret) > 0)
+  ) : 'mysql-exporter: exactly one of _config.mysql_password and _config.mysql_password_secret must be defined.',
+
+  assert (
+    (!(std.length($.mysql_fqdn) == 0 && (std.length($._config.deployment_name) == 0 || std.length($._config.namespace) == 0))) &&
+    (!(std.length($.mysql_fqdn) > 0 && !(std.length($._config.deployment_name) == 0 && std.length($._config.namespace) == 0)))
+  ) : 'mysql-exporter: exactly one of (_config.deployment_name and _config.namespace) or mysql_fqdn must be specified.',
 
   mysqld_exporter_container::
     container.new('mysqld-exporter', $.image) +

--- a/mysql-exporter/mysql-exporter.libsonnet
+++ b/mysql-exporter/mysql-exporter.libsonnet
@@ -17,8 +17,10 @@ local mysql_credential(config) =
 
 
 local mysql_host(config, fqdn) =
-  if std.length(fqdn) > 0 then
-    fqdn
+  if std.length(fqdn) == 0 && (std.length(config.deployment_name) == 0 || std.length(config.namespace) == 0) then
+    error 'must specify deployment_name and namespace unless fqdn is specified.'
+  else if std.length(fqdn) > 0 then
+    '%s' % fqdn
   else
     '%s.%s.svc.cluster.local' % [
       config.deployment_name,
@@ -31,8 +33,8 @@ local mysql_host(config, fqdn) =
     mysql_password: '',
     mysql_password_secret: '',
     mysql_password_secret_key: 'password',
-    deployment_name: error 'must specify deployment name',
-    namespace: error 'must specify namespace',
+    deployment_name: '',
+    namespace: '',
   },
 
   image:: 'prom/mysqld-exporter:v0.12.1',

--- a/mysql-exporter/mysql-exporter.libsonnet
+++ b/mysql-exporter/mysql-exporter.libsonnet
@@ -12,7 +12,7 @@ local volumeMount = k.core.v1.volumeMount;
 
   _config:: {
     mysql_user: error 'must specify mysql user',
-    mysql_password: error 'must specify mysql password',
+    mysql_password: '',
     mysql_password_secret: '',
     deployment_name: error 'must specify deployment name',
     namespace: error 'must specify namespace',
@@ -46,11 +46,16 @@ local volumeMount = k.core.v1.volumeMount;
         $._config.namespace,
       ],
     }) +
-    container.withEnvMixin([
-      { name: 'MYSQL_USER', value: $._config.mysql_user },
-      { name: 'MYSQL_PASSWORD', value: $._config.mysql_password },
-      // envVar.fromSecretRef('MYSQL_PASSWORD', $._config.mysql_password_secret, 'password'),
-    ]) +
+    container.withEnvMixin(
+      [
+        { name: 'MYSQL_USER', value: $._config.mysql_user },
+        // use mysql_password or mysql_password_secret
+      ] + if std.length($._config.mysql_password) > 0 then [
+        { name: 'MYSQL_PASSWORD', value: $._config.mysql_password },
+      ] else if std.length($._config.mysql_password_secret) > 0 then [
+        envVar.fromSecretRef('MYSQL_PASSWORD', $._config.mysql_password_secret, 'password'),
+      ] else error 'must define either _config.mysql_password or _config.mysql_password_secret'
+    ) +
     container.withCommand([
       '/bin/sh',
       '-c',

--- a/mysql-exporter/mysql-exporter.libsonnet
+++ b/mysql-exporter/mysql-exporter.libsonnet
@@ -18,7 +18,7 @@ local mysql_credential(config) =
 
 local mysql_host(config, fqdn) =
   if std.length(fqdn) == 0 && (std.length(config.deployment_name) == 0 || std.length(config.namespace) == 0) then
-    error 'must specify deployment_name and namespace unless fqdn is specified.'
+    error 'must specify _config.deployment_name and _config.namespace unless fqdn is specified.'
   else if std.length(fqdn) > 0 then
     '%s' % fqdn
   else

--- a/mysql-exporter/mysql-exporter.libsonnet
+++ b/mysql-exporter/mysql-exporter.libsonnet
@@ -64,7 +64,7 @@ local volumeMount = k.core.v1.volumeMount;
       |||,
     ],) +
     container.withVolumeMounts([
-      volumeMount.new('init-dir', '/init-dir')
+      volumeMount.new('init-dir', '/init-dir'),
     ]),
 
   mysqld_exporter_container::
@@ -72,10 +72,10 @@ local volumeMount = k.core.v1.volumeMount;
     container.withPorts(k.core.v1.containerPort.new('http-metrics', 9104)) +
     container.withArgsMixin([
       '--collect.info_schema.innodb_metrics',
-      '--config.my-cnf=/etc/mysql/my.cnf'
+      '--config.my-cnf=/etc/mysql/my.cnf',
     ]) +
     container.withVolumeMounts([
-      volumeMount.new('init-dir', '/etc/mysql')
+      volumeMount.new('init-dir', '/etc/mysql'),
     ]),
 
   local volume = k.core.v1.volume,

--- a/mysql-exporter/secrets.libsonnet
+++ b/mysql-exporter/secrets.libsonnet
@@ -1,0 +1,16 @@
+local k = import 'ksonnet-util/kausal.libsonnet';
+local container = k.core.v1.container;
+local envVar = k.core.v1.envVar;
+
+
+{
+  withSecretPassword(name, key='password'):: {
+    mysqld_exporter_env+:: {
+      MYSQL_PASSWORD:: '',
+    },
+    mysqld_exporter_container+::
+      container.withEnvMixin([
+        envVar.fromSecretRef('MYSQL_PASSWORD', name, key),
+      ]),
+  },
+}


### PR DESCRIPTION
Currently the mysql-exporter requires `config.mysql_user` and `config.mysql_password` as jsonnet variables to build the `DATA_SOURCE_NAME` env var. 

To enable the mysql credentials to be sourced from some key store, this change creates env vars for the `mysql_user` and `mysql_password`, and uses those env vars to build the `DATA_SOURCE_NAME` variable.

This change also introduces the ability to optionally define the full host name instead just the deployment name and namespace.

There are assertions for the following:
- `mysql_password` is no longer required, but exactly one of `mysql_password` or `mysql_password_secret` must be defined
- exacrly one of `mysql_fqdn` or (`deployment_name` and `namespace`) must be defined

This change should be backwards compatible.