### PR TITLE
Update from all active users to all users and fix license alert

### DIFF
--- a/jira-mixin/alerts/general.yaml
+++ b/jira-mixin/alerts/general.yaml
@@ -2,7 +2,7 @@ groups:
 - name: alert.rules
   rules:
   - alert: LicenseExpired
-    expr: jira_maintenance_expiry_days_gauge <= 0
+    expr: jira_license_expiry_days_gauge <= 0
     for: 1m
     labels:
       severity: "critical"
@@ -10,7 +10,7 @@ groups:
       summary: "JIRA license expired"
       description: "The JIRA license has expired."
   - alert: LicenseWarning
-    expr: jira_maintenance_expiry_days_gauge <= 7 and jira_maintenance_expiry_days_gauge > 0
+    expr: jira_license_expiry_days_gauge <= 7 and jira_license_expiry_days_gauge > 0
     for: 1m
     labels:
       severity: "warning"
@@ -18,7 +18,7 @@ groups:
       summary: "License expiring soon"
       description: "The JIRA license will expire in less than one week."
   - alert: NoUserCapacity
-    expr: jira_all_active_users_gauge/jira_allowed_users_gauge == 1
+    expr: jira_all_users_gauge/jira_allowed_users_gauge == 1
     for: 1m
     labels:
       severity: "critical"

--- a/jira-mixin/dashboards/jira-overview.json
+++ b/jira-mixin/dashboards/jira-overview.json
@@ -199,7 +199,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "jira_maintenance_expiry_days_gauge{job=\"$job\", instance=\"$instance\"}",
+          "expr": "jira_license_expiry_days_gauge{job=\"$job\", instance=\"$instance\"}",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -269,7 +269,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "1 - (jira_all_active_users_gauge{job=\"$job\", instance=\"$instance\"}/jira_allowed_users_gauge{job=\"$job\", instance=\"$instance\"})",
+          "expr": "1 - (jira_all_users_gauge{job=\"$job\", instance=\"$instance\"}/jira_allowed_users_gauge{job=\"$job\", instance=\"$instance\"})",
           "interval": "",
           "legendFormat": "",
           "refId": "A"


### PR DESCRIPTION
Two bug fixes for alerts:
- Changes jira_all_active_users to jira_all_users. These were the same when running locally, but after looking through the metrics, the max number of users will go off of all users, not all active users.
- Changes jira_maintenance_expiry_days_gauge to jira_license_expiry_days_gauge. These are the same when running locally as well, but the license is what we want to alert on.

Note: this is already fixed in the [integration PR](https://github.com/grafana/cloud-onboarding/pull/179)