### PR TITLE
prometheus-ksonnet: Allow the kube-state-metrics namespace to be configured

### DIFF
--- a/prometheus-ksonnet/lib/config.libsonnet
+++ b/prometheus-ksonnet/lib/config.libsonnet
@@ -7,6 +7,7 @@
     namespace: error 'must specify namespace',
     alertmanager_namespace: self.namespace,
     node_exporter_namespace: self.namespace,
+    kube_state_metrics_namespace: self.namespace,
 
     // Grafana config options.
     grafana_root_url: 'http://nginx.%(namespace)s.svc.%(cluster_dns_suffix)s/grafana' % self,

--- a/prometheus-ksonnet/lib/kube-state-metrics.libsonnet
+++ b/prometheus-ksonnet/lib/kube-state-metrics.libsonnet
@@ -20,7 +20,7 @@ local kube_state_metrics = import 'kube-state-metrics/main.libsonnet';
 
   prometheus_config+:: {
     scrape_configs+: [
-      kube_state_metrics.scrape_config($._config.namespace),
+      kube_state_metrics.scrape_config($._config.kube_state_metrics_namespace),
     ],
   },
 }

--- a/prometheus-ksonnet/mixins.libsonnet
+++ b/prometheus-ksonnet/mixins.libsonnet
@@ -32,7 +32,7 @@
         _config+:: {
           cadvisorSelector: 'job="kube-system/cadvisor"',
           kubeletSelector: 'job="kube-system/kubelet"',
-          kubeStateMetricsSelector: 'job="%s/kube-state-metrics"' % $._config.namespace,
+          kubeStateMetricsSelector: 'job="%s/kube-state-metrics"' % $._config.kube_state_metrics_namespace,
           nodeExporterSelector: 'job="%s/node-exporter"' % $._config.node_exporter_namespace,  // Also used by node-mixin.
           notKubeDnsSelector: 'job!="kube-system/kube-dns"',
           kubeSchedulerSelector: 'job="kube-system/kube-scheduler"',


### PR DESCRIPTION
This change is backwards compatible but allows for customising the namespace if needed.