### PR TITLE
Add additional synthetic-monitoring defaults

### DIFF
--- a/synthetic-monitoring/sm.libsonnet
+++ b/synthetic-monitoring/sm.libsonnet
@@ -7,6 +7,8 @@
     labels: [],
     target: target,
     job: name,
+    alertSensitivity: '',
+    basicMetricsOnly: true,
   },
 
   local _new = self._new,


### PR DESCRIPTION
New defaults added when creating synthetic-monitoring checks:

`alertSensitivity: ''`
`basicMetricsOnly: true`