### PR TITLE
Postgres-mixin: Bugfixes and linting

### DIFF
--- a/postgres-mixin/dashboards/postgres-overview.json
+++ b/postgres-mixin/dashboards/postgres-overview.json
@@ -584,7 +584,7 @@
         {
           "alias": "Buffers Allocated",
           "dsType": "prometheus",
-          "expr": "irate(pg_stat_bgwriter_buffers_alloc{job=~'$job',instance=~'$instance'}[$__rate_interval])",
+          "expr": "irate(pg_stat_bgwriter_buffers_alloc{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval])",
           "format": "time_series",
           "groupBy": [
             {
@@ -636,7 +636,7 @@
         {
           "alias": "Buffers Allocated",
           "dsType": "prometheus",
-          "expr": "irate(pg_stat_bgwriter_buffers_backend_fsync{job=~'$job',instance=~'$instance'}[$__rate_interval])",
+          "expr": "irate(pg_stat_bgwriter_buffers_backend_fsync{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval])",
           "format": "time_series",
           "groupBy": [
             {
@@ -688,7 +688,7 @@
         {
           "alias": "Buffers Allocated",
           "dsType": "prometheus",
-          "expr": "irate(pg_stat_bgwriter_buffers_backend{job=~'$job',instance=~'$instance'}[$__rate_interval])",
+          "expr": "irate(pg_stat_bgwriter_buffers_backend{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval])",
           "format": "time_series",
           "groupBy": [
             {
@@ -740,7 +740,7 @@
         {
           "alias": "Buffers Allocated",
           "dsType": "prometheus",
-          "expr": "irate(pg_stat_bgwriter_buffers_clean{job=~'$job',instance=~'$instance'}[$__rate_interval])",
+          "expr": "irate(pg_stat_bgwriter_buffers_clean{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval])",
           "format": "time_series",
           "groupBy": [
             {
@@ -792,7 +792,7 @@
         {
           "alias": "Buffers Allocated",
           "dsType": "prometheus",
-          "expr": "irate(pg_stat_bgwriter_buffers_checkpoint{job=~'$job',instance=~'$instance'}[$__rate_interval])",
+          "expr": "irate(pg_stat_bgwriter_buffers_checkpoint{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval])",
           "format": "time_series",
           "groupBy": [
             {
@@ -1136,7 +1136,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (datname) (rate(pg_stat_database_blks_hit{datname=~\"$db\",job=~\"$job\",instance=~\"$instance\"}[$__rate_interval])) / (sum by (datname)(rate(pg_stat_database_blks_hit{datname=~\"$db\",job=~\"$job\",instance=~\"$instance\"}[$__rate_interval])) + sum by (datname)(rate(pg_stat_database_blks_read{datname=~\"$db\",instance=~\"$instance\"}[$__rate_interval])))",
+          "expr": "sum by (datname) (rate(pg_stat_database_blks_hit{datname=~\"$db\",job=~\"$job\",instance=~\"$instance\"}[$__rate_interval])) / (sum by (datname)(rate(pg_stat_database_blks_hit{datname=~\"$db\",job=~\"$job\",instance=~\"$instance\"}[$__rate_interval])) + sum by (datname)(rate(pg_stat_database_blks_read{datname=~\"$db\",job=~\"$job\",instance=~\"$instance\"}[$__rate_interval])))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{datname}} - cache hit rate",
@@ -1299,11 +1299,6 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "selected": false,
-          "text": "Postgres Overview",
-          "value": "Postgres Overview"
-        },
         "hide": 0,
         "includeAll": false,
         "label": "Data Source",
@@ -1317,26 +1312,15 @@
         "type": "datasource"
       },      
       {
-        "allValue": null,
-        "current": {
-          "selected": true,
-          "text": "postgres",
-          "value": "postgres"
-        },
+        "allValue": ".+",
         "datasource": "$datasource",
         "definition": "label_values(pg_up, job)",
         "hide": 0,
-        "includeAll": false,
+        "includeAll": true,
         "label": "job",
-        "multi": false,
+        "multi": true,
         "name": "job",
-        "options": [
-          {
-            "selected": true,
-            "text": "postgres",
-            "value": "postgres"
-          }
-        ],
+        "options": [],
         "query": "label_values(pg_up, job)",
         "refresh": 0,
         "regex": "",
@@ -1349,21 +1333,16 @@
         "useTags": false
       },
       {
-        "allValue": ".*",
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
+        "allValue": ".+",
         "datasource": "$datasource",
         "definition": "",
         "hide": 0,
         "includeAll": true,
-        "label": null,
-        "multi": false,
+        "label": "instance",
+        "multi": true,
         "name": "instance",
         "options": [],
-        "query": "label_values(up{job=~\"postgres.*\"},instance)",
+        "query": "label_values(up{job=~\"$job\"},instance)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -1375,12 +1354,7 @@
         "useTags": false
       },
       {
-        "allValue": null,
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
+        "allValue": ".+",
         "datasource": "$datasource",
         "definition": "label_values(pg_stat_database_tup_fetched{instance=~\"$instance\",datname!~\"template.*|postgres\"},datname)",
         "hide": 0,

--- a/postgres-mixin/dashboards/postgres-overview.json
+++ b/postgres-mixin/dashboards/postgres-overview.json
@@ -1299,6 +1299,56 @@
   "templating": {
     "list": [
       {
+        "current": {
+          "selected": false,
+          "text": "Postgres Overview",
+          "value": "Postgres Overview"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Data Source",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },      
+      {
+        "allValue": null,
+        "current": {
+          "selected": true,
+          "text": "postgres",
+          "value": "postgres"
+        },
+        "datasource": "$datasource",
+        "definition": "label_values(pg_up, job)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "job",
+        "multi": false,
+        "name": "job",
+        "options": [
+          {
+            "selected": true,
+            "text": "postgres",
+            "value": "postgres"
+          }
+        ],
+        "query": "label_values(pg_up, job)",
+        "refresh": 0,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
         "allValue": ".*",
         "current": {
           "selected": false,
@@ -1341,56 +1391,6 @@
         "options": [],
         "query": "label_values(pg_stat_database_tup_fetched{instance=~\"$instance\",datname!~\"template.*|postgres\"},datname)",
         "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "tagValuesQuery": "",
-        "tags": [],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      },
-      {
-        "current": {
-          "selected": false,
-          "text": "Postgres Overview",
-          "value": "Postgres Overview"
-        },
-        "hide": 0,
-        "includeAll": false,
-        "label": "Data Source",
-        "multi": false,
-        "name": "datasource",
-        "options": [],
-        "query": "prometheus",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "type": "datasource"
-      },
-      {
-        "allValue": null,
-        "current": {
-          "selected": true,
-          "text": "postgres",
-          "value": "postgres"
-        },
-        "datasource": "$datasource",
-        "definition": "label_values(pg_up, job)",
-        "hide": 0,
-        "includeAll": false,
-        "label": "job",
-        "multi": false,
-        "name": "job",
-        "options": [
-          {
-            "selected": true,
-            "text": "postgres",
-            "value": "postgres"
-          }
-        ],
-        "query": "label_values(pg_up, job)",
-        "refresh": 0,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,

--- a/postgres-mixin/dashboards/postgres-overview.json
+++ b/postgres-mixin/dashboards/postgres-overview.json
@@ -77,7 +77,7 @@
         {
           "alias": "fetched",
           "dsType": "prometheus",
-          "expr": "sum(irate(pg_stat_database_tup_fetched{datname=~\"$db\",instance=~\"$instance\"}[$__rate_interval]))",
+          "expr": "sum(irate(pg_stat_database_tup_fetched{datname=~\"$db\",job=~\"$job\",instance=~\"$instance\"}[$__rate_interval]))",
           "format": "time_series",
           "groupBy": [
             {
@@ -131,7 +131,7 @@
         {
           "alias": "fetched",
           "dsType": "prometheus",
-          "expr": "sum(irate(pg_stat_database_tup_returned{datname=~\"$db\",instance=~\"$instance\"}[$__rate_interval]))",
+          "expr": "sum(irate(pg_stat_database_tup_returned{datname=~\"$db\",job=~\"$job\",instance=~\"$instance\"}[$__rate_interval]))",
           "format": "time_series",
           "groupBy": [
             {
@@ -185,7 +185,7 @@
         {
           "alias": "fetched",
           "dsType": "prometheus",
-          "expr": "sum(irate(pg_stat_database_tup_inserted{datname=~\"$db\",instance=~\"$instance\"}[$__rate_interval]))",
+          "expr": "sum(irate(pg_stat_database_tup_inserted{datname=~\"$db\",job=~\"$job\",instance=~\"$instance\"}[$__rate_interval]))",
           "format": "time_series",
           "groupBy": [
             {
@@ -239,7 +239,7 @@
         {
           "alias": "fetched",
           "dsType": "prometheus",
-          "expr": "sum(irate(pg_stat_database_tup_updated{datname=~\"$db\",instance=~\"$instance\"}[$__rate_interval]))",
+          "expr": "sum(irate(pg_stat_database_tup_updated{datname=~\"$db\",job=~\"$job\",instance=~\"$instance\"}[$__rate_interval]))",
           "format": "time_series",
           "groupBy": [
             {
@@ -293,7 +293,7 @@
         {
           "alias": "fetched",
           "dsType": "prometheus",
-          "expr": "sum(irate(pg_stat_database_tup_deleted{datname=~\"$db\",instance=~\"$instance\"}[$__rate_interval]))",
+          "expr": "sum(irate(pg_stat_database_tup_deleted{datname=~\"$db\",job=~\"$job\",instance=~\"$instance\"}[$__rate_interval]))",
           "format": "time_series",
           "groupBy": [
             {
@@ -460,7 +460,7 @@
       "targets": [
         {
           "dsType": "prometheus",
-          "expr": "sum(irate(pg_stat_database_xact_commit{datname=~\"$db\",instance=~\"$instance\"}[$__rate_interval])) + sum(irate(pg_stat_database_xact_rollback{datname=~\"$db\",instance=~\"$instance\"}[$__rate_interval]))",
+          "expr": "sum(irate(pg_stat_database_xact_commit{datname=~\"$db\",job=~\"$job\",instance=~\"$instance\"}[$__rate_interval])) + sum(irate(pg_stat_database_xact_rollback{datname=~\"$db\",job=~\"$job\",instance=~\"$instance\"}[$__rate_interval]))",
           "format": "time_series",
           "groupBy": [
             {
@@ -584,7 +584,7 @@
         {
           "alias": "Buffers Allocated",
           "dsType": "prometheus",
-          "expr": "irate(pg_stat_bgwriter_buffers_alloc{instance=~'$instance'}[$__rate_interval])",
+          "expr": "irate(pg_stat_bgwriter_buffers_alloc{job=~'$job',instance=~'$instance'}[$__rate_interval])",
           "format": "time_series",
           "groupBy": [
             {
@@ -636,7 +636,7 @@
         {
           "alias": "Buffers Allocated",
           "dsType": "prometheus",
-          "expr": "irate(pg_stat_bgwriter_buffers_backend_fsync{instance=~'$instance'}[$__rate_interval])",
+          "expr": "irate(pg_stat_bgwriter_buffers_backend_fsync{job=~'$job',instance=~'$instance'}[$__rate_interval])",
           "format": "time_series",
           "groupBy": [
             {
@@ -688,7 +688,7 @@
         {
           "alias": "Buffers Allocated",
           "dsType": "prometheus",
-          "expr": "irate(pg_stat_bgwriter_buffers_backend{instance=~'$instance'}[$__rate_interval])",
+          "expr": "irate(pg_stat_bgwriter_buffers_backend{job=~'$job',instance=~'$instance'}[$__rate_interval])",
           "format": "time_series",
           "groupBy": [
             {
@@ -740,7 +740,7 @@
         {
           "alias": "Buffers Allocated",
           "dsType": "prometheus",
-          "expr": "irate(pg_stat_bgwriter_buffers_clean{instance=~'$instance'}[$__rate_interval])",
+          "expr": "irate(pg_stat_bgwriter_buffers_clean{job=~'$job',instance=~'$instance'}[$__rate_interval])",
           "format": "time_series",
           "groupBy": [
             {
@@ -792,7 +792,7 @@
         {
           "alias": "Buffers Allocated",
           "dsType": "prometheus",
-          "expr": "irate(pg_stat_bgwriter_buffers_checkpoint{instance=~'$instance'}[$__rate_interval])",
+          "expr": "irate(pg_stat_bgwriter_buffers_checkpoint{job=~'$job',instance=~'$instance'}[$__rate_interval])",
           "format": "time_series",
           "groupBy": [
             {
@@ -939,7 +939,7 @@
         {
           "alias": "conflicts",
           "dsType": "prometheus",
-          "expr": "sum(rate(pg_stat_database_deadlocks{datname=~\"$db\",instance=~\"$instance\"}[$__rate_interval]))",
+          "expr": "sum(rate(pg_stat_database_deadlocks{datname=~\"$db\",job=~\"$job\",instance=~\"$instance\"}[$__rate_interval]))",
           "format": "time_series",
           "groupBy": [
             {
@@ -991,7 +991,7 @@
         {
           "alias": "deadlocks",
           "dsType": "prometheus",
-          "expr": "sum(rate(pg_stat_database_conflicts{datname=~\"$db\",instance=~\"$instance\"}[$__rate_interval]))",
+          "expr": "sum(rate(pg_stat_database_conflicts{datname=~\"$db\",job=~\"$job\",instance=~\"$instance\"}[$__rate_interval]))",
           "format": "time_series",
           "groupBy": [
             {
@@ -1136,7 +1136,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (datname) (rate(pg_stat_database_blks_hit{datname=~\"$db\",instance=~\"$instance\"}[$__rate_interval])) / (sum by (datname)(rate(pg_stat_database_blks_hit{datname=~\"$db\",instance=~\"$instance\"}[$__rate_interval])) + sum by (datname)(rate(pg_stat_database_blks_read{datname=~\"$db\",instance=~\"$instance\"}[$__rate_interval])))",
+          "expr": "sum by (datname) (rate(pg_stat_database_blks_hit{datname=~\"$db\",job=~\"$job\",instance=~\"$instance\"}[$__rate_interval])) / (sum by (datname)(rate(pg_stat_database_blks_hit{datname=~\"$db\",job=~\"$job\",instance=~\"$instance\"}[$__rate_interval])) + sum by (datname)(rate(pg_stat_database_blks_read{datname=~\"$db\",instance=~\"$instance\"}[$__rate_interval])))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{datname}} - cache hit rate",
@@ -1239,7 +1239,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "pg_stat_database_numbackends{datname=~\"$db\",instance=~\"$instance\"}",
+          "expr": "pg_stat_database_numbackends{datname=~\"$db\",job=~\"$job\",instance=~\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{datname}} - {{__name__}}",


### PR DESCRIPTION
Some changes to accommodate the dashboard linter, caught several minor (or moderate?) issues.

- Most (all?) queries were not using the `$job` matcher
- The template vars were set with default selected values, which weren't ideal
- The instance template var was not filtering to instances belonging to the selected job(s)