### PR TITLE
Update to Prometheus 2.31.1 and enable exemplars

### DIFF
--- a/prometheus/config.libsonnet
+++ b/prometheus/config.libsonnet
@@ -20,6 +20,7 @@
     prometheus_web_route_prefix: self.prometheus_path,
     prometheus_config_dir: '/etc/prometheus',
     prometheus_config_file: self.prometheus_config_dir + '/prometheus.yml',
+    prometheus_enabled_features: ['exemplar-storage'],
   },
 
   scrape_configs: {},

--- a/prometheus/images.libsonnet
+++ b/prometheus/images.libsonnet
@@ -1,6 +1,6 @@
 {
   _images+:: {
-    prometheus: 'prom/prometheus:v2.30.3',
+    prometheus: 'prom/prometheus:v2.31.1',
     watch: 'weaveworks/watch:master-5fc29a9',
   },
 }

--- a/prometheus/prometheus.libsonnet
+++ b/prometheus/prometheus.libsonnet
@@ -97,6 +97,9 @@ local kausal = import 'ksonnet-util/kausal.libsonnet';
       '--web.route-prefix=%s' % _config.prometheus_web_route_prefix,
       '--storage.tsdb.path=/prometheus/data',
       '--storage.tsdb.wal-compression',
+      (if std.length(_config.prometheus_enabled_features) != 0
+       then '--enable-feature=%s' % std.join(',', _config.prometheus_enabled_features)
+       else ''),
     ])
     + k.util.resourcesRequests(_config.prometheus_requests_cpu,
                                _config.prometheus_requests_memory)


### PR DESCRIPTION
Update Prometheus to the current stable release and enable exemplar
storage. This allows exemplars to be scraped, stored in memory, and
persisted to the WAL.

Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>