### PR TITLE
wso2-enterprise-integrator-mixin rate and timerange standardization

### DIFF
--- a/wso2-enterprise-integrator-mixin/dashboards/API_Metrics.json
+++ b/wso2-enterprise-integrator-mixin/dashboards/API_Metrics.json
@@ -823,7 +823,7 @@
     ]
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-6h",
     "to": "now"
   },
   "timepicker": {

--- a/wso2-enterprise-integrator-mixin/dashboards/API_Metrics.json
+++ b/wso2-enterprise-integrator-mixin/dashboards/API_Metrics.json
@@ -823,7 +823,7 @@
     ]
   },
   "time": {
-    "from": "now-6h",
+    "from": "now-30m",
     "to": "now"
   },
   "timepicker": {

--- a/wso2-enterprise-integrator-mixin/dashboards/Cluster_Metrics.json
+++ b/wso2-enterprise-integrator-mixin/dashboards/Cluster_Metrics.json
@@ -998,7 +998,7 @@
     ]
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-6h",
     "to": "now"
   },
   "timepicker": {

--- a/wso2-enterprise-integrator-mixin/dashboards/Cluster_Metrics.json
+++ b/wso2-enterprise-integrator-mixin/dashboards/Cluster_Metrics.json
@@ -998,7 +998,7 @@
     ]
   },
   "time": {
-    "from": "now-6h",
+    "from": "now-30m",
     "to": "now"
   },
   "timepicker": {

--- a/wso2-enterprise-integrator-mixin/dashboards/Inbound_Endpoint_Metrics.json
+++ b/wso2-enterprise-integrator-mixin/dashboards/Inbound_Endpoint_Metrics.json
@@ -813,7 +813,7 @@
     ]
   },
   "time": {
-    "from": "now-6h",
+    "from": "now-30m",
     "to": "now"
   },
   "timepicker": {

--- a/wso2-enterprise-integrator-mixin/dashboards/Inbound_Endpoint_Metrics.json
+++ b/wso2-enterprise-integrator-mixin/dashboards/Inbound_Endpoint_Metrics.json
@@ -813,7 +813,7 @@
     ]
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-6h",
     "to": "now"
   },
   "timepicker": {

--- a/wso2-enterprise-integrator-mixin/dashboards/Node_Metrics.json
+++ b/wso2-enterprise-integrator-mixin/dashboards/Node_Metrics.json
@@ -1307,7 +1307,7 @@
     ]
   },
   "time": {
-    "from": "now-6h",
+    "from": "now-30m",
     "to": "now"
   },
   "timepicker": {

--- a/wso2-enterprise-integrator-mixin/dashboards/Node_Metrics.json
+++ b/wso2-enterprise-integrator-mixin/dashboards/Node_Metrics.json
@@ -1307,7 +1307,7 @@
     ]
   },
   "time": {
-    "from": "now-30m",
+    "from": "now-6h",
     "to": "now"
   },
   "timepicker": {

--- a/wso2-enterprise-integrator-mixin/dashboards/Proxy_Service_Metrics.json
+++ b/wso2-enterprise-integrator-mixin/dashboards/Proxy_Service_Metrics.json
@@ -830,7 +830,7 @@
     ]
   },
   "time": {
-    "from": "now-6h",
+    "from": "now-30m",
     "to": "now"
   },
   "timepicker": {

--- a/wso2-enterprise-integrator-mixin/dashboards/Proxy_Service_Metrics.json
+++ b/wso2-enterprise-integrator-mixin/dashboards/Proxy_Service_Metrics.json
@@ -518,7 +518,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(wso2_integration_proxy_request_count_total{service_name=~\"$service\", instance=~\"$instance\"}[$__interval]))",
+          "expr": "sum(rate(wso2_integration_proxy_request_count_total{service_name=~\"$service\", instance=~\"$instance\"}[$__rate_interval]))",
           "interval": "70s",
           "intervalFactor": 1,
           "legendFormat": "",
@@ -619,7 +619,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(wso2_integration_proxy_request_count_error_total{service_name=~\"$service\", instance=~\"$instance\"}[$__interval]))",
+          "expr": "sum(rate(wso2_integration_proxy_request_count_error_total{service_name=~\"$service\", instance=~\"$instance\"}[$__rate_interval]))",
           "interval": "1m",
           "legendFormat": "{{kubernetes_pod_name}}",
           "refId": "A"
@@ -701,7 +701,7 @@
       "reverseYBuckets": false,
       "targets": [
         {
-          "expr": "sum by (le)(increase(wso2_integration_proxy_latency_seconds{service_name=~\"$service\", instance=~\"$instance\", le=~\".+\"}[5m]))",
+          "expr": "sum by (le)(increase(wso2_integration_proxy_latency_seconds{service_name=~\"$service\", instance=~\"$instance\", le=~\".+\"}[$__rate_interval]))",
           "format": "heatmap",
           "hide": false,
           "interval": "1m",
@@ -830,7 +830,7 @@
     ]
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-6h",
     "to": "now"
   },
   "timepicker": {


### PR DESCRIPTION
Update all queries to use `$__rate_interval` for rate, irate, and increase function calls.

Update all dashboards to default to 30m timerange.