### PR TITLE
Allow smaller memcached deployments

### DIFF
--- a/memcached/memcached.libsonnet
+++ b/memcached/memcached.libsonnet
@@ -25,10 +25,11 @@ k {
     overprovision_factor:: 1.2,
     cpu_limits:: '3',
     connection_limit:: 1024,
+    memory_request_overhead_mb:: 100,
     memory_request_bytes::
-      std.ceil((self.memory_limit_mb * self.overprovision_factor) + 100) * 1024 * 1024,
+      std.ceil((self.memory_limit_mb * self.overprovision_factor) + self.memory_request_overhead_mb) * 1024 * 1024,
     memory_limits_bytes::
-      self.memory_limit_mb * 1.5 * 1024 * 1024,
+      std.max(self.memory_limit_mb * 1.5 * 1024 * 1024, self.memory_request_bytes),
 
     local container = $.core.v1.container,
     local containerPort = $.core.v1.containerPort,


### PR DESCRIPTION
Sometimes in dev env we want to deploy some small memcached instances,
with memory limits like 64Mb. However, the calculation for
memory_request_bytes adds an extra 100Mb overhead to the requested
memory but not to the memory limit, which makes k8s fail to schedule the
StatefulSet.

This changes two things: we ensure that memory_limit_bytes is at least
as big as memory_request_bytes, plus we make the the requested memory
overhead configurable.

Signed-off-by: Oleg Zaytsev <mail@olegzaytsev.com>
