### PR TITLE
Update node exporter.

### DIFF
--- a/prometheus-ksonnet/images.libsonnet
+++ b/prometheus-ksonnet/images.libsonnet
@@ -8,7 +8,7 @@ local prometheus_images = import 'prometheus/images.libsonnet';
     {
       watch: 'weaveworks/watch:master-5fc29a9',
       kubeStateMetrics: 'gcr.io/google_containers/kube-state-metrics:v1.9.5',
-      nodeExporter: 'prom/node-exporter:v0.18.1',
+      nodeExporter: 'prom/node-exporter:v1.1.2',
       nginx: 'nginx:1.15.1-alpine',
     },
 }

--- a/prometheus-ksonnet/lib/node-exporter.libsonnet
+++ b/prometheus-ksonnet/lib/node-exporter.libsonnet
@@ -8,7 +8,7 @@
       '--path.procfs=/host/proc',
       '--path.sysfs=/host/sys',
 
-      '--collector.netdev.ignored-devices=^veth.+$',
+      '--collector.netdev.device-exclude=^veth.+$',
 
       // We run an older version due to the renamed metrics.  There ignores are from newer version.
       '--collector.filesystem.ignored-fs-types=^(tmpfs|autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$',


### PR DESCRIPTION
This updates node exporter to v1.1.2. There are breaking changes in this update: 

https://github.com/prometheus/node_exporter/blob/v1.0.0/CHANGELOG.md#breaking-changes

Would appreciate any feedback, if this is feasible 