### PR TITLE
Balance Grafana dashboard shards more smartly

### DIFF
--- a/grafana/dashboards.libsonnet
+++ b/grafana/dashboards.libsonnet
@@ -56,10 +56,6 @@
             {
               [key]+: {
                 dashboards+: (mixins[name] + mixinProto).grafanaDashboards,
-                shards:
-                  if std.objectHasAll(mixins[name], 'grafanaDashboardShards')
-                  then mixins[name].grafanaDashboardShards
-                  else 1,
                 name:
                   if std.objectHasAll(mixins[name], 'grafanaDashboardFolder')
                   then mixins[name].grafanaDashboardFolder

--- a/istio-mixin/mixin.libsonnet
+++ b/istio-mixin/mixin.libsonnet
@@ -1,4 +1,5 @@
 {
+  grafanaDashboardShards: 2,
   grafanaDashboards: {
     'istio_control_plane_dashboard.json': (import 'dashboards/istio_control_plane_dashboard.json'),
     'istio_mesh_dashboard.json': (import 'dashboards/istio_mesh_dashboard.json'),

--- a/istio-mixin/mixin.libsonnet
+++ b/istio-mixin/mixin.libsonnet
@@ -1,5 +1,4 @@
 {
-  grafanaDashboardShards: 2,
   grafanaDashboards: {
     'istio_control_plane_dashboard.json': (import 'dashboards/istio_control_plane_dashboard.json'),
     'istio_mesh_dashboard.json': (import 'dashboards/istio_mesh_dashboard.json'),

--- a/prometheus-ksonnet/mixins.libsonnet
+++ b/prometheus-ksonnet/mixins.libsonnet
@@ -28,7 +28,6 @@
     kubernetes:
       (import 'kubernetes-mixin/mixin.libsonnet') {
         grafanaDashboardFolder: 'Kubernetes',
-        grafanaDashboardShards: 8,
 
         _config+:: {
           cadvisorSelector: 'job="kube-system/cadvisor"',


### PR DESCRIPTION
Instead of going randomly, this algorithm tries to balance them
We used to have shards with no dashboards at all and other huge shards

Also, this calculates dashboard shards dynamically. It limits at 100kB per shard so the `grafanaDashboardShards` attribute is no longer needed

Example from Cortex:

**Before with 10 shards:**
Number of dashboards - Number of lines
```
ConfigMap-dashboards-cortex-0.yaml: 1 - 167
ConfigMap-dashboards-cortex-1.yaml: 0 - 7
ConfigMap-dashboards-cortex-2.yaml: 4 - 1629
ConfigMap-dashboards-cortex-3.yaml: 2 - 434
ConfigMap-dashboards-cortex-4.yaml: 2 - 289
ConfigMap-dashboards-cortex-5.yaml: 0 - 7
ConfigMap-dashboards-cortex-6.yaml: 1 - 270
ConfigMap-dashboards-cortex-7.yaml: 1 - 1027
ConfigMap-dashboards-cortex-8.yaml: 3 - 371
ConfigMap-dashboards-cortex-9.yaml: 5 - 1652
```

**After with 6 shards:**
Number of dashboards - Number of lines
```
ConfigMap-dashboards-cortex-0.yaml: 3 - 1131
ConfigMap-dashboards-cortex-1.yaml: 3 - 840
ConfigMap-dashboards-cortex-2.yaml: 3 - 834
ConfigMap-dashboards-cortex-3.yaml: 3 - 940
ConfigMap-dashboards-cortex-4.yaml: 3 - 962
ConfigMap-dashboards-cortex-5.yaml: 4 - 1115
```

