### PR TITLE
refactor(prometheus): shard mixins over multiple configmaps

### DIFF
--- a/mixin-utils/utils.libsonnet
+++ b/mixin-utils/utils.libsonnet
@@ -161,7 +161,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
         group {
           rules: std.map(function(rule)
             rule +
-            if std.objectHas(overrides, rule.alert)
+            if 'alert' in rule && std.objectHas(overrides, rule.alert)
             then overrides[rule.alert]
             else {}, super.rules),
         }, super.groups),

--- a/mixin-utils/utils.libsonnet
+++ b/mixin-utils/utils.libsonnet
@@ -147,14 +147,24 @@ local g = import 'grafana-builder/grafana.libsonnet';
     groups: std.prune(std.map(removeRuleGroup, currentRuleGroups)),
   },
 
+  removeAlertRuleGroup(ruleName):: {
+    prometheusAlerts+:: $.removeRuleGroup(ruleName),
+  },
+
+  removeRecordingRuleGroup(ruleName):: {
+    prometheusRules+:: $.removeRuleGroup(ruleName),
+  },
+
   overrideAlerts(overrides):: {
-    groups: std.map(function(group)
-      group {
-        rules: std.map(function(rule)
-          rule +
-          if std.objectHas(overrides, rule.alert)
-          then overrides[rule.alert]
-          else {}, super.rules),
-      }, super.groups),
+    prometheusAlerts+:: {
+      groups: std.map(function(group)
+        group {
+          rules: std.map(function(rule)
+            rule +
+            if std.objectHas(overrides, rule.alert)
+            then overrides[rule.alert]
+            else {}, super.rules),
+        }, super.groups),
+    },
   },
 }

--- a/mixin-utils/utils.libsonnet
+++ b/mixin-utils/utils.libsonnet
@@ -140,4 +140,21 @@ local g = import 'grafana-builder/grafana.libsonnet';
       }
       for group in groups
     ],
+
+  removeRuleGroup(ruleName):: {
+    local removeRuleGroup(rule) = if rule.name == ruleName then null else rule,
+    local currentRuleGroups = super.groups,
+    groups: std.prune(std.map(removeRuleGroup, currentRuleGroups)),
+  },
+
+  overrideAlerts(overrides):: {
+    groups: std.map(function(group)
+      group {
+        rules: std.map(function(rule)
+          rule +
+          if std.objectHas(overrides, rule.alert)
+          then overrides[rule.alert]
+          else {}, super.rules),
+      }, super.groups),
+  },
 }

--- a/mixin-utils/utils.libsonnet
+++ b/mixin-utils/utils.libsonnet
@@ -156,15 +156,13 @@ local g = import 'grafana-builder/grafana.libsonnet';
   },
 
   overrideAlerts(overrides):: {
+    local overrideRule(rule) =
+      if 'alert' in rule && std.objectHas(overrides, rule.alert)
+      then rule + overrides[rule.alert]
+      else rule,
+    local overrideInGroup(group) = group { rules: std.map(overrideRule, super.rules) },
     prometheusAlerts+:: {
-      groups: std.map(function(group)
-        group {
-          rules: std.map(function(rule)
-            rule +
-            if 'alert' in rule && std.objectHas(overrides, rule.alert)
-            then overrides[rule.alert]
-            else {}, super.rules),
-        }, super.groups),
+      groups: std.map(overrideInGroup, super.groups),
     },
   },
 }

--- a/prometheus-ksonnet/lib/prometheus.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus.libsonnet
@@ -19,8 +19,8 @@ prometheus_mixins {
     _config+:: $._config { name: name },
     _images+:: $._images,
     mixins:: $.mixins,
-    prometheusRules:: $.prometheusRules,
-    prometheusAlerts:: $.prometheusAlerts,
+    prometheusRules:: if std.objectHas($, 'prometheusRules') then $.prometheusRules else {},
+    prometheusAlerts:: if std.objectHas($, 'prometheusAlerts') then $.prometheusAlerts else {},
     prometheus_config+:: $.prometheus_config,
 
   },

--- a/prometheus/mixins.libsonnet
+++ b/prometheus/mixins.libsonnet
@@ -111,7 +111,7 @@ local k = import 'ksonnet-util/kausal.libsonnet';
       prometheusRules+:: {},
     },
 
-    prometheusAlerts::
+    prometheusAlerts+::
       std.foldr(
         function(mixinName, acc)
           local mixin = mixins[mixinName] + emptyMixin;
@@ -120,7 +120,7 @@ local k = import 'ksonnet-util/kausal.libsonnet';
         {}
       ),
 
-    prometheusRules::
+    prometheusRules+::
       std.foldr(
         function(mixinName, acc)
           local mixin = mixins[mixinName] + emptyMixin;

--- a/prometheus/mixins.libsonnet
+++ b/prometheus/mixins.libsonnet
@@ -57,13 +57,16 @@ local k = import 'ksonnet-util/kausal.libsonnet';
     },
   },
 
+  // Legacy Extension points for adding alerts, recording rules and prometheus config.
+  local emptyMixin = {
+    prometheusAlerts+:: {},
+    prometheusRules+:: {},
+  },
+
   withMixinsConfigmaps(mixins):: {
     local configMap = k.core.v1.configMap,
     prometheus_config_maps_mixins+: [
-      local mixin = mixins[mixinName] {
-        prometheusAlerts+:: {},
-        prometheusRules+:: {},
-      };
+      local mixin = mixins[mixinName] + emptyMixin;
       local prometheusAlerts = mixin.prometheusAlerts;
       local prometheusRules = mixin.prometheusRules;
       configMap.new(
@@ -106,11 +109,6 @@ local k = import 'ksonnet-util/kausal.libsonnet';
   // the alerts and recording rules to root-level. This functions
   // should be applied if you want to retain the legacy behavior.
   withMixinsLegacyConfigmaps(mixins):: {
-    local emptyMixin = {
-      prometheusAlerts+:: {},
-      prometheusRules+:: {},
-    },
-
     prometheusAlerts+::
       std.foldr(
         function(mixinName, acc)


### PR DESCRIPTION
We are hitting bug https://github.com/kubernetes/kubernetes/issues/85840

Smaller configmaps should workaround that. This PR will break a few backwards compat assumptions.