### PR TITLE
chore(enterprise-metrics): remove pinned k8s lib

### DIFF
--- a/enterprise-metrics/Makefile
+++ b/enterprise-metrics/Makefile
@@ -15,7 +15,7 @@ help:
 .PHONY: test
 test: ## Run library tests.
 test:
-	jsonnet -J lib -J vendor main_test.jsonnet
+	jsonnet -J test/lib -J test/vendor -J vendor main_test.jsonnet
 
 docs/README.md: ## Remake the library README file.
 docs/README.md: main.libsonnet

--- a/enterprise-metrics/README.md
+++ b/enterprise-metrics/README.md
@@ -24,3 +24,8 @@ $ cat <<EOF > lib/k.libsonnet
 > + (import "github.com/jsonnet-libs/k8s-alpha/1.18/extensions/kausal-shim.libsonnet")
 EOF
 ```
+
+## Unit Tests
+
+To run the unit tests in this repo you first need to ensure the vendored dependencies are installed in the `enterprise-metrics/test/` directory. To do this
+`cd` in to the `test` directory and run `jb install`. Then return to the `enterprise-metrics` directory and run `make test`.

--- a/enterprise-metrics/jsonnetfile.json
+++ b/enterprise-metrics/jsonnetfile.json
@@ -27,15 +27,6 @@
         }
       },
       "version": "master"
-    },
-    {
-      "source": {
-        "git": {
-          "remote": "https://github.com/jsonnet-libs/k8s-alpha.git",
-          "subdir": "1.18"
-        }
-      },
-      "version": "master"
     }
   ],
   "legacyImports": true

--- a/enterprise-metrics/test/jsonnetfile.json
+++ b/enterprise-metrics/test/jsonnetfile.json
@@ -1,0 +1,15 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/jsonnet-libs/k8s-alpha.git",
+          "subdir": "1.18"
+        }
+      },
+      "version": "master"
+    }
+  ],
+  "legacyImports": true
+}

--- a/enterprise-metrics/test/lib/k.libsonnet
+++ b/enterprise-metrics/test/lib/k.libsonnet
@@ -1,0 +1,2 @@
+(import 'github.com/jsonnet-libs/k8s-alpha/1.18/main.libsonnet')
++ (import 'github.com/jsonnet-libs/k8s-alpha/1.18/extensions/kausal-shim.libsonnet')


### PR DESCRIPTION
- Remove the pinned k8s directory from the root jsonnet file
- Create a `enterprise-metrics/test` directory and pin dependencies for unit tests there

This PR is meant to unblock https://github.com/grafana/deployment_tools/pull/8392