### PR TITLE
fix: Remove auth.type=default override on querier

### DIFF
--- a/enterprise-metrics/CHANGELOG.md
+++ b/enterprise-metrics/CHANGELOG.md
@@ -27,7 +27,6 @@ Entries should include a reference to the Pull Request that introduced the chang
 - [ENHANCEMENT] Make Secret name for GEM admin token configurable via `adminTokenSecretName`. #600- [BUGFIX] The `gossip-ring` Service now publishes not ready addresses. #523
 - [BUGFIX] All ring members now have the `gossip_ring-member` label set. #523
 - [BUGFIX] All microservices now use the `gossip-ring` Service as `memberlist.join` address. #523
-- [BUGFIX] `auth.type=default` is set on the `querier` to fix hanging query_range queries. #549
 - [BUGFIX] Enable admin-api leader election. This change does not affect single replica deployments of the admin-api but does fix the potential for an inconsistent state when running with multiple replicas of the admin-api and experiencing parallel writes for the same objects.
 - [BUGFIX] Ensure only a single tokengen Pod is created by having the container restart on failure. #647
 

--- a/enterprise-metrics/main.libsonnet
+++ b/enterprise-metrics/main.libsonnet
@@ -445,10 +445,7 @@ local removeNamespaceReferences(args) = std.map(function(arg) std.strReplace(arg
   querier: {
     local querier = self,
     '#args':: d.obj('`args` is a convenience field that can be used to modify the querier container arguments as key-value pairs.'),
-    args:: cortex.querier_args + this._config.commonArgs {
-      // Disable enterprise authentication on the querier so that query_range queries succeed.
-      'auth.type': 'default',
-    },
+    args:: cortex.querier_args + this._config.commonArgs,
     '#container':: d.obj('`container` is a convenience field that can be used to modify the querier container.'),
     container::
       cortex.querier_container


### PR DESCRIPTION
The bug that this worked around is fixed in recent versions of GEM.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>