### PR TITLE
Not all Prometheus rules are alerts.

### DIFF
--- a/mixin-utils/utils.libsonnet
+++ b/mixin-utils/utils.libsonnet
@@ -126,10 +126,10 @@ local g = import 'grafana-builder/grafana.libsonnet';
     local update_rule(rule) =
       if std.objectHas(rule, 'alert')
       then rule {
-            annotations+: {
-              runbook_url: url_format % rule.alert,
-            },
-          }
+        annotations+: {
+          runbook_url: url_format % rule.alert,
+        },
+      }
       else rule;
     [
       group {

--- a/mixin-utils/utils.libsonnet
+++ b/mixin-utils/utils.libsonnet
@@ -123,14 +123,18 @@ local g = import 'grafana-builder/grafana.libsonnet';
   // - url_format: an URL format for the runbook, the alert name will be substituted in the URL.
   // - groups: the list of rule groups containing alerts.
   withRunbookURL(url_format, groups)::
+    local update_rule(rule) =
+      if std.objectHas(rule, 'alert')
+      then rule {
+            annotations+: {
+              runbook_url: url_format % rule.alert,
+            },
+          }
+      else rule;
     [
       group {
         rules: [
-          alert {
-            annotations+: {
-              runbook_url: url_format % alert.alert,
-            },
-          }
+          update_rule(alert)
           for alert in group.rules
         ],
       }


### PR DESCRIPTION
This allows us to put recording rules in the same rule groups as alerts, which is useful when the alerts depend on the recording rules.

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>