### PR TITLE
nodejs-mixin rate standardization

### DIFF
--- a/nodejs-mixin/dashboards/nodejs-overview.json
+++ b/nodejs-mixin/dashboards/nodejs-overview.json
@@ -291,19 +291,19 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(process_cpu_user_seconds_total{job=~\"$job\", instance=~\"$instance\"}[1m]) * 100",
+          "expr": "irate(process_cpu_user_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]) * 100",
           "interval": "",
           "legendFormat": "User CPU - {{instance}}",
           "refId": "A"
         },
         {
-          "expr": "irate(process_cpu_system_seconds_total{job=~\"$job\", instance=~\"$instance\"}[1m]) * 100",
+          "expr": "irate(process_cpu_system_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]) * 100",
           "interval": "",
           "legendFormat": "System CPU - {{instance}}",
           "refId": "B"
         },
         {
-          "expr": "irate(process_cpu_seconds_total{job=~\"$job\", instance=~\"$instance\"}[1m]) * 100",
+          "expr": "irate(process_cpu_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]) * 100",
           "interval": "",
           "legendFormat": "Total CPU - {{instance}}",
           "refId": "C"
@@ -404,7 +404,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(process_cpu_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$interval])",
+          "expr": "rate(process_cpu_seconds_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])",
           "interval": "",
           "legendFormat": "{{instance}}",
           "refId": "A"
@@ -855,7 +855,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(nodejs_gc_duration_seconds_sum{job=~\"$job\", instance=~\"$instance\"}[$interval])",
+          "expr": "rate(nodejs_gc_duration_seconds_sum{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])",
           "interval": "",
           "legendFormat": "{{kind}} - {{instance}}",
           "refId": "A"
@@ -1175,7 +1175,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(nodejs_gc_duration_seconds_count{job=~\"$job\", instance=~\"$instance\"}[$interval])",
+          "expr": "rate(nodejs_gc_duration_seconds_count{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])",
           "interval": "",
           "legendFormat": "{{instance}} - {{kind}}",
           "refId": "A"
@@ -1515,76 +1515,6 @@
         "tagsQuery": "",
         "type": "query",
         "useTags": false
-      },
-      {
-        "auto": false,
-        "auto_count": 30,
-        "auto_min": "10s",
-        "current": {
-          "selected": false,
-          "text": "1m",
-          "value": "1m"
-        },
-        "error": null,
-        "hide": 0,
-        "label": "Interval",
-        "name": "interval",
-        "options": [
-          {
-            "selected": true,
-            "text": "1m",
-            "value": "1m"
-          },
-          {
-            "selected": false,
-            "text": "10m",
-            "value": "10m"
-          },
-          {
-            "selected": false,
-            "text": "30m",
-            "value": "30m"
-          },
-          {
-            "selected": false,
-            "text": "1h",
-            "value": "1h"
-          },
-          {
-            "selected": false,
-            "text": "6h",
-            "value": "6h"
-          },
-          {
-            "selected": false,
-            "text": "12h",
-            "value": "12h"
-          },
-          {
-            "selected": false,
-            "text": "1d",
-            "value": "1d"
-          },
-          {
-            "selected": false,
-            "text": "7d",
-            "value": "7d"
-          },
-          {
-            "selected": false,
-            "text": "14d",
-            "value": "14d"
-          },
-          {
-            "selected": false,
-            "text": "30d",
-            "value": "30d"
-          }
-        ],
-        "query": "1m,10m,30m,1h,6h,12h,1d,7d,14d,30d",
-        "refresh": 2,
-        "skipUrlSync": false,
-        "type": "interval"
       }
     ]
   },


### PR DESCRIPTION
Update all queries to use $__rate_interval for rate, irate, and increase function calls.

Consequently, removed the `interval` templating variable as well.