### PR TITLE
refactor(prometheus): generic HA setup

### DIFF
--- a/prometheus-ksonnet/lib/prometheus-ha-mixin.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus-ha-mixin.libsonnet
@@ -1,1 +1,1 @@
-(import 'prometheus/ha-mixin.libsonnet')
+(import 'prometheus/ha-mixin.libsonnet')(replicas=2)

--- a/prometheus/ha-mixin.libsonnet
+++ b/prometheus/ha-mixin.libsonnet
@@ -40,17 +40,15 @@ function(replicas=2) {
     function(i, acc)
       local name = _config.name + '-' + i;
       local config =
-        this._config.prometheus_config {
-          prometheus+: {
-            global+: {
-              external_labels+: {
-                __replica__: name,
-              },
+        this.prometheus_config {
+          global+: {
+            external_labels+: {
+              __replica__: name,
             },
           },
         };
       {
-        name: name,
+        name:: name,
         base: configMap.new('%s-config' % name) +
               configMap.withData({
                 'prometheus.yml': k.util.manifestYaml(config),
@@ -73,7 +71,7 @@ function(replicas=2) {
         mounts
         + k.util.configMapVolumeMount(obj.base, '/etc/%s' % obj.name)
         + k.util.configMapVolumeMount(obj.alerts, '/etc/%s/alerts' % obj.name)
-        + k.util.configMapVolumeMount(obj.rules, '/etc/%s/rules' % obj.name),
+        + k.util.configMapVolumeMount(obj.rules, '/etc/%s/recording' % obj.name),
       self.prometheus_config_maps,
       {},
     )

--- a/prometheus/ha-mixin.libsonnet
+++ b/prometheus/ha-mixin.libsonnet
@@ -1,6 +1,6 @@
 local kausal = import 'ksonnet-util/kausal.libsonnet';
 
-{
+function(replicas=2) {
   local this = self,
   local _config = self._config,
   local k = kausal {
@@ -35,67 +35,48 @@ local kausal = import 'ksonnet-util/kausal.libsonnet';
     },
   },
 
-  prometheus_zero+:: {
-    config+:: this.prometheus_config {
-      global+: {
-        external_labels+: {
-          __replica__: 'prometheus-0',
-        },
-      },
-    },
-    alerts+:: this.prometheusAlerts,
-    rules+:: this.prometheusRules,
-  },
-
-  prometheus_one+:: {
-    config+:: this.prometheus_config {
-      global+: {
-        external_labels+: {
-          __replica__: 'prometheus-1',
-        },
-      },
-    },
-    alerts+:: this.prometheusAlerts,
-    rules+:: this.prometheusRules,
-  },
-
   local configMap = k.core.v1.configMap,
-
-  prometheus_config_maps: [
-    configMap.new('%s-0-config' % _config.name) +
-    configMap.withData({
-      'prometheus.yml': k.util.manifestYaml(this.prometheus_zero.config),
-    }),
-    configMap.new('%s-0-alerts' % _config.name) +
-    configMap.withData({
-      'alerts.rules': k.util.manifestYaml(this.prometheus_zero.alerts),
-    }),
-    configMap.new('%s-0-recording' % _config.name) +
-    configMap.withData({
-      'recording.rules': k.util.manifestYaml(this.prometheus_zero.rules),
-    }),
-
-    configMap.new('%s-1-config' % _config.name) +
-    configMap.withData({
-      'prometheus.yml': k.util.manifestYaml(this.prometheus_one.config),
-    }),
-    configMap.new('%s-1-alerts' % _config.name) +
-    configMap.withData({
-      'alerts.rules': k.util.manifestYaml(this.prometheus_one.alerts),
-    }),
-    configMap.new('%s-1-recording' % _config.name) +
-    configMap.withData({
-      'recording.rules': k.util.manifestYaml(this.prometheus_one.rules),
-    }),
-  ],
+  prometheus_config_maps: std.mapWithIndex(
+    function(i, acc)
+      local name = _config.name + '-' + i;
+      local config =
+        this._config.prometheus_config {
+          prometheus+: {
+            global+: {
+              external_labels+: {
+                __replica__: name,
+              },
+            },
+          },
+        };
+      {
+        name: name,
+        base: configMap.new('%s-config' % name) +
+              configMap.withData({
+                'prometheus.yml': k.util.manifestYaml(config),
+              }),
+        alerts: configMap.new('%s-alerts' % name) +
+                configMap.withData({
+                  'alerts.rules': k.util.manifestYaml(this.prometheusAlerts),
+                }),
+        rules: configMap.new('%s-recording' % name) +
+               configMap.withData({
+                 'recording.rules': k.util.manifestYaml(this.prometheusRules),
+               }),
+      },
+    std.repeat('r', replicas),
+  ),
 
   prometheus_config_mount::
-    k.util.configVolumeMount('%s-0-config' % _config.name, '/etc/%s-0' % _config.name)
-    + k.util.configVolumeMount('%s-0-alerts' % _config.name, '/etc/%s-0/alerts' % _config.name)
-    + k.util.configVolumeMount('%s-0-recording' % _config.name, '/etc/%s-0/recording' % _config.name)
-    + k.util.configVolumeMount('%s-1-config' % _config.name, '/etc/%s-1' % _config.name)
-    + k.util.configVolumeMount('%s-1-alerts' % _config.name, '/etc/%s-1/alerts' % _config.name)
-    + k.util.configVolumeMount('%s-1-recording' % _config.name, '/etc/%s-1/recording' % _config.name)
+    std.foldl(
+      function(mounts, obj)
+        mounts
+        + k.util.configMapVolumeMount(obj.base, '/etc/%s' % obj.name)
+        + k.util.configMapVolumeMount(obj.alerts, '/etc/%s/alerts' % obj.name)
+        + k.util.configMapVolumeMount(obj.rules, '/etc/%s/rules' % obj.name),
+      self.prometheus_config_maps,
+      {},
+    )
   ,
 
   local container = k.core.v1.container,
@@ -119,6 +100,6 @@ local kausal = import 'ksonnet-util/kausal.libsonnet';
   local statefulset = k.apps.v1.statefulSet,
 
   prometheus_statefulset+:
-    statefulset.mixin.spec.withReplicas(2)
+    statefulset.mixin.spec.withReplicas(replicas)
     + k.util.antiAffinityStatefulSet,
 }

--- a/prometheus/prometheus.libsonnet
+++ b/prometheus/prometheus.libsonnet
@@ -23,7 +23,7 @@ local kausal = import 'ksonnet-util/kausal.libsonnet';
     else {}
   ),
 
-  withHighAvailability():: ha_mixin,
+  withHighAvailability(replicas=2):: ha_mixin(replicas),
 
   local configMap = k.core.v1.configMap,
 


### PR DESCRIPTION
Reduce code duplication by iterating over `replicas`. As a side effect this also allows for more than 2 replicas.

This is generally a no-op, only the `__replica__` external label is now using `_config.name` to prevent conflict when
running multiple prometheis in the same cluster with remote write enabled.