### PR TITLE
Replace rbac.authorization.k8s.io/v1beta1 with v1

### DIFF
--- a/prometheus/prometheus.libsonnet
+++ b/prometheus/prometheus.libsonnet
@@ -18,7 +18,7 @@ local kausal = import 'ksonnet-util/kausal.libsonnet';
           servicePort: kausal.core.v1.service.mixin.spec.portsType,
         } },
         rbac+: { v1+: {
-          policyRule: kausal.rbac.v1beta1.clusterRole.rulesType,
+          policyRule: kausal.rbac.v1.clusterRole.rulesType,
         } },
       }
     else {}


### PR DESCRIPTION
rbac.authorization.k8s.io/v1beta1 is removed in k8s 1.22 https://kubernetes.io/docs/reference/using-api/deprecation-guide/#rbac-resources-v122