### PR TITLE
feat(tanka-util): add base to create inline tk envs

### DIFF
--- a/tanka-util/README.md
+++ b/tanka-util/README.md
@@ -73,6 +73,16 @@ Kustomize functionality.
 
 ## Index
 
+* [`obj environment`](#obj-environment)
+  * [`fn new(name, namespace, apiserver)`](#fn-environmentnew)
+  * [`fn withApiServer(apiserver)`](#fn-environmentwithapiserver)
+  * [`fn withData(data)`](#fn-environmentwithdata)
+  * [`fn withDataMixin(data)`](#fn-environmentwithdatamixin)
+  * [`fn withInjectLabels(bool)`](#fn-environmentwithinjectlabels)
+  * [`fn withLabels(labels)`](#fn-environmentwithlabels)
+  * [`fn withLabelsMixin(labels)`](#fn-environmentwithlabelsmixin)
+  * [`fn withName(name)`](#fn-environmentwithname)
+  * [`fn withNamespace(namespace)`](#fn-environmentwithnamespace)
 * [`obj helm`](#obj-helm)
   * [`fn new(calledFrom)`](#fn-helmnew)
   * [`fn template(name, chart, conf)`](#fn-helmtemplate)
@@ -84,6 +94,93 @@ Kustomize functionality.
   * [`fn build(path, conf)`](#fn-kustomizebuild)
 
 ## Fields
+
+## obj environment
+
+`environment` provides a base to create an [inline Tanka
+environment](https://tanka.dev/inline-environments#inline-environments).
+
+
+### fn environment.new
+
+```ts
+new(name, namespace, apiserver)
+```
+
+`new` initiates an [inline Tanka environment](https://tanka.dev/inline-environments#inline-environments)
+
+
+### fn environment.withApiServer
+
+```ts
+withApiServer(apiserver)
+```
+
+`withApiServer` sets the Kubernetes cluster this environment should apply to.
+Must be the full URL, e.g. https://cluster.fqdn:6443
+
+
+### fn environment.withData
+
+```ts
+withData(data)
+```
+
+`withData` adds the actual Kubernetes resources to the inline environment.
+
+### fn environment.withDataMixin
+
+```ts
+withDataMixin(data)
+```
+
+`withDataMixin` adds the actual Kubernetes resources to the inline environment.
+*Note:* This function appends passed data to existing values
+
+
+### fn environment.withInjectLabels
+
+```ts
+withInjectLabels(bool)
+```
+
+`withInjectLabels` adds a "tanka.dev/environment" label to each created resource.
+Required for [garbage collection](https://tanka.dev/garbage-collection).
+
+
+### fn environment.withLabels
+
+```ts
+withLabels(labels)
+```
+
+`withLabels` adds arbitrary key:value labels.
+
+### fn environment.withLabelsMixin
+
+```ts
+withLabelsMixin(labels)
+```
+
+`withLabels` adds arbitrary key:value labels.
+*Note:* This function appends passed data to existing values
+
+
+### fn environment.withName
+
+```ts
+withName(name)
+```
+
+`withName` sets the environment `name`.
+
+### fn environment.withNamespace
+
+```ts
+withNamespace(namespace)
+```
+
+`withNamespace` sets the default namespace for objects that don't explicitely specify one.
 
 ## obj helm
 

--- a/tanka-util/environment.libsonnet
+++ b/tanka-util/environment.libsonnet
@@ -1,0 +1,122 @@
+local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
+{
+  local this = self,
+
+  '#new':
+    d.fn(
+      |||
+        `new` initiates an [inline Tanka environment](https://tanka.dev/inline-environments#inline-environments)
+      |||,
+      [
+        d.arg('name', d.T.string),
+        d.arg('namespace', d.T.string),
+        d.arg('apiserver', d.T.string),
+      ]
+    ),
+  new(name, namespace, apiserver)::
+    {
+      apiVersion: 'tanka.dev/v1alpha1',
+      kind: 'Environment',
+    }
+    + this.withName(name)
+    + this.withNamespace(namespace)
+    + this.withApiServer(apiserver)
+  ,
+
+  '#withData'::
+    d.fn(
+      '`withData` adds the actual Kubernetes resources to the inline environment.',
+      [d.arg('data', d.T.string)]
+    ),
+  withData(data):: {
+    data: data,
+  },
+
+  '#withDataMixin'::
+    d.fn(
+      |||
+        `withDataMixin` adds the actual Kubernetes resources to the inline environment.
+        *Note:* This function appends passed data to existing values
+      |||,
+      [d.arg('data', d.T.string)]
+    ),
+  withDataMixin(data):: {
+    data+: data,
+  },
+
+
+  '#withName'::
+    d.fn(
+      '`withName` sets the environment `name`.',
+      [d.arg('name', d.T.string)]
+    ),
+  withName(name):: {
+    metadata+: {
+      name: name,
+    },
+  },
+
+  '#withApiServer'::
+    d.fn(
+      |||
+        `withApiServer` sets the Kubernetes cluster this environment should apply to.
+        Must be the full URL, e.g. https://cluster.fqdn:6443
+      |||,
+      [d.arg('apiserver', d.T.string)]
+    ),
+  withApiServer(apiserver):: {
+    spec+: {
+      apiServer: apiserver,
+    },
+  },
+
+  '#withNamespace'::
+    d.fn(
+      "`withNamespace` sets the default namespace for objects that don't explicitely specify one.",
+      [d.arg('namespace', d.T.string)]
+    ),
+  withNamespace(namespace):: {
+    spec+: {
+      namespace: namespace,
+    },
+  },
+
+  '#withLabels'::
+    d.fn(
+      '`withLabels` adds arbitrary key:value labels.',
+      [d.arg('labels', d.T.string)]
+    ),
+  withLabels(labels):: {
+    metadata+: {
+      labels: labels,
+    },
+  },
+
+  '#withLabelsMixin'::
+    d.fn(
+      |||
+        `withLabels` adds arbitrary key:value labels.
+        *Note:* This function appends passed data to existing values
+      |||,
+      [d.arg('labels', d.T.string)]
+    ),
+  withLabelsMixin(labels):: {
+    metadata+: {
+      labels+: labels,
+    },
+  },
+
+  '#withInjectLabels'::
+    d.fn(
+      |||
+        `withInjectLabels` adds a "tanka.dev/environment" label to each created resource.
+        Required for [garbage collection](https://tanka.dev/garbage-collection).
+      |||,
+      [d.arg('bool', d.T.string)]
+    ),
+  withInjectLabels(bool=true):: {
+    spec+: {
+      injectLabels: bool,
+    },
+  },
+}

--- a/tanka-util/main.libsonnet
+++ b/tanka-util/main.libsonnet
@@ -15,6 +15,14 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
   ),
   k8s: (import 'k8s.libsonnet'),
 
+  '#environment':: d.obj(
+    |||
+      `environment` provides a base to create an [inline Tanka
+      environment](https://tanka.dev/inline-environments#inline-environments).
+    |||
+  ),
+  environment: (import 'environment.libsonnet'),
+
   '#helm':: d.obj(
     |||
       `helm` allows the user to consume Helm Charts as plain Jsonnet resources.


### PR DESCRIPTION
The title says it all.

Docstrings based on https://tanka.dev/config