### PR TITLE
grizzly: remove .json/.yaml in the dashboards names

### DIFF
--- a/grizzly/grafana.libsonnet
+++ b/grizzly/grafana.libsonnet
@@ -5,7 +5,12 @@ local util = import 'util.libsonnet';
   getFolder(main):: util.get(main, 'grafanaDashboardFolder', 'General'),
 
   fromMap(dashboards, folder):: {
-    [k]: util.makeResource('Dashboard', k, dashboards[k], { folder: folder })
+    [k]: util.makeResource(
+      'Dashboard',
+      std.strReplace(std.strReplace(std.strReplace(k, '.json', ''), '.yaml', ''), '.yml', ''),
+      dashboards[k],
+      { folder: folder }
+    )
     for k in std.objectFields(dashboards)
   },
 
@@ -14,7 +19,12 @@ local util = import 'util.libsonnet';
       local mixin = mixins[key];
       {
         local folder = util.get(mixin, 'grafanaDashboardFolder', 'General'),
-        [k]: util.makeResource('Dashboard', k, mixin.grafanaDashboards[k], { folder: folder })
+        [k]: util.makeResource(
+          'Dashboard',
+          std.strReplace(std.strReplace(std.strReplace(k, '.json', ''), '.yaml', ''), '.yml', ''),
+          mixin.grafanaDashboards[k],
+          { folder: folder }
+        )
         for k in std.objectFieldsAll(util.get(mixin, 'grafanaDashboards', {}))
       }
     for key in std.objectFields(mixins)

--- a/grizzly/prometheus.libsonnet
+++ b/grizzly/prometheus.libsonnet
@@ -15,7 +15,12 @@ local resource = import 'resource.libsonnet';
 
   fromMapsFiltered(rules, excludes):: {
     local filterRules(rules, exclude_list) = [rule for rule in rules.groups if !std.member(exclude_list, rule.name)],
-    [k]: util.makeResource(kind, k, { groups: filterRules(rules, excludes) }, {})
+    [k]: util.makeResource(
+      kind,
+      std.strReplace(std.strReplace(std.strReplace(k, '.json', ''), '.yaml', ''), '.yml', ''),
+      { groups: filterRules(rules, excludes) },
+      {}
+    )
     for k in std.objectFields(rules)
   },
 
@@ -23,7 +28,7 @@ local resource = import 'resource.libsonnet';
     [if std.objectHasAll(mixins[key], alertRules) || std.objectHasAll(mixins[key], recordingRules) then key else null]:
       util.makeResource(
         kind,
-        key,
+        std.strReplace(std.strReplace(std.strReplace(key, '.json', ''), '.yaml', ''), '.yml', ''),
         (if std.objectHasAll(mixins[key], alertRules) then mixins[key].prometheusAlerts else {})
         + (if std.objectHasAll(mixins[key], recordingRules) then mixins[key].prometheusRules else {})
       )


### PR DESCRIPTION
Mixins typically append .json or .yaml at the end of the name.
Remove those so that Grizzly can deploy them like the jsonnet code embed
into Grizzly does (grizzly.jsonnet).

Signed-off-by: Arthur Outhenin-Chalandre <arthur.outhenin-chalandre@cern.ch>