### PR TITLE
fix(prometheus): don't mount if not exists

### DIFF
--- a/prometheus/prometheus.libsonnet
+++ b/prometheus/prometheus.libsonnet
@@ -5,6 +5,7 @@ local kausal = import 'ksonnet-util/kausal.libsonnet';
 + (import 'images.libsonnet')
 + (import 'mixins.libsonnet')
 + {
+  local this = self,
   local _config = self._config,
   local k = kausal {
     _config+:: _config,


### PR DESCRIPTION
Missed this in the main prometheus.libsonnet, we should not create the configmaps there either, nor should we mount if
they don't exist.