### PR TITLE
prometheus/ha-mixin: Add a startup probe

### DIFF
--- a/prometheus/ha-mixin.libsonnet
+++ b/prometheus/ha-mixin.libsonnet
@@ -89,6 +89,13 @@ function(replicas=2) {
     + container.mixin.readinessProbe.httpGet.withPort(self._config.prometheus_port)
     + container.mixin.readinessProbe.withInitialDelaySeconds(15)
     + container.mixin.readinessProbe.withTimeoutSeconds(1)
+    // Give 50 * 30 seconds (= 25 minutes) to start up, then start checking readiness
+    + container.mixin.startupProbe.httpGet.withPath('%(prometheus_path)s-/ready' % self._config)
+    + container.mixin.startupProbe.httpGet.withPort(self._config.prometheus_port)
+    + container.mixin.startupProbe.withInitialDelaySeconds(15)
+    + container.mixin.startupProbe.withTimeoutSeconds(1)
+    + container.mixin.startupProbe.withFailureThreshold(50)
+    + container.mixin.startupProbe.withPeriodSeconds(30)
   ,
 
   prometheus_watch_container+::


### PR DESCRIPTION
Prometheus replays the WAL on startup, during which time it's not ready
for requests. This can take a long time for large environments, longer
than the period the readiness probe considers to be OK. So we give a
generous 25 minutes for this to happen. This can be tuned up or down by
consumers of course.