### PR TITLE
nginx-directory: allow disabling downstream subfilter

### DIFF
--- a/nginx-directory/configfile.libsonnet
+++ b/nginx-directory/configfile.libsonnet
@@ -31,16 +31,25 @@ function(services) {
       else ''
     )
     + (
+      if service.disable_downstream_subfilter
+      then |||
+        add_header X-Nginx-Subfilter disable;
+      ||| % service
+      else ''
+    )
+    + (
       if service.subfilter
       then |||
-        sub_filter 'href="/' 'href="/%(path)s/';
-        sub_filter 'src="/' 'src="/%(path)s/';
-        sub_filter 'action="/' 'action="/%(path)s/';
-        sub_filter 'endpoint:"/' 'endpoint:"/%(path)s/';  # for XHRs.
-        sub_filter 'href:"/v1/' 'href:"/%(path)s/v1/';
-        sub_filter_once off;
-        sub_filter_types text/css application/xml application/json application/javascript;
-        proxy_redirect   "/" "/%(path)s/";
+        if ($http_x_nginx_subfilter != "disable") {
+          sub_filter 'href="/' 'href="/%(path)s/';
+          sub_filter 'src="/' 'src="/%(path)s/';
+          sub_filter 'action="/' 'action="/%(path)s/';
+          sub_filter 'endpoint:"/' 'endpoint:"/%(path)s/';  # for XHRs.
+          sub_filter 'href:"/v1/' 'href:"/%(path)s/v1/';
+          sub_filter_once off;
+          sub_filter_types text/css application/xml application/json application/javascript;
+          proxy_redirect   "/" "/%(path)s/";
+        }
       ||| % service
       else ''
     ),

--- a/nginx-directory/directory.libsonnet
+++ b/nginx-directory/directory.libsonnet
@@ -25,6 +25,7 @@ local link_data = import 'link_data.libsonnet';
       redirect: false,
       allowWebsockets: false,
       subfilter: false,
+      disable_downstream_subfilter: false,
       custom: [],
 
       // backwards compatible, service level config allows for more granular configuration


### PR DESCRIPTION
There's a `subfilter` property that allows rewriting request paths. Sometimes, several nginx-directory instances are chained, and if first has subfilter enabled, then the next ones have no control over what happens to the HTML they return.

This might be undesirable since subfilter doesn't always cover all the cases, and some apps just want to know the data they return.

This adds a `disable_downstream_subfilter` option to the route, which makes the directory proxy_pass to add `X-Nginx-Subfilter: disable` to all responses. On the other hand, the subfilter rules now check for that header, and if it's set to `disable` then subfilter is not applied.

Signed-off-by: Oleg Zaytsev <mail@olegzaytsev.com>
