### PR TITLE
feat(cert-manager): configurable cluster issuers

### DIFF
--- a/cert-manager/config.libsonnet
+++ b/cert-manager/config.libsonnet
@@ -3,9 +3,12 @@
     name: 'cert-manager',
     namespace: error '$._config.namespace needs to be configured.',
     version: 'v1.1.0',
+    install_crds: !$._config.custom_crds,
+    issuer_email: error '$._config.issuer_email needs to be configured.',
+
+    // backwards compat
     custom_crds: false,  // newer cert-manager charts can install CRDs
     default_issuer: null,
     default_issuer_group: 'cert-manager.io',
-    issuer_email: error '$._config.issuer_email needs to be configured.',
   },
 }

--- a/cert-manager/default_clusterissuers.libsonnet
+++ b/cert-manager/default_clusterissuers.libsonnet
@@ -1,86 +1,98 @@
 {
-  local _containers = super.labeled.deployment_cert_manager.spec.template.spec.containers,
-  labeled+: {
-    deployment_cert_manager+: {
+
+  withDefaultIssuer(name, kind='ClusterIssuer', group='cert-manager.io'):: {
+    values+:: {
+      ingressShim: {
+        defaultIssuerName: name,
+        defaultIssuerKind: kind,
+        defaultIssuerGroup: group,
+      },
+    },
+  },
+
+  clusterIssuer:: {
+    new(name): {
+      apiVersion: 'cert-manager.io/v1alpha2',
+      kind: 'ClusterIssuer',
+      metadata: {
+        name: 'letsencrypt-staging',
+      },
+    },
+    withACME(email, server='https://acme-v02.api.letsencrypt.org/directory'): {
+      local name = super.metadata.name,
       spec+: {
-        template+: {
-          spec+: {
-            containers: [
-              _container {
-                args+:
-                  [
-                    '--default-issuer-kind=ClusterIssuer',
-                  ]
-                  + (if $._config.default_issuer != null then ['--default-issuer-name=' + $._config.default_issuer] else [])
-                  + (if $._config.default_issuer_group != null then ['--default-issuer-group=' + $._config.default_issuer_group] else []),
-              }
-              for _container in _containers
-            ],
+        acme: {
+          // You must replace this email address with your own.
+          // Let's Encrypt will use this to contact you about expiring
+          // certificates, and issues related to your account.
+          email: email,
+          server: server,
+          privateKeySecretRef: {
+            // Secret resource used to store the account's private key.
+            name: '%s-account' % name,
           },
+        },
+      },
+    },
+    reuseAccount(secret_name): {
+      spec+: {
+        acme+: {
+          // re-use an existing account
+          // https://cert-manager.io/docs/configuration/acme/#reusing-an-acme-account
+          disableAccountKeyGeneration: true,
+          privateKeySecretRef: {
+            // Secret resource used to retrieve the account's private key.
+            name: secret_name,
+          },
+        },
+      },
+    },
+    withACMESolverHttp01(class='nginx'): {
+      spec+: {
+        acme+: {
+          // Add a single challenge solver, HTTP01 using nginx
+          solvers: [
+            {
+              http01: {
+                ingress: {
+                  class: class,
+                },
+              },
+            },
+          ],
         },
       },
     },
   },
 
-  cluster_issuer_staging: {
-    apiVersion: 'cert-manager.io/v1alpha2',
-    kind: 'ClusterIssuer',
-    metadata: {
-      name: 'letsencrypt-staging',
-    },
-    spec: {
-      acme: {
-        // You must replace this email address with your own.
-        // Let's Encrypt will use this to contact you about expiring
-        // certificates, and issues related to your account.
-        email: $._config.issuer_email,
-        server: 'https://acme-staging-v02.api.letsencrypt.org/directory',
-        privateKeySecretRef: {
-          // Secret resource used to store the account's private key.
-          name: 'letsencrypt-staging-account',
-        },
-        // Add a single challenge solver, HTTP01 using nginx
-        solvers: [
-          {
-            http01: {
-              ingress: {
-                class: 'nginx',
-              },
-            },
-          },
-        ],
-      },
-    },
+  // backward compat
+  values+:: {
+    ingressShim:
+      {
+        defaultIssuerKind: 'ClusterIssuer',
+      }
+
+      + (
+        if $._config.default_issuer != null
+        then { defaultIssuerName: $._config.default_issuer }
+        else {}
+      )
+      + (
+        if $._config.default_issuer_group != null
+        then { defaultIssuerGroup: $._config.default_issuer_group }
+        else {}
+      ),
   },
 
-  cluster_issuer_prod: {
-    apiVersion: 'cert-manager.io/v1alpha2',
-    kind: 'ClusterIssuer',
-    metadata: {
-      name: 'letsencrypt-prod',
-    },
-    spec: {
-      acme: {
-        // You must replace this email address with your own.
-        // Let's Encrypt will use this to contact you about expiring
-        // certificates, and issues related to your account.
-        email: $._config.issuer_email,
-        server: 'https://acme-v02.api.letsencrypt.org/directory',
-        privateKeySecretRef: {
-          // Secret resource used to store the account's private key.
-          name: 'letsencrypt-prod-account',
-        },
-        // Add a single challenge solver, HTTP01 using nginx
-        solvers: [
-          {
-            http01: {
-              ingress: {
-                class: 'nginx',
-              },
-            },
-          },
-        ],
-      },
-    },
-  },
+  // backward compat
+  cluster_issuer_staging:
+    self.clusterIssuer.new('letsencrypt-staging')
+    + self.clusterIssuer.withACME($._config.issuer_email, 'https://acme-staging-v02.api.letsencrypt.org/directory')
+    + self.clusterIssuer.withACMESolverHttp01(),
+
+  // backward compat
+  cluster_issuer_prod:
+    self.clusterIssuer.new('letsencrypt-prod')
+    + self.clusterIssuer.withACME($._config.issuer_email)
+    + self.clusterIssuer.withACMESolverHttp01(),
 }

--- a/cert-manager/default_clusterissuers.libsonnet
+++ b/cert-manager/default_clusterissuers.libsonnet
@@ -15,7 +15,7 @@
       apiVersion: 'cert-manager.io/v1alpha2',
       kind: 'ClusterIssuer',
       metadata: {
-        name: 'letsencrypt-staging',
+        name: name,
       },
     },
     withACME(email, server='https://acme-v02.api.letsencrypt.org/directory'): {

--- a/cert-manager/main.libsonnet
+++ b/cert-manager/main.libsonnet
@@ -3,7 +3,7 @@ local helm = tanka.helm.new(std.thisFile);
 
 {
   values:: {
-    installCRDs: if $._config.custom_crds then false else true,
+    installCRDs: $._config.install_crds,
     global: {
       podSecurityPolicy: {
         enabled: true,


### PR DESCRIPTION
Adds functionality to add a default issuer and reuse an existing issuer secret.

The args are now set through the variables, it changes the order of args but is a no-op in practice.