### PR TITLE
nginx-directory: preserve url encoded chars

### DIFF
--- a/nginx-directory/configfile.libsonnet
+++ b/nginx-directory/configfile.libsonnet
@@ -11,9 +11,9 @@ function(services) {
         return 302 %(url)s;
       ||| % service
       else |||
-        #automagically replaces non-regex location identifier with given proxy_pass url.
+        # automagically replaces non-regex location identifier with given proxy_pass url.
         proxy_pass          %(url)s;
-        #specifying redirect with scheme and http_host because the "default" option doesn't persist the same port.
+        # specifying redirect with scheme and http_host because the "default" option doesn't persist the same port.
         proxy_redirect      %(url)s $scheme://$http_host/%(path)s/;
         proxy_set_header    X-Real-IP $remote_addr;
         proxy_set_header    X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/nginx-directory/configfile.libsonnet
+++ b/nginx-directory/configfile.libsonnet
@@ -51,7 +51,7 @@ function(services) {
     |||
       location ^~ /%(path)s {
         # Append trailing / as needed
-        return 302 $scheme://$http_host$request_uri/;
+        rewrite ^/%(path)s$ $scheme://$http_host/%(path)s/ redirect;
       }
       location ^~ /%(path)s/ {
     ||| % service +


### PR DESCRIPTION
It was discovered that encoded characters such as `%20` were converted through the proxy engine, resulting in 400 "bad request." This would affect urls such as:
  e.g., `baseurl.com/server_name/resource%20with%20space`

The previous solution uses a regex location selector, and with that approach the `$2` group variable would decode the url, causing the 400 if there were any special %-encoded characters. The example above, resulted in:
`baseurl.com/server_name/resource with space`

After replacing to a non-regex location selector, some additional efforts were required to ensure:
- relative urls work within the proxy subdir
- redirects from the target server are translated correctly
- %-encoded characters proxy without 400 "bad request"