### PR TITLE
Add simple datasource functions

### DIFF
--- a/prometheus-ksonnet/grafana/datasources.libsonnet
+++ b/prometheus-ksonnet/grafana/datasources.libsonnet
@@ -1,4 +1,26 @@
 {
+  datasource+:: {
+    new(name, url, type, default=false):: {
+      name: name,
+      type: type,
+      access: 'proxy',
+      url: url,
+      isDefault: default,
+      version: 1,
+      editable: false,
+    },
+    withBasicAuth(username, password):: {
+      basicAuth: true,
+      basicAuthUser: username,
+      basicAuthPassword: password,
+    },
+    withJsonData(data):: {
+      jsonData+: data,
+    },
+    withHttpMethod(httpMethod):: self.withJsonData({ httpMethod: httpMethod }),
+  },
+
+
   local configMap = $.core.v1.configMap,
 
   /*
@@ -12,42 +34,10 @@
   grafanaDatasources+:: {},
 
   // Generates yaml string containing datasource config
-  grafana_datasource(name, url, default=false, method='GET', type='prometheus'):: {
-    name: name,
-    type: type,
-    access: 'proxy',
-    url: url,
-    isDefault: default,
-    version: 1,
-    editable: false,
-    jsonData: {
-      httpMethod: method,
-    },
-  },
-
-  datasource+:: {
-    new(name, url, type, default=false, method='GET'):: {
-      name: name,
-      type: type,
-      access: 'proxy',
-      url: url,
-      isDefault: default,
-      version: 1,
-      editable: false,
-      jsonData: {
-        httpMethod: method,
-      },
-    },
-    withBasicAuth(username, password):: {
-      basicAuth: true,
-      basicAuthUser: username,
-      basicAuthPassword: password,
-    },
-    withJsonData(data):: {
-      jsonData+: data,
-    },
-  },
-
+  grafana_datasource(name, url, default=false, method='GET', type='prometheus')::
+    self.datasource.new(name, url, type, default)
+    + self.datasource.withHttpMethod(method)
+  ,
   /*
     helper to allow adding datasources directly to the datasource_config_map
     eg:
@@ -64,21 +54,11 @@
     }),
 
   // Generates yaml string containing datasource config
-  grafana_datasource_with_basicauth(name, url, username, password, default=false, method='GET', type='prometheus'):: {
-    name: name,
-    type: type,
-    access: 'proxy',
-    url: url,
-    isDefault: default,
-    version: 1,
-    editable: false,
-    basicAuth: true,
-    basicAuthUser: username,
-    basicAuthPassword: password,
-    jsonData: {
-      httpMethod: method,
-    },
-  },
+  grafana_datasource_with_basicauth(name, url, username, password, default=false, method='GET', type='prometheus')::
+    self.datasource.new(name, url, type, default)
+    + self.datasource.withHttpMethod(method)
+    + self.datasource.withBasicAuth(username, password)
+  ,
 
   /*
    helper to allow adding datasources directly to the datasource_config_map

--- a/prometheus-ksonnet/grafana/datasources.libsonnet
+++ b/prometheus-ksonnet/grafana/datasources.libsonnet
@@ -25,6 +25,29 @@
     },
   },
 
+  datasource+:: {
+    new(name, url, type, default=false, method='GET'):: {
+      name: name,
+      type: type,
+      access: 'proxy',
+      url: url,
+      isDefault: default,
+      version: 1,
+      editable: false,
+      jsonData: {
+        httpMethod: method,
+      },
+    },
+    withBasicAuth(username, password):: {
+      basicAuth: true,
+      basicAuthUser: username,
+      basicAuthPassword: password,
+    },
+    withJsonData(data):: {
+      jsonData+: data,
+    },
+  },
+
   /*
     helper to allow adding datasources directly to the datasource_config_map
     eg:


### PR DESCRIPTION
There are various functions in this file to add new datasources, but they all include the word 'grafana' in the name.

This naming scheme is based upon the assumption that the library will be merged into the root of the jsonnet tree, which is a bad practice anyway. If, however, this grafana library is loaded into a local variable called 'grafana', then, with this new change, we can do `grafana.datasource.new()` which makes plenty sense.