### PR TITLE
fix(postgres-exporter): correct use of DATA_SOURCE_URI

### DIFF
--- a/postgres-exporter/main.libsonnet
+++ b/postgres-exporter/main.libsonnet
@@ -3,7 +3,7 @@ local k = import 'ksonnet-util/kausal.libsonnet';
 {
   new(
     name,
-    data_source_uri='postgresql://$(HOSTNAME):$(PORT)/postgres',
+    data_source_uri='$(HOSTNAME):$(PORT)/postgres',
     ssl=true,
     image='quay.io/prometheuscommunity/postgres-exporter:v0.10.0',
   ):: {


### PR DESCRIPTION
apparently we need to drop the prefix