### PR TITLE
use std.manifestYamlDoc function instead of custom native function

### DIFF
--- a/ksonnet-util/util.libsonnet
+++ b/ksonnet-util/util.libsonnet
@@ -202,8 +202,7 @@ local util(k) = {
     ]),
 
   manifestYaml(value):: (
-    local f = std.native('manifestYamlFromJson');
-    f(std.toString(value))
+    std.manifestYamlDoc(value)
   ),
 
   resourcesRequests(cpu, memory)::


### PR DESCRIPTION
In case of using jsonnet-libs outside of Tanka, there is no function `std.native('manifestYamlFromJson')` available.
But there are semantically similar function exists in jsonnet itself: `std.manifestYamlDoc`.

So, for portability reasons, I prefer to use std functions instead of custom native function in util.manifestYaml helper function.

Without it, I cannot use this simple code to manage grafana with [qbec](https://qbec.io/)
```
  prometheusDatasource:
    grafana.datasource.new(
      'prometheus',
      p.components.prometheus.ingress.host,
      type = 'prometheus',
      default = true,
    ),

  grafana:
    grafana
    + grafana.withAnonymous()
    + grafana.addFolder('Example')
    + grafana.addDatasource('prometheus', $.prometheusDatasource),
```
because it fails:
```
✘ evaluate 'grafana': RUNTIME ERROR: Unexpected type null, expected function
        vendor/ksonnet-util/util.libsonnet:206:5-27     function <anonymous>
        vendor/github.com/grafana/jsonnet-libs/grafana/configmaps.libsonnet:(40:25)-(56:9)      object <anonymous>
        Field "dashboards.yml"
        Field "data"
        Field "dashboard_provisioning_config_map"
        Array element 0
        During manifestation
```