### PR TITLE
grafana-builder: make allValue configurable

### DIFF
--- a/grafana-builder/grafana.libsonnet
+++ b/grafana-builder/grafana.libsonnet
@@ -13,10 +13,10 @@
       rows+: [row { panels: panels }],
     },
 
-    addTemplate(name, metric_name, label_name, hide=0):: self {
+    addTemplate(name, metric_name, label_name, hide=0, allValue=null):: self {
       templating+: {
         list+: [{
-          allValue: null,
+          allValue: allValue,
           current: {
             text: 'prod',
             value: 'prod',
@@ -41,10 +41,10 @@
       },
     },
 
-    addMultiTemplate(name, metric_name, label_name, hide=0):: self {
+    addMultiTemplate(name, metric_name, label_name, hide=0, allValue='.+'):: self {
       templating+: {
         list+: [{
-          allValue: '.+',
+          allValue: allValue,
           current: {
             selected: true,
             text: 'All',


### PR DESCRIPTION
https://github.com/grafana/jsonnet-libs/pull/469 changed the default allValue for addMultiTemplate from `null` to `'.+'`. I want to make it configurable.

Reason: we use addMultiTemplate to add a namespace dropdown in the tempo-mixin:

https://github.com/grafana/tempo/blob/a1a95b35e15741061fc7119256aaeab78083dfbc/operations/tempo-mixin/dashboard-utils.libsonnet#L28
https://github.com/grafana/tempo/blob/a1a95b35e15741061fc7119256aaeab78083dfbc/operations/tempo-mixin/yamls/tempo-resources.json#L1873-L1900

This dropdown is populated with the namespaces a Tempo cluster is running in. The current behaviour (with `allValue: '.+'`) is confusing, because selecting All in the dropdown ends up querying all namespaces.
The previous behaviour (with `allValue: null`) only queries the namespaces that are returned by the query.

The reason we got confused is that in our dashboard you can select a cluster and if you know there is only 1 Tempo namespace in that cluster you kind of expect to only see data from that namespace. But with `allValue: '.+'` you get data from all the namespaces in that cluster. So we were mistakenly looking at queriers from a non-Tempo cluster and wondering why CPU was so high.