### PR TITLE
Cloud Integration: Fixing WSO2 Enterprise Integrator templating bugs

### DIFF
--- a/wso2-enterprise-integrator-mixin/dashboards/API_Metrics.json
+++ b/wso2-enterprise-integrator-mixin/dashboards/API_Metrics.json
@@ -847,5 +847,5 @@
   "timezone": "",
   "title": "WSO2 API Metrics",
   "uid": "0KIvzUI7z",
-  "version": 2
+  "version": 8
 }

--- a/wso2-enterprise-integrator-mixin/dashboards/Cluster_Metrics.json
+++ b/wso2-enterprise-integrator-mixin/dashboards/Cluster_Metrics.json
@@ -1026,5 +1026,5 @@
   "timezone": "",
   "title": "WSO2 Integration Cluster Metrics",
   "uid": "TdzS6sS7z",
-  "version": 2
+  "version": 6
 }

--- a/wso2-enterprise-integrator-mixin/dashboards/Inbound_Endpoint_Metrics.json
+++ b/wso2-enterprise-integrator-mixin/dashboards/Inbound_Endpoint_Metrics.json
@@ -839,5 +839,5 @@
   "timezone": "",
   "title": "WSO2 Inbound Endpoint Metrics",
   "uid": "x5VJI8S7z",
-  "version": 2
+  "version": 5
 }

--- a/wso2-enterprise-integrator-mixin/dashboards/Node_Metrics.json
+++ b/wso2-enterprise-integrator-mixin/dashboards/Node_Metrics.json
@@ -1328,5 +1328,5 @@
   "timezone": "",
   "title": "WSO2 Integration Node Metrics",
   "uid": "j509RUS7z",
-  "version": 2
+  "version": 3
 }

--- a/wso2-enterprise-integrator-mixin/dashboards/Proxy_Service_Metrics.json
+++ b/wso2-enterprise-integrator-mixin/dashboards/Proxy_Service_Metrics.json
@@ -853,5 +853,5 @@
   "timezone": "",
   "title": "WSO2 Proxy Service Metrics",
   "uid": "68SKM8I7z",
-  "version": 2
+  "version": 7
 }


### PR DESCRIPTION
I`ve found some templating bugs, which were fixing Cortex as the datasource, giving some errors while loading some dashboards.

Some panels were also not set to use $datasource variable.