### PR TITLE
Allow datasource's regex to be configured

### DIFF
--- a/grafana-builder/grafana.libsonnet
+++ b/grafana-builder/grafana.libsonnet
@@ -1,5 +1,5 @@
 {
-  dashboard(title, uid='', datasource='default'):: {
+  dashboard(title, uid='', datasource='default', datasource_regex=''):: {
     // Stuff that isn't materialised.
     _nextPanel:: 1,
     addRow(row):: self {
@@ -114,7 +114,7 @@
           options: [],
           query: 'prometheus',
           refresh: 1,
-          regex: '',
+          regex: datasource_regex,
           type: 'datasource',
         },
       ],


### PR DESCRIPTION
With a lot of datasource it is handy to be able to list only on part of
the prometheus datasource available in the organization.

Signed-off-by: Wilfried Roset <wilfriedroset@users.noreply.github.com>