### PR TITLE
ksm: update image location

### DIFF
--- a/kube-state-metrics/main.libsonnet
+++ b/kube-state-metrics/main.libsonnet
@@ -3,7 +3,7 @@ local kausal = import 'github.com/grafana/jsonnet-libs/ksonnet-util/kausal.libso
 {
   new(
     namespace,
-    image='gcr.io/google_containers/kube-state-metrics:v2.1.0',
+    image='k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.1.0',
   ):: {
     local k = kausal {
       _config+: {


### PR DESCRIPTION
The current URL results in `Failed to fetch "v2.1.0" from request "/v2/google_containers/kube-state-metrics/manifests/v2.1.0".`

As mentioned in https://github.com/kubernetes/kube-state-metrics#container-image.