### PR TITLE
node-exporter: Allow the namespace to be configured

### DIFF
--- a/prometheus-ksonnet/lib/config.libsonnet
+++ b/prometheus-ksonnet/lib/config.libsonnet
@@ -6,6 +6,7 @@
     cluster_name: error 'must specify cluster name',
     namespace: error 'must specify namespace',
     alertmanager_namespace: self.namespace,
+    node_exporter_namespace: self.namespace,
 
     // Grafana config options.
     grafana_root_url: 'http://nginx.%(namespace)s.svc.%(cluster_dns_suffix)s/grafana' % self,

--- a/prometheus-ksonnet/lib/node-exporter.libsonnet
+++ b/prometheus-ksonnet/lib/node-exporter.libsonnet
@@ -15,7 +15,7 @@ local node_exporter = import 'github.com/grafana/jsonnet-libs/node-exporter/main
 
   prometheus_config+:: {
     scrape_configs+: [
-      node_exporter.scrape_config($._config.namespace),
+      node_exporter.scrape_config($._config.node_exporter_namespace),
     ],
   },
 }

--- a/prometheus-ksonnet/mixins.libsonnet
+++ b/prometheus-ksonnet/mixins.libsonnet
@@ -33,7 +33,7 @@
           cadvisorSelector: 'job="kube-system/cadvisor"',
           kubeletSelector: 'job="kube-system/kubelet"',
           kubeStateMetricsSelector: 'job="%s/kube-state-metrics"' % $._config.namespace,
-          nodeExporterSelector: 'job="%s/node-exporter"' % $._config.namespace,  // Also used by node-mixin.
+          nodeExporterSelector: 'job="%s/node-exporter"' % $._config.node_exporter_namespace,  // Also used by node-mixin.
           notKubeDnsSelector: 'job!="kube-system/kube-dns"',
           kubeSchedulerSelector: 'job="kube-system/kube-scheduler"',
           kubeControllerManagerSelector: 'job="kube-system/kube-controller-manager"',
@@ -71,7 +71,7 @@
         grafanaDashboardFolder: 'node_exporter',
 
         _config+:: {
-          nodeExporterSelector: 'job="%s/node-exporter"' % $._config.namespace,  // Also used by node-mixin.
+          nodeExporterSelector: 'job="%s/node-exporter"' % $._config.node_exporter_namespace,  // Also used by node-mixin.
 
           // Do not page if nodes run out of disk space.
           nodeCriticalSeverity: 'warning',


### PR DESCRIPTION
Sometimes the exporter can be run in a different namespace to where the
mixin is imported, support this.