### PR TITLE
Simpler API for Grizzly resources

### DIFF
--- a/grizzly/check.libsonnet
+++ b/grizzly/check.libsonnet
@@ -1,0 +1,8 @@
+local resource = import 'resource.libsonnet';
+{
+    new(type, name, check)::
+        resource.new('SyntheticMonitoringCheck', name)
+        + resource.addMetadata('type', type)
+        + resource.withSpec(check)
+        ,
+}

--- a/grizzly/check.libsonnet
+++ b/grizzly/check.libsonnet
@@ -1,8 +1,7 @@
 local resource = import 'resource.libsonnet';
 {
-    new(type, name, check)::
-        resource.new('SyntheticMonitoringCheck', name)
-        + resource.addMetadata('type', type)
-        + resource.withSpec(check)
-        ,
+  new(type, name, check)::
+    resource.new('SyntheticMonitoringCheck', name)
+    + resource.addMetadata('type', type)
+    + resource.withSpec(check),
 }

--- a/grizzly/grafana.libsonnet
+++ b/grizzly/grafana.libsonnet
@@ -1,3 +1,4 @@
+local resource = import 'resource.libsonnet';
 local util = import 'util.libsonnet';
 
 {
@@ -17,5 +18,25 @@ local util = import 'util.libsonnet';
         for k in std.objectFieldsAll(util.get(mixin, 'grafanaDashboards', {}))
       }
     for key in std.objectFields(mixins)
+  },
+
+  dashboard: {
+    new(name, dashboard_json)::
+      resource.new('Dashboard', name)
+      + resource.withSpec(dashboard_json),
+  },
+
+  folder: {
+    new(name, title)::
+      resource.new('DashboardFolder', name)
+      + resource.withSpec({
+        title: title,
+      }),
+  },
+
+  datasource: {
+    new(name, datasource_json)::
+      resource.new('Datasource', name)
+      + resource.withSpec(datasource_json),
   },
 }

--- a/grizzly/grizzly.libsonnet
+++ b/grizzly/grizzly.libsonnet
@@ -15,4 +15,12 @@ local prometheus = import 'prometheus.libsonnet';
                 + prometheus.fromMapsFiltered(main.prometheusRules, mixinRules)
                 + prometheus.fromMixins(main.mixins),
   },
+
+  resource: (import 'resource.libsonnet'),
+  dashboard: grafana.dashboard,
+  folder: grafana.folder,
+  datasource: grafana.datasource,
+  rule_group: prometheus.rule_group,
+  synthetic_monitoring_check: (import 'check.libsonnet'),
+
 }

--- a/grizzly/prometheus.libsonnet
+++ b/grizzly/prometheus.libsonnet
@@ -2,6 +2,8 @@ local util = import 'util.libsonnet';
 local kind = 'PrometheusRuleGroup';
 local recordingRules = 'prometheusRules';
 local alertRules = 'prometheusAlerts';
+local resource = import 'resource.libsonnet';
+
 {
   getMixinRuleNames(mixins)::
     local flatMixins = [mixins[key] for key in std.objectFieldsAll(mixins)];
@@ -26,5 +28,12 @@ local alertRules = 'prometheusAlerts';
         + (if std.objectHasAll(mixins[key], recordingRules) then mixins[key].prometheusRules else {})
       )
     for key in std.objectFields(mixins)
+  },
+
+  rule_group: {
+    new(namespace, name, group)::
+      resource.new('PrometheusRuleGroup', name)
+      + resource.addMetadata('namespace', namespace)
+      + resource.withSpec(group),
   },
 }

--- a/grizzly/resource.libsonnet
+++ b/grizzly/resource.libsonnet
@@ -1,0 +1,22 @@
+{
+  defaultApiVersion:: 'grizzly.grafana.com/v1alpha1',
+  new(kind, name):: {
+    apiVersion: $.defaultApiVersion,
+    kind: kind,
+    metadata: {
+      name: name,
+    },
+  },
+  withApiVersion(apiVersion):: {
+    defaultApiVersion:: apiVersion,
+    apiVersion: apiVersion,
+  },
+  addMetadata(name, value):: {
+    metadata+: {
+      [name]: value,
+    },
+  },
+  withSpec(spec):: {
+    spec: spec,
+  },
+}


### PR DESCRIPTION
The current `util.makeResource()` method for creating resources doesn't feel right.

This PR adds a better way of describing resources, e.g. embedding the apiVersion/kind
into a Jsonnet function. Grizzly examples will be updated to use this clearer method
once merged.
