### PR TITLE
Adding "hidden" flag to not render in HTML

### DIFF
--- a/nginx-directory/html.libsonnet
+++ b/nginx-directory/html.libsonnet
@@ -7,6 +7,8 @@ local configMap = k.core.v1.configMap;
   nginx_html_config_map:
     local vars = {
       link_stanzas: [
+        // adding a "hidden" field set to true will cause the link to not be rendered in HTML
+
         if !$.isHidden(service) then (importstr 'files/link.html') % ({ params: '' } + service) else null
         for service in $._config.admin_services
       ],

--- a/nginx-directory/html.libsonnet
+++ b/nginx-directory/html.libsonnet
@@ -1,11 +1,13 @@
 local k = import 'k.libsonnet';
 local configMap = k.core.v1.configMap;
 {
+  isHidden(service)::
+    std.objectHas(service, 'hidden') && service.hidden == true,
 
   nginx_html_config_map:
     local vars = {
       link_stanzas: [
-        (importstr 'files/link.html') % ({ params: '' } + service)
+        if !$.isHidden(service) then (importstr 'files/link.html') % ({ params: '' } + service) else null
         for service in $._config.admin_services
       ],
       links: std.join('\n', self.link_stanzas),


### PR DESCRIPTION
I have a tricky scenario where I need two location blocks for one service:

```nginx
    location ~ ^/a/b(/?)(.*)$ {
    proxy_pass      http://a.ns.svc.cluster.local:80/b/$2$is_args$args;
    proxy_set_header    Host $host;
    proxy_set_header    X-Real-IP $remote_addr;
    proxy_set_header    X-Forwarded-For $proxy_add_x_forwarded_for;
    proxy_set_header    X-Forwarded-Proto $scheme;
    proxy_set_header    X-Forwarded-Host $http_host;
    proxy_read_timeout  360;
    proxy_send_timeout  360;
    }

    location ~ ^/a(/?)(.*)$ {
    rewrite_log on;
    sub_filter "./" "/a/";
    sub_filter_once off;
    proxy_pass      http://a.ns.svc.cluster.local:80/$2$is_args$args;
    proxy_set_header    Host $host;
    proxy_set_header    X-Real-IP $remote_addr;
    proxy_set_header    X-Forwarded-For $proxy_add_x_forwarded_for;
    proxy_set_header    X-Forwarded-Proto $scheme;
    proxy_set_header    X-Forwarded-Host $http_host;
    proxy_read_timeout  360;
    proxy_send_timeout  360;
    }
```

When defining this service, I'm creating a service as normal and appending this:
```jsonnet
{ path: 'a/b', url: 'http://a.%s.svc.cluster.local:80/b' % ns, hidden: true }
```

The `hidden` field causes the HTML component of the service in the service listing to be skipped.