### PR TITLE
Default Vault version updated to 1.6.3

### DIFF
--- a/vault/config.libsonnet
+++ b/vault/config.libsonnet
@@ -23,6 +23,6 @@
   },
 
   _images+:: {
-    vault: 'vault:1.6.0',
+    vault: 'vault:1.6.3',
   },
 }


### PR DESCRIPTION
1.6.3 is the latest stable version. There's quite a few security updates and bug fixes since 1.6.0 ([changelog](https://github.com/hashicorp/vault/blob/master/CHANGELOG.md#163)). No configuration changes necessary.