### PR TITLE
Hass namespace prefix

### DIFF
--- a/hass-mixin/Makefile
+++ b/hass-mixin/Makefile
@@ -1,0 +1,31 @@
+JSONNET_FMT := jsonnetfmt -n 2 --max-blank-lines 1 --string-style s --comment-style s
+
+.PHONY: all
+all: build dashboards_out
+
+vendor: jsonnetfile.json
+	jb install
+
+.PHONY: build
+build: vendor
+
+.PHONY: fmt
+fmt:
+	find . -name 'vendor' -prune -o -name '*.libsonnet' -print -o -name '*.jsonnet' -print | \
+		xargs -n 1 -- $(JSONNET_FMT) -i
+
+.PHONY: lint
+lint: build
+	find . -name 'vendor' -prune -o -name '*.libsonnet' -print -o -name '*.jsonnet' -print | \
+		while read f; do \
+			$(JSONNET_FMT) "$$f" | diff -u "$$f" -; \
+		done
+	mixtool lint mixin.libsonnet
+
+dashboards_out: mixin.libsonnet
+	@mkdir -p dashboards_out
+	jsonnet -J vendor -m dashboards_out -e "(import 'mixin.libsonnet').grafanaDashboards"
+
+.PHONY: clean
+clean:
+	rm -rf dashboards_out

--- a/hass-mixin/dashboard.libsonnet
+++ b/hass-mixin/dashboard.libsonnet
@@ -5,6 +5,7 @@ local base_matcher = 'job=~"$job", instance=~"$instance"';
 local entity_matcher = base_matcher + ', entity=~"$entity", friendly_name=~"$friendly_name"';
 local available_entity_matcher_decoration = 'and on (entity) entity_available > 0';
 
+local prefix_default = 'homeassistant';
 local queries = {
   unsupported_sensor_count: 'count({__name__=~"$prefix\\\\_?sensor_unit_.+", ' + base_matcher + '})',
   unsupported_sensors: '{__name__=~"$prefix\\\\_?sensor_unit_.+", ' + base_matcher + '}',
@@ -112,8 +113,8 @@ local fname_template = grafana.template.new(
 local prefix_template = {
   current: {
     selected: false,
-    text: '',
-    value: '',
+    text: prefix_default,
+    value: prefix_default,
   },
   description: null,
   'error': null,
@@ -123,11 +124,11 @@ local prefix_template = {
   options: [
     {
       selected: true,
-      text: '',
-      value: '',
+      text: prefix_default,
+      value: prefix_default,
     },
   ],
-  query: '',
+  query: prefix_default,
   skipUrlSync: false,
   type: 'textbox',
 };
@@ -246,7 +247,6 @@ local input_bool_panel = grafana.statPanel.new(
                            span: 2,
                            options+: { textMode: 'name' },
                          };
-
 
 local climate_panel = grafana.statPanel.new(
                         'Climate',


### PR DESCRIPTION
This sets prefix template on the dashboard to 'homeassistant' by default.
![image](https://user-images.githubusercontent.com/14870891/150510526-64c4af1a-3076-49d3-afd0-7eac8f176720.png)


Default is chosen according to
https://github.com/home-assistant/core/blob/dev/homeassistant/components/prometheus/__init__.py#L63


So, in fact `homeassistant_` namespace is used by default with minimalistic configuration.yaml config like
```yaml
prometheus:
```

...even though documentation states otherwise:
https://www.home-assistant.io/integrations/prometheus/#namespace

This PR also adds mixin makefile.

Hass version: homeassistant/home-assistant:2021.12.8
