### PR TITLE
Pentagon vaultEngineType Defaults to kv-v2

### DIFF
--- a/pentagon/config.libsonnet
+++ b/pentagon/config.libsonnet
@@ -17,18 +17,18 @@
     pentagon: 'grafana/pentagon:41',
   },
 
-  pentagonKVMapping(path, secret):: {
+  pentagonKVMapping(path, secret, type='kv-v2'):: {
     vaultPath: path,
     secretName: secret,
-    vaultEngineType: 'kv',
+    vaultEngineType: type,
   },
 
-  addPentagonMapping(path, secret, type='kv'):: {
+  addPentagonMapping(path, secret, type='kv-v2'):: {
     pentagon_mappings_map+: {
       [secret]+: {
         vaultPath: path,
         secretName: secret,
-        vaultEngineType: 'kv',
+        vaultEngineType: type,
       },
     },
   },


### PR DESCRIPTION
Previously hardcoded to 'kv', it can be set with the `type` argument which defaults to 'kv-v2'. [V2](https://www.vaultproject.io/docs/secrets/kv/kv-v2) is preferred since it can retain a configurable number of versions.