### PR TITLE
Fix cache hit ratio and buffers timeseries for postgres-mixin

### DIFF
--- a/postgres-mixin/dashboards/postgres-overview.json
+++ b/postgres-mixin/dashboards/postgres-overview.json
@@ -584,7 +584,7 @@
         {
           "alias": "Buffers Allocated",
           "dsType": "prometheus",
-          "expr": "irate(pg_stat_bgwriter_buffers_alloc{instance='$instance'}[5m])",
+          "expr": "irate(pg_stat_bgwriter_buffers_alloc{instance=~'$instance'}[5m])",
           "format": "time_series",
           "groupBy": [
             {
@@ -636,7 +636,7 @@
         {
           "alias": "Buffers Allocated",
           "dsType": "prometheus",
-          "expr": "irate(pg_stat_bgwriter_buffers_backend_fsync{instance='$instance'}[5m])",
+          "expr": "irate(pg_stat_bgwriter_buffers_backend_fsync{instance=~'$instance'}[5m])",
           "format": "time_series",
           "groupBy": [
             {
@@ -688,7 +688,7 @@
         {
           "alias": "Buffers Allocated",
           "dsType": "prometheus",
-          "expr": "irate(pg_stat_bgwriter_buffers_backend{instance='$instance'}[5m])",
+          "expr": "irate(pg_stat_bgwriter_buffers_backend{instance=~'$instance'}[5m])",
           "format": "time_series",
           "groupBy": [
             {
@@ -740,7 +740,7 @@
         {
           "alias": "Buffers Allocated",
           "dsType": "prometheus",
-          "expr": "irate(pg_stat_bgwriter_buffers_clean{instance='$instance'}[5m])",
+          "expr": "irate(pg_stat_bgwriter_buffers_clean{instance=~'$instance'}[5m])",
           "format": "time_series",
           "groupBy": [
             {
@@ -792,7 +792,7 @@
         {
           "alias": "Buffers Allocated",
           "dsType": "prometheus",
-          "expr": "irate(pg_stat_bgwriter_buffers_checkpoint{instance='$instance'}[5m])",
+          "expr": "irate(pg_stat_bgwriter_buffers_checkpoint{instance=~'$instance'}[5m])",
           "format": "time_series",
           "groupBy": [
             {
@@ -1136,10 +1136,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(pg_stat_database_blks_hit{datname=~\"$db\",instance=~\"$instance\"}) / (sum(pg_stat_database_blks_hit{datname=~\"$db\",instance=~\"$instance\"}) + sum(pg_stat_database_blks_read{datname=~\"$db\",instance=~\"$instance\"}))",
+          "expr": "sum by (datname) (rate(pg_stat_database_blks_hit{datname=~\"$db\",instance=~\"$instance\"}[5m])) / (sum by (datname)(rate(pg_stat_database_blks_hit{datname=~\"$db\",instance=~\"$instance\"}[5m])) + sum by (datname)(rate(pg_stat_database_blks_read{datname=~\"$db\",instance=~\"$instance\"}[5m])))",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "cache hit rate",
+          "legendFormat": "{{datname}} - cache hit rate",
           "refId": "A",
           "step": 240
         }
@@ -1242,7 +1242,7 @@
           "expr": "pg_stat_database_numbackends{datname=~\"$db\",instance=~\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "{{__name__}}",
+          "legendFormat": "{{datname}} - {{__name__}}",
           "refId": "A",
           "step": 240
         }
@@ -1325,7 +1325,7 @@
         "useTags": false
       },
       {
-        "allValue": ".*",
+        "allValue": null,
         "current": {
           "selected": false,
           "text": "All",


### PR DESCRIPTION
This fixes the cache hit ratio visualization, which wasn't correctly applying a rate() to the counter.

It also filters out bogus series (system series like `template.*` and `postgres`) from the cache hit measurement. 

Finally, it will graph each remaining database as it's own line in the graph.

For buffers, it fixes the query which wasn't properly matching the selected instance(s)

Before 
![image](https://user-images.githubusercontent.com/428415/121067057-72755c00-c77f-11eb-9cfb-fa22de0589cc.png)

After
![image](https://user-images.githubusercontent.com/428415/121067076-786b3d00-c77f-11eb-970d-7ddbf6518440.png)

