### PR TITLE
alertmanager: fix pagerduty routing key

### DIFF
--- a/alertmanager/receivers/pagerduty.libsonnet
+++ b/alertmanager/receivers/pagerduty.libsonnet
@@ -45,8 +45,8 @@
       service_key: service_key,
     } + this.config.withConfigTemplate(),
 
-    newRouting(service_key): {
-      service_key: service_key,
+    newRouting(routing_key): {
+      routing_key: routing_key,
     } + this.config.withConfigTemplate(),
 
     withConfigTemplate(): configTemplate,


### PR DESCRIPTION
The correct name for apiv2 is `routing_key`.

Cf. https://prometheus.io/docs/alerting/latest/configuration/#pagerduty_config