### PR TITLE
WSO2 Streaming Integrator Mixin fix

### DIFF
--- a/wso2-streaming-integrator-mixin/README.md
+++ b/wso2-streaming-integrator-mixin/README.md
@@ -1,0 +1,42 @@
+# WSO2 Streaming Integrator Mixin
+
+This mixin was designed based on the dashboards publicly available on [WSO2 Github](https://github.com/wso2/streaming-integrator/tree/master/modules/distribution/carbon-home/resources/dashboards). It is updated to use the most recent panel versions and enables both a course and fine grained evaluation of your Streaming Integrator instances and Siddhi server and applications.
+
+1- Streaming Integrator Overall Statistics
+![image](https://user-images.githubusercontent.com/9431850/150526548-4c25fe44-7d59-4357-9b60-fd09891ca8d3.png)
+2- Streaming Integrator Application Statistics
+![image](https://user-images.githubusercontent.com/9431850/150526244-38ca324b-df0b-4957-8d4d-d30c8fb2d168.png)
+3- Siddhi Overall Statistics
+![image](https://user-images.githubusercontent.com/9431850/150526144-6771082a-68e1-4d44-bdf5-98a9ee736eb8.png)
+4- Siddhi Server Statistics
+![image](https://user-images.githubusercontent.com/9431850/150526190-2ca23803-f08f-42b1-bd11-1ddeb2ae6a7b.png)
+5- Siddhi Aggregation Statistics
+![image](https://user-images.githubusercontent.com/9431850/150526607-75aeac3d-8b96-4b98-881d-47180b133cff.png)
+6- Siddhi On-Demand Query Statistics
+![image](https://user-images.githubusercontent.com/9431850/150526656-493988c6-b6b6-4f57-b0b5-204b35809a98.png)
+7- Siddhi Query Statistics
+![image](https://user-images.githubusercontent.com/9431850/150526735-7269c63b-1b12-4920-bece-b0e9a2ddf8cb.png)
+8- Siddhi Sink Statistics
+![image](https://user-images.githubusercontent.com/9431850/150526777-bc654fe9-9941-4a76-809d-24ca0bb81be0.png)
+9- Siddhi Source Statistics
+![image](https://user-images.githubusercontent.com/9431850/150526835-8ce768ce-0f4c-4888-87e5-187052a8f14b.png)
+10- Siddhi Table Statistics
+![image](https://user-images.githubusercontent.com/9431850/150526887-095fc69a-919d-4bce-a055-464ba5e30120.png)
+11- Siddhi Stream Statistics
+![image](https://user-images.githubusercontent.com/9431850/150684114-fc646457-5a6f-443d-8958-17b8115413ed.png)
+
+To use it, you need to have `mixtool` and `jsonnetfmt` installed. If you have a working Go development environment, it's easiest to run the following:
+
+```bash
+$ go get github.com/monitoring-mixins/mixtool/cmd/mixtool
+$ go get github.com/google/go-jsonnet/cmd/jsonnetfmt
+```git commit -m ""
+
+You can then build a directory `dashboard_out` with the JSON dashboard files for Grafana:
+
+```bash
+$ make build
+```
+
+For more advanced uses of mixins, see [Prometheus Monitoring Mixins docs](https://github.com/monitoring-mixins/docs).
+

--- a/wso2-streaming-integrator-mixin/dashboards/Siddhi_aggregation.json
+++ b/wso2-streaming-integrator-mixin/dashboards/Siddhi_aggregation.json
@@ -654,7 +654,7 @@
     }
   ],
   "refresh": false,
-  "schemaVersion": 34,
+  "schemaVersion": 32,
   "style": "dark",
   "tags": [
     "prometheus",

--- a/wso2-streaming-integrator-mixin/dashboards/Siddhi_aggregation.json
+++ b/wso2-streaming-integrator-mixin/dashboards/Siddhi_aggregation.json
@@ -27,10 +27,7 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -221,10 +218,7 @@
       "repeatDirection": "h",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_aggregation_memory{instance=~\"$instance\",app=~\"$application\",element=~\"$element\",operation=~\"$operation\",quantile=~\"$quantile\"}) by (instance,app,element,operation,quantile)",
           "format": "table",
@@ -234,10 +228,7 @@
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_aggregation_latency{instance=~\"$instance\",app=~\"$application\",element=~\"$element\",operation=~\"$operation\",quantile=~\"$quantile\"}) by (instance,app,element,operation,quantile)",
           "format": "table",
@@ -247,10 +238,7 @@
           "refId": "B"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_aggregation_throughput_total{instance=~\"$instance\",app=~\"$application\",element=~\"$element\"}) by (instance,app,element)",
           "format": "table",
@@ -295,9 +283,7 @@
       "type": "table"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "gridPos": {
         "h": 3,
         "w": 5,
@@ -332,10 +318,7 @@
       "type": "dashlist"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -396,10 +379,7 @@
       "pluginVersion": "8.3.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(count(count by (element) (siddhi_aggregation_throughput_total{instance=~\"$instance\",app=~\"$application\"})))",
           "instant": true,
@@ -412,10 +392,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -488,10 +465,7 @@
       "pluginVersion": "8.3.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": true,
           "expr": "siddhi_aggregation_memory{instance=~\"$instance\",app=~\"$application\",element=~\"$element\",operation=~\"$operation\"}",
           "format": "time_series",
@@ -505,10 +479,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -581,10 +552,7 @@
       "pluginVersion": "8.3.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": true,
           "expr": "siddhi_aggregation_latency{instance=~\"$instance\",app=~\"$application\",element=\"$element\",operation=~\"$operation\",quantile=~\"$quantile\"}",
           "format": "time_series",
@@ -598,10 +566,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -674,10 +639,7 @@
       "pluginVersion": "8.3.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": true,
           "expr": "siddhi_aggregation_throughput_total{instance=~\"$instance\",app=~\"$application\",element=\"$element\",operation=~\"$operation\"}",
           "format": "time_series",
@@ -703,8 +665,8 @@
       {
         "current": {
           "selected": false,
-          "text": "grafanacloud-gabrielantunes-prom",
-          "value": "grafanacloud-gabrielantunes-prom"
+          "text": "Prometheus",
+          "value": "Prometheus"
         },
         "hide": 0,
         "includeAll": false,
@@ -728,9 +690,7 @@
             "$__all"
           ]
         },
-        "datasource": {
-          "uid": "$datasource"
-        },
+        "datasource": "$datasource",
         "definition": "label_values(siddhi_aggregation_latency,instance)",
         "hide": 0,
         "includeAll": true,
@@ -761,9 +721,7 @@
             "$__all"
           ]
         },
-        "datasource": {
-          "uid": "$datasource"
-        },
+        "datasource": "$datasource",
         "definition": "label_values(siddhi_aggregation_latency{instance=~\"$instance\"},app)",
         "hide": 0,
         "includeAll": true,
@@ -794,10 +752,7 @@
             "$__all"
           ]
         },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
+        "datasource": "$datasource",
         "definition": "label_values(siddhi_aggregation_latency{instance=~\"$instance\",app=~\"$application\"},element)",
         "hide": 0,
         "includeAll": true,
@@ -825,10 +780,7 @@
             "$__all"
           ]
         },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
+        "datasource": "$datasource",
         "definition": "label_values(siddhi_aggregation_latency{instance=~\"$instance\",app=~\"$application\",element=~\"$element\"},operation)",
         "hide": 0,
         "includeAll": true,
@@ -852,10 +804,7 @@
           "text": "All",
           "value": "$__all"
         },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
+        "datasource": "$datasource",
         "definition": "label_values(siddhi_aggregation_latency{instance=~\"$instance\"},quantile)",
         "description": "",
         "hide": 0,

--- a/wso2-streaming-integrator-mixin/dashboards/Siddhi_ondemandquery.json
+++ b/wso2-streaming-integrator-mixin/dashboards/Siddhi_ondemandquery.json
@@ -27,10 +27,7 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -172,10 +169,7 @@
       "repeatDirection": "h",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_ondemandquery_latency{instance=~\"$instance\",app=~\"$application\",element=~\"$element\",quantile=~\"$quantile\"}) by (instance,app,element,quantile)",
           "format": "table",
@@ -209,9 +203,7 @@
       "type": "table"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "gridPos": {
         "h": 7,
         "w": 5,
@@ -246,10 +238,7 @@
       "type": "dashlist"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -322,10 +311,7 @@
       "pluginVersion": "8.3.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": true,
           "expr": "siddhi_ondemandquery_latency{instance=~\"$instance\",app=~\"$application\",element=~\"$element\",quantile=~\"$quantile\"}",
           "format": "time_series",
@@ -351,8 +337,8 @@
       {
         "current": {
           "selected": false,
-          "text": "grafanacloud-gabrielantunes-prom",
-          "value": "grafanacloud-gabrielantunes-prom"
+          "text": "Prometheus",
+          "value": "Prometheus"
         },
         "hide": 0,
         "includeAll": false,
@@ -376,9 +362,7 @@
             "$__all"
           ]
         },
-        "datasource": {
-          "uid": "$datasource"
-        },
+        "datasource": "$datasource",
         "definition": "label_values(siddhi_ondemandquery_latency,instance)",
         "hide": 0,
         "includeAll": true,
@@ -409,9 +393,7 @@
             "$__all"
           ]
         },
-        "datasource": {
-          "uid": "$datasource"
-        },
+        "datasource": "$datasource",
         "definition": "label_values(siddhi_ondemandquery_latency{instance=~\"$instance\"},app)",
         "hide": 0,
         "includeAll": true,
@@ -442,10 +424,7 @@
             "$__all"
           ]
         },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
+        "datasource": "$datasource",
         "definition": "label_values(siddhi_ondemandquery_latency{instance=~\"$instance\",app=~\"$application\"},element)",
         "hide": 0,
         "includeAll": true,
@@ -473,10 +452,7 @@
             "$__all"
           ]
         },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
+        "datasource": "$datasource",
         "definition": "label_values(siddhi_ondemandquery_latency,quantile)",
         "hide": 0,
         "includeAll": true,

--- a/wso2-streaming-integrator-mixin/dashboards/Siddhi_ondemandquery.json
+++ b/wso2-streaming-integrator-mixin/dashboards/Siddhi_ondemandquery.json
@@ -326,7 +326,7 @@
     }
   ],
   "refresh": false,
-  "schemaVersion": 34,
+  "schemaVersion": 32,
   "style": "dark",
   "tags": [
     "prometheus",

--- a/wso2-streaming-integrator-mixin/dashboards/Siddhi_overall.json
+++ b/wso2-streaming-integrator-mixin/dashboards/Siddhi_overall.json
@@ -27,11 +27,9 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "gridPos": {
-        "h": 1.25,
+        "h": 1,
         "w": 24,
         "x": 0,
         "y": 0
@@ -55,9 +53,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "links": []
@@ -70,7 +66,7 @@
         "h": 6,
         "w": 19,
         "x": 0,
-        "y": 1.25
+        "y": 1
       },
       "hiddenSeries": false,
       "id": 18,
@@ -138,14 +134,12 @@
       }
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "gridPos": {
         "h": 3,
         "w": 5,
         "x": 19,
-        "y": 1.25
+        "y": 1
       },
       "id": 441,
       "links": [
@@ -176,9 +170,7 @@
       "type": "dashlist"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -216,7 +208,7 @@
         "h": 3,
         "w": 5,
         "x": 19,
-        "y": 4.25
+        "y": 4
       },
       "id": 364,
       "links": [],
@@ -247,10 +239,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -506,7 +495,7 @@
         "h": 5,
         "w": 24,
         "x": 0,
-        "y": 7.25
+        "y": 7
       },
       "id": 468,
       "interval": "1s",
@@ -524,10 +513,7 @@
       "repeatDirection": "h",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_source_throughput_total{instance=~\"$instance\",type=\"source\",operation!=\"inMemory\"}) by (instance)",
           "format": "table",
@@ -537,10 +523,7 @@
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(jvm_os_system_load_average{instance=~\"$instance\"}) by (instance)",
           "format": "table",
@@ -550,10 +533,7 @@
           "refId": "B"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(jvm_os_cpu_load_system{instance=~\"$instance\"}) by (insance)",
           "format": "table",
@@ -563,10 +543,7 @@
           "refId": "C"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(jvm_memory_heap_usage{instance=~\"$instance\"}) by (instance)",
           "format": "table",
@@ -607,9 +584,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "links": []
@@ -622,7 +597,7 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 12.25
+        "y": 12
       },
       "hiddenSeries": false,
       "id": 10,
@@ -696,9 +671,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "links": []
@@ -711,7 +684,7 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 12.25
+        "y": 12
       },
       "hiddenSeries": false,
       "id": 8,
@@ -784,10 +757,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "links": []
@@ -800,7 +770,7 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 18.25
+        "y": 18
       },
       "hiddenSeries": false,
       "id": 12,
@@ -830,10 +800,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": true,
           "expr": "jvm_os_cpu_load_process{instance=~\"$instance\"}",
           "interval": "",
@@ -880,10 +847,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "links": []
@@ -896,7 +860,7 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 18.25
+        "y": 18
       },
       "hiddenSeries": false,
       "id": 14,
@@ -926,10 +890,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": true,
           "expr": "jvm_memory_heap_usage{instance=~\"$instance\"}",
           "interval": "",
@@ -968,9 +929,7 @@
       }
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1008,7 +967,7 @@
         "h": 3,
         "w": 6,
         "x": 0,
-        "y": 24.25
+        "y": 24
       },
       "id": 4,
       "links": [],
@@ -1040,9 +999,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1080,7 +1037,7 @@
         "h": 3,
         "w": 6,
         "x": 6,
-        "y": 24.25
+        "y": 24
       },
       "id": 362,
       "links": [],
@@ -1112,9 +1069,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1152,7 +1107,7 @@
         "h": 3,
         "w": 6,
         "x": 12,
-        "y": 24.25
+        "y": 24
       },
       "id": 16,
       "links": [],
@@ -1184,9 +1139,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1224,7 +1177,7 @@
         "h": 3,
         "w": 6,
         "x": 18,
-        "y": 24.25
+        "y": 24
       },
       "id": 6,
       "interval": "",
@@ -1257,14 +1210,12 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "gridPos": {
-        "h": 1.25,
+        "h": 1,
         "w": 24,
         "x": 0,
-        "y": 27.25
+        "y": 27
       },
       "id": 444,
       "options": {
@@ -1276,10 +1227,7 @@
       "type": "text"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1399,7 +1347,7 @@
         "h": 7,
         "w": 19,
         "x": 0,
-        "y": 28.5
+        "y": 28
       },
       "id": 282,
       "options": {
@@ -1416,10 +1364,7 @@
       "repeatDirection": "h",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_stream_throughput_total{instance=~\"$instance\",app=~\"$application\"}) by (app,element)",
           "format": "table",
@@ -1445,14 +1390,12 @@
       "type": "table"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "gridPos": {
         "h": 3,
         "w": 5,
         "x": 19,
-        "y": 28.5
+        "y": 28
       },
       "id": 442,
       "links": [
@@ -1482,9 +1425,7 @@
       "type": "dashlist"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -1523,7 +1464,7 @@
         "h": 4,
         "w": 5,
         "x": 19,
-        "y": 31.5
+        "y": 31
       },
       "id": 284,
       "links": [],
@@ -1554,14 +1495,12 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "gridPos": {
-        "h": 1.25,
+        "h": 1,
         "w": 24,
         "x": 0,
-        "y": 35.5
+        "y": 35
       },
       "id": 446,
       "options": {
@@ -1573,10 +1512,7 @@
       "type": "text"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1727,7 +1663,7 @@
         "h": 7,
         "w": 19,
         "x": 0,
-        "y": 36.75
+        "y": 36
       },
       "id": 380,
       "options": {
@@ -1744,10 +1680,7 @@
       "repeatDirection": "h",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_query_memory{instance=~\"$instance\",app=~\"$application\"}) by (app,element)",
           "format": "table",
@@ -1757,10 +1690,7 @@
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_query_latency{instance=~\"$instance\",app=~\"$application\"}) by (app,element)",
           "format": "table",
@@ -1786,14 +1716,12 @@
       "type": "table"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "gridPos": {
         "h": 3,
         "w": 5,
         "x": 19,
-        "y": 36.75
+        "y": 36
       },
       "id": 447,
       "links": [
@@ -1823,9 +1751,7 @@
       "type": "dashlist"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -1864,7 +1790,7 @@
         "h": 4,
         "w": 5,
         "x": 19,
-        "y": 39.75
+        "y": 39
       },
       "id": 379,
       "links": [],
@@ -1895,14 +1821,12 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "gridPos": {
-        "h": 1.25,
+        "h": 1,
         "w": 24,
         "x": 0,
-        "y": 43.75
+        "y": 43
       },
       "id": 448,
       "options": {
@@ -1914,10 +1838,7 @@
       "type": "text"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2127,10 +2048,7 @@
       "repeatDirection": "h",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_sourcemapper_latency{instance=~\"$instance\",app=~\"$application\"}) by (app,element,operation,operationType)",
           "format": "table",
@@ -2140,10 +2058,7 @@
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_source_throughput_total{instance=~\"$instance\",app=~\"$application\"}) by (app,element,operation)",
           "format": "table",
@@ -2175,9 +2090,7 @@
       "type": "table"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "gridPos": {
         "h": 3,
         "w": 4,
@@ -2212,9 +2125,7 @@
       "type": "dashlist"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -2284,11 +2195,9 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "gridPos": {
-        "h": 1.25,
+        "h": 1,
         "w": 24,
         "x": 0,
         "y": 52
@@ -2303,10 +2212,7 @@
       "type": "text"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2499,7 +2405,7 @@
         "h": 7,
         "w": 20,
         "x": 0,
-        "y": 53.25
+        "y": 53
       },
       "id": 469,
       "options": {
@@ -2516,10 +2422,7 @@
       "repeatDirection": "h",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_sinkmapper_latency{instance=~\"$instance\",app=~\"$application\"}) by (app,element,operation,operationType)",
           "format": "table",
@@ -2529,10 +2432,7 @@
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_sink_throughput_total{instance=~\"$instance\",app=~\"$application\"}) by (app,element)",
           "format": "table",
@@ -2564,14 +2464,12 @@
       "type": "table"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "gridPos": {
         "h": 3,
         "w": 4,
         "x": 20,
-        "y": 53.25
+        "y": 53
       },
       "id": 453,
       "links": [
@@ -2601,9 +2499,7 @@
       "type": "dashlist"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -2642,7 +2538,7 @@
         "h": 4,
         "w": 4,
         "x": 20,
-        "y": 56.25
+        "y": 56
       },
       "id": 374,
       "links": [],
@@ -2673,14 +2569,12 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "gridPos": {
-        "h": 1.25,
+        "h": 1,
         "w": 24,
         "x": 0,
-        "y": 60.25
+        "y": 60
       },
       "id": 456,
       "options": {
@@ -2692,10 +2586,7 @@
       "type": "text"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2865,7 +2756,7 @@
         "h": 7,
         "w": 19,
         "x": 0,
-        "y": 61.5
+        "y": 61
       },
       "id": 386,
       "options": {
@@ -2882,10 +2773,7 @@
       "repeatDirection": "h",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_table_latency{instance=~\"$instance\",app=~\"$application\"}) by (app,element,operation)",
           "format": "table",
@@ -2895,10 +2783,7 @@
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_table_throughput_total{instance=~\"$instance\",app=~\"$application\"}) by (app,element,operation)",
           "format": "table",
@@ -2920,14 +2805,12 @@
       "type": "table"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "gridPos": {
         "h": 3,
         "w": 5,
         "x": 19,
-        "y": 61.5
+        "y": 61
       },
       "id": 457,
       "links": [
@@ -2957,9 +2840,7 @@
       "type": "dashlist"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -2998,7 +2879,7 @@
         "h": 4,
         "w": 5,
         "x": 19,
-        "y": 64.5
+        "y": 64
       },
       "id": 385,
       "links": [],
@@ -3029,14 +2910,12 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "gridPos": {
-        "h": 1.25,
+        "h": 1,
         "w": 24,
         "x": 0,
-        "y": 68.5
+        "y": 68
       },
       "id": 460,
       "options": {
@@ -3048,10 +2927,7 @@
       "type": "text"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -3225,7 +3101,7 @@
         "h": 7,
         "w": 19,
         "x": 0,
-        "y": 69.75
+        "y": 69
       },
       "id": 421,
       "options": {
@@ -3242,10 +3118,7 @@
       "repeatDirection": "h",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_aggregation_memory{instance=~\"$instance\",app=~\"$application\"}) by (app,element)",
           "format": "table",
@@ -3255,10 +3128,7 @@
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_aggregation_latency{instance=~\"$instance\",app=~\"$application\"}) by (app,element)",
           "format": "table",
@@ -3268,10 +3138,7 @@
           "refId": "B"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_aggregation_throughput_total{instance=~\"$instance\",app=~\"$application\"}) by (app,element)",
           "format": "table",
@@ -3303,14 +3170,12 @@
       "type": "table"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "gridPos": {
         "h": 3,
         "w": 5,
         "x": 19,
-        "y": 69.75
+        "y": 69
       },
       "id": 461,
       "links": [
@@ -3340,9 +3205,7 @@
       "type": "dashlist"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -3381,7 +3244,7 @@
         "h": 4,
         "w": 5,
         "x": 19,
-        "y": 72.75
+        "y": 72
       },
       "id": 418,
       "links": [],
@@ -3412,14 +3275,12 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "gridPos": {
-        "h": 1.25,
+        "h": 1,
         "w": 24,
         "x": 0,
-        "y": 76.75
+        "y": 76
       },
       "id": 465,
       "options": {
@@ -3431,10 +3292,7 @@
       "type": "text"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -3575,10 +3433,7 @@
       "repeatDirection": "h",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_ondemandquery_latency{instance=~\"$instance\",app=~\"$application\"}) by (app)",
           "format": "table",
@@ -3610,9 +3465,7 @@
       "type": "table"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "gridPos": {
         "h": 7,
         "w": 5,
@@ -3659,8 +3512,8 @@
       {
         "current": {
           "selected": false,
-          "text": "grafanacloud-gabrielantunes-prom",
-          "value": "grafanacloud-gabrielantunes-prom"
+          "text": "Prometheus",
+          "value": "Prometheus"
         },
         "hide": 0,
         "includeAll": false,
@@ -3680,9 +3533,7 @@
           "text": "All",
           "value": "$__all"
         },
-        "datasource": {
-          "uid": "$datasource"
-        },
+        "datasource": "$datasource",
         "definition": "label_values(siddhi_stream_throughput_total,instance)",
         "hide": 0,
         "includeAll": true,
@@ -3692,7 +3543,7 @@
         "options": [],
         "query": {
           "query": "label_values(siddhi_stream_throughput_total,instance)",
-          "refId": "grafanacloud-gabrielantunes-prom-instance-Variable-Query"
+          "refId": "StandardVariableQuery"
         },
         "refresh": 2,
         "regex": "",
@@ -3713,9 +3564,7 @@
             "$__all"
           ]
         },
-        "datasource": {
-          "uid": "$datasource"
-        },
+        "datasource": "$datasource",
         "definition": "label_values(siddhi_stream_throughput_total,app)",
         "hide": 0,
         "includeAll": true,
@@ -3725,7 +3574,7 @@
         "options": [],
         "query": {
           "query": "label_values(siddhi_stream_throughput_total,app)",
-          "refId": "grafanacloud-gabrielantunes-prom-application-Variable-Query"
+          "refId": "StandardVariableQuery"
         },
         "refresh": 1,
         "regex": "",
@@ -3742,9 +3591,7 @@
           "text": "All",
           "value": "$__all"
         },
-        "datasource": {
-          "uid": "$datasource"
-        },
+        "datasource": "$datasource",
         "definition": "label_values(type)",
         "hide": 2,
         "includeAll": true,
@@ -3754,7 +3601,7 @@
         "options": [],
         "query": {
           "query": "label_values(type)",
-          "refId": "grafanacloud-gabrielantunes-prom-type-Variable-Query"
+          "refId": "StandardVariableQuery"
         },
         "refresh": 1,
         "regex": "",
@@ -3771,9 +3618,7 @@
           "text": "All",
           "value": "$__all"
         },
-        "datasource": {
-          "uid": "$datasource"
-        },
+        "datasource": "$datasource",
         "definition": "label_values(metrics)",
         "hide": 2,
         "includeAll": true,
@@ -3783,7 +3628,7 @@
         "options": [],
         "query": {
           "query": "label_values(metrics)",
-          "refId": "grafanacloud-gabrielantunes-prom-metrics-Variable-Query"
+          "refId": "StandardVariableQuery"
         },
         "refresh": 1,
         "regex": "",
@@ -3800,9 +3645,7 @@
           "text": "All",
           "value": "$__all"
         },
-        "datasource": {
-          "uid": "$datasource"
-        },
+        "datasource": "$datasource",
         "definition": "label_values(element)",
         "hide": 2,
         "includeAll": true,
@@ -3812,7 +3655,7 @@
         "options": [],
         "query": {
           "query": "label_values(element)",
-          "refId": "grafanacloud-gabrielantunes-prom-element-Variable-Query"
+          "refId": "StandardVariableQuery"
         },
         "refresh": 1,
         "regex": "",
@@ -3829,9 +3672,7 @@
           "text": "0",
           "value": "0"
         },
-        "datasource": {
-          "uid": "$datasource"
-        },
+        "datasource": "$datasource",
         "definition": "label_values(quantile)",
         "hide": 2,
         "includeAll": true,
@@ -3841,7 +3682,7 @@
         "options": [],
         "query": {
           "query": "label_values(quantile)",
-          "refId": "grafanacloud-gabrielantunes-prom-quantile-Variable-Query"
+          "refId": "StandardVariableQuery"
         },
         "refresh": 1,
         "regex": "",
@@ -3858,9 +3699,7 @@
           "text": "contains",
           "value": "contains"
         },
-        "datasource": {
-          "uid": "$datasource"
-        },
+        "datasource": "$datasource",
         "definition": "label_values(operation)",
         "hide": 2,
         "includeAll": true,
@@ -3870,7 +3709,7 @@
         "options": [],
         "query": {
           "query": "label_values(operation)",
-          "refId": "grafanacloud-gabrielantunes-prom-operation-Variable-Query"
+          "refId": "StandardVariableQuery"
         },
         "refresh": 1,
         "regex": "",
@@ -3887,9 +3726,7 @@
           "text": "All",
           "value": "$__all"
         },
-        "datasource": {
-          "uid": "$datasource"
-        },
+        "datasource": "$datasource",
         "definition": "label_values(job)",
         "hide": 2,
         "includeAll": true,
@@ -3899,7 +3736,7 @@
         "options": [],
         "query": {
           "query": "label_values(job)",
-          "refId": "grafanacloud-gabrielantunes-prom-job-Variable-Query"
+          "refId": "StandardVariableQuery"
         },
         "refresh": 1,
         "regex": "",

--- a/wso2-streaming-integrator-mixin/dashboards/Siddhi_overall.json
+++ b/wso2-streaming-integrator-mixin/dashboards/Siddhi_overall.json
@@ -3501,7 +3501,7 @@
     }
   ],
   "refresh": "",
-  "schemaVersion": 34,
+  "schemaVersion": 32,
   "style": "dark",
   "tags": [
     "prometheus",

--- a/wso2-streaming-integrator-mixin/dashboards/Siddhi_query.json
+++ b/wso2-streaming-integrator-mixin/dashboards/Siddhi_query.json
@@ -520,7 +520,7 @@
     }
   ],
   "refresh": false,
-  "schemaVersion": 34,
+  "schemaVersion": 32,
   "style": "dark",
   "tags": [
     "prometheus",

--- a/wso2-streaming-integrator-mixin/dashboards/Siddhi_query.json
+++ b/wso2-streaming-integrator-mixin/dashboards/Siddhi_query.json
@@ -27,10 +27,7 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -198,10 +195,7 @@
       "repeatDirection": "h",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_query_memory{instance=~\"$instance\",app=~\"$application\",element=~\"$element\"}) by (instance,app,element)",
           "format": "table",
@@ -211,10 +205,7 @@
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_query_latency{instance=~\"$instance\",app=~\"$application\",element=~\"$element\",quantile=~\"$quantile\"}) by (instance,app,element,quantile)",
           "format": "table",
@@ -249,9 +240,7 @@
       "type": "table"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "gridPos": {
         "h": 3,
         "w": 5,
@@ -286,9 +275,7 @@
       "type": "dashlist"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -358,10 +345,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -434,10 +418,7 @@
       "pluginVersion": "8.3.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": true,
           "expr": "siddhi_query_memory{instance=~\"$instance\",app=~\"$application\",element=~\"$element\"}",
           "format": "time_series",
@@ -451,10 +432,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -527,10 +505,7 @@
       "pluginVersion": "8.3.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": true,
           "expr": "siddhi_query_latency{instance=~\"$instance\",app=~\"$application\",element=~\"$element\"}",
           "format": "time_series",
@@ -556,8 +531,8 @@
       {
         "current": {
           "selected": false,
-          "text": "grafanacloud-gabrielantunes-prom",
-          "value": "grafanacloud-gabrielantunes-prom"
+          "text": "Prometheus",
+          "value": "Prometheus"
         },
         "hide": 0,
         "includeAll": false,
@@ -581,9 +556,7 @@
             "$__all"
           ]
         },
-        "datasource": {
-          "uid": "$datasource"
-        },
+        "datasource": "$datasource",
         "definition": "label_values(siddhi_query_latency,instance)",
         "hide": 0,
         "includeAll": true,
@@ -614,9 +587,7 @@
             "$__all"
           ]
         },
-        "datasource": {
-          "uid": "$datasource"
-        },
+        "datasource": "$datasource",
         "definition": "label_values(siddhi_query_latency{instance=~\"$instance\"},app)",
         "hide": 0,
         "includeAll": true,
@@ -647,9 +618,7 @@
             "$__all"
           ]
         },
-        "datasource": {
-          "uid": "$datasource"
-        },
+        "datasource": "$datasource",
         "definition": "label_values(siddhi_query_latency{instance=~\"$instance\",app=~\"$application\"},element)",
         "hide": 0,
         "includeAll": true,
@@ -679,10 +648,7 @@
             "$__all"
           ]
         },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
+        "datasource": "$datasource",
         "definition": "label_values(siddhi_query_latency,quantile)",
         "hide": 0,
         "includeAll": true,

--- a/wso2-streaming-integrator-mixin/dashboards/Siddhi_server.json
+++ b/wso2-streaming-integrator-mixin/dashboards/Siddhi_server.json
@@ -28,9 +28,7 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -174,9 +172,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "gridPos": {
         "h": 3,
         "w": 5,
@@ -212,9 +208,7 @@
       "type": "dashlist"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -283,10 +277,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -560,10 +551,7 @@
       "repeatDirection": "h",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_source_throughput_total{instance=~\"$instance\",type=\"source\",operation!=\"inMemory\"}) by (instance)",
           "format": "table",
@@ -573,10 +561,7 @@
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(jvm_os_system_load_average{instance=~\"$instance\"}) by (instance)",
           "format": "table",
@@ -586,10 +571,7 @@
           "refId": "B"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(jvm_os_cpu_load_system{instance=~\"$instance\"}) by (instance)",
           "format": "table",
@@ -599,10 +581,7 @@
           "refId": "C"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(jvm_memory_heap_usage{instance=~\"$instance\"}) by (instance)",
           "format": "table",
@@ -634,10 +613,7 @@
       "type": "table"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -772,10 +748,7 @@
       "pluginVersion": "8.3.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": true,
           "expr": "sum by (instance)(siddhi_source_throughput_total{instance=~\"$instance\",type=\"source\",operation!=\"inMemory\"})",
           "format": "time_series",
@@ -789,10 +762,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -896,10 +866,7 @@
       "pluginVersion": "8.3.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": true,
           "expr": "jvm_os_system_load_average{instance=~\"$instance\"}",
           "interval": "",
@@ -911,10 +878,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1048,10 +1012,7 @@
       "pluginVersion": "8.3.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": true,
           "expr": "jvm_os_cpu_load_system{instance=~\"$instance\"}",
           "interval": "",
@@ -1059,10 +1020,7 @@
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": true,
           "expr": "jvm_os_cpu_load_process{instance=~\"$instance\"}",
           "interval": "",
@@ -1074,9 +1032,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1224,9 +1180,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1419,9 +1373,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1614,9 +1566,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1859,9 +1809,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2036,8 +1984,8 @@
       {
         "current": {
           "selected": false,
-          "text": "grafanacloud-gabrielantunes-prom",
-          "value": "grafanacloud-gabrielantunes-prom"
+          "text": "Prometheus",
+          "value": "Prometheus"
         },
         "hide": 0,
         "includeAll": false,
@@ -2061,9 +2009,7 @@
             "$__all"
           ]
         },
-        "datasource": {
-          "uid": "$datasource"
-        },
+        "datasource": "$datasource",
         "definition": "label_values(jvm_memory_heap_max,instance)",
         "hide": 0,
         "includeAll": true,
@@ -2073,7 +2019,7 @@
         "options": [],
         "query": {
           "query": "label_values(jvm_memory_heap_max,instance)",
-          "refId": "grafanacloud-gabrielantunes-prom-instance-Variable-Query"
+          "refId": "StandardVariableQuery"
         },
         "refresh": 2,
         "regex": "",
@@ -2094,9 +2040,7 @@
             "$__all"
           ]
         },
-        "datasource": {
-          "uid": "$datasource"
-        },
+        "datasource": "$datasource",
         "definition": "label_values(siddhi_stream_throughput_total,app)",
         "hide": 2,
         "includeAll": true,
@@ -2106,7 +2050,7 @@
         "options": [],
         "query": {
           "query": "label_values(siddhi_stream_throughput_total,app)",
-          "refId": "grafanacloud-gabrielantunes-prom-application-Variable-Query"
+          "refId": "StandardVariableQuery"
         },
         "refresh": 1,
         "regex": "",
@@ -2127,9 +2071,7 @@
             "$__all"
           ]
         },
-        "datasource": {
-          "uid": "$datasource"
-        },
+        "datasource": "$datasource",
         "definition": "label_values(siddhi_stream_throughput_total{app=\"$application\"},element)",
         "hide": 2,
         "includeAll": true,
@@ -2139,7 +2081,7 @@
         "options": [],
         "query": {
           "query": "label_values(siddhi_stream_throughput_total{app=\"$application\"},element)",
-          "refId": "grafanacloud-gabrielantunes-prom-element-Variable-Query"
+          "refId": "StandardVariableQuery"
         },
         "refresh": 1,
         "regex": "",
@@ -2160,9 +2102,7 @@
             "$__all"
           ]
         },
-        "datasource": {
-          "uid": "$datasource"
-        },
+        "datasource": "$datasource",
         "definition": "label_values(type)",
         "hide": 2,
         "includeAll": true,
@@ -2172,7 +2112,7 @@
         "options": [],
         "query": {
           "query": "label_values(type)",
-          "refId": "grafanacloud-gabrielantunes-prom-type-Variable-Query"
+          "refId": "StandardVariableQuery"
         },
         "refresh": 1,
         "regex": "",

--- a/wso2-streaming-integrator-mixin/dashboards/Siddhi_server.json
+++ b/wso2-streaming-integrator-mixin/dashboards/Siddhi_server.json
@@ -1973,7 +1973,7 @@
     }
   ],
   "refresh": "5s",
-  "schemaVersion": 34,
+  "schemaVersion": 32,
   "style": "dark",
   "tags": [
     "prometheus ",

--- a/wso2-streaming-integrator-mixin/dashboards/Siddhi_sink.json
+++ b/wso2-streaming-integrator-mixin/dashboards/Siddhi_sink.json
@@ -561,7 +561,7 @@
     }
   ],
   "refresh": "",
-  "schemaVersion": 34,
+  "schemaVersion": 32,
   "style": "dark",
   "tags": [
     "prometheus",

--- a/wso2-streaming-integrator-mixin/dashboards/Siddhi_sink.json
+++ b/wso2-streaming-integrator-mixin/dashboards/Siddhi_sink.json
@@ -27,10 +27,7 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -240,10 +237,7 @@
       "repeatDirection": "h",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_sinkmapper_latency{instance=~\"$instance\",app=~\"$application\",element=~\"$element\",operation=~\"$operation\",quantile=~\"$quantile\"}) by (instance,app,element,operation,operationType,quantile)",
           "format": "table",
@@ -253,10 +247,7 @@
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_sink_throughput_total{instance=~\"$instance\",app=~\"$application\",element=~\"$element\"}) by (instance,app,element)",
           "format": "table",
@@ -290,9 +281,7 @@
       "type": "table"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "gridPos": {
         "h": 3,
         "w": 4,
@@ -327,9 +316,7 @@
       "type": "dashlist"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -399,10 +386,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -475,10 +459,7 @@
       "pluginVersion": "8.3.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": true,
           "expr": "siddhi_sink_throughput_total{instance=~\"$instance\",app=~\"$application\",element=~\"$element\",operation=~\"$operation\"}",
           "format": "time_series",
@@ -492,10 +473,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -568,10 +546,7 @@
       "pluginVersion": "8.3.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": true,
           "expr": "siddhi_sinkmapper_latency{instance=~\"$instance\",app=~\"$application\",element=~\"$element\",operation=~\"$operation\",quantile=~\"$quantile\"}",
           "format": "time_series",
@@ -597,8 +572,8 @@
       {
         "current": {
           "selected": false,
-          "text": "grafanacloud-gabrielantunes-prom",
-          "value": "grafanacloud-gabrielantunes-prom"
+          "text": "Prometheus",
+          "value": "Prometheus"
         },
         "hide": 0,
         "includeAll": false,
@@ -622,9 +597,7 @@
             "$__all"
           ]
         },
-        "datasource": {
-          "uid": "$datasource"
-        },
+        "datasource": "$datasource",
         "definition": "label_values(siddhi_sinkmapper_latency,instance)",
         "hide": 0,
         "includeAll": true,
@@ -655,9 +628,7 @@
             "$__all"
           ]
         },
-        "datasource": {
-          "uid": "$datasource"
-        },
+        "datasource": "$datasource",
         "definition": "label_values(siddhi_sinkmapper_latency{instance=~\"$instance\"},app)",
         "hide": 0,
         "includeAll": true,
@@ -688,10 +659,7 @@
             "$__all"
           ]
         },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
+        "datasource": "$datasource",
         "definition": "label_values(siddhi_sinkmapper_latency{instance=~\"$instance\",app=~\"$application\"},element)",
         "hide": 0,
         "includeAll": true,
@@ -719,10 +687,7 @@
             "$__all"
           ]
         },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
+        "datasource": "$datasource",
         "definition": "label_values(siddhi_sinkmapper_latency{instance=~\"$instance\",app=~\"$application\",element=~\"$element\"},operation)",
         "hide": 0,
         "includeAll": true,
@@ -750,10 +715,7 @@
             "$__all"
           ]
         },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
+        "datasource": "$datasource",
         "definition": "label_values(siddhi_sinkmapper_latency,quantile)",
         "hide": 0,
         "includeAll": true,

--- a/wso2-streaming-integrator-mixin/dashboards/Siddhi_source.json
+++ b/wso2-streaming-integrator-mixin/dashboards/Siddhi_source.json
@@ -576,7 +576,7 @@
     }
   ],
   "refresh": false,
-  "schemaVersion": 34,
+  "schemaVersion": 32,
   "style": "dark",
   "tags": [
     "prometheus",

--- a/wso2-streaming-integrator-mixin/dashboards/Siddhi_source.json
+++ b/wso2-streaming-integrator-mixin/dashboards/Siddhi_source.json
@@ -27,10 +27,7 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -242,10 +239,7 @@
       "repeatDirection": "h",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_sourcemapper_latency{instance=~\"$instance\",app=~\"$application\",element=~\"$element\",operation=~\"$operation\",quantile=~\"$quantile\"}) by (instance,app,element,operation,operationType,quantile)",
           "format": "table",
@@ -255,10 +249,7 @@
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_source_throughput_total{instance=~\"$instance\",app=~\"$application\",element=~\"$element\",operation=~\"$operation\"}) by (instance,app,element,operation)",
           "format": "table",
@@ -305,9 +296,7 @@
       "type": "table"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "gridPos": {
         "h": 3,
         "w": 4,
@@ -342,9 +331,7 @@
       "type": "dashlist"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -414,10 +401,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -490,10 +474,7 @@
       "pluginVersion": "8.3.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": true,
           "expr": "siddhi_source_throughput_total{instance=~\"$instance\",app=~\"$application\",element=~\"$element\",operation=~\"$operation\"}",
           "format": "time_series",
@@ -507,10 +488,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -583,10 +561,7 @@
       "pluginVersion": "8.3.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": true,
           "expr": "siddhi_sourcemapper_latency{instance=~\"$instance\",app=~\"$application\",element=~\"$element\",operation=~\"$operation\",quantile=~\"$quantile\"}",
           "format": "time_series",
@@ -612,8 +587,8 @@
       {
         "current": {
           "selected": false,
-          "text": "grafanacloud-gabrielantunes-prom",
-          "value": "grafanacloud-gabrielantunes-prom"
+          "text": "Prometheus",
+          "value": "Prometheus"
         },
         "hide": 0,
         "includeAll": false,
@@ -637,9 +612,7 @@
             "$__all"
           ]
         },
-        "datasource": {
-          "uid": "$datasource"
-        },
+        "datasource": "$datasource",
         "definition": "label_values(siddhi_sourcemapper_latency,instance)",
         "hide": 0,
         "includeAll": true,
@@ -670,9 +643,7 @@
             "$__all"
           ]
         },
-        "datasource": {
-          "uid": "$datasource"
-        },
+        "datasource": "$datasource",
         "definition": "label_values(siddhi_sourcemapper_latency{instance=~\"$instance\"},app)",
         "hide": 0,
         "includeAll": true,
@@ -703,10 +674,7 @@
             "$__all"
           ]
         },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
+        "datasource": "$datasource",
         "definition": "label_values(siddhi_sourcemapper_latency{instance=~\"$instance\",app=~\"$application\"},element)",
         "hide": 0,
         "includeAll": true,
@@ -734,10 +702,7 @@
             "$__all"
           ]
         },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
+        "datasource": "$datasource",
         "definition": "label_values(siddhi_sourcemapper_latency{instance=~\"$instance\",app=~\"$application\",element=~\"$element\"},operation)",
         "hide": 0,
         "includeAll": true,
@@ -765,10 +730,7 @@
             "$__all"
           ]
         },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
+        "datasource": "$datasource",
         "definition": "label_values(siddhi_sourcemapper_latency,quantile)",
         "hide": 0,
         "includeAll": true,

--- a/wso2-streaming-integrator-mixin/dashboards/Siddhi_stream.json
+++ b/wso2-streaming-integrator-mixin/dashboards/Siddhi_stream.json
@@ -27,10 +27,7 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -167,10 +164,7 @@
       "repeatDirection": "h",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_stream_throughput_total{instance=~\"$instance\",app=~\"$application\",element=~\"$element\"}) by (instance,app,element)",
           "format": "table",
@@ -206,9 +200,7 @@
       "type": "table"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "gridPos": {
         "h": 3,
         "w": 5,
@@ -243,9 +235,7 @@
       "type": "dashlist"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -315,10 +305,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -391,10 +378,7 @@
       "pluginVersion": "8.3.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": true,
           "expr": "siddhi_stream_throughput_total{instance=~\"$instance\",app=~\"$application\",element=~\"$element\"}",
           "format": "time_series",
@@ -420,8 +404,8 @@
       {
         "current": {
           "selected": false,
-          "text": "grafanacloud-gabrielantunes-prom",
-          "value": "grafanacloud-gabrielantunes-prom"
+          "text": "Prometheus",
+          "value": "Prometheus"
         },
         "hide": 0,
         "includeAll": false,
@@ -441,9 +425,7 @@
           "text": "All",
           "value": "$__all"
         },
-        "datasource": {
-          "uid": "$datasource"
-        },
+        "datasource": "$datasource",
         "definition": "label_values(siddhi_stream_throughput_total,instance)",
         "hide": 0,
         "includeAll": true,
@@ -453,7 +435,7 @@
         "options": [],
         "query": {
           "query": "label_values(siddhi_stream_throughput_total,instance)",
-          "refId": "grafanacloud-gabrielantunes-prom-instance-Variable-Query"
+          "refId": "StandardVariableQuery"
         },
         "refresh": 2,
         "regex": "",
@@ -474,9 +456,7 @@
             "$__all"
           ]
         },
-        "datasource": {
-          "uid": "$datasource"
-        },
+        "datasource": "$datasource",
         "definition": "label_values(siddhi_stream_throughput_total{instance=~\"$instance\"},app)",
         "hide": 0,
         "includeAll": true,
@@ -507,9 +487,7 @@
             "$__all"
           ]
         },
-        "datasource": {
-          "uid": "$datasource"
-        },
+        "datasource": "$datasource",
         "definition": "label_values(siddhi_stream_throughput_total{instance=~\"$instance\",app=~\"$application\"},element)",
         "hide": 0,
         "includeAll": true,

--- a/wso2-streaming-integrator-mixin/dashboards/Siddhi_stream.json
+++ b/wso2-streaming-integrator-mixin/dashboards/Siddhi_stream.json
@@ -393,7 +393,7 @@
     }
   ],
   "refresh": false,
-  "schemaVersion": 34,
+  "schemaVersion": 32,
   "style": "dark",
   "tags": [
     "prometheus",

--- a/wso2-streaming-integrator-mixin/dashboards/Siddhi_table.json
+++ b/wso2-streaming-integrator-mixin/dashboards/Siddhi_table.json
@@ -27,10 +27,7 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -217,10 +214,7 @@
       "repeatDirection": "h",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_table_latency{instance=~\"$instance\",app=~\"$application\",element=~\"$element\",operation=~\"$operation\"}) by (instance,app,element,operation)",
           "format": "table",
@@ -230,10 +224,7 @@
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_table_throughput_total{instance=~\"$instance\",app=~\"$application\",element=~\"$element\",operation=~\"$operation\"}) by (instance,app,element,operation)",
           "format": "table",
@@ -255,9 +246,7 @@
       "type": "table"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "gridPos": {
         "h": 3,
         "w": 5,
@@ -292,9 +281,7 @@
       "type": "dashlist"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -364,10 +351,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -440,10 +424,7 @@
       "pluginVersion": "8.3.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": true,
           "expr": "siddhi_table_latency{instance=~\"$instance\",app=~\"$application\",element=~\"$element\",operation=~\"$operation\"}",
           "format": "time_series",
@@ -457,10 +438,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -533,10 +511,7 @@
       "pluginVersion": "8.3.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": true,
           "expr": "siddhi_table_throughput_total{instance=~\"$instance\",app=~\"$application\",element=~\"$element\",operation=~\"$operation\"}",
           "format": "time_series",
@@ -562,8 +537,8 @@
       {
         "current": {
           "selected": false,
-          "text": "grafanacloud-gabrielantunes-prom",
-          "value": "grafanacloud-gabrielantunes-prom"
+          "text": "Prometheus",
+          "value": "Prometheus"
         },
         "hide": 0,
         "includeAll": false,
@@ -587,9 +562,7 @@
             "$__all"
           ]
         },
-        "datasource": {
-          "uid": "$datasource"
-        },
+        "datasource": "$datasource",
         "definition": "label_values(siddhi_table_latency,instance)",
         "hide": 0,
         "includeAll": true,
@@ -620,9 +593,7 @@
             "$__all"
           ]
         },
-        "datasource": {
-          "uid": "$datasource"
-        },
+        "datasource": "$datasource",
         "definition": "label_values(siddhi_table_latency{instance=~\"$instance\"},app)",
         "hide": 0,
         "includeAll": true,
@@ -653,9 +624,7 @@
             "$__all"
           ]
         },
-        "datasource": {
-          "uid": "$datasource"
-        },
+        "datasource": "$datasource",
         "definition": "label_values(siddhi_table_latency{instance=~\"$instance\",app=~\"$application\"},element)",
         "hide": 0,
         "includeAll": true,
@@ -685,10 +654,7 @@
             "$__all"
           ]
         },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
+        "datasource": "$datasource",
         "definition": "label_values(siddhi_table_latency{instance=~\"$instance\",app=~\"$application\",element=~\"$element\"},operation)",
         "hide": 0,
         "includeAll": true,

--- a/wso2-streaming-integrator-mixin/dashboards/Siddhi_table.json
+++ b/wso2-streaming-integrator-mixin/dashboards/Siddhi_table.json
@@ -526,7 +526,7 @@
     }
   ],
   "refresh": false,
-  "schemaVersion": 34,
+  "schemaVersion": 32,
   "style": "dark",
   "tags": [
     "prometheus",

--- a/wso2-streaming-integrator-mixin/dashboards/StreamingIntegrator_apps.json
+++ b/wso2-streaming-integrator-mixin/dashboards/StreamingIntegrator_apps.json
@@ -28,9 +28,7 @@
   "panels": [
     {
       "collapsed": false,
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -43,10 +41,7 @@
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -106,10 +101,7 @@
       "pluginVersion": "8.3.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_total_reads{app=~\"$app\", type=~\"file|cdc|kafka|http\"}) ",
           "format": "time_series",
@@ -123,9 +115,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -283,10 +273,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -347,10 +334,7 @@
       "pluginVersion": "8.3.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(rate(siddhi_total_reads{app=~\"$app\"}[$__interval]))",
           "format": "time_series",
@@ -365,10 +349,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -428,10 +409,7 @@
       "pluginVersion": "8.3.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_total_writes{app=~\"$app\", type=~\"file|rdbms|kafka|http\"})",
           "format": "time_series",
@@ -446,9 +424,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -520,10 +496,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "description": "Total errors occurred while consuming & publishing events",
       "fieldConfig": {
         "defaults": {
@@ -584,10 +557,7 @@
       "pluginVersion": "8.3.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "(sum(siddhi_store_rdbms_total_error_count{app=~\"$app\"}) or vector(0)) + (sum(siddhi_file_source_error_count{app=~\"$app\"}) or vector(0)) + (sum(siddhi_cdc_source_listening_mode_total_error_count{app=~\"$app\"}) or vector(0)) + (sum(siddhi_cdc_source_polling_mode_total_error_count{app=~\"$app\"}) or vector(0)) + (sum(siddhi_file_sink_total_error_count{app=~\"$app\"}) or vector(0)) + (sum(siddhi_kafka_source_error_count_per_stream{app=~\"$app\"}) or vector(0)) + (sum(siddhi_kafka_sink_error_count{app=~\"$app\"}) or vector(0))",
           "format": "time_series",
@@ -602,9 +572,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "description": "Number of dropped events due to invalid mapping.",
       "fieldConfig": {
         "defaults": {
@@ -677,9 +645,7 @@
     },
     {
       "collapsed": false,
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -692,9 +658,7 @@
       "type": "row"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "gridPos": {
         "h": 2,
         "w": 24,
@@ -711,10 +675,7 @@
       "type": "text"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -949,10 +910,7 @@
       "pluginVersion": "8.3.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_http_source_event_count{app=~\"$app\"}) by (url, stream_name)",
           "format": "table",
@@ -963,10 +921,7 @@
           "refId": "B"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(rate(siddhi_http_source_event_count{app=~\"$app\"}[$__rate_interval])) by (url, stream_name)",
           "format": "table",
@@ -977,10 +932,7 @@
           "refId": "C"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_http_source_error_count{app=~\"$app\"}) by (url, stream_name)",
           "format": "table",
@@ -990,10 +942,7 @@
           "refId": "G"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_http_source_status{app=~\"$app\"}) by (url, stream_name)",
           "format": "table",
@@ -1003,10 +952,7 @@
           "refId": "D"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_http_source_request_size{app=~\"$app\"}) by (url, stream_name) / sum(siddhi_http_source_event_count{app=~\"$app\"}) by (url, stream_name)",
           "format": "table",
@@ -1039,9 +985,7 @@
       "type": "table"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "gridPos": {
         "h": 2,
         "w": 24,
@@ -1065,9 +1009,7 @@
       "type": "text"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1505,9 +1447,7 @@
       "type": "table"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "gridPos": {
         "h": 2,
         "w": 24,
@@ -1524,10 +1464,7 @@
       "type": "text"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1930,10 +1867,7 @@
       "pluginVersion": "8.3.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_file_source_event_count{app=~\"$app\"}) by (file_name, mode, stream_name, file_path, app)",
           "format": "table",
@@ -1944,10 +1878,7 @@
           "refId": "B"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_file_source_file_size{app=~\"$app\"}) by (file_path)",
           "format": "table",
@@ -1958,10 +1889,7 @@
           "refId": "C"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_file_source_file_status{app=~\"$app\"}) by (file_path)",
           "format": "table",
@@ -1972,10 +1900,7 @@
           "refId": "D"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_file_source_elapse_time{app=~\"$app\"}) by (file_path)",
           "format": "table",
@@ -1986,10 +1911,7 @@
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_file_source_started_time{app=~\"$app\"}) by (file_path)",
           "format": "table",
@@ -2000,10 +1922,7 @@
           "refId": "E"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum((siddhi_file_source_event_count{app=~\"$app\"} - ignoring(file_name, mode, stream_name)siddhi_file_source_total_valid_events_count{app=~\"$app\"}) + siddhi_file_source_error_count{app=~\"$app\"}) by (file_path)",
           "format": "table",
@@ -2036,9 +1955,7 @@
       "type": "table"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "gridPos": {
         "h": 2,
         "w": 24,
@@ -2055,10 +1972,7 @@
       "type": "text"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2423,10 +2337,7 @@
       "pluginVersion": "8.3.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_cdc_source_listening_mode_event_count{app=~\"$app\"}) by (db_url, A_db_type, C_database, D_tablename, B_host, app)",
           "format": "table",
@@ -2437,10 +2348,7 @@
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(rate(siddhi_cdc_source_listening_mode_events_per_table{app=~\"$app\"}[$__rate_interval])) by (db_url)",
           "format": "table",
@@ -2451,10 +2359,7 @@
           "refId": "D"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_cdc_source_listening_mode_db_status{app=~\"$app\"}) by (db_url)",
           "format": "table",
@@ -2465,10 +2370,7 @@
           "refId": "B"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_cdc_source_listening_mode_idle_time{app=~\"$app\"}) by (db_url)",
           "format": "table",
@@ -2479,10 +2381,7 @@
           "refId": "C"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_cdc_source_listening_mode_last_receive_time{app=~\"$app\"}) by (db_url)",
           "format": "table",
@@ -2493,10 +2392,7 @@
           "refId": "E"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_cdc_source_listening_mode_events_per_table{app=~\"$app\"} - ignoring(tablename)siddhi_cdc_source_listening_mode_total_valid_events_count{app=~\"$app\"} + siddhi_cdc_source_listening_mode_total_error_count{app=~\"$app\"}) by (db_url)",
           "format": "table",
@@ -2529,10 +2425,7 @@
       "type": "table"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2897,10 +2790,7 @@
       "pluginVersion": "8.3.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_cdc_source_polling_mode_event_count{app=~\"$app\"}) by (db_url, A_db_type, C_database, D_tablename, B_host, app)",
           "format": "table",
@@ -2911,10 +2801,7 @@
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_cdc_source_polling_mode_events_in_last_polling_interval{app=~\"$app\"}) by (db_url)",
           "format": "table",
@@ -2925,10 +2812,7 @@
           "refId": "D"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_cdc_source_polling_mode_db_status{app=~\"$app\"}) by (db_url)",
           "format": "table",
@@ -2939,10 +2823,7 @@
           "refId": "B"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_cdc_source_polling_mode_idle_time{app=~\"$app\"}) by (db_url)",
           "format": "table",
@@ -2953,10 +2834,7 @@
           "refId": "F"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_cdc_source_polling_mode_last_receive_time{app=~\"$app\"}) by (db_url)",
           "format": "table",
@@ -2967,10 +2845,7 @@
           "refId": "C"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_cdc_source_polling_mode_event_count{app=~\"$app\"} - ignoring(A_db_type, B_host, C_database, D_tablename)siddhi_cdc_source_polling_mode_total_valid_events_count{app=~\"$app\"} + siddhi_cdc_source_polling_mode_total_error_count{app=~\"$app\"}) by (db_url)",
           "format": "table",
@@ -3004,9 +2879,7 @@
     },
     {
       "collapsed": false,
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -3019,9 +2892,7 @@
       "type": "row"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "gridPos": {
         "h": 2,
         "w": 24,
@@ -3038,10 +2909,7 @@
       "type": "text"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -3342,10 +3210,7 @@
       "pluginVersion": "8.3.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_http_sink_event_count{app=~\"$app\"}) by (url, stream_name)",
           "format": "table",
@@ -3356,10 +3221,7 @@
           "refId": "B"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_http_sink_error_count{app=~\"$app\"}) by (url, stream_name)",
           "format": "table",
@@ -3370,10 +3232,7 @@
           "refId": "D"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(rate(siddhi_http_sink_event_count{app=~\"$app\"}[$__rate_interval])) by (url, stream_name)",
           "format": "table",
@@ -3384,10 +3243,7 @@
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_http_sink_status{app=~\"$app\"}) by (url, stream_name)",
           "format": "table",
@@ -3397,10 +3253,7 @@
           "refId": "C"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_http_sink_request_size{app=~\"$app\"}) by (url, stream_name) / sum(siddhi_http_sink_event_count{app=~\"$app\"}) by (url, stream_name)",
           "format": "table",
@@ -3410,10 +3263,7 @@
           "refId": "E"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_http_sink_average_latency{app=~\"$app\"}) by (url, stream_name)",
           "format": "table",
@@ -3445,9 +3295,7 @@
       "type": "table"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "gridPos": {
         "h": 2,
         "w": 24,
@@ -3464,10 +3312,7 @@
       "type": "text"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -3773,10 +3618,7 @@
       "pluginVersion": "8.3.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_kafka_sink_current_offset{app=~\"$app\"}) by (stream_id)",
           "format": "table",
@@ -3786,10 +3628,7 @@
           "refId": "F"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_kafka_sink_write_count_per_stream{app=~\"$app\"}) by (stream_id)",
           "format": "table",
@@ -3799,10 +3638,7 @@
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(rate(siddhi_kafka_sink_write_count_per_stream{app=~\"$app\"}[$__rate_interval])) by (stream_id)",
           "format": "table",
@@ -3812,10 +3648,7 @@
           "refId": "G"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "avg(siddhi_kafka_sink_per_stream_last_message_size_in_bytes{app=~\"$app\"}) by (stream_id)",
           "format": "table",
@@ -3825,10 +3658,7 @@
           "refId": "D"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "avg(siddhi_kafka_sink_per_stream_last_message_latency_in_millis{app=~\"$app\"}) by (stream_id)",
           "format": "table",
@@ -3838,10 +3668,7 @@
           "refId": "E"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_kafka_sink_error_count_per_stream{app=~\"$app\"}) by (stream_id) ",
           "format": "table",
@@ -3851,10 +3678,7 @@
           "refId": "B"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "(sum(siddhi_kafka_sink_error_count_per_stream{app=~\"$app\"}) by (stream_id) / sum(siddhi_kafka_sink_write_count_per_stream{app=~\"$app\"}) by (stream_id)) ",
           "format": "table",
@@ -3864,10 +3688,7 @@
           "refId": "C"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_kafka_sink_per_stream_last_message_published_at{app=~\"$app\"}) by (stream_id)",
           "format": "table",
@@ -3899,9 +3720,7 @@
       "type": "table"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "gridPos": {
         "h": 2,
         "w": 24,
@@ -3918,10 +3737,7 @@
       "type": "text"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -4334,10 +4150,7 @@
       "pluginVersion": "8.3.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_file_sink_event_count{app=~\"$app\"}) by (file_name, mode, stream_name, file_path,app)",
           "format": "table",
@@ -4348,10 +4161,7 @@
           "refId": "B"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_file_sink_file_size{app=~\"$app\"}) by (file_path)",
           "format": "table",
@@ -4362,10 +4172,7 @@
           "refId": "C"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_file_sink_file_status{app=~\"$app\"}) by (file_path)",
           "format": "table",
@@ -4376,10 +4183,7 @@
           "refId": "D"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_file_sink_lines_count{app=~\"$app\"}) by (file_path)",
           "format": "table",
@@ -4389,10 +4193,7 @@
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_file_sink_elapsed_time{app=~\"$app\"}) by (file_path)",
           "format": "table",
@@ -4402,10 +4203,7 @@
           "refId": "E"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_file_sink_total_error_count{app=~\"$app\"} + siddhi_file_sink_dropped_events{app=~\"$app\"} ) by (file_path)",
           "format": "table",
@@ -4437,9 +4235,7 @@
       "type": "table"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "gridPos": {
         "h": 2,
         "w": 24,
@@ -4457,9 +4253,7 @@
     },
     {
       "columns": [],
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fontSize": "120%",
       "gridPos": {
         "h": 8,
@@ -4775,8 +4569,8 @@
       {
         "current": {
           "selected": false,
-          "text": "grafanacloud-gabrielantunes-prom",
-          "value": "grafanacloud-gabrielantunes-prom"
+          "text": "Prometheus",
+          "value": "Prometheus"
         },
         "hide": 0,
         "includeAll": false,
@@ -4800,9 +4594,7 @@
             "$__all"
           ]
         },
-        "datasource": {
-          "uid": "$datasource"
-        },
+        "datasource": "$datasource",
         "definition": "label_values(siddhi_stream_throughput_total, app)",
         "hide": 0,
         "includeAll": true,
@@ -4812,7 +4604,7 @@
         "options": [],
         "query": {
           "query": "label_values(siddhi_stream_throughput_total, app)",
-          "refId": "grafanacloud-gabrielantunes-prom-app-Variable-Query"
+          "refId": "StandardVariableQuery"
         },
         "refresh": 1,
         "regex": "",

--- a/wso2-streaming-integrator-mixin/dashboards/StreamingIntegrator_apps.json
+++ b/wso2-streaming-integrator-mixin/dashboards/StreamingIntegrator_apps.json
@@ -4561,7 +4561,7 @@
     }
   ],
   "refresh": "5s",
-  "schemaVersion": 34,
+  "schemaVersion": 32,
   "style": "dark",
   "tags": [],
   "templating": {

--- a/wso2-streaming-integrator-mixin/dashboards/StreamingIntegrator_overall.json
+++ b/wso2-streaming-integrator-mixin/dashboards/StreamingIntegrator_overall.json
@@ -607,7 +607,7 @@
     }
   ],
   "refresh": "5s",
-  "schemaVersion": 34,
+  "schemaVersion": 32,
   "style": "dark",
   "tags": [
     "wso2",

--- a/wso2-streaming-integrator-mixin/dashboards/StreamingIntegrator_overall.json
+++ b/wso2-streaming-integrator-mixin/dashboards/StreamingIntegrator_overall.json
@@ -37,9 +37,7 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -111,10 +109,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -329,10 +324,7 @@
       "pluginVersion": "8.3.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_total_reads{type=~\"cdc|file|kafka|http\"}) by (app)",
           "format": "table",
@@ -343,10 +335,7 @@
           "refId": "B"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum by(app) (rate(siddhi_total_reads{type=~\"cdc|file|kafka|http\"}[$__rate_interval]))",
           "format": "table",
@@ -357,10 +346,7 @@
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(siddhi_total_writes{type=~\"rdbms|file|kafka|http\"}) by (app)",
           "format": "table",
@@ -371,10 +357,7 @@
           "refId": "C"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum (rate(siddhi_total_writes{type=~\"rdbms|file|kafka|http\"}[$__rate_interval]))",
           "format": "table",
@@ -407,9 +390,7 @@
       "type": "table"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -481,9 +462,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -641,8 +620,8 @@
       {
         "current": {
           "selected": false,
-          "text": "grafanacloud-gabrielantunes-prom",
-          "value": "grafanacloud-gabrielantunes-prom"
+          "text": "Prometheus",
+          "value": "Prometheus"
         },
         "hide": 0,
         "includeAll": false,
@@ -662,10 +641,7 @@
           "text": "AggregateDataIncrementally",
           "value": "AggregateDataIncrementally"
         },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
+        "datasource": "$datasource",
         "definition": "label_values(siddhi_stream_throughput_total, app)",
         "hide": 2,
         "includeAll": false,

--- a/wso2-streaming-integrator-mixin/mixin.libsonnet
+++ b/wso2-streaming-integrator-mixin/mixin.libsonnet
@@ -8,6 +8,7 @@
     'Siddhi_table.json': (import 'dashboards/Siddhi_table.json'),
     'Siddhi_aggregation.json': (import 'dashboards/Siddhi_aggregation.json'),
     'Siddhi_ondemandquery.json': (import 'dashboards/Siddhi_ondemandquery.json'),
+    'Siddhi_stream.json': (import 'dashboards/Siddhi_stream.json'),
     'StreamingIntegrator_apps.json': (import 'dashboards/StreamingIntegrator_apps.json'),
     'StreamingIntegrator_overall.json': (import 'dashboards/StreamingIntegrator_overall.json'),
   },


### PR DESCRIPTION
This downgrades the schema version to version 32, so that the datasource variable can be parsed as an string. This needs to be upgraded in the future to the new datasource object schema, as in https://github.com/grafana/grafana/pull/33817.

Also adding the README file, and a missing dashboard to mixin.libsonnet file.
