### PR TITLE
version update: bringing prometheus up to 2.29.1

### DIFF
--- a/prometheus/images.libsonnet
+++ b/prometheus/images.libsonnet
@@ -1,6 +1,6 @@
 {
   _images+:: {
-    prometheus: 'prom/prometheus:v2.28.1',
+    prometheus: 'prom/prometheus:v2.29.1',
     watch: 'weaveworks/watch:master-5fc29a9',
   },
 }


### PR DESCRIPTION
tested the update on ops-us-east-0 and the upgrade went well. was recommended to roll the update out to the rest of the clusters