### PR TITLE
Support status.hostIP as JAEGER_AGENT_HOST

### DIFF
--- a/jaeger-agent-mixin/jaeger.libsonnet
+++ b/jaeger-agent-mixin/jaeger.libsonnet
@@ -10,10 +10,16 @@
   jaeger_mixin::
     if $._config.jaeger_agent_host == null
     then {}
+    else if $._config.jaeger_agent_host == 'status.hostIP' then
+      container.withEnvMixin([
+        { "name": "JAEGER_AGENT_HOST", "valueFrom": { "fieldRef": { "fieldPath": "status.hostIP" } } },
+        container.envType.new('JAEGER_TAGS', 'namespace=%s,cluster=%s' % [$._config.namespace, $._config.cluster]),
+        container.envType.new('JAEGER_SAMPLER_MANAGER_HOST_PORT', 'http://$(JAEGER_AGENT_HOST):5778/sampling'),
+      ])
     else
       container.withEnvMixin([
         container.envType.new('JAEGER_AGENT_HOST', $._config.jaeger_agent_host),
         container.envType.new('JAEGER_TAGS', 'namespace=%s,cluster=%s' % [$._config.namespace, $._config.cluster]),
-        container.envType.new('JAEGER_SAMPLER_MANAGER_HOST_PORT', 'http://%s:5778/sampling' % $._config.jaeger_agent_host),
+        container.envType.new('JAEGER_SAMPLER_MANAGER_HOST_PORT', 'http://$(JAEGER_AGENT_HOST):5778/sampling'),
       ]),
 }

--- a/jaeger-agent-mixin/jaeger.libsonnet
+++ b/jaeger-agent-mixin/jaeger.libsonnet
@@ -12,7 +12,7 @@
     then {}
     else if $._config.jaeger_agent_host == 'status.hostIP' then
       container.withEnvMixin([
-        { "name": "JAEGER_AGENT_HOST", "valueFrom": { "fieldRef": { "fieldPath": "status.hostIP" } } },
+        { "name": "JAEGER_AGENT_HOST", "valueFrom": {"fieldRef":{"fieldPath":"status.hostIP"}}},
         container.envType.new('JAEGER_TAGS', 'namespace=%s,cluster=%s' % [$._config.namespace, $._config.cluster]),
         container.envType.new('JAEGER_SAMPLER_MANAGER_HOST_PORT', 'http://$(JAEGER_AGENT_HOST):5778/sampling'),
       ])

--- a/jaeger-agent-mixin/jaeger.libsonnet
+++ b/jaeger-agent-mixin/jaeger.libsonnet
@@ -12,7 +12,7 @@
     then {}
     else if $._config.jaeger_agent_host == 'status.hostIP' then
       container.withEnvMixin([
-        { "name": "JAEGER_AGENT_HOST", "valueFrom": {"fieldRef":{"fieldPath":"status.hostIP"}}},
+        { name: 'JAEGER_AGENT_HOST', valueFrom: { fieldRef: { fieldPath: 'status.hostIP' } } },
         container.envType.new('JAEGER_TAGS', 'namespace=%s,cluster=%s' % [$._config.namespace, $._config.cluster]),
         container.envType.new('JAEGER_SAMPLER_MANAGER_HOST_PORT', 'http://$(JAEGER_AGENT_HOST):5778/sampling'),
       ])


### PR DESCRIPTION
In case the jaeger agent runs as DaemonSet without Service, a container should talk to the agent using the node's IP which is available  through environment variables called `status.hostIP`.

Propose to allow users specify `jaeger_agent_host` as `status.hostIP`.

Expected outcome:
```
        - name: JAEGER_AGENT_HOST
          valueFrom:
            fieldRef:
              fieldPath: status.hostIP
        - name: JAEGER_TAGS
          value: namespace=loki,cluster=cluster1
        - name: JAEGER_SAMPLER_MANAGER_HOST_PORT
          value: http://$(JAEGER_AGENT_HOST):5778/sampling
```

Reference 
* https://kubernetes.io/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/
* https://bravopooper.wordpress.com/2017/07/17/communicating-with-local-daemon-set-pods-in-kubernetes/