### PR TITLE
Rename legacy vendor name for rfrail3

### DIFF
--- a/prometheus-ksonnet/jsonnetfile.json
+++ b/prometheus-ksonnet/jsonnetfile.json
@@ -98,7 +98,7 @@
           "subdir": ""
         }
       },
-      "rfrail3-grafana-dashboards",
+      "name": "rfrail3-grafana-dashboards",
       "version": "master"
     }
   ],

--- a/prometheus-ksonnet/jsonnetfile.json
+++ b/prometheus-ksonnet/jsonnetfile.json
@@ -98,6 +98,7 @@
           "subdir": ""
         }
       },
+      "rfrail3-grafana-dashboards",
       "version": "master"
     }
   ],


### PR DESCRIPTION
Prometheus Ksonnet imports a dashboard from an rfrail3 github repo. Except, jsonnet-bundler
puts a symink into `/vendor/grafana-dashboards`, which is misleading. This fix fixes the
link to be `rfrail3-grafana-dashboards` which is much more informative.
