### PR TITLE
Prometheus has renamed its default branch from master to main.

### DIFF
--- a/prometheus-ksonnet/jsonnetfile.json
+++ b/prometheus-ksonnet/jsonnetfile.json
@@ -71,7 +71,7 @@
           "subdir": "doc/alertmanager-mixin"
         }
       },
-      "version": "master"
+      "version": "main"
     },
     {
       "source": {


### PR DESCRIPTION
Prometheus git repo doesn't have `master` branch any more, as per https://github.com/prometheus/prometheus/issues/8527.

This change is to follow that change, to track `main` branch.