### PR TITLE
Correct naming of plugins element

### DIFF
--- a/prometheus-ksonnet/grafana/deployment.libsonnet
+++ b/prometheus-ksonnet/grafana/deployment.libsonnet
@@ -11,5 +11,5 @@
   ),
 
   // support legacy extension point (grafana_plugins)
-  plugins+:: self.grafana_plugins,
+  grafanaPlugins+:: self.grafana_plugins,
 }


### PR DESCRIPTION
With the addition of the new grafana lib #449 we accidentally broke the code handing plugins from the prometheus-ksonnet to grafana/grafana.libsonnet. This PR fixes that.