### PR TITLE
Add apache-http-mixin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .DS_Store
 vendor
 jsonnetfile.lock.json
+prometheus_alerts.yaml
+dashboards_out
 *.zip

--- a/apache-http-mixin/Makefile
+++ b/apache-http-mixin/Makefile
@@ -1,0 +1,52 @@
+JSONNET_FMT := jsonnetfmt -n 2 --max-blank-lines 1 --string-style s --comment-style s
+
+.PHONY: all
+all: build dashboards_out prometheus_alerts.yaml
+
+vendor: jsonnetfile.json
+	jb install
+
+.PHONY: build
+build: vendor
+
+.PHONY: fmt
+fmt:
+	find . -name 'vendor' -prune -o -name '*.libsonnet' -print -o -name '*.jsonnet' -print | \
+		xargs -n 1 -- $(JSONNET_FMT) -i
+
+.PHONY: lint
+lint: build
+	find . -name 'vendor' -prune -o -name '*.libsonnet' -print -o -name '*.jsonnet' -print | \
+		while read f; do \
+			$(JSONNET_FMT) "$$f" | diff -u "$$f" -; \
+		done
+	mixtool lint mixin.libsonnet
+
+dashboards_out: mixin.libsonnet config.libsonnet $(wildcard dashboards/*)
+	@mkdir -p dashboards_out
+	mixtool generate dashboards mixin.libsonnet -d dashboards_out
+
+prometheus_alerts.yaml: mixin.libsonnet alerts/*.libsonnet
+	mixtool generate alerts mixin.libsonnet -a prometheus_alerts.yaml
+
+
+.PHONY: deploy deploy_rules deploy_dashboards
+deploy: deploy_rules deploy_dashboards
+
+deploy_dashboards:
+ifdef GRAFANA_URL
+	grr apply mixin.libsonnet --target "Dashboard.*" --target "DashboardFolder.*"
+else
+	$(warning GRAFANA_URL is not set, skipping grafana dashboards deployment)
+endif
+
+deploy_rules:
+ifdef CORTEX_ADDRESS
+	grr apply mixin.libsonnet --target "PrometheusRuleGroup.*"
+else
+	$(warning CORTEX_ADDRESS is not set, skipping prometheus alerts deployment)
+endif
+
+.PHONY: clean
+clean:
+	rm -rf dashboards_out prometheus_alerts.yaml

--- a/apache-http-mixin/README.md
+++ b/apache-http-mixin/README.md
@@ -1,0 +1,48 @@
+# Apache HTTP server mixin
+
+Apache HTTP mixin is a set of configurable Grafana dashboards and alerts based on the metrics exported by the [Apache exporter](https://github.com/Lusitaniae/apache_exporter).
+
+Based on Apache dashboard by rfrail3: https://github.com/rfrail3/grafana-dashboards.
+
+![image](https://user-images.githubusercontent.com/14870891/167886371-92c60942-bbfa-43d2-ba16-ee13e629020a.png)
+
+## Install tools
+
+```bash
+go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@latest
+go install github.com/monitoring-mixins/mixtool/cmd/mixtool@latest
+```
+
+For linting and formatting, you would also need and `jsonnetfmt` installed. If you
+have a working Go development environment, it's easiest to run the following:
+
+```bash
+go install github.com/google/go-jsonnet/cmd/jsonnetfmt@latest
+```
+
+The files in `dashboards_out` need to be imported
+into your Grafana server.  The exact details will be depending on your environment.
+
+`prometheus_alerts.yaml` needs to be imported into Prometheus.
+
+## Generate dashboards and alerts
+
+Edit `config.libsonnet` if required and then build JSON dashboard files for Grafana:
+
+```bash
+make
+```
+
+## Import dashboards and alerts using Grizzly tool
+
+Install grizzly first: https://grafana.github.io/grizzly/installation/
+
+Set env variables GRAFANA_URL and optionally CORTEX_ADDRESS (see for [details](https://grafana.github.io/grizzly/authentication/)).
+
+Then run to actually import the dashboards and alerts into Grafana instance:
+```bash
+make deploy
+```
+
+For more advanced uses of mixins, see
+https://github.com/monitoring-mixins/docs.

--- a/apache-http-mixin/alerts/alerts.libsonnet
+++ b/apache-http-mixin/alerts/alerts.libsonnet
@@ -1,0 +1,52 @@
+{
+  prometheusAlerts+:: {
+    groups+: [
+      {
+        name: 'apache-http',
+        rules: [
+          {
+            alert: 'ApacheDown',
+            expr: 'apache_up == 0',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              summary: 'Apache is down.',
+              description: 'Apache is down on {{ $labels.instance }}.',
+            },
+            'for': '5m',
+          },
+          {
+            alert: 'ApacheRestart',
+            expr: 'apache_uptime_seconds_total / 60 < 1',
+            labels: {
+              severity: 'info',
+            },
+            annotations: {
+              summary: 'Apache restart.',
+              description: 'Apache has just been restarted.',
+            },
+            'for': '0',
+          },
+          {
+            alert: 'ApacheWorkersLoad',
+            expr: |||
+              (sum by (instance) (apache_workers{state="busy"}) / sum by (instance) (apache_scoreboard) ) * 100 > %(alertsWarningWorkersBusy)s
+            ||| % $._config,
+            'for': '15m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              summary: 'Apache workers load is too high.',
+              description: |||
+                Apache workers in busy state approach the max workers count %(alertsWarningWorkersBusy)s%% workers busy on {{ $labels.instance }}.
+                The currect value is {{ $value }}%%.
+              ||| % $._config,
+            },
+          },
+        ],
+      },
+    ],
+  },
+}

--- a/apache-http-mixin/config.libsonnet
+++ b/apache-http-mixin/config.libsonnet
@@ -1,0 +1,11 @@
+{
+  _config+:: {
+    dashboardTags: ['apache-http-mixin'],
+    dashboardPeriod: 'now-1h',
+    dashboardTimezone: 'default',
+    dashboardRefresh: '1m',
+
+    // for alerts
+    alertsWarningWorkersBusy: '80',  // %
+  },
+}

--- a/apache-http-mixin/dashboards/apache-exporter-full.libsonnet
+++ b/apache-http-mixin/dashboards/apache-exporter-full.libsonnet
@@ -1,6 +1,8 @@
 local grafana = import 'github.com/grafana/grafonnet-lib/grafonnet/grafana.libsonnet';
 local dashboard = grafana.dashboard;
 local template = grafana.template;
+local dashboardUid = 'apache-http';
+local matcher = 'job=~"$job", instance=~"$instance"';
 
 {
   grafanaDashboards+:: {
@@ -14,6 +16,7 @@ local template = grafana.template;
         timezone='%s' % $._config.dashboardTimezone,
         refresh='%s' % $._config.dashboardRefresh,
         graphTooltip='shared_crosshair',
+        uid=dashboardUid,
       ).addTemplates(
         [
           {
@@ -37,6 +40,8 @@ local template = grafana.template;
             current='',
             refresh=2,
             includeAll=true,
+            multi=true,
+            allValues='.+',
             sort=1
           ),
           template.new(
@@ -116,7 +121,7 @@ local template = grafana.template;
           pluginVersion: '8.4.5',
           targets: [
             {
-              expr: 'apache_uptime_seconds_total{instance=~"$instance"}',
+              expr: 'apache_uptime_seconds_total{' + matcher + '}',
               format: 'time_series',
               intervalFactor: 1,
               refId: 'A',
@@ -193,7 +198,7 @@ local template = grafana.template;
           },
           targets: [
             {
-              expr: 'apache_version{instance=~"$instance"}',
+              expr: 'apache_version{' + matcher + '}',
               legendFormat: '',
               interval: '',
               exemplar: true,
@@ -201,10 +206,6 @@ local template = grafana.template;
               intervalFactor: 1,
               refId: 'A',
               step: 240,
-              datasource: {
-                type: 'prometheus',
-                uid: 'grafanacloud-prom',
-              },
             },
           ],
         },
@@ -240,7 +241,7 @@ local template = grafana.template;
           },
           targets: [
             {
-              expr: 'apache_up{instance=~"$instance"}',
+              expr: 'apache_up{' + matcher + '}',
               legendFormat: 'Apache up',
               interval: '',
               exemplar: true,
@@ -248,10 +249,6 @@ local template = grafana.template;
               intervalFactor: 1,
               refId: 'A',
               step: 240,
-              datasource: {
-                type: 'prometheus',
-                uid: 'grafanacloud-prom',
-              },
             },
           ],
           fieldConfig: {
@@ -329,7 +326,7 @@ local template = grafana.template;
           },
           targets: [
             {
-              expr: 'rate(apache_sent_kilobytes_total{instance=~"$instance"}[$__rate_interval]) * 1000',
+              expr: 'rate(apache_sent_kilobytes_total{' + matcher + '}[$__rate_interval]) * 1000',
               format: 'time_series',
               intervalFactor: 1,
               legendFormat: 'Bytes sent',
@@ -424,7 +421,7 @@ local template = grafana.template;
           },
           targets: [
             {
-              expr: 'rate(apache_accesses_total{instance=~"$instance"}[$__rate_interval])',
+              expr: 'rate(apache_accesses_total{' + matcher + '}[$__rate_interval])',
               format: 'time_series',
               intervalFactor: 1,
               legendFormat: 'Accesses',
@@ -521,7 +518,7 @@ local template = grafana.template;
           },
           targets: [
             {
-              expr: 'apache_scoreboard{instance=~"$instance"}',
+              expr: 'apache_scoreboard{' + matcher + '}',
               format: 'time_series',
               intervalFactor: 1,
               legendFormat: '{{ state }}',
@@ -616,7 +613,7 @@ local template = grafana.template;
           },
           targets: [
             {
-              expr: 'apache_workers{instance=~"$instance"}\n',
+              expr: 'apache_workers{' + matcher + '}\n',
               format: 'time_series',
               intervalFactor: 1,
               legendFormat: '{{ state }}',
@@ -711,7 +708,7 @@ local template = grafana.template;
           },
           targets: [
             {
-              expr: 'apache_cpuload{instance=~"$instance"}',
+              expr: 'apache_cpuload{' + matcher + '}',
               format: 'time_series',
               intervalFactor: 1,
               legendFormat: 'Load',

--- a/apache-http-mixin/dashboards/apache-exporter-full.libsonnet
+++ b/apache-http-mixin/dashboards/apache-exporter-full.libsonnet
@@ -1,0 +1,780 @@
+local grafana = import 'github.com/grafana/grafonnet-lib/grafonnet/grafana.libsonnet';
+local dashboard = grafana.dashboard;
+local template = grafana.template;
+
+{
+  grafanaDashboards+:: {
+
+    'apache-http.json':
+      dashboard.new(
+        'Apache HTTP server',
+        time_from='%s' % $._config.dashboardPeriod,
+        editable=false,
+        tags=($._config.dashboardTags),
+        timezone='%s' % $._config.dashboardTimezone,
+        refresh='%s' % $._config.dashboardRefresh,
+        graphTooltip='shared_crosshair',
+      ).addTemplates(
+        [
+          {
+            current: {
+              text: 'default',
+              value: 'default',
+            },
+            hide: 0,
+            label: 'Data Source',
+            name: 'datasource',
+            query: 'prometheus',
+            refresh: 1,
+            regex: '',
+            type: 'datasource',
+          },
+          template.new(
+            name='job',
+            label='job',
+            datasource='$datasource',
+            query='label_values(apache_up, job)',
+            current='',
+            refresh=2,
+            includeAll=true,
+            sort=1
+          ),
+          template.new(
+            name='instance',
+            label='instance',
+            datasource='$datasource',
+            query='label_values(apache_up{job=~"$job"}, instance)',
+            current='',
+            refresh=2,
+            includeAll=false,
+            sort=1
+          ),
+        ]
+      )
+      .addPanels([
+        {
+          datasource: {
+            uid: '${datasource}',
+          },
+          fieldConfig: {
+            defaults: {
+              color: {
+                mode: 'thresholds',
+              },
+              decimals: 1,
+              mappings: [
+                {
+                  options: {
+                    match: 'null',
+                    result: {
+                      text: 'N/A',
+                    },
+                  },
+                  type: 'special',
+                },
+              ],
+              thresholds: {
+                mode: 'absolute',
+                steps: [
+                  {
+                    color: 'green',
+                    value: null,
+                  },
+                  {
+                    color: 'red',
+                    value: 80,
+                  },
+                ],
+              },
+              unit: 's',
+            },
+            overrides: [],
+          },
+          gridPos: {
+            h: 3,
+            w: 4,
+            x: 0,
+            y: 0,
+          },
+          id: 8,
+          links: [],
+          maxDataPoints: 100,
+          options: {
+            colorMode: 'none',
+            graphMode: 'none',
+            justifyMode: 'auto',
+            orientation: 'horizontal',
+            reduceOptions: {
+              calcs: [
+                'lastNotNull',
+              ],
+              fields: '',
+              values: false,
+            },
+            textMode: 'auto',
+          },
+          pluginVersion: '8.4.5',
+          targets: [
+            {
+              expr: 'apache_uptime_seconds_total{instance=~"$instance"}',
+              format: 'time_series',
+              intervalFactor: 1,
+              refId: 'A',
+              step: 240,
+            },
+          ],
+          title: 'Uptime',
+          type: 'stat',
+        },
+        {
+          id: 9,
+          gridPos: {
+            h: 3,
+            w: 4,
+            x: 4,
+            y: 0,
+          },
+          type: 'stat',
+          title: 'Version',
+          datasource: {
+            uid: '${datasource}',
+            type: 'prometheus',
+          },
+          pluginVersion: '8.4.5',
+          maxDataPoints: 100,
+          links: [],
+          fieldConfig: {
+            defaults: {
+              mappings: [
+                {
+                  options: {
+                    match: 'null',
+                    result: {
+                      text: 'N/A',
+                    },
+                  },
+                  type: 'special',
+                },
+              ],
+              thresholds: {
+                mode: 'absolute',
+                steps: [
+                  {
+                    color: 'green',
+                    value: null,
+                  },
+                  {
+                    color: 'red',
+                    value: 80,
+                  },
+                ],
+              },
+              color: {
+                mode: 'thresholds',
+              },
+              decimals: 1,
+              unit: 'none',
+            },
+            overrides: [],
+          },
+          options: {
+            reduceOptions: {
+              values: false,
+              calcs: [
+                'lastNotNull',
+              ],
+              fields: '',
+            },
+            orientation: 'horizontal',
+            textMode: 'auto',
+            colorMode: 'none',
+            graphMode: 'none',
+            justifyMode: 'auto',
+          },
+          targets: [
+            {
+              expr: 'apache_version{instance=~"$instance"}',
+              legendFormat: '',
+              interval: '',
+              exemplar: true,
+              format: 'time_series',
+              intervalFactor: 1,
+              refId: 'A',
+              step: 240,
+              datasource: {
+                type: 'prometheus',
+                uid: 'grafanacloud-prom',
+              },
+            },
+          ],
+        },
+        {
+          id: 5,
+          gridPos: {
+            h: 3,
+            w: 16,
+            x: 8,
+            y: 0,
+          },
+          type: 'state-timeline',
+          title: 'Apache Up / Down',
+          datasource: {
+            uid: '${datasource}',
+            type: 'prometheus',
+          },
+          pluginVersion: '8.4.5',
+          links: [],
+          options: {
+            mergeValues: false,
+            showValue: 'never',
+            alignValue: 'left',
+            rowHeight: 0.9,
+            legend: {
+              displayMode: 'list',
+              placement: 'right',
+            },
+            tooltip: {
+              mode: 'single',
+              sort: 'none',
+            },
+          },
+          targets: [
+            {
+              expr: 'apache_up{instance=~"$instance"}',
+              legendFormat: 'Apache up',
+              interval: '',
+              exemplar: true,
+              format: 'time_series',
+              intervalFactor: 1,
+              refId: 'A',
+              step: 240,
+              datasource: {
+                type: 'prometheus',
+                uid: 'grafanacloud-prom',
+              },
+            },
+          ],
+          fieldConfig: {
+            defaults: {
+              custom: {
+                lineWidth: 0,
+                fillOpacity: 70,
+                spanNulls: false,
+              },
+              color: {
+                mode: 'continuous-GrYlRd',
+              },
+              mappings: [
+                {
+                  type: 'value',
+                  options: {
+                    '0': {
+                      text: 'Down',
+                      color: 'red',
+                      index: 1,
+                    },
+                    '1': {
+                      text: 'Up',
+                      color: 'green',
+                      index: 0,
+                    },
+                  },
+                },
+              ],
+              thresholds: {
+                mode: 'absolute',
+                steps: [
+                  {
+                    color: 'green',
+                    value: null,
+                  },
+                ],
+              },
+            },
+            overrides: [],
+          },
+          timeFrom: null,
+          timeShift: null,
+        },
+        {
+          id: 3,
+          gridPos: {
+            h: 10,
+            w: 12,
+            x: 0,
+            y: 3,
+          },
+          type: 'timeseries',
+          title: 'Bytes sent',
+          datasource: {
+            uid: '${datasource}',
+          },
+          pluginVersion: '8.4.5',
+          links: [],
+          options: {
+            tooltip: {
+              mode: 'multi',
+              sort: 'none',
+            },
+            legend: {
+              displayMode: 'table',
+              placement: 'bottom',
+              calcs: [
+                'mean',
+                'lastNotNull',
+                'max',
+                'min',
+              ],
+            },
+          },
+          targets: [
+            {
+              expr: 'rate(apache_sent_kilobytes_total{instance=~"$instance"}[$__rate_interval]) * 1000',
+              format: 'time_series',
+              intervalFactor: 1,
+              legendFormat: 'Bytes sent',
+              refId: 'A',
+              step: 240,
+            },
+          ],
+          fieldConfig: {
+            defaults: {
+              custom: {
+                drawStyle: 'line',
+                lineInterpolation: 'linear',
+                barAlignment: 0,
+                lineWidth: 1,
+                fillOpacity: 10,
+                gradientMode: 'none',
+                spanNulls: true,
+                showPoints: 'never',
+                pointSize: 5,
+                stacking: {
+                  mode: 'none',
+                  group: 'A',
+                },
+                axisPlacement: 'auto',
+                axisLabel: '',
+                scaleDistribution: {
+                  type: 'linear',
+                },
+                hideFrom: {
+                  tooltip: false,
+                  viz: false,
+                  legend: false,
+                },
+                thresholdsStyle: {
+                  mode: 'off',
+                },
+              },
+              color: {
+                mode: 'palette-classic',
+              },
+              mappings: [],
+              thresholds: {
+                mode: 'absolute',
+                steps: [
+                  {
+                    value: null,
+                    color: 'green',
+                  },
+                  {
+                    value: 80,
+                    color: 'red',
+                  },
+                ],
+              },
+              unit: 'Bps',
+            },
+            overrides: [],
+          },
+          timeFrom: null,
+          timeShift: null,
+        },
+        {
+          id: 5,
+          gridPos: {
+            h: 10,
+            w: 12,
+            x: 12,
+            y: 3,
+          },
+          type: 'timeseries',
+          title: 'Apache accesses',
+          datasource: {
+            uid: '${datasource}',
+          },
+          pluginVersion: '8.4.5',
+          links: [],
+          options: {
+            tooltip: {
+              mode: 'multi',
+              sort: 'none',
+            },
+            legend: {
+              displayMode: 'table',
+              placement: 'bottom',
+              calcs: [
+                'mean',
+                'lastNotNull',
+                'max',
+                'min',
+              ],
+            },
+          },
+          targets: [
+            {
+              expr: 'rate(apache_accesses_total{instance=~"$instance"}[$__rate_interval])',
+              format: 'time_series',
+              intervalFactor: 1,
+              legendFormat: 'Accesses',
+              refId: 'A',
+              step: 240,
+            },
+          ],
+          fieldConfig: {
+            defaults: {
+              custom: {
+                drawStyle: 'line',
+                lineInterpolation: 'linear',
+                barAlignment: 0,
+                lineWidth: 1,
+                fillOpacity: 10,
+                gradientMode: 'none',
+                spanNulls: true,
+                showPoints: 'never',
+                pointSize: 5,
+                stacking: {
+                  mode: 'none',
+                  group: 'A',
+                },
+                axisPlacement: 'auto',
+                axisLabel: '',
+                scaleDistribution: {
+                  type: 'linear',
+                },
+                hideFrom: {
+                  tooltip: false,
+                  viz: false,
+                  legend: false,
+                },
+                thresholdsStyle: {
+                  mode: 'off',
+                },
+              },
+              color: {
+                mode: 'palette-classic',
+              },
+              mappings: [],
+              thresholds: {
+                mode: 'absolute',
+                steps: [
+                  {
+                    value: null,
+                    color: 'green',
+                  },
+                  {
+                    value: 80,
+                    color: 'red',
+                  },
+                ],
+              },
+              unit: 'reqps',
+            },
+            overrides: [],
+          },
+          timeFrom: null,
+          timeShift: null,
+        },
+        {
+          id: 2,
+          gridPos: {
+            h: 10,
+            w: 24,
+            x: 0,
+            y: 13,
+          },
+          type: 'timeseries',
+          title: 'Apache scoreboard statuses',
+          datasource: {
+            uid: '${datasource}',
+          },
+          pluginVersion: '8.4.5',
+          links: [],
+          options: {
+            tooltip: {
+              mode: 'multi',
+              sort: 'desc',
+            },
+            legend: {
+              displayMode: 'table',
+              placement: 'right',
+              calcs: [
+                'mean',
+                'lastNotNull',
+                'max',
+                'min',
+              ],
+              sortBy: 'Last *',
+              sortDesc: true,
+            },
+          },
+          targets: [
+            {
+              expr: 'apache_scoreboard{instance=~"$instance"}',
+              format: 'time_series',
+              intervalFactor: 1,
+              legendFormat: '{{ state }}',
+              refId: 'A',
+              step: 240,
+            },
+          ],
+          fieldConfig: {
+            defaults: {
+              custom: {
+                drawStyle: 'line',
+                lineInterpolation: 'stepAfter',
+                barAlignment: 0,
+                lineWidth: 1,
+                fillOpacity: 10,
+                gradientMode: 'none',
+                spanNulls: true,
+                showPoints: 'never',
+                pointSize: 5,
+                stacking: {
+                  mode: 'normal',
+                  group: 'A',
+                },
+                axisPlacement: 'auto',
+                axisLabel: '',
+                scaleDistribution: {
+                  type: 'linear',
+                },
+                hideFrom: {
+                  tooltip: false,
+                  viz: false,
+                  legend: false,
+                },
+                thresholdsStyle: {
+                  mode: 'off',
+                },
+              },
+              color: {
+                mode: 'palette-classic',
+              },
+              mappings: [],
+              thresholds: {
+                mode: 'absolute',
+                steps: [
+                  {
+                    value: null,
+                    color: 'green',
+                  },
+                  {
+                    value: 80,
+                    color: 'red',
+                  },
+                ],
+              },
+              unit: 'short',
+            },
+            overrides: [],
+          },
+          timeFrom: null,
+          timeShift: null,
+        },
+        {
+          id: 7,
+          gridPos: {
+            h: 10,
+            w: 12,
+            x: 0,
+            y: 23,
+          },
+          type: 'timeseries',
+          title: 'Apache worker statuses',
+          datasource: {
+            uid: '${datasource}',
+          },
+          pluginVersion: '8.4.5',
+          links: [],
+          options: {
+            tooltip: {
+              mode: 'multi',
+              sort: 'none',
+            },
+            legend: {
+              displayMode: 'table',
+              placement: 'bottom',
+              calcs: [
+                'mean',
+                'lastNotNull',
+                'max',
+                'min',
+              ],
+            },
+          },
+          targets: [
+            {
+              expr: 'apache_workers{instance=~"$instance"}\n',
+              format: 'time_series',
+              intervalFactor: 1,
+              legendFormat: '{{ state }}',
+              refId: 'A',
+              step: 240,
+            },
+          ],
+          fieldConfig: {
+            defaults: {
+              custom: {
+                drawStyle: 'line',
+                lineInterpolation: 'stepAfter',
+                barAlignment: 0,
+                lineWidth: 1,
+                fillOpacity: 10,
+                gradientMode: 'none',
+                spanNulls: true,
+                showPoints: 'never',
+                pointSize: 5,
+                stacking: {
+                  mode: 'normal',
+                  group: 'A',
+                },
+                axisPlacement: 'auto',
+                axisLabel: '',
+                scaleDistribution: {
+                  type: 'linear',
+                },
+                hideFrom: {
+                  tooltip: false,
+                  viz: false,
+                  legend: false,
+                },
+                thresholdsStyle: {
+                  mode: 'off',
+                },
+              },
+              color: {
+                mode: 'palette-classic',
+              },
+              mappings: [],
+              thresholds: {
+                mode: 'absolute',
+                steps: [
+                  {
+                    value: null,
+                    color: 'green',
+                  },
+                  {
+                    value: 80,
+                    color: 'red',
+                  },
+                ],
+              },
+              unit: 'short',
+            },
+            overrides: [],
+          },
+          timeFrom: null,
+          timeShift: null,
+        },
+        {
+          id: 8,
+          gridPos: {
+            h: 10,
+            w: 12,
+            x: 12,
+            y: 23,
+          },
+          type: 'timeseries',
+          title: 'Apache CPU load',
+          datasource: {
+            uid: '${datasource}',
+          },
+          pluginVersion: '8.4.5',
+          links: [],
+          options: {
+            tooltip: {
+              mode: 'multi',
+              sort: 'none',
+            },
+            legend: {
+              displayMode: 'table',
+              placement: 'bottom',
+              calcs: [
+                'mean',
+                'lastNotNull',
+                'max',
+                'min',
+              ],
+            },
+          },
+          targets: [
+            {
+              expr: 'apache_cpuload{instance=~"$instance"}',
+              format: 'time_series',
+              intervalFactor: 1,
+              legendFormat: 'Load',
+              refId: 'A',
+              step: 240,
+            },
+          ],
+          fieldConfig: {
+            defaults: {
+              custom: {
+                drawStyle: 'line',
+                lineInterpolation: 'linear',
+                barAlignment: 0,
+                lineWidth: 1,
+                fillOpacity: 10,
+                gradientMode: 'none',
+                spanNulls: true,
+                showPoints: 'never',
+                pointSize: 5,
+                stacking: {
+                  mode: 'none',
+                  group: 'A',
+                },
+                axisPlacement: 'auto',
+                axisLabel: '',
+                scaleDistribution: {
+                  type: 'linear',
+                },
+                hideFrom: {
+                  tooltip: false,
+                  viz: false,
+                  legend: false,
+                },
+                thresholdsStyle: {
+                  mode: 'off',
+                },
+              },
+              color: {
+                mode: 'palette-classic',
+              },
+              mappings: [],
+              thresholds: {
+                mode: 'absolute',
+                steps: [
+                  {
+                    value: null,
+                    color: 'green',
+                  },
+                  {
+                    value: 80,
+                    color: 'red',
+                  },
+                ],
+              },
+              unit: 'short',
+              min: 0,
+            },
+            overrides: [],
+          },
+          timeFrom: null,
+          timeShift: null,
+        },
+      ]),
+
+  },
+}

--- a/apache-http-mixin/jsonnetfile.json
+++ b/apache-http-mixin/jsonnetfile.json
@@ -1,0 +1,15 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/grafonnet-lib.git",
+          "subdir": "grafonnet"
+        }
+      },
+      "version": "master"
+    }
+  ],
+  "legacyImports": false
+}

--- a/apache-http-mixin/mixin.libsonnet
+++ b/apache-http-mixin/mixin.libsonnet
@@ -1,0 +1,3 @@
+(import 'dashboards/apache-exporter-full.libsonnet') +
+(import 'alerts/alerts.libsonnet') +
+(import 'config.libsonnet')


### PR DESCRIPTION
Based on the dashboard from here https://github.com/rfrail3/grafana-dashboards. (https://grafana.com/grafana/dashboards/3894). With @rfrail3 we have decided that this dashboard can land here, and transformed into monitoring-mixin. Future updates would be in this repo. 

As of now, this mixin would generate the same dashboard , but with slight changes (see below and in commit messages). Prometheus alerts are also added. Just run make and follow the README file.

![image](https://user-images.githubusercontent.com/14870891/167886371-92c60942-bbfa-43d2-ba16-ee13e629020a.png)

- Add stepAfter for Apache worker statuses panel
- Add stepAfter for apache scorecard
- Rename apache dashboard
- Add apache version panel
- Convert to timeseries from old graph
- Change rate panels to Bps and reqps
- Use rate with $__rate_inteval
- Fix uptime panel
- Change host:port to instance and replace apache up/down panel to state timeline
- Add alerts to apache mixin
- Transform dashboard to use grafonnet library
- Rename DS_LOCALHOST to prometheus $datasource
- Convert apache json dahboard to jsonnet mixin