### PR TITLE
Grafana builder: enable shared tooltip by default

### DIFF
--- a/grafana-builder/grafana.libsonnet
+++ b/grafana-builder/grafana.libsonnet
@@ -196,8 +196,8 @@
     timeShift: null,
     title: title,
     tooltip: {
-      shared: false,
-      sort: 0,
+      shared: true,
+      sort: 2,
       value_type: 'individual',
     },
     type: 'graph',


### PR DESCRIPTION
This PR enables a shared tooltip by default that includes all series when hovering a graph. 

Ex
![image](https://user-images.githubusercontent.com/618863/135725860-7a3d4eb7-d946-4144-84d4-6c5e773cec8f.png)


instead of 
![image](https://user-images.githubusercontent.com/618863/135725816-150d5f68-8409-460e-b363-87bddf28e77a.png)



Signed-off-by: bergquist <carl.bergquist@gmail.com>