### PR TITLE
DNS calls get multiplied by Kubernetes search path

### DIFF
--- a/mysql-exporter/mysql-exporter.libsonnet
+++ b/mysql-exporter/mysql-exporter.libsonnet
@@ -6,7 +6,7 @@ local exporter = std.trace('Deprecated: please consider switching to github.com/
 {
   local this = self,
   image:: 'prom/mysqld-exporter:v0.13.0-rc.0',
-  mysql_fqdn:: '%s.%s.svc.cluster.local' % [
+  mysql_fqdn:: '%s.%s.svc.cluster.local.' % [
     this._config.deployment_name,
     this._config.namespace,
   ],

--- a/nginx-directory/config.libsonnet
+++ b/nginx-directory/config.libsonnet
@@ -10,7 +10,7 @@
       //    # Required
       //    title: 'Prometheus',
       //    path: 'prometheus',
-      //    url: 'http://prometheus.default.svc.cluster.local/prometheus/',
+      //    url: 'http://prometheus.default.svc.cluster.local./prometheus/',
       //
       //    # Optional
       //    params: '',

--- a/vault/vault.libsonnet
+++ b/vault/vault.libsonnet
@@ -151,11 +151,11 @@ local kausal = import 'ksonnet-util/kausal.libsonnet';
       envVar.fromFieldPath('POD_NAME', 'metadata.name'),
       envVar.new(
         'VAULT_CLUSTER_ADDR',
-        'https://$(POD_NAME).vault.vault.svc.cluster.local:%s' % this._config.vault.clusterPort
+        'https://$(POD_NAME).vault.vault.svc.cluster.local.:%s' % this._config.vault.clusterPort
       ),
       envVar.new(
         'VAULT_API_ADDR',
-        'https://$(POD_NAME).vault.vault.svc.cluster.local:%s' % this._config.vault.port
+        'https://$(POD_NAME).vault.vault.svc.cluster.local.:%s' % this._config.vault.port
       ),
       envVar.new('VAULT_LOG_LEVEL', k._config.vault.logLevel),
     ])


### PR DESCRIPTION
Following an internal issue, put best practice into public libs:

> Each name is queried both for `A` (ipv4) and `AAAA` (ipv6), and along the search path
> `loki-ops.svc.cluster.local`, `svc.cluster.local`, `cluster.local`,
> `c.ops-tools-1203.internal`, `google.internal`. Finally the un-decorated name is tried,
> and succeeds.
>
> So for every one DNS lookup, eleven pointless requests are made. These add latency, take
> up space in the conntrack table and add some load to the DNS service.
>
> A simple improvement is to make the name absolute instead of relative \<by putting a dot
> a the end>.

Internet points for @bboreham