### PR TITLE
ksonnet-util: Check mapToFlags input

### DIFF
--- a/ksonnet-util/util.libsonnet
+++ b/ksonnet-util/util.libsonnet
@@ -11,12 +11,11 @@ local util(k) = {
 
   // mapToFlags converts a map to a set of golang-style command line flags.
   // if check=true, it will check for 'foo' and '-foo' presence, failing in that case.
-  mapToFlags(map, prefix='-', check=true):
-    if check then $.checkFlagsMap(map, prefix) else [] + [
-      '%s%s=%s' % [prefix, key, map[key]]
-      for key in std.objectFields(map)
-      if map[key] != null
-    ],
+  mapToFlags(map, prefix='-', check=true): [
+    '%s%s=%s' % [prefix, key, map[key]]
+    for key in std.objectFields(map)
+    if map[key] != null
+  ] + if check then $.checkFlagsMap(map, prefix) else [],
 
   // serviceFor create service for a given deployment.
   serviceFor(deployment, ignored_labels=[], nameFormat='%(container)s-%(port)s')::

--- a/ksonnet-util/util.libsonnet
+++ b/ksonnet-util/util.libsonnet
@@ -1,12 +1,22 @@
 // util.libsonnet provides a number of useful (opinionated) shortcuts to replace boilerplate code
 
 local util(k) = {
-  // mapToFlags converts a map to a set of golang-style command line flags.
-  mapToFlags(map, prefix='-'): [
-    '%s%s=%s' % [prefix, key, map[key]]
+  // checkFlagsMap checks map for presence of flags that values with both with and without prefix set ('foo' and '-foo').
+  checkFlagsMap(map, prefix): [
+    error 'key "%(key)s" provided with value "%(value)s" but key "%(prefix)s%(key)s" was provided too with value "%(otherValue)s", if want to ignore this, set check=false in mapToFlags' %
+          { key: key, value: map[key], prefix: prefix, otherValue: map[prefix + key] }
     for key in std.objectFields(map)
-    if map[key] != null
+    if map[key] != null && std.objectHas(map, prefix + key) && map[prefix + key] != null
   ],
+
+  // mapToFlags converts a map to a set of golang-style command line flags.
+  // if check=true, it will check for 'foo' and '-foo' presence, failing in that case.
+  mapToFlags(map, prefix='-', check=true):
+    if check then $.checkFlagsMap(map, prefix) else [] + [
+      '%s%s=%s' % [prefix, key, map[key]]
+      for key in std.objectFields(map)
+      if map[key] != null
+    ],
 
   // serviceFor create service for a given deployment.
   serviceFor(deployment, ignored_labels=[], nameFormat='%(container)s-%(port)s')::


### PR DESCRIPTION
Golang accepts both -foo and --foo flags, and sometimes jsonnet can become complex and there can be a 'foo' option and a '-foo' override somewhere else, causing both flags to be rendered. I don't think that's a desired behavior for anyone, so added a check by default, that can be
disabled if needed.

This is an example of the old behavior:
```jsonnet
local mapToFlags(map, prefix='-') = [
  '%s%s=%s' % [prefix, key, map[key]]
  for key in std.objectFields(map)
  if map[key] != null
];

local defaultFlags = {
  foo: '1',
  bar: '2',
};

local flagsOverride = {
  '-foo': '12',
  '-bar': 14,
};

mapToFlags(defaultFlags + flagsOverride)
```

```shell
$ jsonnet old.jsonnet
[
   "--bar=14",
   "--foo=12",
   "-bar=2",
   "-foo=1"
]
```

And the new one:

```jsonnet
local checkFlagsMap(map, prefix) = [
  error 'key "%(key)s" provided with value "%(value)s" but key "%(prefix)s%(key)s" was provided too with value "%(otherValue)s", if want to ignore this, set check=false in mapToFlags' %
        { key: key, value: map[key], prefix: prefix, otherValue: map[prefix + key] }
  for key in std.objectFields(map)
  if map[key] != null && std.objectHas(map, prefix + key) && map[prefix + key] != null
];

local mapToFlags(map, prefix='-', check=true) = [
  '%s%s=%s' % [prefix, key, map[key]]
  for key in std.objectFields(map)
  if map[key] != null
] + if check then checkFlagsMap(map, prefix) else [];

local defaultFlags = {
  foo: '1',
  bar: '2',
};

local flagsOverride = {
  '-foo': '12',
  '-bar': 14,
};

mapToFlags(defaultFlags + flagsOverride)
```

```shell
$ jsonnet new.jsonnet
RUNTIME ERROR: key "bar" provided with value "2" but key "-bar" was provided too with value "14", if want to ignore this, set check=false in mapToFlags
	new.jsonnet:(2:3)-(3:85)	thunk <array_element>
	During manifestation	
```
