### PR TITLE
`nginx-directory`: Allow setting custom oauth2_proxy image

### DIFF
--- a/nginx-directory/directory.libsonnet
+++ b/nginx-directory/directory.libsonnet
@@ -63,7 +63,7 @@ local link_data = import 'link_data.libsonnet';
   nginx_service:
     k.util.serviceFor(this.nginx_deployment),
 
-  withOAuth2Proxy(config):: {
+  withOAuth2Proxy(config, images={}):: {
     local oauth2_proxy = import 'oauth2-proxy/oauth2-proxy.libsonnet',
 
     oauth2_proxy:
@@ -71,12 +71,16 @@ local link_data = import 'link_data.libsonnet';
         _config+:: config {
           oauth_upstream: 'http://nginx.%(namespace)s.svc.%(cluster_dns_suffix)s/' % config,
         },
+        _images+:: images,
       },
   },
 
   // backwards compatible
   oauth2_proxy:
     if this._config.oauth_enabled
-    then this.withOAuth2Proxy(this._config).oauth2_proxy
+    then this.withOAuth2Proxy(
+      this._config,
+      images=if std.objectHasAll(this, '_images') then this._images else {}
+    ).oauth2_proxy
     else {},
 }


### PR DESCRIPTION
Currently, the `_images` attribute is not passed from the `nginx-directory` lib
This means that the image cannot be overriden