### PR TITLE
Add jsonnetfile for the envoy mixin.

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -18,7 +18,7 @@ RUN chmod +x /usr/bin/jb
 
 # Build mixtool
 FROM golang:1.15-alpine AS mixtool-builder
-RUN GO111MODULE=on go get github.com/monitoring-mixins/mixtool/cmd/mixtool@59d44357240d
+RUN GO111MODULE=on go get github.com/monitoring-mixins/mixtool/cmd/mixtool@ae18e31161ea
 
 FROM alpine:3.7
 RUN apk --no-cache add make python git openssh-client bash

--- a/consul-mixin/dashboards.libsonnet
+++ b/consul-mixin/dashboards.libsonnet
@@ -14,7 +14,7 @@ local panel_settings = {
 {
   grafanaDashboards+:: {
     'consul-overview.json':
-      g.dashboard('Consul Overview')
+      g.dashboard('Consul Overview', std.md5('20210205-consul'))
       .addTemplate('job', 'consul_up', 'job')
       .addMultiTemplate('instance', 'consul_up{job="$job"}', 'instance')
       .addRow(

--- a/envoy-mixin/dashboards.libsonnet
+++ b/envoy-mixin/dashboards.libsonnet
@@ -21,7 +21,7 @@ local template = import 'grafonnet/template.libsonnet';
   // - HTTP: https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/router_filter#statistics
   grafanaDashboards+:: {
     'envoy-overview.json':
-      g.dashboard('Envoy Overview')
+      g.dashboard('Envoy Overview', std.md5('20210205-envoy'))
       .addTemplate('job', 'envoy_server_uptime', 'job')
 
       // Hidden variables to be able to repeat panels for each upstream/downstream.

--- a/envoy-mixin/jsonnetfile.json
+++ b/envoy-mixin/jsonnetfile.json
@@ -1,0 +1,24 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": "grafana-builder"
+        }
+      },
+      "version": "master"
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/grafonnet-lib.git",
+          "subdir": "grafonnet"
+        }
+      },
+      "version": "master"
+    }
+  ],
+  "legacyImports": true
+}


### PR DESCRIPTION
Add jsonnetfile for the envoy mixin and fix other linting errors.

This fixes the `mixin lint` step with more recent versions of the
`mixtool` tool. The problem is likely not appearing in CI as the
`mixtool` version used is a few months old.

I've updated the Dockerfile as well to use the latest available revision
of `mixtool`, so the a new docker image should be published once this is
merged.