### PR TITLE
Allow overriding of UID construction

### DIFF
--- a/prometheus-ksonnet/grafana/dashboards.libsonnet
+++ b/prometheus-ksonnet/grafana/dashboards.libsonnet
@@ -31,6 +31,8 @@
     },
   },
 
+  uidForDashboard(filename, dashboard):: std.md5(filename),
+
   // mixinProto allows us to reliably do `mixin.grafanaDashboards` without
   // having to check the field exists first. Some mixins don't declare all
   // the fields, and that's fine.
@@ -48,7 +50,7 @@
       [filename]:
         local dashboard = grafanaDashboards[filename];
         dashboard {
-          uid: std.md5(filename),
+          uid: $.uidForDashboard(filename, dashboard),
           timezone: '',
 
           [if std.objectHas(dashboard, 'rows') then 'rows']: [


### PR DESCRIPTION
Prometheus-ksonnet currently forces the UID to be a hash of the filename. It is totally legitimate to use a human readable string as a UID, and that UID is then used in the dashboard URL.

This PR allows a user to override the UID creation mechanism - it defaults to being a no-op, but allows override.