### PR TITLE
enterprise-metrics: replace use of deprecated license path flag

### DIFF
--- a/enterprise-metrics/CHANGELOG.md
+++ b/enterprise-metrics/CHANGELOG.md
@@ -12,6 +12,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## Unreleased
 
+- [CHANGE] Use of the deprecated `-bootstrap.license.path` flag has been replaced with `-license.path`. #645 
 - [CHANGE] The tokengen configuration is now hidden by default to avoid confusing errors when immutable fields are changed. #541
 - [CHANGE] Arbitrary storage class names are removed from PersistentVolumeClaims. If you were using those storage class names, you will need to configure the storageClassName in the persistentVolume object. For example in `$.ingester.persistentVolumeClaim`. #577
 - [CHANGE] Enabled the self-monitoring feature, which was part of the GEM 1.4 release, by default. #608

--- a/enterprise-metrics/main.libsonnet
+++ b/enterprise-metrics/main.libsonnet
@@ -197,12 +197,12 @@ local removeNamespaceReferences(args) = std.map(function(arg) std.strReplace(arg
   adminApi: {
     '#args':: d.obj('`args` is a convenience field that can be used to modify the admin-api container arguments as key value pairs.'),
     args:: this._config.commonArgs {
-      '#bootstrap.license.path':: d.val(
-        default=self['bootstrap.license.path'],
-        help='`bootstrap.license.path` configures where the admin-api expects to find a Grafana Enterprise Metrics License.',
+      '#license.path':: d.val(
+        default=self['license.path'],
+        help='`license.path` configures where the admin-api expects to find a Grafana Enterprise Metrics License.',
         type=d.T.string
       ),
-      'bootstrap.license.path': '/etc/gem-license/license.jwt',
+      'license.path': '/etc/gem-license/license.jwt',
       '#admin-api.leader-election.enabled':: d.val(
         default=self['admin-api.leader-election.enabled'],
         help='`admin-api.leader-election.enabled` enables leader election for to avoid inconsistent state with parallel writes when multiple replicas of the admin-api are running.',
@@ -472,12 +472,12 @@ local removeNamespaceReferences(args) = std.map(function(arg) std.strReplace(arg
   overridesExporter: {
     '#args':: d.obj('`args` is a convenience field that can be used to modify the overrides-exporter container arguments as key value pairs.'),
     args:: this._config.commonArgs {
-      '#bootstrap.license.path':: d.val(
-        default=self['bootstrap.license.path'],
-        help='`bootstrap.license.path` configures where the overrides-exporter expects to find a Grafana Enterprise Metrics License.',
+      '#license.path':: d.val(
+        default=self['license.path'],
+        help='`license.path` configures where the overrides-exporter expects to find a Grafana Enterprise Metrics License.',
         type=d.T.string
       ),
-      'bootstrap.license.path': '/etc/gem-license/license.jwt',
+      'license.path': '/etc/gem-license/license.jwt',
       target: 'overrides-exporter',
     },
     '#container':: d.obj('`container` is a convenience field that can be used to modify the overrides-exporter container.'),


### PR DESCRIPTION
Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>