### PR TITLE
Enable netstat metrics again.

### DIFF
--- a/prometheus-ksonnet/lib/node-exporter.libsonnet
+++ b/prometheus-ksonnet/lib/node-exporter.libsonnet
@@ -8,7 +8,6 @@
       '--path.procfs=/host/proc',
       '--path.sysfs=/host/sys',
 
-      '--no-collector.netstat',
       '--collector.netdev.ignored-devices=^veth.+$',
 
       // We run an older version due to the renamed metrics.  There ignores are from newer version.


### PR DESCRIPTION
Netstat metrics are fairly useful when it comes to debugging ingress issues and cascading failures. I couldn't find a good reason why they were disable (cf. https://github.com/grafana/jsonnet-libs/commit/755b20239c0ca235744421744d4c3c5c99225746) and think those metrics are not adding cardinality too excessively.