### PR TITLE
feat(alertmanager): add slack and pd receiver libs

### DIFF
--- a/alertmanager/receivers.libsonnet
+++ b/alertmanager/receivers.libsonnet
@@ -1,0 +1,4 @@
+{
+  pagerduty: (import './receivers/pagerduty.libsonnet'),
+  slack: (import './receivers/slack.libsonnet'),
+}

--- a/alertmanager/receivers/pagerduty.libsonnet
+++ b/alertmanager/receivers/pagerduty.libsonnet
@@ -1,0 +1,54 @@
+{
+  local this = self,
+
+  local configTemplate = {
+    description: |||
+      [{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .GroupLabels.cluster }}: {{ .GroupLabels.alertname }} ({{ .GroupLabels.namespace }})
+      {{ .CommonAnnotations.summary }}
+      {{ if .Alerts.Firing | len }}Firing alerts:
+      {{ range .Alerts.Firing }}- {{ .Annotations.message }}{{ .Annotations.description }}
+      {{ end }}{{ end }}{{ if .Alerts.Resolved | len }}Resolved alerts:
+      {{ range .Alerts.Resolved }}- {{ .Annotations.message }}{{ .Annotations.description }}
+      {{ end }}{{ end }}
+    |||,
+    details: {
+      firing: |||
+        {{ with .Alerts.Firing }}
+        {{ range . }}Labels:
+        {{ range .Labels.SortedPairs }} - {{ .Name }} = {{ .Value }}
+        {{ end }}Annotations:
+        {{ range .Annotations.SortedPairs }} - {{ .Name }} = {{ .Value }}
+        {{ end }}Source: {{ .GeneratorURL }}
+        {{ end }}{{ end }}
+        Silence: {{ template "__alert_silence_link" . }}
+      |||,
+    },
+  },
+
+  new(name): this.withName(name),
+
+  withName(name):: {
+    name: name,
+  },
+
+  withConfig(config):: {
+    pagerduty_configs: [config],
+  },
+
+  withConfigMixin(config):: {
+    pagerduty_configs+: [config],
+  },
+
+
+  config: {
+    newService(service_key): {
+      service_key: service_key,
+    } + this.config.withConfigTemplate(),
+
+    newRouting(service_key): {
+      service_key: service_key,
+    } + this.config.withConfigTemplate(),
+
+    withConfigTemplate(): configTemplate,
+  },
+}

--- a/alertmanager/receivers/slack.libsonnet
+++ b/alertmanager/receivers/slack.libsonnet
@@ -1,0 +1,75 @@
+{
+  local this = self,
+
+  new(name, channel):
+    this.withName(name)
+    + this.withConfig(this.config.new(channel)),
+
+  withName(name):: {
+    name: name,
+  },
+
+  withConfig(config):: {
+    slack_configs: [config],
+  },
+
+  withConfigMixin(config):: {
+    slack_configs+: [config],
+  },
+
+  withAPIUrl(api_url):: {
+    slack_configs: [
+      config + this.config.withAPIUrl(api_url)
+      for config in super.slack_configs
+    ],
+  },
+
+  withAPIUrlFile(api_url_file):: {
+    slack_configs: [
+      config + this.config.withAPIUrlFile(api_url_file)
+      for config in super.slack_configs
+    ],
+  },
+
+  config: {
+    new(channel): {
+      channel: channel,
+      send_resolved: true,
+      title: '{{ template "__alert_title" . }}',
+      text: '{{ template "__alert_text" . }}',
+      actions: [
+        {
+          type: 'button',
+          text: 'Runbook :green_book:',
+          url: '{{ (index .Alerts 0).Annotations.runbook_url }}',
+        },
+
+        {
+          type: 'button',
+          text: 'Source :information_source:',
+          url: '{{ (index .Alerts 0).GeneratorURL }}',
+        },
+
+        {
+          type: 'button',
+          text: 'Silence :no_bell:',
+          url: '{{ template "__alert_silence_link" . }}',
+        },
+
+        {
+          type: 'button',
+          text: 'Dashboard :grafana:',
+          url: '{{ (index .Alerts 0).Annotations.dashboard_url }}',
+        },
+      ],
+    },
+
+    withAPIUrl(api_url): {
+      api_url: api_url,
+    },
+
+    withAPIUrlFile(api_url_file): {
+      api_url_file: api_url_file,
+    },
+  },
+}

--- a/alertmanager/slack.libsonnet
+++ b/alertmanager/slack.libsonnet
@@ -1,3 +1,6 @@
+// This file is for backwards compat, please use alertmanager/receivers.libsonnet instead.
+local slack = import './receivers/slack.libsonnet';
+
 {
   local this = self,
 
@@ -7,38 +10,8 @@
   },
 
   build_slack_receiver(name, slack_channel)::
-    {
-      name: name,
-      slack_configs: [{
-        api_url: this._config.slack_url,
-        channel: slack_channel,
-        send_resolved: true,
-        title: '{{ template "__alert_title" . }}',
-        text: '{{ template "__alert_text" . }}',
-        actions: [
-          {
-            type: 'button',
-            text: 'Runbook :green_book:',
-            url: '{{ (index .Alerts 0).Annotations.runbook_url }}',
-          },
-          {
-            type: 'button',
-            text: 'Source :information_source:',
-            url: '{{ (index .Alerts 0).GeneratorURL }}',
-          },
-          {
-            type: 'button',
-            text: 'Silence :no_bell:',
-            url: '{{ template "__alert_silence_link" . }}',
-          },
-          {
-            type: 'button',
-            text: 'Dashboard :grafana:',
-            url: '{{ (index .Alerts 0).Annotations.dashboard_url }}',
-          },
-        ],
-      }],
-    },
+    slack.new(name, slack_channel)
+    + slack.withAPIUrl(this._config.slack_url),
 
   alertmanager_config+:: {
     route+: {


### PR DESCRIPTION
- Moves the Slack one into a composable lib.
- Adds Pagerduty one with battle tested templates.

Ideally these would be generated from the Prometheus code or docs instead of manually curated.