### PR TITLE
feat(alertmanager/prometheus): abstract building blocks for global alertmanager setup

### DIFF
--- a/alertmanager/alertmanager.libsonnet
+++ b/alertmanager/alertmanager.libsonnet
@@ -49,12 +49,12 @@ local kausal = import 'ksonnet-util/kausal.libsonnet';
       memory: '40Mi',
     }),
 
-  // `buildPeers` constructs an array of alertmanager gossiping peer
-  // URLs. Together with `withAlertmanagers` in the prometheus
-  // jsonnetlib, this is a building block for configuring one global
-  // alertmanager über-cluster spread over multiple kubernetes
-  // clusters. This requires all those clusters to have inter-cluster
-  // network connectivity.
+  // `buildPeers` constructs an array of alertmanager peers. Together
+  // with `withAlertmanagers` in the prometheus jsonnetlib, this is a
+  // building block for configuring one global alertmanager
+  // über-cluster spread over multiple kubernetes clusters. This
+  // requires all those clusters to have inter-cluster network
+  // connectivity.
   //
   // ref: https://github.com/grafana/jsonnet-libs/tree/master/prometheus
   //
@@ -83,6 +83,11 @@ local kausal = import 'ksonnet-util/kausal.libsonnet';
     for i in std.range(0, alertmanagers[am].replicas - 1)
   ],
 
+  // `isGossiping` configures alertmanager to take part in a highly
+  // available cluster. The gossiping peers can be constructed with
+  // `buildPeers`.
+  //
+  // ref: https://github.com/prometheus/alertmanager#high-availability
   isGossiping(peers, port=9094):: {
     alertmanager_container+:
       container.withPortsMixin(

--- a/prometheus-ksonnet/lib/alertmanager.libsonnet
+++ b/prometheus-ksonnet/lib/alertmanager.libsonnet
@@ -15,7 +15,7 @@ alertmanager_slack +
       if $.alertmanagers[am].global
     }
     else {
-      [cluster_name]: $.alertmanagers[cluster_name],
+      [$._config.cluster_name]: $.alertmanagers[$._config.cluster_name],
     }
   ),
 

--- a/prometheus-ksonnet/lib/alertmanager.libsonnet
+++ b/prometheus-ksonnet/lib/alertmanager.libsonnet
@@ -7,20 +7,17 @@ alertmanager_slack +
   local replicas = self._config.alertmanager_cluster_self.replicas,
   local isGlobal = self._config.alertmanager_cluster_self.global,
   local isGossiping = replicas > 1 || isGlobal,
-  local peers = if isGlobal
-  then
-    [
-      'alertmanager-%d.alertmanager.%s.svc.%s.%s:%s' % [i, $._config.alertmanager_namespace, cluster, $._config.cluster_dns_tld, $._config.alertmanager_gossip_port]
-      for cluster in std.objectFields($._config.alertmanager_clusters)
-      if $._config.alertmanager_clusters[cluster].global
-      for i in std.range(0, $._config.alertmanager_clusters[cluster].replicas - 1)
-    ]
-  else if isGossiping then
-    [
-      'alertmanager-%d.alertmanager.%s.svc.%s.%s:%s' % [i, $._config.alertmanager_namespace, $._config.cluster_name, $._config.cluster_dns_tld, $._config.alertmanager_gossip_port]
-      for i in std.range(0, replicas - 1)
-    ]
-  else [],
+  local peers = $.buildPeers(
+    if isGlobal
+    then {
+      [am]: $.alertmanagers[am]
+      for am in std.objectFields($.alertmanagers)
+      if $.alertmanagers[am].global
+    }
+    else {
+      [cluster_name]: $.alertmanagers[cluster_name],
+    }
+  ),
 
   _config+:: {
     alertmanager_peers: peers,
@@ -31,7 +28,10 @@ alertmanager_slack +
 
   alertmanager_container+:: (
     if isGossiping
-    then self.isGossiping($._config.alertmanager_peers, $._config.alertmanager_gossip_port).alertmanager_container
+    then self.isGossiping(
+      $._config.alertmanager_peers,
+      $._config.alertmanager_gossip_port
+    ).alertmanager_container
     else {}
   ),
 

--- a/prometheus-ksonnet/lib/prometheus-config.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus-config.libsonnet
@@ -10,46 +10,10 @@
     ],
 
     alerting: {
-      alertmanagers: std.prune(
-        [
-          // For local alertmanager or local instances of the global alertmanager, use K8s SD.
-          if !$._config.alertmanager_cluster_self.global || $._config.alertmanager_cluster_self.replicas > 0 then
-            {
-              api_version: 'v2',
-              kubernetes_sd_configs: [{
-                role: 'pod',
-              }],
-              path_prefix: $._config.alertmanager_path,
-              relabel_configs: [{
-                source_labels: ['__meta_kubernetes_pod_label_name'],
-                regex: 'alertmanager',
-                action: 'keep',
-              }, {
-                source_labels: ['__meta_kubernetes_namespace'],
-                regex: $._config.alertmanager_namespace,
-                action: 'keep',
-              }, {
-                // This prevents port-less containers and the gossip ports from showing up.
-                source_labels: ['__meta_kubernetes_pod_container_port_number'],
-                regex: $._config.alertmanager_port,
-                action: 'keep',
-              }],
-            },
-        ] + if $._config.alertmanager_cluster_self.global then [{
-          // For non-local instances, use static DNS entries.
-          // Sadly, the K8s-provided DNS-SRV records only point to the service IP,
-          // but we need to send alerts to every Alertmanager instance individually.
-          api_version: 'v2',
-          path_prefix: $._config.alertmanager_path,
-          static_configs: [{ targets: [
-            'alertmanager-%d.alertmanager.%s.svc.%s.%s:%s' % [i, $._config.alertmanager_namespace, cluster, $._config.cluster_dns_tld, $._config.alertmanager_port]
-            for cluster in std.objectFields($._config.alertmanager_clusters)
-            if $._config.cluster_name != cluster && $._config.alertmanager_clusters[cluster].global && $._config.alertmanager_clusters[cluster].replicas > 1
-            for i in std.range(0, $._config.alertmanager_clusters[cluster].replicas - 1)
-          ] }],
-        }]
-        else [],
-      ),
+      alertmanagers: $.withAlertmanagers(
+        $._config.alertmanagers,
+        $._config.cluster_name
+      ).prometheus_config.alerting.alertmanagers,
     },
 
     scrape_configs: [

--- a/prometheus-ksonnet/lib/prometheus-config.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus-config.libsonnet
@@ -1,3 +1,5 @@
+local prometheus = import 'prometheus/prometheus.libsonnet';
+
 {
   prometheus_config:: {
     global: {
@@ -10,7 +12,7 @@
     ],
 
     alerting: {
-      alertmanagers: $.withAlertmanagers(
+      alertmanagers: prometheus.withAlertmanagers(
         $._config.alertmanagers,
         $._config.cluster_name
       ).prometheus_config.alerting.alertmanagers,

--- a/prometheus/config.libsonnet
+++ b/prometheus/config.libsonnet
@@ -42,4 +42,105 @@
         {}
       ),
   },
+
+  // `withAlertmanagers` adds an alertmanager configuration to
+  // prometheus. It is intended to work with `buildPeers` in the
+  // alertmanager jsonnet lib to provide one global alertmanager
+  // über-cluster spread over multiple kubernetes clusters. This
+  // requires all those clusters to have inter-cluster network
+  // connectivity.
+  //
+  // ref: https://github.com/grafana/jsonnet-libs/tree/master/alertmanager
+  //
+  // `global` is set to 'true' if the alertmanager is participating in
+  // the global alertmanager über-cluster.
+  //
+  // `cluster_name` has 2 functions:
+  // 1. Prometheus will prefer looking up the alertmanagers through
+  //    k8s service discovery if the alertmanager is running in the
+  //    same cluster, this will be done by comparing `cluster_name`.
+  // 2. If the `cluster_name` does not match, then this will be used
+  //    to construct the URLs to the alertmanager pods to fill the
+  //    static_configs.
+  //
+  // `withAlertmanagers` is intended to be compatible with `buildPeers`
+  // in the alertmanager jsonnet lib.
+  //
+  // Example `alertmanagers` object:
+  // alertmanagers: {
+  //   alertmanager_name: {
+  //     // path prefix where the alertmanager is running
+  //     path: '/alertmanager/',
+  //
+  //     // for service discovery and global static config
+  //     namespace: 'alertmanager',
+  //     port: 9093,
+  //
+  //     // for global static config
+  //     replicas: 2,
+  //     global: true,
+  //     cluster_name: 'us-central1',
+  //     cluster_dns_tld: 'local',
+  //   },
+  // }
+  withAlertmanagers(alertmanagers, cluster_name):: {
+    prometheus_config+: {
+      alerting+: {
+        alertmanagers: std.prune(
+          [
+            local alertmanager = alertmanagers[am];
+
+            // For local alertmanager or local instances of the global alertmanager, use K8s SD.
+            if cluster_name == alertmanager.cluster_name &&
+               alertmanager.replicas > 0
+            then {
+              api_version: 'v2',
+              kubernetes_sd_configs: [{
+                role: 'pod',
+              }],
+              path_prefix: alertmanager.path,
+
+              relabel_configs: [{
+                source_labels: ['__meta_kubernetes_pod_label_name'],
+                regex: 'alertmanager',
+                action: 'keep',
+              }, {
+                source_labels: ['__meta_kubernetes_namespace'],
+                regex: alertmanager.namespace,
+                action: 'keep',
+              }, {
+                // This prevents port-less containers and the gossip ports
+                // from showing up.
+                source_labels: ['__meta_kubernetes_pod_container_port_number'],
+                regex: alertmanager.port,
+                action: 'keep',
+              }],
+            }
+            else
+              // For non-local instances, use static DNS entries.
+              if alertmanager.global &&
+                 alertmanager.replicas > 0
+              then {
+                api_version: 'v2',
+                path_prefix: alertmanager.path,
+                static_configs: [{
+                  targets: [
+                    'alertmanager-%d.alertmanager.%s.svc.%s.%s:%s' % [
+                      i,
+                      alertmanager.namespace,
+                      alertmanager.cluster_name,
+                      alertmanager.cluster_dns_tld,
+                      alertmanager.port,
+                    ]
+                    for i in std.range(0, alertmanager.replicas - 1)
+                  ],
+                }],
+              }
+              else {}
+            for am in std.objectFields(alertmanagers)
+          ]
+        ),
+      },
+    },
+  },
 }


### PR DESCRIPTION
This PR reconstructs a powerful idea from prometheus-ksonnet into building blocks to configure a global alertmanager
cluster. I've included inline documentation that should explain these building blocks, the intention is to document the
respective libraries with docsonnet at some point.

I expect this to be fully backwards compatible on the prometheus-ksonnet end, however a small no-op diff should be
expected.