### PR TITLE
fix(prometheus): don't generate empty files

### DIFF
--- a/prometheus/mixins.libsonnet
+++ b/prometheus/mixins.libsonnet
@@ -64,43 +64,44 @@ local k = import 'ksonnet-util/kausal.libsonnet';
   },
 
   withMixinsConfigmaps(mixins):: {
+    local this = self,
     local configMap = k.core.v1.configMap,
-    prometheus_config_maps_mixins+: [
+
+    mixin_data:: [
       local mixin = mixins[mixinName] + emptyMixin;
       local prometheusAlerts = mixin.prometheusAlerts;
       local prometheusRules = mixin.prometheusRules;
-      configMap.new(
-        std.strReplace('%s-%s-mixin' % [_config.name, mixinName], '_', '-')
-      )
-      + configMap.withData({
-        'alerts.rules': k.util.manifestYaml(prometheusAlerts),
-        'recording.rules': k.util.manifestYaml(prometheusRules),
-      })
+      {
+        mixinName: mixinName,
+        configmapName: std.strReplace('%s-%s-mixin' % [_config.name, mixinName], '_', '-'),
+        path: '%s/mixins/%s' % [_config.prometheus_config_dir, mixinName],
+        files: {
+          [if std.prune(prometheusAlerts) != {} then 'alerts.rules']: k.util.manifestYaml(prometheusAlerts),
+          [if std.prune(prometheusRules) != {} then 'recording.rules']: k.util.manifestYaml(prometheusRules),
+        },
+      }
       for mixinName in std.objectFields(mixins)
     ],
 
+    prometheus_config_maps_mixins+: [
+      configMap.new(mixin.configmapName)
+      + configMap.withData(mixin.files)
+      for mixin in this.mixin_data
+    ],
+
     prometheus_config+: {
-      rule_files+:
-        std.foldr(
-          function(mixinName, acc)
-            acc + [
-              '%s/mixins/%s/alerts.rules' % [_config.prometheus_config_dir, mixinName],
-              '%s/mixins/%s/recording.rules' % [_config.prometheus_config_dir, mixinName],
-            ],
-          std.objectFields(mixins),
-          []
-        ),
+      rule_files+: [
+        '%s/%s' % [mixin.path, file]
+        for mixin in this.mixin_data
+        for file in std.objectFields(mixin.files)
+      ],
     },
 
     prometheus_config_mount+::
       std.foldr(
-        function(mixinName, acc)
-          acc
-          + k.util.configVolumeMount(
-            std.strReplace('%s-%s-mixin' % [_config.name, mixinName], '_', '-'),
-            '%s/mixins/%s' % [_config.prometheus_config_dir, mixinName]
-          ),
-        std.objectFields(mixins),
+        function(mixin, acc)
+          acc + k.util.configVolumeMount(mixin.configmapName, mixin.path),
+        this.mixin_data,
         {}
       ),
   },

--- a/prometheus/mixins.libsonnet
+++ b/prometheus/mixins.libsonnet
@@ -92,11 +92,11 @@ local k = import 'ksonnet-util/kausal.libsonnet';
     ],
 
     prometheus_config+: {
-      rule_files+: [
+      rule_files+: std.sort([
         '%s/%s' % [mixin.path, file]
         for mixin in this.mixin_data
         for file in std.objectFields(mixin.files)
-      ],
+      ]),
     },
 
     prometheus_config_mount+::

--- a/prometheus/mixins.libsonnet
+++ b/prometheus/mixins.libsonnet
@@ -92,11 +92,11 @@ local k = import 'ksonnet-util/kausal.libsonnet';
     ],
 
     prometheus_config+: {
-      rule_files+: std.sort([
+      rule_files+: std.reverse(std.sort([
         '%s/%s' % [mixin.path, file]
         for mixin in this.mixin_data
         for file in std.objectFields(mixin.files)
-      ]),
+      ])),
     },
 
     prometheus_config_mount+::


### PR DESCRIPTION
Even though it is not a problem for prometheus to receive empty rules files, it is much cleaner not to generate them.