### PR TITLE
Add missing datasource template

### DIFF
--- a/spring-boot-mixin/dashboards/spring-boot-statistics_rev2.json
+++ b/spring-boot-mixin/dashboards/spring-boot-statistics_rev2.json
@@ -3250,6 +3250,20 @@
   "templating": {
     "list": [
       {
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
         "allValue": null,
         "current": {},
         "datasource": "${DS_PROMETHEUS}",


### PR DESCRIPTION
Other template vars failing to load since they rely on `DS_PROMETHEUS`
![image](https://user-images.githubusercontent.com/10603766/109314238-19f50100-7817-11eb-8e41-576445694d9a.png)


Working change example:
![image](https://user-images.githubusercontent.com/10603766/109314131-f8941500-7816-11eb-8e91-3b9f45652241.png)
