### PR TITLE
prometheus-ksonnet: remove kausal from root, explicitly set imports where needed

### DIFF
--- a/prometheus-ksonnet/grafana/datasources.libsonnet
+++ b/prometheus-ksonnet/grafana/datasources.libsonnet
@@ -1,5 +1,5 @@
 local grafana = import 'grafana/grafana.libsonnet';
-local k = import 'k.libsonnet';
+local k = import 'ksonnet-util/kausal.libsonnet';
 local datasource = grafana.datasource;
 {
   local configMap = k.core.v1.configMap,
@@ -28,7 +28,7 @@ local datasource = grafana.datasource;
   */
   grafana_add_datasource(name, url, default=false, method='GET')::
     configMap.withDataMixin({
-      ['%s.yml' % name]: $.util.manifestYaml({
+      ['%s.yml' % name]: k.util.manifestYaml({
         apiVersion: 1,
         datasources: [$.grafana_datasource(name, url, default, method)],
       }),
@@ -50,7 +50,7 @@ local datasource = grafana.datasource;
   */
   grafana_add_datasource_with_basicauth(name, url, username, password, default=false, method='GET', type='prometheus')::
     configMap.withDataMixin({
-      ['%s.yml' % name]: $.util.manifestYaml({
+      ['%s.yml' % name]: k.util.manifestYaml({
         apiVersion: 1,
         datasources: [$.grafana_datasource_with_basicauth(name, url, username, password, default, method, type)],
       }),
@@ -63,7 +63,7 @@ local datasource = grafana.datasource;
         if std.isString($.grafanaDatasources[name]) then
           $.grafanaDatasources[name]
         else
-          $.util.manifestYaml({
+          k.util.manifestYaml({
             apiVersion: 1,
             datasources: [$.grafanaDatasources[name]],
           })

--- a/prometheus-ksonnet/lib/kube-state-metrics.libsonnet
+++ b/prometheus-ksonnet/lib/kube-state-metrics.libsonnet
@@ -1,3 +1,4 @@
+local k = import 'ksonnet-util/kausal.libsonnet';
 local kube_state_metrics = import 'kube-state-metrics/main.libsonnet';
 
 {
@@ -12,11 +13,11 @@ local kube_state_metrics = import 'kube-state-metrics/main.libsonnet';
 
   kube_state_metrics_deployment:
     ksm.deployment
-    + $.apps.v1.deployment.spec.template.spec.withContainers([$.kube_state_metrics_container])
-    + $.util.podPriority('critical'),
+    + k.apps.v1.deployment.spec.template.spec.withContainers([$.kube_state_metrics_container])
+    + k.util.podPriority('critical'),
 
   kube_state_metrics_service:
-    $.util.serviceFor($.kube_state_metrics_deployment),
+    k.util.serviceFor($.kube_state_metrics_deployment),
 
   prometheus_config+:: {
     scrape_configs+: [

--- a/prometheus-ksonnet/lib/node-exporter.libsonnet
+++ b/prometheus-ksonnet/lib/node-exporter.libsonnet
@@ -1,4 +1,5 @@
 local node_exporter = import 'github.com/grafana/jsonnet-libs/node-exporter/main.libsonnet';
+local k = import 'ksonnet-util/kausal.libsonnet';
 
 {
   local exporter =
@@ -11,7 +12,7 @@ local node_exporter = import 'github.com/grafana/jsonnet-libs/node-exporter/main
 
   node_exporter_daemonset:
     (exporter { container:: $.node_exporter_container }).daemonset
-    + $.util.podPriority('critical'),
+    + k.util.podPriority('critical'),
 
   prometheus_config+:: {
     scrape_configs+: [

--- a/prometheus-ksonnet/prometheus-ksonnet.libsonnet
+++ b/prometheus-ksonnet/prometheus-ksonnet.libsonnet
@@ -1,4 +1,3 @@
-(import 'ksonnet-util/kausal.libsonnet') +
 (import 'images.libsonnet') +
 (import 'grafana/grafana.libsonnet') +
 (import 'lib/datasources.libsonnet') +


### PR DESCRIPTION
By removing `(import 'ksonnet-util/kausal.libsonnet') +` from being mixed in the root element, it facilitates that we can import each of the libraries that compose prometheus-ksonnet.