### PR TITLE
Update prometheus branch name after master->main rename

### DIFF
--- a/prometheus-ksonnet/jsonnetfile.json
+++ b/prometheus-ksonnet/jsonnetfile.json
@@ -89,7 +89,7 @@
           "subdir": "documentation/prometheus-mixin"
         }
       },
-      "version": "master"
+      "version": "main"
     }
   ],
   "legacyImports": true

--- a/prometheus-metamonitoring/jsonnetfile.json
+++ b/prometheus-metamonitoring/jsonnetfile.json
@@ -26,7 +26,7 @@
           "subdir": "documentation/prometheus-mixin"
         }
       },
-      "version": "master"
+      "version": "main"
     }
   ],
   "legacyImports": true


### PR DESCRIPTION
Prometheus has renamed their "master" branch to "main". Currently this makes `jb install prometheus-ksonnet` fail with the message

```
archive install failed: unexpected status code 404
retrying with git...
Initialized empty Git repository in .tmp/jsonnetpkg-github.com-prometheus-prometheus-documentation-prometheus-mixin-master868070065/.git/
fatal: couldn't find remote ref master
```

Signed-off-by: W. Andrew Denton <git@flying-snail.net>