### PR TITLE
Nginx directory separate html

### DIFF
--- a/nginx-directory/configfile.libsonnet
+++ b/nginx-directory/configfile.libsonnet
@@ -57,33 +57,6 @@ local kausal = import 'ksonnet-util/kausal.libsonnet';
 
     configMap.new('nginx-config') +
     configMap.withData({
-      'nginx.conf': |||
-        worker_processes     5;  ## Default: 1
-        error_log            /dev/stderr;
-        pid                  /tmp/nginx.pid;
-        worker_rlimit_nofile 8192;
-
-        events {
-          worker_connections  4096;  ## Default: 1024
-        }
-
-        http {
-          default_type application/octet-stream;
-          log_format   main '$remote_addr - $remote_user [$time_local]  $status '
-            '"$request" $body_bytes_sent "$http_referer" '
-            '"$http_user_agent" "$http_x_forwarded_for"';
-          access_log   /dev/stderr  main;
-          sendfile     on;
-          tcp_nopush   on;
-          resolver     kube-dns.kube-system.svc.%(cluster_dns_suffix)s;
-          server {
-            listen 80;
-            %(locations)s
-            location ~ /(index.html)? {
-              root /var/www/html;
-            }
-          }
-        }
-      ||| % ($._config + vars),
+      'nginx.conf': (importstr 'files/nginx.conf') % ($._config + vars),
     }),
 }

--- a/nginx-directory/configfile.libsonnet
+++ b/nginx-directory/configfile.libsonnet
@@ -53,13 +53,6 @@ local kausal = import 'ksonnet-util/kausal.libsonnet';
         for service in std.set($._config.admin_services, function(s) s.url)
       ],
       locations: std.join('\n', self.location_stanzas),
-      link_stanzas: [
-        |||
-          <li><a href="/%(path)s%(params)s">%(title)s</a></li>
-        ||| % ({ params: '' } + service)
-        for service in $._config.admin_services
-      ],
-      links: std.join('\n', self.link_stanzas),
     };
 
     configMap.new('nginx-config') +
@@ -87,21 +80,10 @@ local kausal = import 'ksonnet-util/kausal.libsonnet';
             listen 80;
             %(locations)s
             location ~ /(index.html)? {
-              root /etc/nginx;
+              root /var/www/html;
             }
           }
         }
       ||| % ($._config + vars),
-      'index.html': |||
-        <html>
-          <head><title>Admin</title></head>
-          <body>
-            <h1>Admin</h1>
-            <ul>
-              %(links)s
-            </ul>
-          </body>
-        </html>
-      ||| % vars,
     }),
 }

--- a/nginx-directory/deployment.libsonnet
+++ b/nginx-directory/deployment.libsonnet
@@ -14,6 +14,7 @@ local kausal = import 'ksonnet-util/kausal.libsonnet';
   nginx_deployment:
     deployment.new('nginx', 1, [$.nginx_container]) +
     k.util.configMapVolumeMount($.nginx_config_map, '/etc/nginx') +
+    k.util.configMapVolumeMount($.nginx_html_config_map, '/var/www/html') +
     k.util.podPriority('critical'),
 
   nginx_service:

--- a/nginx-directory/directory.libsonnet
+++ b/nginx-directory/directory.libsonnet
@@ -1,3 +1,4 @@
 (import 'config.libsonnet')
 + (import 'configfile.libsonnet')
++ (import 'html.libsonnet')
 + (import 'deployment.libsonnet')

--- a/nginx-directory/files/index.html
+++ b/nginx-directory/files/index.html
@@ -1,0 +1,9 @@
+<html>
+  <head><title>Admin</title></head>
+  <body>
+    <h1>Admin</h1>
+    <ul>
+      %(links)s
+    </ul>
+  </body>
+</html>

--- a/nginx-directory/files/link.html
+++ b/nginx-directory/files/link.html
@@ -1,0 +1,1 @@
+<li><a href="/%(path)s%(params)s">%(title)s</a></li>

--- a/nginx-directory/files/nginx.conf
+++ b/nginx-directory/files/nginx.conf
@@ -1,0 +1,26 @@
+worker_processes     5;  ## Default: 1
+error_log            /dev/stderr;
+pid                  /tmp/nginx.pid;
+worker_rlimit_nofile 8192;
+
+events {
+  worker_connections  4096;  ## Default: 1024
+}
+
+http {
+  default_type application/octet-stream;
+  log_format   main '$remote_addr - $remote_user [$time_local]  $status '
+    '"$request" $body_bytes_sent "$http_referer" '
+    '"$http_user_agent" "$http_x_forwarded_for"';
+  access_log   /dev/stderr  main;
+  sendfile     on;
+  tcp_nopush   on;
+  resolver     kube-dns.kube-system.svc.%(cluster_dns_suffix)s;
+  server {
+    listen 80;
+    %(locations)s
+    location ~ /(index.html)? {
+      root /var/www/html;
+    }
+  }
+}

--- a/nginx-directory/html.libsonnet
+++ b/nginx-directory/html.libsonnet
@@ -1,16 +1,11 @@
-local kausal = import 'ksonnet-util/kausal.libsonnet';
+local k = import 'k.libsonnet';
+local configMap = k.core.v1.configMap;
 {
-  local _config = self._config,
-  local k = kausal { _config+:: _config },
-
-  local configMap = k.core.v1.configMap,
 
   nginx_html_config_map:
     local vars = {
       link_stanzas: [
-        |||
-          <li><a href="/%(path)s%(params)s">%(title)s</a></li>
-        ||| % ({ params: '' } + service)
+        (importstr 'files/link.html') % ({ params: '' } + service)
         for service in $._config.admin_services
       ],
       links: std.join('\n', self.link_stanzas),
@@ -18,16 +13,6 @@ local kausal = import 'ksonnet-util/kausal.libsonnet';
 
     configMap.new('nginx-config-html') +
     configMap.withData({
-      'index.html': |||
-        <html>
-          <head><title>Admin</title></head>
-          <body>
-            <h1>Admin</h1>
-            <ul>
-              %(links)s
-            </ul>
-          </body>
-        </html>
-      ||| % vars,
+      'index.html': (importstr 'files/index.html') % vars,
     }),
 }

--- a/nginx-directory/html.libsonnet
+++ b/nginx-directory/html.libsonnet
@@ -1,0 +1,33 @@
+local kausal = import 'ksonnet-util/kausal.libsonnet';
+{
+  local _config = self._config,
+  local k = kausal { _config+:: _config },
+
+  local configMap = k.core.v1.configMap,
+
+  nginx_html_config_map:
+    local vars = {
+      link_stanzas: [
+        |||
+          <li><a href="/%(path)s%(params)s">%(title)s</a></li>
+        ||| % ({ params: '' } + service)
+        for service in $._config.admin_services
+      ],
+      links: std.join('\n', self.link_stanzas),
+    };
+
+    configMap.new('nginx-config-html') +
+    configMap.withData({
+      'index.html': |||
+        <html>
+          <head><title>Admin</title></head>
+          <body>
+            <h1>Admin</h1>
+            <ul>
+              %(links)s
+            </ul>
+          </body>
+        </html>
+      ||| % vars,
+    }),
+}


### PR DESCRIPTION
In the current nginx-directory, the HTML and config are intimately entwined. This PR separates them out into their own jsonnet files and their own configmaps. Functionally this is a no-op, in terms of actual diffs, we should just see the HTML move into its own configmap.