### PR TITLE
prometheus-ksonnet: upgrade node-exporter to v1.3.1

### DIFF
--- a/prometheus-ksonnet/images.libsonnet
+++ b/prometheus-ksonnet/images.libsonnet
@@ -8,7 +8,7 @@ local prometheus_images = import 'prometheus/images.libsonnet';
     {
       watch: 'weaveworks/watch:master-5fc29a9',
       kubeStateMetrics: 'k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.1.0',
-      nodeExporter: 'prom/node-exporter:v1.1.2',
+      nodeExporter: 'prom/node-exporter:v1.2.0',
       nginx: 'nginx:1.15.1-alpine',
     },
 }

--- a/prometheus-ksonnet/images.libsonnet
+++ b/prometheus-ksonnet/images.libsonnet
@@ -8,7 +8,7 @@ local prometheus_images = import 'prometheus/images.libsonnet';
     {
       watch: 'weaveworks/watch:master-5fc29a9',
       kubeStateMetrics: 'k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.1.0',
-      nodeExporter: 'prom/node-exporter:v1.2.0',
+      nodeExporter: 'prom/node-exporter:v1.3.1',
       nginx: 'nginx:1.15.1-alpine',
     },
 }


### PR DESCRIPTION
https://github.com/grafana/jsonnet-libs/commit/b46355107c024e0aa4932adadd939294c3b8260d 
Introduced the new flag for excluding filesystem paths for node-exporter, but was only introduced in node-exporter 1.2.0, breaking prometheus-kssonnet.