### PR TITLE
feat: Expose PersistentVolumeClaim configuration.

### DIFF
--- a/enterprise-metrics/CHANGELOG.md
+++ b/enterprise-metrics/CHANGELOG.md
@@ -13,8 +13,10 @@ Entries should include a reference to the Pull Request that introduced the chang
 ## Unreleased
 
 - [CHANGE] The tokengen configuration is now hidden by default to avoid confusing errors when immutable fields are changed. #541
+- [CHANGE] Arbitrary storage class names are removed from PersistentVolumeClaims. If you were using those storage class names, you will need to configure the storageClassName in the persistentVolume object. For example in `$.ingester.persistentVolumeClaim`. #577
 - [FEATURE] Upgrade to [Grafana Enterprise Metrics v1.3.0](https://grafana.com/docs/metrics-enterprise/latest/downloads/#v130----april-26th-2021). #552
 - [FEATURE] Alertmanager and ruler Kubernetes App manifests are now included. #541
+- [FEATURE] PersistentVolumeClaims can be configured on all components run as a StatefulSet. This includes the alertmanager, compactor, ingester, and store-gateway components. #577
 - [BUGFIX] The `gossip-ring` Service now publishes not ready addresses. #523
 - [BUGFIX] All ring members now have the `gossip_ring-member` label set. #523
 - [BUGFIX] All microservices now use the `gossip-ring` Service as `memberlist.join` address. #523

--- a/enterprise-metrics/docs/README.md
+++ b/enterprise-metrics/docs/README.md
@@ -47,6 +47,8 @@ local enterprise-metrics = import "github.com/grafana/jsonnet-libs/enterprise-me
     * [`string alertmanager.args.runtime-config.file`](#string-alertmanagerargsruntime-configfile)
   * [`obj alertmanager.container`](#obj-alertmanagercontainer)
     
+  * [`obj alertmanager.persistentVolumeClaim`](#obj-alertmanagerpersistentvolumeclaim)
+    
   * [`obj alertmanager.service`](#obj-alertmanagerservice)
     
   * [`obj alertmanager.statefulSet`](#obj-alertmanagerstatefulset)
@@ -59,6 +61,8 @@ local enterprise-metrics = import "github.com/grafana/jsonnet-libs/enterprise-me
     * [`string compactor.args.memberlist.join`](#string-compactorargsmemberlistjoin)
     * [`string compactor.args.runtime-config.file`](#string-compactorargsruntime-configfile)
   * [`obj compactor.container`](#obj-compactorcontainer)
+    
+  * [`obj compactor.persistentVolumeClaim`](#obj-compactorpersistentvolumeclaim)
     
   * [`obj compactor.service`](#obj-compactorservice)
     
@@ -109,6 +113,8 @@ local enterprise-metrics = import "github.com/grafana/jsonnet-libs/enterprise-me
     * [`string ingester.args.memberlist.join`](#string-ingesterargsmemberlistjoin)
     * [`string ingester.args.runtime-config.file`](#string-ingesterargsruntime-configfile)
   * [`obj ingester.container`](#obj-ingestercontainer)
+    
+  * [`obj ingester.persistentVolumeClaim`](#obj-ingesterpersistentvolumeclaim)
     
   * [`obj ingester.podDisruptionBudget`](#obj-ingesterpoddisruptionbudget)
     
@@ -181,6 +187,8 @@ local enterprise-metrics = import "github.com/grafana/jsonnet-libs/enterprise-me
     * [`string storeGateway.args.memberlist.join`](#string-storegatewayargsmemberlistjoin)
     * [`string storeGateway.args.runtime-config.file`](#string-storegatewayargsruntime-configfile)
   * [`obj storeGateway.container`](#obj-storegatewaycontainer)
+    
+  * [`obj storeGateway.persistentVolumeClaim`](#obj-storegatewaypersistentvolumeclaim)
     
   * [`obj storeGateway.podDisruptionBudget`](#obj-storegatewaypoddisruptionbudget)
     
@@ -375,6 +383,10 @@ $ kubectl create secret generic gem-license -from-file=license.jwt
 
 `container` is a convenience field that can be used to modify the alertmanager container.
 
+## obj alertmanager.persistentVolumeClaim
+
+`persistentVolumeClaim` is a convenience field that can be used to modify the alertmanager PersistentVolumeClaim.
+
 ## obj alertmanager.service
 
 `service` is the Kubernetes Service for the alertmanager.
@@ -423,6 +435,10 @@ $ kubectl create secret generic gem-license -from-file=license.jwt
 ## obj compactor.container
 
 `container` is a convenience field that can be used to modify the compactor container.
+
+## obj compactor.persistentVolumeClaim
+
+`persistentVolumeClaim` is a convenience field that can be used to modify the compactor PersistentVolumeClaim.
 
 ## obj compactor.service
 
@@ -626,6 +642,10 @@ $ kubectl create secret generic gem-license -from-file=license.jwt
 ## obj ingester.container
 
 `container` is a convenience field that can be used to modify the ingester container.
+
+## obj ingester.persistentVolumeClaim
+
+`persistentVolumeClaim` is a convenience field that can be used to modify the ingester PersistentVolumeClaim. It is recommended to use a fast storage class.
 
 ## obj ingester.podDisruptionBudget
 
@@ -872,6 +892,10 @@ $ kubectl create secret generic gem-license -from-file=license.jwt
 ## obj storeGateway.container
 
 `container` is a convenience field that can be used to modify the store-gateway container.
+
+## obj storeGateway.persistentVolumeClaim
+
+`persistentVolumeClaim` is a convenience field that can be used to modify the store-gateway PersistentVolumeClaim.
 
 ## obj storeGateway.podDisruptionBudget
 

--- a/enterprise-metrics/main.libsonnet
+++ b/enterprise-metrics/main.libsonnet
@@ -184,7 +184,6 @@ local removeNamespaceReferences(args) = std.map(function(arg) std.strReplace(arg
       + container.withPorts(cortex.util.defaultPorts)
       + container.resources.withLimits({ cpu: '2', memory: '4Gi' })
       + container.resources.withRequests({ cpu: '500m', memory: '1Gi' })
-      + cortex.jaeger_mixin
       + cortex.util.readinessProbe,
     '#deployment':: d.obj('`deployment` is the Kubernetes Deployment for the admin-api.'),
     deployment:
@@ -328,7 +327,6 @@ local removeNamespaceReferences(args) = std.map(function(arg) std.strReplace(arg
       + container.withPorts(cortex.util.defaultPorts)
       + container.resources.withLimits({ cpu: '2', memory: '4Gi' })
       + container.resources.withRequests({ cpu: '500m', memory: '1Gi' })
-      + cortex.jaeger_mixin
       + cortex.util.readinessProbe,
     '#deployment':: d.obj('`deployment` is the Kubernetes Deployment for the gateway.'),
     deployment:


### PR DESCRIPTION
This change allows users to conveniently override the configuration of
PersistentVolumeClaims used to store state in stateful components.

It is a breaking change as it removes some of the explicitly named
storage classes that were defined in cortex-jsonnet.