### PR TITLE
refactor(etcd-operator): Remove kausal from root element

### DIFF
--- a/etcd-operator/etcd-cluster.libsonnet
+++ b/etcd-operator/etcd-cluster.libsonnet
@@ -1,5 +1,6 @@
 {
-  local podAntiAffinity = $.apps.v1.deployment.mixin.spec.template.spec.affinity.podAntiAffinity,
+  local k = import 'ksonnet-util/kausal.libsonnet',
+  local podAntiAffinity = k.apps.v1.deployment.mixin.spec.template.spec.affinity.podAntiAffinity,
 
   etcd_cluster(name, size=3, version='3.3.13', env=[]):: {
     apiVersion: 'etcd.database.coreos.com/v1beta2',
@@ -29,8 +30,8 @@
         } + (
           // Run etcd with the Burstable QoS class, and without a CPU limit
           // to avoid CFS throttling (best for low latency)
-          $.util.resourcesRequests('500m', '512Mi') +
-          $.util.resourcesLimits(null, '512Mi')
+          k.util.resourcesRequests('500m', '512Mi') +
+          k.util.resourcesLimits(null, '512Mi')
         ),
     },
   },

--- a/etcd-operator/etcd-operator.libsonnet
+++ b/etcd-operator/etcd-operator.libsonnet
@@ -1,3 +1,2 @@
-(import 'ksonnet-util/kausal.libsonnet') +
 (import 'operator.libsonnet') +
 (import 'etcd-cluster.libsonnet')

--- a/etcd-operator/operator.libsonnet
+++ b/etcd-operator/operator.libsonnet
@@ -3,10 +3,11 @@
     operator: 'quay.io/coreos/etcd-operator:v0.9.4',
   },
 
-  local policyRule = $.rbac.v1beta1.policyRule,
+  local k = import 'ksonnet-util/kausal.libsonnet',
+  local policyRule = k.rbac.v1beta1.policyRule,
 
   operator_rbac:
-    $.util.rbac('etcd-operator', [
+    k.util.rbac('etcd-operator', [
       policyRule.new() +
       policyRule.withApiGroups(['etcd.database.coreos.com']) +
       policyRule.withResources(['etcdclusters', 'etcdbackups', 'etcdrestores']) +
@@ -28,7 +29,7 @@
       policyRule.withVerbs(['*']),
     ]),
 
-  local container = $.core.v1.container,
+  local container = k.core.v1.container,
   local env = container.envType,
   operator_container::
     container.new('operator', $._images.operator) +
@@ -38,11 +39,11 @@
       env.fromFieldPath('MY_POD_NAMESPACE', 'metadata.namespace'),
       env.fromFieldPath('MY_POD_NAME', 'metadata.name'),
     ]) +
-    container.withPorts([$.core.v1.containerPort.new('http-metrics', 8080)]) +
-    $.util.resourcesRequests('500m', '200Mi') +
-    $.util.resourcesLimits('1', '500Mi'),
+    container.withPorts([k.core.v1.containerPort.new('http-metrics', 8080)]) +
+    k.util.resourcesRequests('500m', '200Mi') +
+    k.util.resourcesLimits('1', '500Mi'),
 
-  local deployment = $.apps.v1.deployment,
+  local deployment = k.apps.v1.deployment,
 
   operator_deployment:
     deployment.new('etcd-operator', 1, [$.operator_container]) +


### PR DESCRIPTION
 Instead, declare it explicitly, because it is an implementation detail
 that is leaking to the consumers of the libraries, polluting the root
 element.

 Particularly, this solves one use case, which is importing
 `etcd_cluster`:

 ```
 local etcd_cluster = import 'etcd-operator/etcd-cluster.libsonnet';

 {
   etcd_cluster: etcd_cluster.etcd_cluster('etcd')
 }
 ```

 won't work if kausal is not available on the root element.

 To solve that we would need to do:

 ```
 local etcd_cluster = import 'etcd-operator/etcd-cluster.libsonnet';
 local k = import 'ksonnet-util/kausal.libsonnet';

 {
   etcd_cluster: (k + etcd_cluster).etcd_cluster('etcd')
 }
 ```

 For what is worth, that behaviour was not present when importing
`etcd-operator/etcd-operator.libsonnet` because it already imported it.