### PR TITLE
grafana: bump image to 8.2.5 and remove outdated feature toggles section

### DIFF
--- a/grafana/config.libsonnet
+++ b/grafana/config.libsonnet
@@ -1,6 +1,6 @@
 {
   _images+:: {
-    grafana: 'grafana/grafana:7.4.0',
+    grafana: 'grafana/grafana:8.2.5',
   },
 
   _config+:: {
@@ -26,9 +26,6 @@
         },
         users: {
           default_theme: 'light',
-        },
-        feature_toggle: {
-          enable: 'http_request_histogram, database_metrics',
         },
       },
     },


### PR DESCRIPTION
I noticed the Grafana jsonnet library is still using 7.4.0. Might be a good time to bump to the latest stable :)

Additionally, the feature toggles section in grafana_ini is not accurate anymore:
- the section is now called `feature_toggles` instead of `feature_toggle`
- the feature toggles set by default do not exist anymore, see https://grafana.com/docs/grafana/latest/packages_api/data/featuretoggles/