### PR TITLE
Promsonnet extra patching

### DIFF
--- a/promsonnet/README.md
+++ b/promsonnet/README.md
@@ -6,6 +6,10 @@ rules internally as a map, which allows users to easily patch alerts and
 recording rules after the fact. In contrast, lists require complex
 iteration logic.
 
+It also provides useful functions for patching existing rules and rule
+groups, along with patching these embedded in [monitoring mixins](https://github.com/monitoring-mixins/docs).
+
+## Creating Rule Groups with PromSonnet
 Take this example:
 
 ```
@@ -55,8 +59,9 @@ simply with code such as:
 
 We no longer need to iterate over all alerts to do so.
 
-Better than this though, `PromSonnet` provides a helper function, making
-this trivial:
+## Patching Rules
+The power of Jsonnet is its ability to patch existing resources. PromSonnet provides support for
+patching existing rule groups, e.g.:
 ```
 prometheusAlerts+: prom.v1.patchRule('prometheus_metamon', 'PrometheusDown', { 'for': '10m' }),
 ```
@@ -68,10 +73,39 @@ $ jsonnet example.jsonnet
 $ # or:
 $ jsonnet patch.jsonnet
 ```
+> NOTE: This `v1.patchRule` function is intelligent: it can work with PromSonnet created rule groups
+as well as ones that were created manually (without the `groups_map` for example).
 
+## Working with Mixins
 Given that we often want to patch existing rules, and those often exist within mixins,
 we can also do:
 ```
 mixins+: prom.v1.mixin.patchRule('base', 'prometheus_metamon', 'PrometheusDown', { 'for': '10m' }),
 ```
 This will apply the same patch to the `base` mixin.
+
+## 'Upgrading' existing rule groups and mixins
+PromSonnet provides a `v1.legacy` API which includes functions for 'upgrading' rule groups without the
+`groups_map` element into ones that do. This can make manual patching easier. It doesn't make any
+significant difference if using the PromSonnet patch functions. When working with mixins, there are
+two available approaches:
+```
+local mixin = 'my-mixin.libsonnet';
+{
+  mixins+:: {
+    mymixin: mixin + prom.v1.legacy.mixin.update,
+  }
+}
+
+```
+Or, if the mixin has already been added to your `$.mixins`, perhaps by code you don't control:
+```
+local mixin = 'my-mixin.libsonnet';
+{
+  mixins+:: {
+    mymixin: mixin,
+  }
+} + {
+  mixins+:: prom.v1.legacy.mixin.updateExisting('mymixin'),
+}
+```

--- a/promsonnet/README.md
+++ b/promsonnet/README.md
@@ -1,4 +1,4 @@
-#PromSonnet
+# PromSonnet
 
 `PromSonnet` is intended as a very simple library for creating Prometheus
 alerts and rules. It is 'patching friendly', as in, it maintains the

--- a/promsonnet/README.md
+++ b/promsonnet/README.md
@@ -68,3 +68,10 @@ $ jsonnet example.jsonnet
 $ # or:
 $ jsonnet patch.jsonnet
 ```
+
+Given that we often want to patch existing rules, and those often exist within mixins,
+we can also do:
+```
+mixins+: prom.v1.mixin.patchRule('base', 'prometheus_metamon', 'PrometheusDown', { 'for': '10m' }),
+```
+This will apply the same patch to the `base` mixin.

--- a/promsonnet/api.libsonnet
+++ b/promsonnet/api.libsonnet
@@ -1,0 +1,66 @@
+{
+  v1: {
+    ruleGroupSet: {
+      new():: {
+        groups_map:: {},
+        groups_order:: [],
+        local groups_map = self.groups_map,
+        local groups_order = self.groups_order,
+        groups: [groups_map[group] for group in groups_order],
+      },
+
+      addGroup(group):: {
+        groups_map+:: {
+          [group.name]: group,
+        },
+        groups_order+:: [group.name],
+      },
+    },
+
+    ruleGroup: {
+      new(name):: {
+        name: name,
+        rules_map:: {},
+        rules_order:: [],
+        local rules_map = self.rules_map,
+        local rules_order = self.rules_order,
+        rules: [rules_map[rule] for rule in rules_order],
+      },
+
+      rule: {
+        newAlert(name, rule):: {
+          rules_map+:: {
+            [name]: rule { alert: name },
+          },
+          rules_order+:: [name],
+        },
+        newRecording(name, rule):: {
+          rules_map+:: {
+            [name]: rule { record: name },
+          },
+          rules_order+:: [name],
+        },
+      },
+    },
+
+    patchRule(group, rule, patch):: {
+      groups_map+:: {
+        [group]+: {
+          rules_map+:: {
+            [rule]+: patch,
+          },
+        },
+      },
+    },
+
+    local patchRule = self.patchRule,
+    mixin: {
+      patchRule(mixin, group, rule, patch):: {
+        [mixin]+: {
+          prometheusRules+: patchRule(group, rule, patch),
+          prometheusAlerts+: patchRule(group, rule, patch),
+        },
+      },
+    },
+  },
+}

--- a/promsonnet/legacy.libsonnet
+++ b/promsonnet/legacy.libsonnet
@@ -21,7 +21,8 @@
                         if g.name == group
                         then g {
                           rules: std.map(function(r)
-                                           if ('alert' in r && r.alert == rule) || ('record' in r && r.record == rule)
+                                           if ('alert' in r && r.alert == rule) ||
+                                              ('record' in r && r.record == rule)
                                            then r + patch
                                            else r,
                                          g.rules),

--- a/promsonnet/legacy.libsonnet
+++ b/promsonnet/legacy.libsonnet
@@ -1,0 +1,56 @@
+{
+  // In this file, the word 'update' refers to retrofitting maps and _order
+  // lists to data structures that lack them.
+
+  v1: {
+    local v1 = self,
+    ruleGroupSet: {
+      update():: {
+        local groups = super.groups,
+        local this = self,
+        local groupsAsMap(group, acc) = acc { [group.name]+: group + v1.ruleGroup.update() },
+        local groupsAsList(group, acc) = acc + [group.name],
+        groups_map:: std.foldr(groupsAsMap, groups, {}),
+        groups_order:: std.foldr(groupsAsList, groups, []),
+        groups: [this.groups_map[group] for group in this.groups_order],
+      },
+    },
+
+    patchRule(group, rule, patch):: {
+      groups: std.map(function(g)
+                        if g.name == group
+                        then g {
+                          rules: std.map(function(r)
+                                           if ('alert' in r && r.alert == rule) || ('record' in r && r.record == rule)
+                                           then r + patch
+                                           else r,
+                                         g.rules),
+                        }
+                        else g,
+                      super.groups),
+    },
+
+    ruleGroup: {
+      update():: {
+        local rules = super.rules,
+        local this = self,
+        local ruleName(rule) = if 'alert' in rule then rule.alert else rule.record,
+        local rulesAsMap(rule, acc) = acc { [ruleName(rule)]: rule },
+        local rulesAsList(rule, acc) = acc + [ruleName(rule)],
+        rules_map:: std.foldr(rulesAsMap, rules, {}),
+        rules_order:: std.foldr(rulesAsList, rules, []),
+        rules: [this.rules_map[rule] for rule in this.rules_order],
+      },
+    },
+
+    mixin: {
+      update():: {
+        prometheusRules+: v1.ruleGroupSet.update(),
+        prometheusAlerts+: v1.ruleGroupSet.update(),
+      },
+      updateExisting(mixin):: {
+        [mixin]+: $.v1.mixin.update(),
+      },
+    },
+  },
+}


### PR DESCRIPTION
I'm finally using Promsonnet in anger.

What I've been thinking is that while we're not gonna succeed at getting the majority of mixin authors to refactor their mixins to use promsonnet (with its hidden maps), we still want to be able to patch rules.

Therefore, in this PR I've left the original `patchRule` code in place, but added code that detects which mode, and allows us to patch old-style rules.

I also added a `v1.mixin.patchRule()` function that will patch a specific mixin.