### PR TITLE
Add full node exporter dashboard to prometheus mixins

### DIFF
--- a/prometheus-ksonnet/jsonnetfile.json
+++ b/prometheus-ksonnet/jsonnetfile.json
@@ -90,6 +90,15 @@
         }
       },
       "version": "main"
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/rfrail3/grafana-dashboards.git",
+          "subdir": ""
+        }
+      },
+      "version": "master"
     }
   ],
   "legacyImports": true

--- a/prometheus-ksonnet/mixins.libsonnet
+++ b/prometheus-ksonnet/mixins.libsonnet
@@ -84,7 +84,7 @@
     node_exporter_full: {
       grafanaDashboardFolder: 'node_exporter_full',
       grafanaDashboards+:: {
-        "node-exporter-full.json": (import 'grafana-dashboards/prometheus/node-exporter-full.json'),
+        'node-exporter-full.json': (import 'grafana-dashboards/prometheus/node-exporter-full.json'),
       },
     },
 

--- a/prometheus-ksonnet/mixins.libsonnet
+++ b/prometheus-ksonnet/mixins.libsonnet
@@ -80,6 +80,14 @@
         },
       },
 
+    // A more complete view than the node_exporter
+    node_exporter_full: {
+      grafanaDashboardFolder: 'node_exporter_full',
+      grafanaDashboards+:: {
+        "node-exporter-full.json": (import 'grafana-dashboards/prometheus/node-exporter-full.json'),
+      },
+    },
+
     grafana:
       (import 'grafana-mixin/mixin.libsonnet'),
   },


### PR DESCRIPTION
This adds the popular full node exporter dashboard: https://grafana.com/grafana/dashboards/1860

Also, the `node_exporter` folder name doesn't match with the rest of the folders. Should it be named `Node Exporter` instead?