### PR TITLE
Fix aggregation in memcached dashboard

### DIFF
--- a/memcached-mixin/dashboards.libsonnet
+++ b/memcached-mixin/dashboards.libsonnet
@@ -32,29 +32,29 @@ local g = (import 'grafana-builder/grafana.libsonnet');
         g.row('Ops')
         .addPanel(
           g.panel('Commands') +
-          g.queryPanel('sum without (job, instance) (rate(memcached_commands_total{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[1m]))', '{{command}} {{status}}')
+          g.queryPanel('sum by(command, status) (rate(memcached_commands_total{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[1m]))', '{{command}} {{status}}')
         )
         .addPanel(
           g.panel('Evictions') +
-          g.queryPanel('sum without (job) (rate(memcached_items_evicted_total{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[1m]))', '{{instance}}')
+          g.queryPanel('sum by(instance) (rate(memcached_items_evicted_total{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[1m]))', '{{instance}}')
         )
         .addPanel(
           g.panel('Stored') +
-          g.queryPanel('sum without (job) (rate(memcached_items_total{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[1m]))', '{{instance}}')
+          g.queryPanel('sum by(instance) (rate(memcached_items_total{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[1m]))', '{{instance}}')
         )
       )
       .addRow(
         g.row('Memory')
         .addPanel(
           g.panel('Memory') +
-          g.queryPanel('sum without (job) (memcached_current_bytes{cluster=~"$cluster", job=~"$job", instance=~"$instance"})', '{{instance}}') +
+          g.queryPanel('sum by(instance) (memcached_current_bytes{cluster=~"$cluster", job=~"$job", instance=~"$instance"})', '{{instance}}') +
           g.stack +
           { yaxes: g.yaxes('bytes') },
           // TODO add memcached_limit_bytes
         )
         .addPanel(
           g.panel('Items') +
-          g.queryPanel('sum without (job) (memcached_current_items{cluster=~"$cluster", job=~"$job", instance=~"$instance"})', '{{instance}}') +
+          g.queryPanel('sum by(instance) (memcached_current_items{cluster=~"$cluster", job=~"$job", instance=~"$instance"})', '{{instance}}') +
           g.stack,
         )
       )
@@ -63,9 +63,9 @@ local g = (import 'grafana-builder/grafana.libsonnet');
         .addPanel(
           g.panel('Connections') +
           g.queryPanel([
-            'sum without (job) (rate(memcached_connections_total{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[1m]))',
-            'sum without (job) (memcached_current_connections{cluster=~"$cluster", job=~"$job", instance=~"$instance"})',
-            'sum without (job) (memcached_max_connections{cluster=~"$cluster", job=~"$job", instance=~"$instance"})',
+            'sum by(instance) (rate(memcached_connections_total{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[1m]))',
+            'sum by(instance) (memcached_current_connections{cluster=~"$cluster", job=~"$job", instance=~"$instance"})',
+            'sum by(instance) (memcached_max_connections{cluster=~"$cluster", job=~"$job", instance=~"$instance"})',
           ], [
             '{{instance}} - Connection Rate',
             '{{instance}} - Current Connrections',
@@ -74,12 +74,12 @@ local g = (import 'grafana-builder/grafana.libsonnet');
         )
         .addPanel(
           g.panel('Reads') +
-          g.queryPanel('sum without (job) (rate(memcached_read_bytes_total{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[1m]))', '{{instance}}') +
+          g.queryPanel('sum by(instance) (rate(memcached_read_bytes_total{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[1m]))', '{{instance}}') +
           { yaxes: g.yaxes('bps') },
         )
         .addPanel(
           g.panel('Writes') +
-          g.queryPanel('sum without (job) (rate(memcached_written_bytes_total{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[1m]))', '{{instance}}') +
+          g.queryPanel('sum by(instance) (rate(memcached_written_bytes_total{cluster=~"$cluster", job=~"$job", instance=~"$instance"}[1m]))', '{{instance}}') +
           { yaxes: g.yaxes('bps') },
         )
       )


### PR DESCRIPTION
The memcached dashboard uses many queries aggregating by `without (...)`, but the label displayed is just `{{ instance }}`. This leads to panels like the following, where multiple series have the same exact label:
![Screenshot 2021-09-24 at 16 49 03](https://user-images.githubusercontent.com/1701904/134694893-175736ab-a06f-4d27-b1e4-c274e94546ce.png)

To fix it, I suggest to group by the same labels we configure in the panel output.
