### PR TITLE
fix(elasticsearch-mixin): Fix Cluster health panel for yellow color

### DIFF
--- a/elasticsearch-mixin/dashboards/elasticsearch-overview.json
+++ b/elasticsearch-mixin/dashboards/elasticsearch-overview.json
@@ -18,53 +18,7 @@
   "graphTooltip": 1,
   "id": 14,
   "iteration": 1611742973621,
-  "links": [
-    {
-      "asDropdown": true,
-      "icon": "external link",
-      "includeVars": false,
-      "keepTime": true,
-      "tags": [
-        "OS"
-      ],
-      "targetBlank": true,
-      "title": "OS",
-      "type": "dashboards"
-    },
-    {
-      "asDropdown": true,
-      "icon": "external link",
-      "keepTime": true,
-      "tags": [
-        "MySQL"
-      ],
-      "targetBlank": true,
-      "title": "MySQL",
-      "type": "dashboards"
-    },
-    {
-      "asDropdown": true,
-      "icon": "external link",
-      "keepTime": true,
-      "tags": [
-        "MongoDB"
-      ],
-      "targetBlank": true,
-      "title": "MongoDB",
-      "type": "dashboards"
-    },
-    {
-      "asDropdown": true,
-      "icon": "external link",
-      "keepTime": true,
-      "tags": [
-        "App"
-      ],
-      "targetBlank": true,
-      "title": "App",
-      "type": "dashboards"
-    }
-  ],
+  "links": [],
   "panels": [
     {
       "collapsed": false,
@@ -149,7 +103,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "elasticsearch_cluster_health_status{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",color=\"red\"}==1 or (elasticsearch_cluster_health_status{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",color=\"green\"}==1)+4 or (elasticsearch_cluster_health_status{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",color=\"yellow\"}==1)+22",
+          "expr": "elasticsearch_cluster_health_status{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",color=\"red\"}==1 or (elasticsearch_cluster_health_status{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",color=\"green\"}==1)+4 or (elasticsearch_cluster_health_status{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",color=\"yellow\"}==1)+2",
           "format": "time_series",
           "instant": true,
           "interval": "",


### PR DESCRIPTION
This removes the trailing "2", so 1+2 = 3 (not 1+22 = 23)

https://github.com/grafana/jsonnet-libs/blob/03d32a72a2a0bf0ee00ffc853be5f07ad3bafcbe/elasticsearch-mixin/dashboards/elasticsearch-overview.json#L176-L180

I had spotted that in the original dashboard a long time ago, but nowhere to update.

This also removes the external links which probably only making sense in the context of the original dashboard.