### PR TITLE
feat(docker-registry): add debug/metrics + ingress

### DIFF
--- a/docker-registry/README.md
+++ b/docker-registry/README.md
@@ -22,6 +22,12 @@ local registry = import 'github.com/grafana/jsonnet-libs/docker-registry/main.li
 {
   registry:
     registry.new()
-    + registry.withProxy('proxy-credentials-secret'),
+    + registry.withMetrics()
+    + registry.withProxy('proxy-credentials-secret')
+    + registry.withIngress(
+      'registry.example.org',
+      tlsSecretName='example-org-wildcard',
+      allowlist=['10.0.0.0/8']
+    ),
 }
 ```

--- a/docker-registry/main.libsonnet
+++ b/docker-registry/main.libsonnet
@@ -5,9 +5,12 @@ local k_util = import 'github.com/grafana/jsonnet-libs/ksonnet-util/util.libsonn
   new(
     name='registry',
     image='registry:2',
-    disk_size='5Gi'
+    disk_size='5Gi',
+    port=5000,
   ): {
     local this = self,
+
+    port:: port,
 
     local container = k.core.v1.container,
     container::
@@ -16,7 +19,7 @@ local k_util = import 'github.com/grafana/jsonnet-libs/ksonnet-util/util.libsonn
         image
       )
       + container.withPorts([
-        k.core.v1.containerPort.new('http-metrics', 5000),
+        k.core.v1.containerPort.new('http', port),
       ])
     ,
 
@@ -40,7 +43,24 @@ local k_util = import 'github.com/grafana/jsonnet-libs/ksonnet-util/util.libsonn
     ,
 
     service:
-      k_util.serviceFor(this.statefulset),
+      k_util.serviceFor(this.statefulset)
+      + k.core.v1.service.spec.withPorts([
+        // Explicitly override ports to prevent exposing debug endpoint
+        k.core.v1.servicePort.newNamed('http', port, port),
+      ]),
+  },
+
+  withMetrics(port=5001): {
+    local container = k.core.v1.container,
+    container+:
+      container.withPortsMixin([
+        k.core.v1.containerPort.new('http-metrics', port),
+      ])
+      + container.withEnvMixin([
+        k.core.v1.envVar.new('REGISTRY_HTTP_DEBUG_ADDR', 'localhost:%d' % port),
+        k.core.v1.envVar.new('REGISTRY_HTTP_DEBUG_PROMETHEUS_ENABLED', 'true'),
+        k.core.v1.envVar.new('REGISTRY_HTTP_DEBUG_PROMETHEUS_PATH', '/metrics'),
+      ]),
   },
 
   withProxy(secretRef, url='https://registry-1.docker.io'): {
@@ -55,5 +75,33 @@ local k_util = import 'github.com/grafana/jsonnet-libs/ksonnet-util/util.libsonn
         k.core.v1.envVar.fromSecretRef('REGISTRY_PROXY_USERNAME', secretRef, 'username'),
         k.core.v1.envVar.fromSecretRef('REGISTRY_PROXY_PASSWORD', secretRef, 'password'),
       ]),
+  },
+
+  withIngress(host, tlsSecretName, allowlist=[]):: {
+    local this = self,
+    local ingress = k.networking.v1.ingress,
+    local rule = k.networking.v1.ingressRule,
+    local path = k.networking.v1beta1.httpIngressPath,
+    ingress:
+      ingress.new(self.service.metadata.name)
+      + (
+        if std.length(allowlist) != 0
+        then ingress.metadata.withAnnotationsMixin({
+          'nginx.ingress.kubernetes.io/whitelist-source-range': std.join(',', allowlist),
+        })
+        else {}
+      )
+      + ingress.spec.withTls({
+        hosts: [host],
+        secretName: tlsSecretName,
+      })
+      + ingress.spec.withRules(
+        rule.withHost(host)
+        + rule.http.withPaths([
+          path.withPath('/')
+          + path.backend.withServiceName(this.service.metadata.name)
+          + path.backend.withServicePort(this.port),
+        ])
+      ),
   },
 }


### PR DESCRIPTION
- Properly expose the metrics endpoint as part of the debug port.
- Add ingress function with IP allowlist to run this publicly.