### PR TITLE
Add pvcVolumeMount function

### DIFF
--- a/ksonnet-util/util.libsonnet
+++ b/ksonnet-util/util.libsonnet
@@ -155,6 +155,21 @@ local util(k) = {
       volume.fromHostPath(name, hostPath),
     ]),
 
+  pvcVolumeMount(pvcName, path, readOnly=false, volumeMountMixin={})::
+    local container = k.core.v1.container,
+          deployment = k.apps.v1.deployment,
+          volumeMount = k.core.v1.volumeMount,
+          volume = k.core.v1.volume,
+          addMount(c) = c + container.withVolumeMountsMixin(
+      volumeMount.new(pvcName, path, readOnly=readOnly) +
+      volumeMountMixin,
+    );
+
+    deployment.mapContainers(addMount) +
+    deployment.mixin.spec.template.spec.withVolumesMixin([
+      volume.fromPersistentVolumeClaim(pvcName, pvcName),
+    ]),
+
   secretVolumeMount(name, path, defaultMode=256, volumeMountMixin={})::
     local container = k.core.v1.container,
           deployment = k.apps.v1.deployment,


### PR DESCRIPTION
We have `configVolumeMount`, `secretVolumeMount` etc, but lack the ability to mount a PVC!

Whilst mostly we will do this with a statefulset, and that is why we haven't seen this need so readily, there are usecases where we might want to mount a PVC manually, e.g. a read/write one to multiple pods.