### PR TITLE
Set shared tooltip to false by default in grafana-builder but don't enforce it. 

### DIFF
--- a/grafana-builder/grafana.libsonnet
+++ b/grafana-builder/grafana.libsonnet
@@ -196,7 +196,7 @@
     timeShift: null,
     title: title,
     tooltip: {
-      shared: true,
+      shared: false,
       sort: 0,
       value_type: 'individual',
     },

--- a/prometheus-ksonnet/grafana/dashboards.libsonnet
+++ b/prometheus-ksonnet/grafana/dashboards.libsonnet
@@ -52,20 +52,6 @@
         dashboard {
           uid: $.uidForDashboard(filename, dashboard),
           timezone: '',
-
-          [if std.objectHas(dashboard, 'rows') then 'rows']: [
-            row {
-              panels: [
-                panel {
-                  tooltip+: {
-                    shared: false,
-                  },
-                }
-                for panel in super.panels
-              ],
-            }
-            for row in super.rows
-          ],
         }
       for filename in std.objectFields(grafanaDashboards)
     },


### PR DESCRIPTION
Signed-off-by: bergquist <carl.bergquist@gmail.com>