### PR TITLE
fix(prometheus): add antiAffinity for HA sts

### DIFF
--- a/prometheus/ha-mixin.libsonnet
+++ b/prometheus/ha-mixin.libsonnet
@@ -119,5 +119,6 @@ local kausal = import 'ksonnet-util/kausal.libsonnet';
   local statefulset = k.apps.v1.statefulSet,
 
   prometheus_statefulset+:
-    statefulset.mixin.spec.withReplicas(2),
+    statefulset.mixin.spec.withReplicas(2)
+    + k.util.antiAffinityStatefulSet,
 }


### PR DESCRIPTION
I think this makes sense here, a HA set should not run on the same node.

for ref: https://github.com/grafana/jsonnet-libs/blob/2cef89c/ksonnet-util/util.libsonnet#L227-L238