### PR TITLE
Set BasicAuth for Grafana Datasource in secureJson

### DIFF
--- a/grafana/datasources.libsonnet
+++ b/grafana/datasources.libsonnet
@@ -13,7 +13,7 @@
     basicAuthUser: username,
     basicAuthPassword: if legacy then password,
     secureJsonData+: if !legacy then {
-        basicAuthPassword: password,
+      basicAuthPassword: password,
     },
   },
   withJsonData(data):: {

--- a/grafana/datasources.libsonnet
+++ b/grafana/datasources.libsonnet
@@ -12,7 +12,7 @@
     basicAuth: true,
     basicAuthUser: username,
     [if legacy then 'basicAuthPassword']: password,
-    secureJsonData+: if !legacy then {
+    [if !legacy] then 'secureJsonData']+: {
       basicAuthPassword: password,
     },
   },

--- a/grafana/datasources.libsonnet
+++ b/grafana/datasources.libsonnet
@@ -11,7 +11,7 @@
   withBasicAuth(username, password, legacy=false):: {
     basicAuth: true,
     basicAuthUser: username,
-    basicAuthPassword: if legacy then password,
+    [if legacy then 'basicAuthPassword']: password,
     secureJsonData+: if !legacy then {
       basicAuthPassword: password,
     },

--- a/grafana/datasources.libsonnet
+++ b/grafana/datasources.libsonnet
@@ -12,7 +12,7 @@
     basicAuth: true,
     basicAuthUser: username,
     [if legacy then 'basicAuthPassword']: password,
-    [if !legacy] then 'secureJsonData']+: {
+    [if !legacy then 'secureJsonData']+: {
       basicAuthPassword: password,
     },
   },

--- a/grafana/datasources.libsonnet
+++ b/grafana/datasources.libsonnet
@@ -8,10 +8,13 @@
     version: 1,
     editable: false,
   },
-  withBasicAuth(username, password):: {
+  withBasicAuth(username, password, legacy=false):: {
     basicAuth: true,
     basicAuthUser: username,
-    basicAuthPassword: password,
+    basicAuthPassword: if legacy then password,
+    secureJsonData+: if !legacy then {
+        basicAuthPassword: password,
+    },
   },
   withJsonData(data):: {
     jsonData+: data,

--- a/grafana/datasources.libsonnet
+++ b/grafana/datasources.libsonnet
@@ -8,6 +8,8 @@
     version: 1,
     editable: false,
   },
+  // `legacy` causes a datasource to use the old, less secure `basicAuthPassword` element
+  // rather than the more up-to-date `secureJsonData.basicAuthPassword` which was introduced in Grafana 6.2
   withBasicAuth(username, password, legacy=false):: {
     basicAuth: true,
     basicAuthUser: username,


### PR DESCRIPTION
Having basicAuthPassword in the plugin configuration body is deprecated according to the provisioning docs (https://grafana.com/docs/grafana/latest/administration/provisioning/)

Now the password is located in the secureJsonData

Since there are inevitably outdated plugins out there, I propse to have an optional `legacy` flag that would default to the newer (non-deprecated) behavior.