### PR TITLE
Add grafana/datasource.withSecureJsonData

### DIFF
--- a/grafana/datasources.libsonnet
+++ b/grafana/datasources.libsonnet
@@ -21,5 +21,8 @@
   withJsonData(data):: {
     jsonData+: data,
   },
+  withSecureJsonData(data):: {
+    secureJsonData+: data,
+  },
   withHttpMethod(httpMethod):: self.withJsonData({ httpMethod: httpMethod }),
 }


### PR DESCRIPTION
Some plugins need additional fields in the secureJsonData, and this
would be the common way to build it.
