### PR TITLE
fix(prometheus): correctly read in scrape configs from dict

### DIFF
--- a/prometheus/config.libsonnet
+++ b/prometheus/config.libsonnet
@@ -24,6 +24,12 @@
 
   scrape_configs: {},
 
+  addScrapeConfig(scrape_config):: {
+    scrape_configs+:: {
+      [scrape_config.job_name]: scrape_config,
+    },
+  },
+
   prometheus_config:: {
     global: {
       scrape_interval: '15s',
@@ -34,13 +40,10 @@
       'recording/recording.rules',
     ],
 
-    scrape_configs+:
-      std.foldr(
-        function(jobName, acc)
-          acc + $.scrape_configs[jobName],
-        std.objectFields($.scrape_configs),
-        {}
-      ),
+    scrape_configs+: [
+      $.scrape_configs[k]
+      for k in std.objectFields($.scrape_configs)
+    ],
   },
 
   // `withAlertmanagers` adds an alertmanager configuration to


### PR DESCRIPTION
The `std.foldr` did not generate the right bit, this does.