### PR TITLE
Allow kube-state-metrics' 'self metrics' to be scraped using service discovery

### DIFF
--- a/kube-state-metrics/main.libsonnet
+++ b/kube-state-metrics/main.libsonnet
@@ -21,7 +21,7 @@ local kausal = import 'github.com/grafana/jsonnet-libs/ksonnet-util/kausal.libso
         '--telemetry-port=8081',
       ])
       + container.withPorts([
-        containerPort.new('http-metrics', 8080),
+        containerPort.new('ksm', 8080),
         containerPort.new('self-metrics', 8081),
       ])
       + k.util.resourcesRequests('50m', '50Mi')
@@ -32,10 +32,7 @@ local kausal = import 'github.com/grafana/jsonnet-libs/ksonnet-util/kausal.libso
       deployment.new('kube-state-metrics', 1, [self.container])
       + deployment.mixin.spec.template.spec.withServiceAccountName(self.rbac.service_account.metadata.name)
       + deployment.mixin.spec.template.spec.securityContext.withRunAsUser(65534)
-      + deployment.mixin.spec.template.spec.securityContext.withRunAsGroup(65534)
-      // Prevent default pod discovery from scraping, use ./scrape_config.libsonnet instead
-      // to preserve namespace etc labels.
-      + deployment.mixin.spec.template.metadata.withAnnotationsMixin({ 'prometheus.io.scrape': 'false' }),
+      + deployment.mixin.spec.template.spec.securityContext.withRunAsGroup(65534),
 
     local policyRule = k.rbac.v1.policyRule,
     rbac:

--- a/kube-state-metrics/scrape_config.libsonnet
+++ b/kube-state-metrics/scrape_config.libsonnet
@@ -22,6 +22,16 @@ function(namespace) {
       action: 'keep',
     },
 
+    // Drop anything whose port is not 'ksm', these are the metrics computed by
+    // kube-state-metrics itself and not the 'self metrics' which should be
+    // scraped by normal prometheus service discovery ('self-metrics' port
+    // name).
+    {
+      source_labels: ['__meta_kubernetes_pod_container_port_name'],
+      regex: 'ksm',
+      action: 'keep',
+    },
+
     // Rename instances to the concatenation of pod:container:port.
     // In the specific case of KSM, we could leave out the container
     // name and still have a unique instance label, but we leave it


### PR DESCRIPTION
kube-state-metrics exposes metrics on two ports:

  - Metrics it gathers about the cluster it is monitoring (port `http-metrics`)
  - 'Self' metrics about itself (port `self-metrics`)

Currently we scrape both of these targets in the same scrape config and deploy
k-s-m with an annotation `prometheus.io.scrape=false` so normal service
discovery doesn't look at it. This is because the standard relabeling would
override the labels to those of k-s-m itself rather than the services being
monitored (e.g. all metrics would get the 'kube-state-metrics' namespace).

This standard service discovery config shipped with jsonnet-libs scrapes all
ports that end with `-metrics`. An alternative approach then would be to rename
the `http-metrics` port to something else, so it is not found by the normal
scrape config, and drop the `prometheus.io.scrape=false` annotation. Then we
can configure k-s-m's scrape config to only look at this port.