### PR TITLE
Manage Prometheus pods in parallel

### DIFF
--- a/prometheus/prometheus.libsonnet
+++ b/prometheus/prometheus.libsonnet
@@ -149,6 +149,7 @@ local kausal = import 'ksonnet-util/kausal.libsonnet';
       self.prometheus_watch_container,
     ], self.prometheus_pvc)
     + self.prometheus_config_mount
+    + statefulset.mixin.spec.withPodManagementPolicy('Parallel')
     + statefulset.mixin.spec.withServiceName('prometheus')
     + statefulset.mixin.spec.template.metadata.withAnnotations({
       'prometheus.io.path': '%smetrics' % _config.prometheus_web_route_prefix,


### PR DESCRIPTION
The default behaviour of Kubernetes Statefulset, `OrderedReady` waits for pod-0 to be ready before starting pod-1.

When running two Prometheus' in "HA" configuration, we very much want pod-1 to be running when pod-0 is not ready. The alternative management policy, `Parallel`, is better for that.

Docs: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies