### PR TITLE
Add all wildcard for job and instance on nginx mixin

### DIFF
--- a/nginx-mixin/dashboards/nginx-overview.json
+++ b/nginx-mixin/dashboards/nginx-overview.json
@@ -1567,7 +1567,7 @@
         "useTags": false
       },
       {
-        "allValue": null,
+        "allValue": ".*",
         "current": {},
         "datasource": "$datasource",
         "definition": "label_values({$label_name=~\"$label_value\"}, job)",
@@ -1591,7 +1591,7 @@
         "useTags": false
       },
       {
-        "allValue": null,
+        "allValue": ".*",
         "current": {},
         "datasource": "$datasource",
         "definition": "label_values({$label_name=~\"$label_value\"}, instance)",


### PR DESCRIPTION
When using this mixin with a custom label, selected by `label_name` and `label-value`, the dashboard still remained blank if the logs did not *also* match the available job and instance labels.

This allows those two labels to be blank, and the query will still work.