### PR TITLE
Fix incorrect field name for namespaced role binding

### DIFF
--- a/ksonnet-util/util.libsonnet
+++ b/ksonnet-util/util.libsonnet
@@ -84,7 +84,7 @@ local util(k) = {
       role.mixin.metadata.withNamespace(namespace) +
       role.withRules(rules),
 
-    cluster_role_binding:
+    role_binding:
       roleBinding.new() +
       roleBinding.mixin.metadata.withName(name) +
       roleBinding.mixin.metadata.withNamespace(namespace) +


### PR DESCRIPTION
Fixes #439

Obviously a typo but quite a confiusing one. May result in dangling `Roles` or `ClusterRoles` if you attempt to mix cluster-wide and namespaced RBAC for a single `ServiceAccount`, as demonstrated by the below example:

```jsonnet
rbac:
  util.rbac(name, clusterRules, namespace)
  + util.namespacedRBAC(name, namespacedRules, namespace)
```
I'd expect this to create a `ServiceAccount` binded to a `ClusterRole` and a `Role`. What happens is that I get a dangling, unbinded `ClusterRole` and a non-functional `ServiceAccount` without the needed permissions
