### PR TITLE
fix(postgres-exporter): extend URL

### DIFF
--- a/postgres-exporter/main.libsonnet
+++ b/postgres-exporter/main.libsonnet
@@ -3,7 +3,8 @@ local k = import 'ksonnet-util/kausal.libsonnet';
 {
   new(
     name,
-    data_source_name='$(USER):$(PASSWORD)@$(HOST):$(PORT)/',
+    data_source_name='postgresql://$(USER):$(PASSWORD)@$(HOST):$(PORT)/postgres',
+    ssl=true,
     image='quay.io/prometheuscommunity/postgres-exporter:v0.10.0',
   ):: {
     local this = self,
@@ -15,6 +16,11 @@ local k = import 'ksonnet-util/kausal.libsonnet';
       + container.withPorts(containerPort.new('http-metrics', 9187))
     ,
 
+    local ssl_suffix =
+      if ssl
+      then ''
+      else '?ssl=disable',
+
     local deployment = k.apps.v1.deployment,
     deployment:
       deployment.new(
@@ -24,7 +30,7 @@ local k = import 'ksonnet-util/kausal.libsonnet';
           this.container
           // Force DATA_SOURCE_NAME to be declared after the variables it references
           + container.withEnvMap({
-            DATA_SOURCE_NAME: data_source_name,
+            DATA_SOURCE_NAME: data_source_name + ssl_suffix,
           }),
         ]
       ),

--- a/postgres-exporter/main.libsonnet
+++ b/postgres-exporter/main.libsonnet
@@ -46,4 +46,24 @@ local k = import 'ksonnet-util/kausal.libsonnet';
   withImage(image):: {
     container+:: k.core.v1.container.withImage(image),
   },
+
+  withAutoDiscover():: {
+    container+:
+      k.core.v1.container.withEnvMixin([
+        k.core.v1.envVar.new(
+          'PG_EXPORTER_AUTO_DISCOVER_DATABASES',
+          'true',
+        ),
+      ]),
+  },
+
+  withExcludeDatabases(databases):: {
+    container+:
+      k.core.v1.container.withEnvMixin([
+        k.core.v1.envVar.new(
+          'PG_EXPORTER_EXCLUDE_DATABASES',
+          std.join(',', databases),
+        ),
+      ]),
+  },
 }


### PR DESCRIPTION
- Protocol is required to get correct parsing
- Not sure if `/postgres` db name suffix is required but added it as that is what upstream
  docs reference.
- Added boolean flag to toggle SSL mode

Also piggybacks two additional options to configure the exporter.