### PR TITLE
Introducing "weight" field to allow for arbitrary location block ordering

### DIFF
--- a/nginx-directory/configfile.libsonnet
+++ b/nginx-directory/configfile.libsonnet
@@ -52,7 +52,7 @@ local kausal = import 'ksonnet-util/kausal.libsonnet';
     local vars = {
       location_stanzas: [
         buildLocation(service)
-        for service in $._config.admin_services
+        for service in std.uniq($.servicesByWeight($._config.admin_services), function(s) s.url)
       ],
       locations: std.join('\n', self.location_stanzas),
     };
@@ -61,4 +61,7 @@ local kausal = import 'ksonnet-util/kausal.libsonnet';
     configMap.withData({
       'nginx.conf': (importstr 'files/nginx.conf') % ($._config + vars),
     }),
+
+  servicesByWeight(services)::
+    std.sort(services, function(s) if std.objectHas(s, 'weight') then s.weight else 0),
 }

--- a/nginx-directory/configfile.libsonnet
+++ b/nginx-directory/configfile.libsonnet
@@ -52,7 +52,7 @@ local kausal = import 'ksonnet-util/kausal.libsonnet';
     local vars = {
       location_stanzas: [
         buildLocation(service)
-        for service in std.set($._config.admin_services, function(s) s.url)
+        for service in $._config.admin_services
       ],
       locations: std.join('\n', self.location_stanzas),
     };


### PR DESCRIPTION
These routes do not need to be sorted, unless i'm missing something @malcolmholmes?

This sorting currently interferes with a definition which relies on precise ordering of `location` blocks.