### PR TITLE
fix: Ensure only a single tokengen Pod is created

### DIFF
--- a/enterprise-metrics/CHANGELOG.md
+++ b/enterprise-metrics/CHANGELOG.md
@@ -29,6 +29,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 - [BUGFIX] All microservices now use the `gossip-ring` Service as `memberlist.join` address. #523
 - [BUGFIX] `auth.type=default` is set on the `querier` to fix hanging query_range queries. #549
 - [BUGFIX] Enable admin-api leader election. This change does not affect single replica deployments of the admin-api but does fix the potential for an inconsistent state when running with multiple replicas of the admin-api and experiencing parallel writes for the same objects.
+- [BUGFIX] Ensure only a single tokengen Pod is created by having the container restart on failure. #647
 
 ## 1.0.0
 

--- a/enterprise-metrics/main.libsonnet
+++ b/enterprise-metrics/main.libsonnet
@@ -646,7 +646,7 @@ local removeNamespaceReferences(args) = std.map(function(arg) std.strReplace(arg
       + job.spec.withParallelism(1)
       + job.spec.template.spec.withContainers([self.createSecretContainer])
       + job.spec.template.spec.withInitContainers([self.container])
-      + job.spec.template.spec.withRestartPolicy('Never')
+      + job.spec.template.spec.withRestartPolicy('OnFailure')
       + job.spec.template.spec.withServiceAccount(target)
       + job.spec.template.spec.withServiceAccountName(target)
       + job.spec.template.spec.withVolumes([{ name: 'shared', emptyDir: {} }]),


### PR DESCRIPTION
Have the container restart on failure.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>