### PR TITLE
Fix Synthetic Monitoring example code

### DIFF
--- a/synthetic-monitoring/README.md
+++ b/synthetic-monitoring/README.md
@@ -23,7 +23,7 @@ local sm = import 'synthetic-monitoring/sm.libsonnet';
                       + sm.withProbes('all'),  // enable all probes
     grafanaPingCheck: sm.ping.new('grafana', 'grafana.com')
                       + sm.withProbes('continents'),  // one check per continent
-    grafanaDnsCheck: sm.dns.new('grafana', 'grafana.com')
+    grafanaDnsCheck: sm.dns.new('grafana-dns', 'grafana.com') // Combination of Job name and Target must be unique
                      + sm.withProbes('europe'),  // just check from Europe
     grafanaTcpCheck: sm.tcp.new('grafana', 'grafana.com:443')
                      + sm.withProbes('small'),  // just use a smaller, predefined set of checks

--- a/synthetic-monitoring/example.jsonnet
+++ b/synthetic-monitoring/example.jsonnet
@@ -6,7 +6,7 @@ local sm = import 'sm.libsonnet';
                       + sm.withProbes('all'),  // enable all probes
     grafanaPingCheck: sm.ping.new('grafana', 'grafana.com')
                       + sm.withProbes('continents'),  // one check per continent
-    grafanaDnsCheck: sm.dns.new('grafana', 'grafana.com')
+    grafanaDnsCheck: sm.dns.new('grafana-dns', 'grafana.com')  // Combination of Job name and Target must be unique
                      + sm.withProbes('europe'),  // just check from Europe
     grafanaTcpCheck: sm.tcp.new('grafana', 'grafana.com:443')
                      + sm.withProbes('small'),  // just use a smaller, predefined set of checks


### PR DESCRIPTION
Previously the example would fail as follows:
```console
➜  jsonnet-libs git:(master) grr apply synthetic-monitoring/example.jsonnet
SyntheticMonitoringCheck/grafana added
SyntheticMonitoringCheck/grafana added
SyntheticMonitoringCheck/grafana added
2021-08-02 11:31:08.638497 I | 11:31:08 check add request: 409 Conflict
```

This change fixes the example
