### PR TITLE
node-exporter: upgrade to v1.3.1

### DIFF
--- a/node-exporter/main.libsonnet
+++ b/node-exporter/main.libsonnet
@@ -1,7 +1,7 @@
 local k = import 'github.com/grafana/jsonnet-libs/ksonnet-util/kausal.libsonnet';
 
 {
-  new(image='prom/node-exporter:v1.2.2'):: {
+  new(image='prom/node-exporter:v1.3.1'):: {
     ignored_fs_types:: [
       'tmpfs',
       'autofs',


### PR DESCRIPTION
Most relevant bits are available in the [v1.3.0 CHANGELOG](https://github.com/prometheus/node_exporter/blob/master/CHANGELOG.md#130--2021-10-20)