### PR TITLE
Adding connection limit alert at 80% (warning) and 95% (critical)

### DIFF
--- a/memcached-mixin/alerts.libsonnet
+++ b/memcached-mixin/alerts.libsonnet
@@ -19,6 +19,36 @@
               |||,
             },
           },
+          {
+            alert: 'MemcachedConnectionLimitApproaching',
+            expr: |||
+              (memcached_current_connections / memcached_max_connections * 100) > 80
+            |||,
+            'for': '15m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              message: |||
+                Memcached Instance {{ $labels.job }} / {{ $labels.instance }} connection usage is at {{ printf "%0.0f" $value }}% for at least 15m.
+              |||,
+            },
+          },
+          {
+            alert: 'MemcachedConnectionLimitApproaching',
+            expr: |||
+              (memcached_current_connections / memcached_max_connections * 100) > 95
+            |||,
+            'for': '15m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              message: |||
+                Memcached Instance {{ $labels.job }} / {{ $labels.instance }} connection usage is at {{ printf "%0.0f" $value }}% for at least 15m.
+              |||,
+            },
+          },
         ],
       },
     ],

--- a/memcached-mixin/dashboards.libsonnet
+++ b/memcached-mixin/dashboards.libsonnet
@@ -17,6 +17,11 @@ local g = (import 'grafana-builder/grafana.libsonnet');
           g.queryPanel('sum(rate(memcached_commands_total{cluster=~"$cluster", job=~"$job", instance=~"$instance", command="get", status="hit"}[1m])) / sum(rate(memcached_commands_total{cluster=~"$cluster", job=~"$job", command="get"}[1m]))', 'Hit Rate') +
           { yaxes: g.yaxes('percentunit') },
         )
+        .addPanel(
+          g.panel('Connection Usage') +
+          g.queryPanel('(memcached_current_connections{cluster=~"$cluster", job=~"$job", instance=~"$instance"} / memcached_max_connections{cluster=~"$cluster", job=~"$job", instance=~"$instance"} * 100)', 'Connection Usage') +
+          { yaxes: g.yaxes('percentunit') },
+        )
       )
       .addRow(
         g.row('Ops')


### PR DESCRIPTION
We've just encountered a scenario where we were hitting the connection limit on some memcache instances, which manifested as the exporter experiencing timeouts (`MemcachedDown`). It would be more clear to receive this alert instead of (or at least, alongside) the exporter alert.