### PR TITLE
rclone mixin

### DIFF
--- a/rclone-mixin/.lint
+++ b/rclone-mixin/.lint
@@ -1,0 +1,6 @@
+exclusions:
+  panel-job-instance-rule:
+    entries:
+    - dashboard: rclone
+      panel: Historical Instances
+      reason: Deliberately getting all instances of the job to provide a comprehensive list of historical executions of rclone

--- a/rclone-mixin/jobTable.libsonnet
+++ b/rclone-mixin/jobTable.libsonnet
@@ -1,0 +1,143 @@
+{
+  new(datasource, dashboardUid, span=12):: {
+    "type": "table",
+    "title": "Historical Instances",
+    "span": 12,
+    "transformations": [
+      {
+        "id": "seriesToColumns",
+        "options": {
+          "byField": "instance"
+        }
+      },
+      {
+        "id": "calculateField",
+        "options": {
+          "mode": "binary",
+          "reduce": {
+            "reducer": "sum"
+          },
+          "binary": {
+            "left": "Value #B",
+            "operator": "-",
+            "right": "Value #A",
+            "reducer": "sum"
+          },
+          "alias": "delta"
+        }
+      },
+      {
+        "id": "filterByValue",
+        "options": {
+          "filters": [
+            {
+              "fieldName": "delta",
+              "config": {
+                "id": "lowerOrEqual",
+                "options": {
+                  "value": 0
+                }
+              }
+            }
+          ],
+          "type": "exclude",
+          "match": "any"
+        }
+      }
+    ],
+    "datasource": datasource,
+    "fieldConfig": {
+      "defaults": {
+        "custom": {
+          "align": "auto",
+          "displayMode": "auto"
+        },
+        "thresholds": {
+          "mode": "absolute",
+          "steps": [
+            {
+              "color": "green",
+              "value": null
+            },
+            {
+              "color": "red",
+              "value": 80
+            }
+          ]
+        },
+        "mappings": [],
+        "color": {
+          "mode": "continuous-GrYlRd"
+        },
+        "links": [],
+        "unit": "string"
+      },
+      "overrides": [
+        {
+          "matcher": {
+            "id": "byRegexp",
+            "options": "^.+[0-9]+|Value\\s#[B-Z]|delta"
+          },
+          "properties": [
+            {
+              "id": "custom.hidden",
+              "value": true
+            }
+          ]
+        },
+        {
+          "matcher": {
+            "id": "byName",
+            "options": "instance"
+          },
+          "properties": [
+            {
+              "id": "links",
+              "value": [
+                {
+                  "title": "View",
+                  "url": "d/"+ dashboardUid + "/rclone?var-instance=${__data.fields.instance}&from=${__data.fields[\"Value #A\"]}&to=${__data.fields[\"Value #B\"]}"
+                }
+              ]
+            },
+            {
+              "id": "displayName",
+              "value": "Instance"
+            }
+          ]
+        },
+        {
+          "matcher": {
+            "id": "byName",
+            "options": "Value #A"
+          },
+          "properties": [
+            {
+              "id": "displayName",
+              "value": "Start Time"
+            }
+          ]
+        }
+      ]
+    },
+    "options": {
+      "showHeader": true,
+      "footer": {
+        "show": false,
+        "reducer": [
+          "sum"
+        ],
+        "fields": ""
+      },
+      "frameIndex": 1
+    },
+    "targets": [],
+    _nextTarget:: 0,
+    addTarget(target):: self {
+      local nextTarget = super._nextTarget,
+      _nextTarget: nextTarget + 1,
+      targets+: [target { refId: std.char(std.codepoint('A') + nextTarget) }],
+    },
+    addTargets(targets):: std.foldl(function(p, t) p.addTarget(t), targets, self),
+  }
+}

--- a/rclone-mixin/jsonnetfile.json
+++ b/rclone-mixin/jsonnetfile.json
@@ -1,0 +1,24 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/grafonnet-lib.git",
+          "subdir": "grafonnet"
+        }
+      },
+      "version": "master"
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": "grafana-builder"
+        }
+      },
+      "version": "master"
+    }
+  ],
+  "legacyImports": true
+}

--- a/rclone-mixin/mixin.libsonnet
+++ b/rclone-mixin/mixin.libsonnet
@@ -1,0 +1,1 @@
+(import './rclone.libsonnet')

--- a/rclone-mixin/rclone.libsonnet
+++ b/rclone-mixin/rclone.libsonnet
@@ -1,0 +1,127 @@
+local grafana = import 'grafonnet/grafana.libsonnet';
+local dashboard = grafana.dashboard;
+local row = grafana.row;
+local prometheus = grafana.prometheus;
+local graphPanel = grafana.graphPanel;
+local piechart = grafana.pieChartPanel;
+local singlestat = grafana.singlestat;
+local statPanel = grafana.statPanel;
+
+local matcher = 'job=~"$job", instance=~"$instance"';
+
+local queries = {
+  fchecked_total: 'sum(increase(rclone_checked_files_total{' + matcher + '}[$__range]))',
+  ftransferred_total: 'sum(increase(rclone_files_transferred_total{' + matcher + '}[$__range]))',
+  frenamed_total: 'sum(increase(rclone_files_renamed_total{' + matcher + '}[$__range]))',
+  fdeleted_total: 'sum(increase(rclone_files_deleted_total{' + matcher + '}[$__range]))',
+  err_total: 'sum(increase(rclone_errors_total{' + matcher + '}[$__range]))',
+  bytes_transferred_rate_sum: 'sum(irate(rclone_bytes_transferred_total{' + matcher + '}[$__rate_interval]))',
+  bytes_transferred_range: 'sum(increase(rclone_bytes_transferred_total{' + matcher + '}[$__range]))',
+  bytes_transferred_day: 'sum(increase(rclone_bytes_transferred_total{' + matcher + '}[24h]))',
+  bytes_transferred_total: 'sum(rclone_bytes_transferred_total{' + matcher + '})',
+  bytes_transferred_rate_ts: 'sum(irate(rclone_bytes_transferred_total{' + matcher + '}[$__rate_interval])) by (instance)',
+};
+
+// Templates
+local ds_template = {
+  current: {
+    text: 'default',
+    value: 'default',
+  },
+  hide: 0,
+  label: 'Data Source',
+  name: 'datasource',
+  options: [],
+  query: 'prometheus',
+  refresh: 1,
+  regex: '',
+  type: 'datasource',
+};
+
+local job_template = grafana.template.new(
+  'job',
+  '$datasource',
+  'label_values(rclone_speed, job)',
+  refresh='load',
+  multi=true,
+  includeAll=true,
+  allValues='.+',
+  sort=1,
+);
+
+local instance_template = grafana.template.new(
+  'instance',
+  '$datasource',
+  'label_values(rclone_speed{job=~"$job"}, instance)',
+  refresh='load',
+  multi=true,
+  includeAll=true,
+  allValues='.+',
+  sort=1,
+);
+
+local statusPiePanel = piechart.new('Status', span=5, datasource='$datasource', legendType='Right side')
+                       .addTarget(grafana.prometheus.target(queries.fchecked_total, legendFormat='Files Checked'))
+                       .addTarget(grafana.prometheus.target(queries.ftransferred_total, legendFormat='Files Transferred'))
+                       .addTarget(grafana.prometheus.target(queries.frenamed_total, legendFormat='Files Renamed'))
+                       .addTarget(grafana.prometheus.target(queries.fdeleted_total, legendFormat='Files Deleted'))
+                       .addTarget(grafana.prometheus.target(queries.err_total, legendFormat='Transfer Errors'));
+
+local transferGauge = singlestat.new(
+  'Transfer Rate',
+  description='Thresholds are; 0-80MB/s (Internet speed), 80-200MB/s (Harddisk speed), 200MB/s+ (Solid State disk speed)',
+  datasource='$datasource',
+  gaugeShow=true,
+  format='Bps',
+  span=2,
+  thresholds='80000000,200000000',
+  gaugeMaxValue='500000000'
+)
+                      .addTarget(grafana.prometheus.target(queries.bytes_transferred_rate_sum));
+
+local transferredStat = statPanel.new(
+  'Data Transferred',
+  datasource='$datasource',
+  unit='bytes',
+)
+                        .addTargets([
+  grafana.prometheus.target(queries.bytes_transferred_range, legendFormat='Range'),
+  grafana.prometheus.target(queries.bytes_transferred_day, legendFormat='24h'),
+  grafana.prometheus.target(queries.bytes_transferred_total, legendFormat='Total'),
+])
+                        .addThreshold({ color: 'green', value: 0 }) { span: 5 };
+
+local transferGraph = graphPanel.new(
+    'Traffic',
+    datasource='$datasource',
+    span=12,
+    stack=true,
+    format='bps',
+)
+.addTarget(grafana.prometheus.target(queries.bytes_transferred_rate_ts, legendFormat='{{instance}}'))
++ {
+  line: 1,
+  fill: 5,
+  fillGradient: 10,
+};
+
+{
+  grafanaDashboards+:: {
+    'rclone.json':
+      dashboard.new('rclone', uid='Mkm2KHPzS').addTemplates([
+        ds_template,
+        job_template,
+        instance_template,
+      ])
+      .addRow(
+        row.new('Overview')
+        .addPanel(statusPiePanel)
+        .addPanel(transferGauge)
+        .addPanel(transferredStat)
+      )
+      .addRow(
+        row.new('Realtime')
+        .addPanel(transferGraph)
+      ),
+  },
+}


### PR DESCRIPTION
This PR adds an rclone mixin. It consists of only one dashboard as there are only 10 metrics emitted by rclone.

It requires that your rclone process be run with the flag `--rc-enable-metrics` in order to expose prometheus metrics which can be scraped.

If a user is running batch sync jobs, which are scraped via a `static_scrape` config with static IPs/hostnames, or a service discovery config, those ephemeral instances (which were created within the last 48hr) will be displayed in a table. The clickable links in that table will take you to the timerange for that particular instance.

![image](https://user-images.githubusercontent.com/428415/149217771-ea793078-57df-4e4a-a066-eeed2ba4b1be.png)
![image](https://user-images.githubusercontent.com/428415/149217785-1e4fcbd7-84b2-4682-a7a0-6280cb90d85a.png)
![image](https://user-images.githubusercontent.com/428415/149217795-2d7ab79f-6ee3-4e64-b6da-4d30a4bb896d.png)
