### PR TITLE
Add missing kube-state-metrics cluster role policies

### DIFF
--- a/prometheus-ksonnet/lib/kube-state-metrics.libsonnet
+++ b/prometheus-ksonnet/lib/kube-state-metrics.libsonnet
@@ -57,6 +57,11 @@
       policyRule.withVerbs(['list', 'watch']),
 
       policyRule.new() +
+      policyRule.withApiGroups(['authorization.k8s.io']) +
+      policyRule.withResources(['subjectaccessreviews']) +
+      policyRule.withVerbs(['create']),
+
+      policyRule.new() +
       policyRule.withApiGroups(['ingresses']) +
       policyRule.withResources(['ingress']) +
       policyRule.withVerbs(['list', 'watch']),
@@ -69,6 +74,35 @@
       policyRule.new() +
       policyRule.withApiGroups(['certificates.k8s.io']) +
       policyRule.withResources(['certificatesigningrequests']) +
+      policyRule.withVerbs(['list', 'watch']),
+
+      policyRule.new() +
+      policyRule.withApiGroups(['storage.k8s.io']) +
+      policyRule.withResources([
+        'storageclasses',
+        'volumeattachments',
+      ]) +
+      policyRule.withVerbs(['list', 'watch']),
+
+      policyRule.new() +
+      policyRule.withApiGroups(['admissionregistration.k8s.io']) +
+      policyRule.withResources([
+        'mutatingwebhookconfigurations',
+        'validatingwebhookconfigurations',
+      ]) +
+      policyRule.withVerbs(['list', 'watch']),
+
+      policyRule.new() +
+      policyRule.withApiGroups(['networking.k8s.io']) +
+      policyRule.withResources([
+        'networkpolicies',
+        'ingresses',
+      ]) +
+      policyRule.withVerbs(['list', 'watch']),
+
+      policyRule.new() +
+      policyRule.withApiGroups(['coordination.k8s.io']) +
+      policyRule.withResources(['leases']) +
       policyRule.withVerbs(['list', 'watch']),
     ]),
 


### PR DESCRIPTION
Add missing `kube-state-metrics` policies from the example [cluster-role.yaml](https://github.com/kubernetes/kube-state-metrics/blob/master/examples/standard/cluster-role.yaml) to our ksonnet library.

These resolve permission errors that we currently see in `kube-state-metrics` pods.