### PR TITLE
fix(alertmanager): accept isGossip arguments

### DIFF
--- a/alertmanager/alertmanager.libsonnet
+++ b/alertmanager/alertmanager.libsonnet
@@ -49,17 +49,17 @@ local kausal = import 'ksonnet-util/kausal.libsonnet';
       memory: '40Mi',
     }),
 
-  isGossiping():: {
+  isGossiping(peers, port=9094):: {
     alertmanager_container+:
       container.withPortsMixin(
         [
-          k.core.v1.containerPort.newUDP('gossip-udp', _config.alertmanager_gossip_port),
-          k.core.v1.containerPort.new('gossip-tcp', _config.alertmanager_gossip_port),
+          k.core.v1.containerPort.newUDP('gossip-udp', port),
+          k.core.v1.containerPort.new('gossip-tcp', port),
         ]
       )
       + container.withArgsMixin(
-        ['--cluster.listen-address=[$(POD_IP)]:%s' % _config.alertmanager_gossip_port]
-        + ['--cluster.peer=%s' % peer for peer in _config.alertmanager_peers]
+        ['--cluster.listen-address=[$(POD_IP)]:%s' % port]
+        + ['--cluster.peer=%s' % peer for peer in peers]
       ),
   },
 

--- a/alertmanager/config.libsonnet
+++ b/alertmanager/config.libsonnet
@@ -1,18 +1,14 @@
 {
   _config+:: {
     // Cluster and environment specific overrides.
-    cluster_dns_tld: 'local',
     cluster_dns_suffix: 'cluster.' + self.cluster_dns_tld,
-    cluster_name: error 'must specify cluster name',
+    cluster_dns_tld: 'local',
     namespace: error 'must specify namespace',
 
     // Alertmanager config options.
     alertmanager_external_hostname: 'http://alertmanager.%(namespace)s.svc.%(cluster_dns_suffix)s' % self,
     alertmanager_path: '/alertmanager/',
     alertmanager_port: 9093,
-    alertmanager_gossip_port: 9094,
-
     alertmanager_replicas: 1,
-    alertmanager_peers: [],
   },
 }

--- a/prometheus-ksonnet/lib/alertmanager.libsonnet
+++ b/prometheus-ksonnet/lib/alertmanager.libsonnet
@@ -24,13 +24,14 @@ alertmanager_slack +
 
   _config+:: {
     alertmanager_peers: peers,
+    alertmanager_gossip_port: 9094,
     alertmanager_replicas: replicas,
     alertmanager_external_hostname: 'http://alertmanager.%(alertmanager_namespace)s.svc.%(cluster_dns_suffix)s' % self,
   },
 
   alertmanager_container+:: (
     if isGossiping
-    then self.isGossiping().alertmanager_container
+    then self.isGossiping($._config.alertmanager_peers, $._config.alertmanager_gossip_port).alertmanager_container
     else {}
   ),
 


### PR DESCRIPTION
This takes peers and port as arguments instead of grabbing it from root. The latter doesn't always work.