### PR TITLE
Add apache logs and error rate metric

### DIFF
--- a/apache-http-mixin/README.md
+++ b/apache-http-mixin/README.md
@@ -33,13 +33,106 @@ Edit `config.libsonnet` if required and then build JSON dashboard files for Graf
 make
 ```
 
+## Apache logs
+
+![image](https://user-images.githubusercontent.com/14870891/170279623-7aa6cc8f-7928-4d90-9c9b-94c5148b4488.png)
+
+Logs support is disabled by default. Change enableLokiLogs to `true` inside `config.libsonnet` to enable log panels. Then run `make` again to regenerate the dashboards:
+
+
+```bash
+make
+```
+
+The easiest to way to collect logs and metrics from apache server is to use [Grafana Agent](https://github.com/grafana/agent) with the config like below:
+The most important part is that `job` and `instance` labels must match for agent integration, logs and metrics configs.
+```yaml
+# For a full configuration reference, see: https://github.com/grafana/agent/blob/main/docs/configuration-reference.md.
+server:
+  log_level: warn
+metrics:
+  wal_directory: /var/lib/grafana-agent/wal
+  global:
+    scrape_interval: 1m
+    external_labels:
+      instance: <yourhostname>
+    remote_write: 
+      - url: https://cortex/api/v1/write
+    scrape_configs:
+      # scrape apache_exporter
+      - job_name: integrations/apache
+        static_configs:
+          - targets: ['localhost:9117']
+
+integrations:
+  
+  agent:
+    enabled: true
+    metric_relabel_configs:
+    # required for apache integrations,
+    # scraping agent endpoint is required for apache histogram metric collection.
+    - source_labels: [exported_job]
+        target_label: job
+        replacement: '$1'
+    - source_labels: [exported_instance]
+        target_label: instance
+    - regex: (exported_instance|exported_job)
+        action: labeldrop
+logs:
+  configs:
+  - name: integrations
+    clients:
+      - url: http://loki:3100/loki/api/v1/push
+        external_labels:
+          instance: <yourhostname>
+    positions:
+      filename: /var/lib/grafana-agent/logs/positions.yaml
+    scrape_configs:
+    - job_name: integrations/apache_error
+      static_configs:
+      - targets:
+        - localhost
+        labels:
+          __path__: /var/log/apache2/error.log
+          job: integrations/apache
+      pipeline_stages:
+        - regex:
+            # https://regex101.com/r/zNIq1V/1
+            expression: '^\[[^ ]* (?P<timestamp>[^\]]*)\] \[(?:(?P<module>[^:\]]+):)?(?P<level>[^\]]+)\](?: \[pid (?P<pid>[^\]]*)\])?(?: \[client (?P<client>[^\]]*)\])? (?P<message>.*)$'
+        - labels:
+            module:
+            level:
+            client:
+    - job_name: integrations/apache_access
+      static_configs:
+      - targets:
+        - localhost
+        labels:
+          __path__: /var/log/apache2/access.log
+          job: integrations/apache
+      pipeline_stages:
+        - regex:
+            # https://regex101.com/r/9G75bY/1
+            expression: '^(?P<ip>[^ ]*) [^ ]* (?P<user>[^ ]*) \[(?P<timestamp>[^\]]*)\] "(?P<method>\S+)(?: +(?P<path>[^ ]*) +\S*)?" (?P<code>[^ ]*) (?P<size>[^ ]*)(?: "(?P<referer>[^\"]*)" "(?P<agent>.*)")?$'
+        - metrics:
+            response_http_codes:
+              type: Histogram
+              description: "Apache reponses by HTTP codes"
+              prefix: apache_
+              source: code
+              config:
+                buckets: [199,299,399,499,599]
+        - labels:
+            method:
+```
+
 ## Import dashboards and alerts using Grizzly tool
 
 Install grizzly first: https://grafana.github.io/grizzly/installation/
 
 Set env variables GRAFANA_URL and optionally CORTEX_ADDRESS (see for [details](https://grafana.github.io/grizzly/authentication/)).
 
-Then run to actually import the dashboards and alerts into Grafana instance:
+Then run to import the dashboards and alerts into Grafana instance:
 ```bash
 make deploy
 ```

--- a/apache-http-mixin/README.md
+++ b/apache-http-mixin/README.md
@@ -102,7 +102,6 @@ logs:
         - labels:
             module:
             level:
-            client:
     - job_name: integrations/apache_access
       static_configs:
       - targets:

--- a/apache-http-mixin/README.md
+++ b/apache-http-mixin/README.md
@@ -4,7 +4,7 @@ Apache HTTP mixin is a set of configurable Grafana dashboards and alerts based o
 
 Based on Apache dashboard by rfrail3: https://github.com/rfrail3/grafana-dashboards.
 
-![image](https://user-images.githubusercontent.com/14870891/169803895-28dfed0c-f5a9-4496-8baa-d4e025e8855f.png)
+![image](https://user-images.githubusercontent.com/14870891/170320166-91bf48a6-0e21-48fd-873b-2483ee402339.png)
 
 ## Install tools
 

--- a/apache-http-mixin/README.md
+++ b/apache-http-mixin/README.md
@@ -102,6 +102,8 @@ logs:
         - labels:
             module:
             level:
+        - static_labels:
+            logtype: error
     - job_name: integrations/apache_access
       static_configs:
       - targets:
@@ -123,6 +125,8 @@ logs:
                 buckets: [199,299,399,499,599]
         - labels:
             method:
+        - static_labels:
+            logtype: access
 ```
 
 ## Import dashboards and alerts using Grizzly tool

--- a/apache-http-mixin/alerts/alerts.libsonnet
+++ b/apache-http-mixin/alerts/alerts.libsonnet
@@ -4,99 +4,99 @@
       {
         name: 'apache-http',
         rules: [
-          {
-            alert: 'ApacheDown',
-            expr: 'apache_up == 0',
-            labels: {
-              severity: 'warning',
-            },
-            annotations: {
-              summary: 'Apache is down.',
-              description: 'Apache is down on {{ $labels.instance }}.',
-            },
-            'for': '5m',
-          },
-          {
-            alert: 'ApacheRestart',
-            expr: 'apache_uptime_seconds_total / 60 < 1',
-            labels: {
-              severity: 'info',
-            },
-            annotations: {
-              summary: 'Apache restart.',
-              description: 'Apache has just been restarted.',
-            },
-            'for': '0',
-          },
-          {
-            alert: 'ApacheWorkersLoad',
-            expr: |||
-              (sum by (instance) (apache_workers{state="busy"}) / sum by (instance) (apache_scoreboard) ) * 100 > %(alertsWarningWorkersBusy)s
-            ||| % $._config,
-            'for': '15m',
-            labels: {
-              severity: 'warning',
-            },
-            annotations: {
-              summary: 'Apache workers load is too high.',
-              description: |||
-                Apache workers in busy state approach the max workers count %(alertsWarningWorkersBusy)s%% workers busy on {{ $labels.instance }}.
-                The currect value is {{ $value }}%%.
-              ||| % $._config,
-            },
-          },
-          {
-            alert: 'ApacheResponseTimeTooHigh',
-            expr: |||
-              increase(apache_duration_ms_total[5m])/increase(apache_accesses_total[5m]) > %(alertsWarningResponseTimeMs)s
-            ||| % $._config,
-            'for': '15m',
-            labels: {
-              severity: 'warning',
-            },
-            annotations: {
-              summary: 'Apache response time is too high.',
-              description: |||
-                Apache average response time is above the threshold of %(alertsWarningResponseTimeMs)s ms on {{ $labels.instance }}.
-                The currect value is {{ $value }} ms.
-              ||| % $._config,
-            },
-          },
-        ]
-        +
-        if $._config.enableLokiLogs then 
-        [
-          {
-            alert: 'ApacheErrorsRateTooHigh',
-            expr: |||
-              avg by (job, instance)
-              (
-              (
-                increase(apache_response_http_codes_bucket{le=~"499"}[5m])
-              - ignoring(le)
-                increase(apache_response_http_codes_bucket{le=~"399"}[5m])
-              )
-              /
-              increase(apache_response_http_codes_count{}[5m]) * 100
-              )
-              > %(alertsCriticalErrorsRate)s
-              unless 
-              # at least 100 calls
-              increase(apache_accesses_total{}[5m]) > 100
-            ||| % $._config,
-            'for': '5m',
-            labels: {
-              severity: 'critical',
-            },
-            annotations: {
-              summary: 'Apache errors rate is too high.',
-              description: |||
-                Apache errors rate (4xx and 5xx HTTP codes) is above the threshold of %(alertsCriticalErrorsRate)s%% on {{ $labels.instance }}.
-                The currect value is {{ $value }}%%.
-              ||| % $._config,
-            },
-          }
-         ] else [],
+                 {
+                   alert: 'ApacheDown',
+                   expr: 'apache_up == 0',
+                   labels: {
+                     severity: 'warning',
+                   },
+                   annotations: {
+                     summary: 'Apache is down.',
+                     description: 'Apache is down on {{ $labels.instance }}.',
+                   },
+                   'for': '5m',
+                 },
+                 {
+                   alert: 'ApacheRestart',
+                   expr: 'apache_uptime_seconds_total / 60 < 1',
+                   labels: {
+                     severity: 'info',
+                   },
+                   annotations: {
+                     summary: 'Apache restart.',
+                     description: 'Apache has just been restarted.',
+                   },
+                   'for': '0',
+                 },
+                 {
+                   alert: 'ApacheWorkersLoad',
+                   expr: |||
+                     (sum by (instance) (apache_workers{state="busy"}) / sum by (instance) (apache_scoreboard) ) * 100 > %(alertsWarningWorkersBusy)s
+                   ||| % $._config,
+                   'for': '15m',
+                   labels: {
+                     severity: 'warning',
+                   },
+                   annotations: {
+                     summary: 'Apache workers load is too high.',
+                     description: |||
+                       Apache workers in busy state approach the max workers count %(alertsWarningWorkersBusy)s%% workers busy on {{ $labels.instance }}.
+                       The currect value is {{ $value }}%%.
+                     ||| % $._config,
+                   },
+                 },
+                 {
+                   alert: 'ApacheResponseTimeTooHigh',
+                   expr: |||
+                     increase(apache_duration_ms_total[5m])/increase(apache_accesses_total[5m]) > %(alertsWarningResponseTimeMs)s
+                   ||| % $._config,
+                   'for': '15m',
+                   labels: {
+                     severity: 'warning',
+                   },
+                   annotations: {
+                     summary: 'Apache response time is too high.',
+                     description: |||
+                       Apache average response time is above the threshold of %(alertsWarningResponseTimeMs)s ms on {{ $labels.instance }}.
+                       The currect value is {{ $value }} ms.
+                     ||| % $._config,
+                   },
+                 },
+               ]
+               +
+               if $._config.enableLokiLogs then
+                 [
+                   {
+                     alert: 'ApacheErrorsRateTooHigh',
+                     expr: |||
+                       avg by (job, instance)
+                       (
+                       (
+                         increase(apache_response_http_codes_bucket{le=~"499"}[5m])
+                       - ignoring(le)
+                         increase(apache_response_http_codes_bucket{le=~"399"}[5m])
+                       )
+                       /
+                       increase(apache_response_http_codes_count{}[5m]) * 100
+                       )
+                       > %(alertsCriticalErrorsRate)s
+                       unless 
+                       # at least 100 calls
+                       increase(apache_accesses_total{}[5m]) > 100
+                     ||| % $._config,
+                     'for': '5m',
+                     labels: {
+                       severity: 'critical',
+                     },
+                     annotations: {
+                       summary: 'Apache errors rate is too high.',
+                       description: |||
+                         Apache errors rate (4xx and 5xx HTTP codes) is above the threshold of %(alertsCriticalErrorsRate)s%% on {{ $labels.instance }}.
+                         The currect value is {{ $value }}%%.
+                       ||| % $._config,
+                     },
+                   },
+                 ] else [],
       },
     ],
   },

--- a/apache-http-mixin/config.libsonnet
+++ b/apache-http-mixin/config.libsonnet
@@ -8,6 +8,7 @@
     // for alerts
     alertsWarningWorkersBusy: '80',  // %
     alertsWarningResponseTimeMs: '5000',  // ms
+    alertsCriticalErrorsRate: '20',  // ratio of 4xx and 5xx responses to all calls
 
     // enable Loki logs
     enableLokiLogs: false,

--- a/apache-http-mixin/config.libsonnet
+++ b/apache-http-mixin/config.libsonnet
@@ -8,5 +8,8 @@
     // for alerts
     alertsWarningWorkersBusy: '80',  // %
     alertsWarningResponseTimeMs: '5000',  // ms
+
+    // enable Loki logs
+    enableLokiLogs: false,
   },
 }

--- a/apache-http-mixin/dashboards/apache-exporter-full.libsonnet
+++ b/apache-http-mixin/dashboards/apache-exporter-full.libsonnet
@@ -73,7 +73,6 @@ local uptimePanel =
 
 local versionPanel =
   {
-
     type: 'stat',
     title: 'Version',
     datasource: {
@@ -124,21 +123,24 @@ local versionPanel =
         fields: '',
       },
       orientation: 'horizontal',
-      textMode: 'auto',
+      textMode: 'name',
       colorMode: 'none',
       graphMode: 'none',
       justifyMode: 'auto',
+      text: {
+        titleSize: 2,
+      },
     },
     targets: [
       {
-        expr: 'apache_version{' + matcher + '}',
-        legendFormat: '',
+        expr: 'apache_info{' + matcher + '}',
+        legendFormat: '{{ version }}',
         interval: '',
-        exemplar: true,
+        exemplar: false,
         format: 'time_series',
         intervalFactor: 1,
-        refId: 'A',
         step: 240,
+        instant: true,
       },
     ],
   };

--- a/apache-http-mixin/dashboards/apache-exporter-full.libsonnet
+++ b/apache-http-mixin/dashboards/apache-exporter-full.libsonnet
@@ -17,16 +17,19 @@ local matcher = 'job=~"$job", instance=~"$instance"';
         refresh='%s' % $._config.dashboardRefresh,
         graphTooltip='shared_crosshair',
         uid=dashboardUid,
-      ).addTemplates(
+      )
+      .addLink(grafana.link.dashboards(
+        asDropdown=false,
+        title='Other Apache HTTP dashboards',
+        includeVars=true,
+        keepTime=true,
+        tags=($._config.dashboardTags),
+      )).addTemplates(
         [
           {
-            current: {
-              text: 'default',
-              value: 'default',
-            },
             hide: 0,
-            label: 'Data Source',
-            name: 'datasource',
+            label: 'Data source',
+            name: 'prometheus_datasource',
             query: 'prometheus',
             refresh: 1,
             regex: '',
@@ -35,7 +38,7 @@ local matcher = 'job=~"$job", instance=~"$instance"';
           template.new(
             name='job',
             label='job',
-            datasource='$datasource',
+            datasource='$prometheus_datasource',
             query='label_values(apache_up, job)',
             current='',
             refresh=2,
@@ -47,7 +50,7 @@ local matcher = 'job=~"$job", instance=~"$instance"';
           template.new(
             name='instance',
             label='instance',
-            datasource='$datasource',
+            datasource='$prometheus_datasource',
             query='label_values(apache_up{job=~"$job"}, instance)',
             current='',
             refresh=2,
@@ -59,7 +62,7 @@ local matcher = 'job=~"$job", instance=~"$instance"';
       .addPanels([
         {
           datasource: {
-            uid: '${datasource}',
+            uid: '${prometheus_datasource}',
           },
           fieldConfig: {
             defaults: {
@@ -142,7 +145,7 @@ local matcher = 'job=~"$job", instance=~"$instance"';
           type: 'stat',
           title: 'Version',
           datasource: {
-            uid: '${datasource}',
+            uid: '${prometheus_datasource}',
             type: 'prometheus',
           },
           pluginVersion: '8.4.5',
@@ -220,7 +223,7 @@ local matcher = 'job=~"$job", instance=~"$instance"';
           type: 'state-timeline',
           title: 'Apache Up / Down',
           datasource: {
-            uid: '${datasource}',
+            uid: '${prometheus_datasource}',
             type: 'prometheus',
           },
           pluginVersion: '8.4.5',
@@ -304,7 +307,7 @@ local matcher = 'job=~"$job", instance=~"$instance"';
           type: 'timeseries',
           title: 'Response time',
           datasource: {
-            uid: '${datasource}',
+            uid: '${prometheus_datasource}',
           },
           pluginVersion: '8.4.5',
           links: [],
@@ -386,7 +389,7 @@ local matcher = 'job=~"$job", instance=~"$instance"';
               refId: 'A',
               step: 240,
               datasource: {
-                uid: '${datasource}',
+                uid: '${prometheus_datasource}',
                 type: 'prometheus',
               },
             },
@@ -405,7 +408,7 @@ local matcher = 'job=~"$job", instance=~"$instance"';
           type: 'timeseries',
           title: 'Load',
           datasource: {
-            uid: '${datasource}',
+            uid: '${prometheus_datasource}',
           },
           pluginVersion: '8.4.5',
           links: [],
@@ -512,7 +515,7 @@ local matcher = 'job=~"$job", instance=~"$instance"';
               step: 240,
               datasource: {
                 type: 'prometheus',
-                uid: '${datasource}',
+                uid: '${prometheus_datasource}',
               },
             },
             {
@@ -521,7 +524,7 @@ local matcher = 'job=~"$job", instance=~"$instance"';
               interval: '',
               exemplar: false,
               datasource: {
-                uid: '${datasource}',
+                uid: '${prometheus_datasource}',
                 type: 'prometheus',
               },
               refId: 'B',
@@ -543,7 +546,7 @@ local matcher = 'job=~"$job", instance=~"$instance"';
           type: 'timeseries',
           title: 'Apache scoreboard statuses',
           datasource: {
-            uid: '${datasource}',
+            uid: '${prometheus_datasource}',
           },
           pluginVersion: '8.4.5',
           links: [],
@@ -640,7 +643,7 @@ local matcher = 'job=~"$job", instance=~"$instance"';
           type: 'timeseries',
           title: 'Apache worker statuses',
           datasource: {
-            uid: '${datasource}',
+            uid: '${prometheus_datasource}',
           },
           pluginVersion: '8.4.5',
           links: [],
@@ -735,7 +738,7 @@ local matcher = 'job=~"$job", instance=~"$instance"';
           type: 'timeseries',
           title: 'Apache CPU load',
           datasource: {
-            uid: '${datasource}',
+            uid: '${prometheus_datasource}',
           },
           pluginVersion: '8.4.5',
           links: [],

--- a/apache-http-mixin/dashboards/apache-exporter-full.libsonnet
+++ b/apache-http-mixin/dashboards/apache-exporter-full.libsonnet
@@ -4,6 +4,883 @@ local template = grafana.template;
 local dashboardUid = 'apache-http';
 local matcher = 'job=~"$job", instance=~"$instance"';
 
+local uptimePanel =
+  {
+    datasource: {
+      uid: '${prometheus_datasource}',
+    },
+    fieldConfig: {
+      defaults: {
+        color: {
+          mode: 'thresholds',
+        },
+        decimals: 1,
+        mappings: [
+          {
+            options: {
+              match: 'null',
+              result: {
+                text: 'N/A',
+              },
+            },
+            type: 'special',
+          },
+        ],
+        thresholds: {
+          mode: 'absolute',
+          steps: [
+            {
+              color: 'green',
+              value: null,
+            },
+            {
+              color: 'red',
+              value: 80,
+            },
+          ],
+        },
+        unit: 's',
+      },
+    },
+    id: 8,
+    maxDataPoints: 100,
+    options: {
+      colorMode: 'none',
+      graphMode: 'none',
+      justifyMode: 'auto',
+      orientation: 'horizontal',
+      reduceOptions: {
+        calcs: [
+          'lastNotNull',
+        ],
+        fields: '',
+        values: false,
+      },
+      textMode: 'auto',
+    },
+    pluginVersion: '8.4.5',
+    targets: [
+      {
+        expr: 'apache_uptime_seconds_total{' + matcher + '}',
+        format: 'time_series',
+        intervalFactor: 1,
+        step: 240,
+      },
+    ],
+    title: 'Uptime',
+    type: 'stat',
+  };
+
+local versionPanel =
+  {
+
+    type: 'stat',
+    title: 'Version',
+    datasource: {
+      uid: '${prometheus_datasource}',
+      type: 'prometheus',
+    },
+    pluginVersion: '8.4.5',
+    maxDataPoints: 100,
+    fieldConfig: {
+      defaults: {
+        mappings: [
+          {
+            options: {
+              match: 'null',
+              result: {
+                text: 'N/A',
+              },
+            },
+            type: 'special',
+          },
+        ],
+        thresholds: {
+          mode: 'absolute',
+          steps: [
+            {
+              color: 'green',
+              value: null,
+            },
+            {
+              color: 'red',
+              value: 80,
+            },
+          ],
+        },
+        color: {
+          mode: 'thresholds',
+        },
+        decimals: 1,
+        unit: 'none',
+      },
+    },
+    options: {
+      reduceOptions: {
+        values: false,
+        calcs: [
+          'lastNotNull',
+        ],
+        fields: '',
+      },
+      orientation: 'horizontal',
+      textMode: 'auto',
+      colorMode: 'none',
+      graphMode: 'none',
+      justifyMode: 'auto',
+    },
+    targets: [
+      {
+        expr: 'apache_version{' + matcher + '}',
+        legendFormat: '',
+        interval: '',
+        exemplar: true,
+        format: 'time_series',
+        intervalFactor: 1,
+        refId: 'A',
+        step: 240,
+      },
+    ],
+  };
+
+local statusPanel =
+  {
+
+    type: 'state-timeline',
+    title: 'Apache Up / Down',
+    datasource: {
+      uid: '${prometheus_datasource}',
+      type: 'prometheus',
+    },
+    pluginVersion: '8.4.5',
+    options: {
+      mergeValues: false,
+      showValue: 'never',
+      alignValue: 'left',
+      rowHeight: 0.9,
+      legend: {
+        displayMode: 'list',
+        placement: 'right',
+      },
+      tooltip: {
+        mode: 'single',
+        sort: 'none',
+      },
+    },
+    targets: [
+      {
+        expr: 'apache_up{' + matcher + '}',
+        legendFormat: 'Apache up',
+        interval: '',
+        exemplar: true,
+        format: 'time_series',
+        intervalFactor: 1,
+        refId: 'A',
+        step: 240,
+      },
+    ],
+    fieldConfig: {
+      defaults: {
+        custom: {
+          lineWidth: 0,
+          fillOpacity: 70,
+          spanNulls: false,
+        },
+        color: {
+          mode: 'continuous-GrYlRd',
+        },
+        mappings: [
+          {
+            type: 'value',
+            options: {
+              '0': {
+                text: 'Down',
+                color: 'red',
+                index: 1,
+              },
+              '1': {
+                text: 'Up',
+                color: 'green',
+                index: 0,
+              },
+            },
+          },
+        ],
+        thresholds: {
+          mode: 'absolute',
+          steps: [
+            {
+              color: 'green',
+              value: null,
+            },
+          ],
+        },
+      },
+    },
+  };
+local responseTimePanel =
+  {
+    type: 'timeseries',
+    title: 'Response time',
+    datasource: {
+      uid: '${prometheus_datasource}',
+    },
+    pluginVersion: '8.4.5',
+    fieldConfig: {
+      defaults: {
+        custom: {
+          drawStyle: 'line',
+          lineInterpolation: 'linear',
+          barAlignment: 0,
+          lineWidth: 1,
+          fillOpacity: 10,
+          gradientMode: 'none',
+          spanNulls: true,
+          showPoints: 'never',
+          pointSize: 5,
+          stacking: {
+            mode: 'none',
+            group: 'A',
+          },
+          axisPlacement: 'auto',
+          axisLabel: '',
+          scaleDistribution: {
+            type: 'linear',
+          },
+          hideFrom: {
+            tooltip: false,
+            viz: false,
+            legend: false,
+          },
+          thresholdsStyle: {
+            mode: 'off',
+          },
+        },
+        color: {
+          mode: 'palette-classic',
+        },
+        mappings: [],
+        thresholds: {
+          mode: 'absolute',
+          steps: [
+            {
+              color: 'green',
+              value: null,
+            },
+            {
+              color: 'red',
+              value: 80,
+            },
+          ],
+        },
+        unit: 'ms',
+      },
+    },
+    options: {
+      tooltip: {
+        mode: 'multi',
+        sort: 'none',
+      },
+      legend: {
+        displayMode: 'table',
+        placement: 'bottom',
+        calcs: [
+          'mean',
+          'lastNotNull',
+          'max',
+          'min',
+        ],
+      },
+    },
+    targets: [
+      {
+        expr: 'increase(apache_duration_ms_total{' + matcher + '}[$__rate_interval])/increase(apache_accesses_total{' + matcher + '}[$__rate_interval])',
+        legendFormat: 'Average response time',
+        interval: '',
+        exemplar: false,
+        format: 'time_series',
+        intervalFactor: 1,
+        refId: 'A',
+        step: 240,
+        datasource: {
+          uid: '${prometheus_datasource}',
+          type: 'prometheus',
+        },
+      },
+    ],
+  };
+local loadPanel =
+  {
+
+    type: 'timeseries',
+    title: 'Load',
+    datasource: {
+      uid: '${prometheus_datasource}',
+    },
+    pluginVersion: '8.4.5',
+    fieldConfig: {
+      defaults: {
+        custom: {
+          drawStyle: 'line',
+          lineInterpolation: 'linear',
+          barAlignment: 0,
+          lineWidth: 1,
+          fillOpacity: 10,
+          gradientMode: 'none',
+          spanNulls: true,
+          showPoints: 'never',
+          pointSize: 5,
+          stacking: {
+            mode: 'none',
+            group: 'A',
+          },
+          axisPlacement: 'auto',
+          axisLabel: '',
+          scaleDistribution: {
+            type: 'linear',
+          },
+          hideFrom: {
+            tooltip: false,
+            viz: false,
+            legend: false,
+          },
+          thresholdsStyle: {
+            mode: 'off',
+          },
+          lineStyle: {
+            fill: 'solid',
+          },
+        },
+        color: {
+          mode: 'palette-classic',
+        },
+        mappings: [],
+        thresholds: {
+          mode: 'absolute',
+          steps: [
+            {
+              color: 'green',
+              value: null,
+            },
+            {
+              color: 'red',
+              value: 80,
+            },
+          ],
+        },
+        unit: 'reqps',
+      },
+      overrides: [
+        {
+          matcher: {
+            id: 'byName',
+            options: 'Bytes sent',
+          },
+          properties: [
+            {
+              id: 'custom.axisPlacement',
+              value: 'right',
+            },
+            {
+              id: 'custom.drawStyle',
+              value: 'bars',
+            },
+            {
+              id: 'unit',
+              value: 'Bps',
+            },
+          ],
+        },
+      ],
+    },
+    options: {
+      tooltip: {
+        mode: 'multi',
+        sort: 'none',
+      },
+      legend: {
+        displayMode: 'table',
+        placement: 'bottom',
+        calcs: [
+          'mean',
+          'lastNotNull',
+          'max',
+          'min',
+        ],
+      },
+    },
+    targets: [
+      {
+        expr: 'rate(apache_accesses_total{' + matcher + '}[$__rate_interval])',
+        legendFormat: 'Calls',
+        interval: '',
+        exemplar: false,
+        format: 'time_series',
+        intervalFactor: 1,
+        refId: 'A',
+        step: 240,
+        datasource: {
+          type: 'prometheus',
+          uid: '${prometheus_datasource}',
+        },
+      },
+      {
+        expr: 'rate(apache_sent_kilobytes_total{' + matcher + '}[$__rate_interval]) * 1000',
+        legendFormat: 'Bytes sent',
+        interval: '',
+        exemplar: false,
+        datasource: {
+          uid: '${prometheus_datasource}',
+          type: 'prometheus',
+        },
+        refId: 'B',
+        hide: false,
+      },
+    ],
+    description: '',
+  };
+local apacheScoreboardPanel =
+  {
+
+    type: 'timeseries',
+    title: 'Apache scoreboard statuses',
+    datasource: {
+      uid: '${prometheus_datasource}',
+    },
+    pluginVersion: '8.4.5',
+    links: [],
+    options: {
+      tooltip: {
+        mode: 'multi',
+        sort: 'desc',
+      },
+      legend: {
+        displayMode: 'table',
+        placement: 'right',
+        calcs: [
+          'mean',
+          'lastNotNull',
+          'max',
+          'min',
+        ],
+        sortBy: 'Last *',
+        sortDesc: true,
+      },
+    },
+    targets: [
+      {
+        expr: 'apache_scoreboard{' + matcher + '}',
+        format: 'time_series',
+        intervalFactor: 1,
+        legendFormat: '{{ state }}',
+        refId: 'A',
+        step: 240,
+      },
+    ],
+    fieldConfig: {
+      defaults: {
+        custom: {
+          drawStyle: 'line',
+          lineInterpolation: 'stepAfter',
+          barAlignment: 0,
+          lineWidth: 1,
+          fillOpacity: 10,
+          gradientMode: 'none',
+          spanNulls: true,
+          showPoints: 'never',
+          pointSize: 5,
+          stacking: {
+            mode: 'normal',
+            group: 'A',
+          },
+          axisPlacement: 'auto',
+          axisLabel: '',
+          scaleDistribution: {
+            type: 'linear',
+          },
+          hideFrom: {
+            tooltip: false,
+            viz: false,
+            legend: false,
+          },
+          thresholdsStyle: {
+            mode: 'off',
+          },
+        },
+        color: {
+          mode: 'palette-classic',
+        },
+        mappings: [],
+        thresholds: {
+          mode: 'absolute',
+          steps: [
+            {
+              value: null,
+              color: 'green',
+            },
+            {
+              value: 80,
+              color: 'red',
+            },
+          ],
+        },
+        unit: 'short',
+      },
+      overrides: [],
+    },
+    timeFrom: null,
+    timeShift: null,
+  };
+
+local apacheWorkerStatusPanel =
+  {
+    type: 'timeseries',
+    title: 'Apache worker statuses',
+    datasource: {
+      uid: '${prometheus_datasource}',
+    },
+    pluginVersion: '8.4.5',
+    links: [],
+    options: {
+      tooltip: {
+        mode: 'multi',
+        sort: 'none',
+      },
+      legend: {
+        displayMode: 'table',
+        placement: 'bottom',
+        calcs: [
+          'mean',
+          'lastNotNull',
+          'max',
+          'min',
+        ],
+      },
+    },
+    targets: [
+      {
+        expr: 'apache_workers{' + matcher + '}\n',
+        format: 'time_series',
+        intervalFactor: 1,
+        legendFormat: '{{ state }}',
+        step: 240,
+      },
+    ],
+    fieldConfig: {
+      defaults: {
+        custom: {
+          drawStyle: 'line',
+          lineInterpolation: 'stepAfter',
+          barAlignment: 0,
+          lineWidth: 1,
+          fillOpacity: 10,
+          gradientMode: 'none',
+          spanNulls: true,
+          showPoints: 'never',
+          pointSize: 5,
+          stacking: {
+            mode: 'normal',
+            group: 'A',
+          },
+          axisPlacement: 'auto',
+          axisLabel: '',
+          scaleDistribution: {
+            type: 'linear',
+          },
+          hideFrom: {
+            tooltip: false,
+            viz: false,
+            legend: false,
+          },
+          thresholdsStyle: {
+            mode: 'off',
+          },
+        },
+        color: {
+          mode: 'palette-classic',
+        },
+        mappings: [],
+        thresholds: {
+          mode: 'absolute',
+          steps: [
+            {
+              value: null,
+              color: 'green',
+            },
+            {
+              value: 80,
+              color: 'red',
+            },
+          ],
+        },
+        unit: 'short',
+      },
+    },
+  };
+local apacheCpuPanel =
+  {
+
+    type: 'timeseries',
+    title: 'Apache CPU load',
+    datasource: {
+      uid: '${prometheus_datasource}',
+    },
+    pluginVersion: '8.4.5',
+    links: [],
+    options: {
+      tooltip: {
+        mode: 'multi',
+        sort: 'none',
+      },
+      legend: {
+        displayMode: 'table',
+        placement: 'bottom',
+        calcs: [
+          'mean',
+          'lastNotNull',
+          'max',
+          'min',
+        ],
+      },
+    },
+    targets: [
+      {
+        expr: 'apache_cpuload{' + matcher + '}',
+        format: 'time_series',
+        intervalFactor: 1,
+        legendFormat: 'Load',
+        refId: 'A',
+        step: 240,
+      },
+    ],
+    fieldConfig: {
+      defaults: {
+        custom: {
+          drawStyle: 'line',
+          lineInterpolation: 'linear',
+          barAlignment: 0,
+          lineWidth: 1,
+          fillOpacity: 10,
+          gradientMode: 'none',
+          spanNulls: true,
+          showPoints: 'never',
+          pointSize: 5,
+          stacking: {
+            mode: 'none',
+            group: 'A',
+          },
+          axisPlacement: 'auto',
+          axisLabel: '',
+          scaleDistribution: {
+            type: 'linear',
+          },
+          hideFrom: {
+            tooltip: false,
+            viz: false,
+            legend: false,
+          },
+          thresholdsStyle: {
+            mode: 'off',
+          },
+        },
+        color: {
+          mode: 'palette-classic',
+        },
+        mappings: [],
+        thresholds: {
+          mode: 'absolute',
+          steps: [
+            {
+              value: null,
+              color: 'green',
+            },
+            {
+              value: 80,
+              color: 'red',
+            },
+          ],
+        },
+        unit: 'short',
+        min: 0,
+      },
+      overrides: [],
+    },
+  };
+local errorsPanel =
+  {
+    type: 'timeseries',
+    title: 'Errors rate',
+    datasource: {
+      uid: '${prometheus_datasource}',
+      type: 'prometheus',
+    },
+    pluginVersion: '8.4.5',
+    fieldConfig: {
+      defaults: {
+        custom: {
+          drawStyle: 'bars',
+          lineInterpolation: 'linear',
+          barAlignment: 0,
+          lineWidth: 0,
+          fillOpacity: 57,
+          gradientMode: 'opacity',
+          spanNulls: true,
+          showPoints: 'never',
+          pointSize: 5,
+          stacking: {
+            mode: 'none',
+            group: 'A',
+          },
+          axisPlacement: 'auto',
+          axisLabel: '',
+          scaleDistribution: {
+            type: 'linear',
+          },
+          hideFrom: {
+            tooltip: false,
+            viz: false,
+            legend: false,
+          },
+          thresholdsStyle: {
+            mode: 'off',
+          },
+        },
+        color: {
+          mode: 'palette-classic',
+        },
+        mappings: [],
+        thresholds: {
+          mode: 'absolute',
+          steps: [
+            {
+              color: 'green',
+              value: null,
+            },
+          ],
+        },
+        unit: 'reqps',
+        max: 100,
+        min: 0,
+      },
+      overrides: [
+        {
+          matcher: {
+            id: 'byName',
+            options: 'HTTP 400-499',
+          },
+          properties: [
+            {
+              id: 'color',
+              value: {
+                fixedColor: 'orange',
+                mode: 'fixed',
+              },
+            },
+          ],
+        },
+        {
+          matcher: {
+            id: 'byName',
+            options: 'HTTP 500-599',
+          },
+          properties: [
+            {
+              id: 'color',
+              value: {
+                fixedColor: 'red',
+                mode: 'fixed',
+              },
+            },
+          ],
+        },
+        {
+          matcher: {
+            id: 'byName',
+            options: 'Error rate',
+          },
+          properties: [
+            {
+              id: 'custom.drawStyle',
+              value: 'line',
+            },
+            {
+              id: 'unit',
+              value: 'percent',
+            },
+            {
+              id: 'color',
+              value: {
+                mode: 'fixed',
+                fixedColor: 'red',
+              },
+            },
+            {
+              id: 'custom.fillOpacity',
+              value: 50,
+            },
+            {
+              id: 'custom.lineWidth',
+              value: 1,
+            },
+            {
+              id: 'custom.lineInterpolation',
+              value: 'smooth',
+            },
+          ],
+        },
+      ],
+    },
+    options: {
+      tooltip: {
+        mode: 'multi',
+        sort: 'none',
+      },
+      legend: {
+        displayMode: 'table',
+        placement: 'bottom',
+        calcs: [
+          'mean',
+          'lastNotNull',
+          'max',
+          'min',
+        ],
+      },
+    },
+    targets: [
+      {
+        expr: 'label_replace(\n  sum by (le,job, instance) (rate(apache_response_http_codes_bucket{le=~"499|599", ' + matcher + '}[$__rate_interval])),\n  "alias", "HTTP ${1}00-${1}99", "le", "(.).+"\n)\n',
+        legendFormat: '{{ alias }}',
+        interval: '',
+        exemplar: false,
+        datasource: {
+          type: 'prometheus',
+          uid: '${prometheus_datasource}',
+        },
+        format: 'heatmap',
+        intervalFactor: 1,
+        refId: 'A',
+        step: 240,
+        hide: true,
+      },
+      {
+        expr: 'avg by (le,job, instance)\n(\n(\n  increase(apache_response_http_codes_bucket{le=~"499", job=~"$job", instance=~"$instance"}[$__rate_interval])\n- ignoring(le)\n  increase(apache_response_http_codes_bucket{le=~"399", job=~"$job", instance=~"$instance"}[$__rate_interval])\n)\n/\nincrease(apache_response_http_codes_count{job=~"$job", instance=~"$instance"}[$__rate_interval]) * 100\n)',
+        legendFormat: 'Error rate',
+        interval: '',
+        exemplar: true,
+        datasource: {
+          type: 'prometheus',
+          uid: '${prometheus_datasource}',
+        },
+        format: 'time_series',
+        intervalFactor: 1,
+        refId: 'B',
+        step: 240,
+        hide: false,
+        instant: false,
+      },
+    ],
+    description: 'Ratio of 4xx and 5xx HTTP responses to all calls.',
+  };
 {
   grafanaDashboards+:: {
 
@@ -59,771 +936,31 @@ local matcher = 'job=~"$job", instance=~"$instance"';
           ),
         ]
       )
-      .addPanels([
-        {
-          datasource: {
-            uid: '${prometheus_datasource}',
-          },
-          fieldConfig: {
-            defaults: {
-              color: {
-                mode: 'thresholds',
-              },
-              decimals: 1,
-              mappings: [
-                {
-                  options: {
-                    match: 'null',
-                    result: {
-                      text: 'N/A',
-                    },
-                  },
-                  type: 'special',
-                },
-              ],
-              thresholds: {
-                mode: 'absolute',
-                steps: [
-                  {
-                    color: 'green',
-                    value: null,
-                  },
-                  {
-                    color: 'red',
-                    value: 80,
-                  },
-                ],
-              },
-              unit: 's',
-            },
-            overrides: [],
-          },
-          gridPos: {
-            h: 3,
-            w: 4,
-            x: 0,
-            y: 0,
-          },
-          id: 8,
-          links: [],
-          maxDataPoints: 100,
-          options: {
-            colorMode: 'none',
-            graphMode: 'none',
-            justifyMode: 'auto',
-            orientation: 'horizontal',
-            reduceOptions: {
-              calcs: [
-                'lastNotNull',
-              ],
-              fields: '',
-              values: false,
-            },
-            textMode: 'auto',
-          },
-          pluginVersion: '8.4.5',
-          targets: [
-            {
-              expr: 'apache_uptime_seconds_total{' + matcher + '}',
-              format: 'time_series',
-              intervalFactor: 1,
-              refId: 'A',
-              step: 240,
-            },
+      .addPanels(
+        std.flattenArrays([
+          [
+            uptimePanel { gridPos: { y: 0, x: 0, h: 3, w: 4 } },
+            versionPanel { gridPos: { y: 0, h: 3, w: 4, x: 4 } },
+            statusPanel { gridPos: { y: 0, h: 3, w: 16, x: 8 } },
           ],
-          title: 'Uptime',
-          type: 'stat',
-        },
-        {
-          id: 9,
-          gridPos: {
-            h: 3,
-            w: 4,
-            x: 4,
-            y: 0,
-          },
-          type: 'stat',
-          title: 'Version',
-          datasource: {
-            uid: '${prometheus_datasource}',
-            type: 'prometheus',
-          },
-          pluginVersion: '8.4.5',
-          maxDataPoints: 100,
-          links: [],
-          fieldConfig: {
-            defaults: {
-              mappings: [
-                {
-                  options: {
-                    match: 'null',
-                    result: {
-                      text: 'N/A',
-                    },
-                  },
-                  type: 'special',
-                },
-              ],
-              thresholds: {
-                mode: 'absolute',
-                steps: [
-                  {
-                    color: 'green',
-                    value: null,
-                  },
-                  {
-                    color: 'red',
-                    value: 80,
-                  },
-                ],
-              },
-              color: {
-                mode: 'thresholds',
-              },
-              decimals: 1,
-              unit: 'none',
-            },
-            overrides: [],
-          },
-          options: {
-            reduceOptions: {
-              values: false,
-              calcs: [
-                'lastNotNull',
-              ],
-              fields: '',
-            },
-            orientation: 'horizontal',
-            textMode: 'auto',
-            colorMode: 'none',
-            graphMode: 'none',
-            justifyMode: 'auto',
-          },
-          targets: [
-            {
-              expr: 'apache_version{' + matcher + '}',
-              legendFormat: '',
-              interval: '',
-              exemplar: true,
-              format: 'time_series',
-              intervalFactor: 1,
-              refId: 'A',
-              step: 240,
-            },
+          //next row
+          if $._config.enableLokiLogs then [
+            loadPanel { gridPos: { y: 1, h: 7, w: 8, x: 0 } },
+            responseTimePanel { gridPos: { y: 1, h: 7, w: 8, x: 8 } },
+            errorsPanel { gridPos: { y: 1, h: 7, w: 8, x: 16 } },
+
+          ] else [
+            loadPanel { gridPos: { y: 1, h: 7, w: 12, x: 0 } },
+            responseTimePanel { gridPos: { y: 1, h: 7, w: 12, x: 12 } },
           ],
-        },
-        {
-          id: 5,
-          gridPos: {
-            h: 3,
-            w: 16,
-            x: 8,
-            y: 0,
-          },
-          type: 'state-timeline',
-          title: 'Apache Up / Down',
-          datasource: {
-            uid: '${prometheus_datasource}',
-            type: 'prometheus',
-          },
-          pluginVersion: '8.4.5',
-          links: [],
-          options: {
-            mergeValues: false,
-            showValue: 'never',
-            alignValue: 'left',
-            rowHeight: 0.9,
-            legend: {
-              displayMode: 'list',
-              placement: 'right',
-            },
-            tooltip: {
-              mode: 'single',
-              sort: 'none',
-            },
-          },
-          targets: [
-            {
-              expr: 'apache_up{' + matcher + '}',
-              legendFormat: 'Apache up',
-              interval: '',
-              exemplar: true,
-              format: 'time_series',
-              intervalFactor: 1,
-              refId: 'A',
-              step: 240,
-            },
+          [  //next row
+            apacheScoreboardPanel { gridPos: { y: 2, h: 10, w: 24, x: 0 } },
+            //next row
+            apacheWorkerStatusPanel { gridPos: { y: 3, h: 10, w: 12, x: 0 } },
+            apacheCpuPanel { gridPos: { y: 3, h: 10, w: 12, x: 12 } },
           ],
-          fieldConfig: {
-            defaults: {
-              custom: {
-                lineWidth: 0,
-                fillOpacity: 70,
-                spanNulls: false,
-              },
-              color: {
-                mode: 'continuous-GrYlRd',
-              },
-              mappings: [
-                {
-                  type: 'value',
-                  options: {
-                    '0': {
-                      text: 'Down',
-                      color: 'red',
-                      index: 1,
-                    },
-                    '1': {
-                      text: 'Up',
-                      color: 'green',
-                      index: 0,
-                    },
-                  },
-                },
-              ],
-              thresholds: {
-                mode: 'absolute',
-                steps: [
-                  {
-                    color: 'green',
-                    value: null,
-                  },
-                ],
-              },
-            },
-            overrides: [],
-          },
-          timeFrom: null,
-          timeShift: null,
-        },
-        {
-          id: 3,
-          gridPos: {
-            h: 7,
-            w: 12,
-            x: 12,
-            y: 3,
-          },
-          type: 'timeseries',
-          title: 'Response time',
-          datasource: {
-            uid: '${prometheus_datasource}',
-          },
-          pluginVersion: '8.4.5',
-          links: [],
-          fieldConfig: {
-            defaults: {
-              custom: {
-                drawStyle: 'line',
-                lineInterpolation: 'linear',
-                barAlignment: 0,
-                lineWidth: 1,
-                fillOpacity: 10,
-                gradientMode: 'none',
-                spanNulls: true,
-                showPoints: 'never',
-                pointSize: 5,
-                stacking: {
-                  mode: 'none',
-                  group: 'A',
-                },
-                axisPlacement: 'auto',
-                axisLabel: '',
-                scaleDistribution: {
-                  type: 'linear',
-                },
-                hideFrom: {
-                  tooltip: false,
-                  viz: false,
-                  legend: false,
-                },
-                thresholdsStyle: {
-                  mode: 'off',
-                },
-              },
-              color: {
-                mode: 'palette-classic',
-              },
-              mappings: [],
-              thresholds: {
-                mode: 'absolute',
-                steps: [
-                  {
-                    color: 'green',
-                    value: null,
-                  },
-                  {
-                    color: 'red',
-                    value: 80,
-                  },
-                ],
-              },
-              unit: 'ms',
-            },
-            overrides: [],
-          },
-          options: {
-            tooltip: {
-              mode: 'multi',
-              sort: 'none',
-            },
-            legend: {
-              displayMode: 'table',
-              placement: 'bottom',
-              calcs: [
-                'mean',
-                'lastNotNull',
-                'max',
-                'min',
-              ],
-            },
-          },
-          targets: [
-            {
-              expr: 'increase(apache_duration_ms_total{' + matcher + '}[$__rate_interval])/increase(apache_accesses_total{' + matcher + '}[$__rate_interval])',
-              legendFormat: 'Average response time',
-              interval: '',
-              exemplar: false,
-              format: 'time_series',
-              intervalFactor: 1,
-              refId: 'A',
-              step: 240,
-              datasource: {
-                uid: '${prometheus_datasource}',
-                type: 'prometheus',
-              },
-            },
-          ],
-          timeFrom: null,
-          timeShift: null,
-        },
-        {
-          id: 6,
-          gridPos: {
-            h: 7,
-            w: 12,
-            x: 0,
-            y: 3,
-          },
-          type: 'timeseries',
-          title: 'Load',
-          datasource: {
-            uid: '${prometheus_datasource}',
-          },
-          pluginVersion: '8.4.5',
-          links: [],
-          fieldConfig: {
-            defaults: {
-              custom: {
-                drawStyle: 'line',
-                lineInterpolation: 'linear',
-                barAlignment: 0,
-                lineWidth: 1,
-                fillOpacity: 10,
-                gradientMode: 'none',
-                spanNulls: true,
-                showPoints: 'never',
-                pointSize: 5,
-                stacking: {
-                  mode: 'none',
-                  group: 'A',
-                },
-                axisPlacement: 'auto',
-                axisLabel: '',
-                scaleDistribution: {
-                  type: 'linear',
-                },
-                hideFrom: {
-                  tooltip: false,
-                  viz: false,
-                  legend: false,
-                },
-                thresholdsStyle: {
-                  mode: 'off',
-                },
-                lineStyle: {
-                  fill: 'solid',
-                },
-              },
-              color: {
-                mode: 'palette-classic',
-              },
-              mappings: [],
-              thresholds: {
-                mode: 'absolute',
-                steps: [
-                  {
-                    color: 'green',
-                    value: null,
-                  },
-                  {
-                    color: 'red',
-                    value: 80,
-                  },
-                ],
-              },
-              unit: 'reqps',
-            },
-            overrides: [
-              {
-                matcher: {
-                  id: 'byName',
-                  options: 'Bytes sent',
-                },
-                properties: [
-                  {
-                    id: 'custom.axisPlacement',
-                    value: 'right',
-                  },
-                  {
-                    id: 'custom.drawStyle',
-                    value: 'bars',
-                  },
-                  {
-                    id: 'unit',
-                    value: 'Bps',
-                  },
-                ],
-              },
-            ],
-          },
-          options: {
-            tooltip: {
-              mode: 'multi',
-              sort: 'none',
-            },
-            legend: {
-              displayMode: 'table',
-              placement: 'bottom',
-              calcs: [
-                'mean',
-                'lastNotNull',
-                'max',
-                'min',
-              ],
-            },
-          },
-          targets: [
-            {
-              expr: 'rate(apache_accesses_total{' + matcher + '}[$__rate_interval])',
-              legendFormat: 'Calls',
-              interval: '',
-              exemplar: false,
-              format: 'time_series',
-              intervalFactor: 1,
-              refId: 'A',
-              step: 240,
-              datasource: {
-                type: 'prometheus',
-                uid: '${prometheus_datasource}',
-              },
-            },
-            {
-              expr: 'rate(apache_sent_kilobytes_total{' + matcher + '}[$__rate_interval]) * 1000',
-              legendFormat: 'Bytes sent',
-              interval: '',
-              exemplar: false,
-              datasource: {
-                uid: '${prometheus_datasource}',
-                type: 'prometheus',
-              },
-              refId: 'B',
-              hide: false,
-            },
-          ],
-          timeFrom: null,
-          timeShift: null,
-          description: '',
-        },
-        {
-          id: 2,
-          gridPos: {
-            h: 10,
-            w: 24,
-            x: 0,
-            y: 13,
-          },
-          type: 'timeseries',
-          title: 'Apache scoreboard statuses',
-          datasource: {
-            uid: '${prometheus_datasource}',
-          },
-          pluginVersion: '8.4.5',
-          links: [],
-          options: {
-            tooltip: {
-              mode: 'multi',
-              sort: 'desc',
-            },
-            legend: {
-              displayMode: 'table',
-              placement: 'right',
-              calcs: [
-                'mean',
-                'lastNotNull',
-                'max',
-                'min',
-              ],
-              sortBy: 'Last *',
-              sortDesc: true,
-            },
-          },
-          targets: [
-            {
-              expr: 'apache_scoreboard{' + matcher + '}',
-              format: 'time_series',
-              intervalFactor: 1,
-              legendFormat: '{{ state }}',
-              refId: 'A',
-              step: 240,
-            },
-          ],
-          fieldConfig: {
-            defaults: {
-              custom: {
-                drawStyle: 'line',
-                lineInterpolation: 'stepAfter',
-                barAlignment: 0,
-                lineWidth: 1,
-                fillOpacity: 10,
-                gradientMode: 'none',
-                spanNulls: true,
-                showPoints: 'never',
-                pointSize: 5,
-                stacking: {
-                  mode: 'normal',
-                  group: 'A',
-                },
-                axisPlacement: 'auto',
-                axisLabel: '',
-                scaleDistribution: {
-                  type: 'linear',
-                },
-                hideFrom: {
-                  tooltip: false,
-                  viz: false,
-                  legend: false,
-                },
-                thresholdsStyle: {
-                  mode: 'off',
-                },
-              },
-              color: {
-                mode: 'palette-classic',
-              },
-              mappings: [],
-              thresholds: {
-                mode: 'absolute',
-                steps: [
-                  {
-                    value: null,
-                    color: 'green',
-                  },
-                  {
-                    value: 80,
-                    color: 'red',
-                  },
-                ],
-              },
-              unit: 'short',
-            },
-            overrides: [],
-          },
-          timeFrom: null,
-          timeShift: null,
-        },
-        {
-          id: 7,
-          gridPos: {
-            h: 10,
-            w: 12,
-            x: 0,
-            y: 23,
-          },
-          type: 'timeseries',
-          title: 'Apache worker statuses',
-          datasource: {
-            uid: '${prometheus_datasource}',
-          },
-          pluginVersion: '8.4.5',
-          links: [],
-          options: {
-            tooltip: {
-              mode: 'multi',
-              sort: 'none',
-            },
-            legend: {
-              displayMode: 'table',
-              placement: 'bottom',
-              calcs: [
-                'mean',
-                'lastNotNull',
-                'max',
-                'min',
-              ],
-            },
-          },
-          targets: [
-            {
-              expr: 'apache_workers{' + matcher + '}\n',
-              format: 'time_series',
-              intervalFactor: 1,
-              legendFormat: '{{ state }}',
-              refId: 'A',
-              step: 240,
-            },
-          ],
-          fieldConfig: {
-            defaults: {
-              custom: {
-                drawStyle: 'line',
-                lineInterpolation: 'stepAfter',
-                barAlignment: 0,
-                lineWidth: 1,
-                fillOpacity: 10,
-                gradientMode: 'none',
-                spanNulls: true,
-                showPoints: 'never',
-                pointSize: 5,
-                stacking: {
-                  mode: 'normal',
-                  group: 'A',
-                },
-                axisPlacement: 'auto',
-                axisLabel: '',
-                scaleDistribution: {
-                  type: 'linear',
-                },
-                hideFrom: {
-                  tooltip: false,
-                  viz: false,
-                  legend: false,
-                },
-                thresholdsStyle: {
-                  mode: 'off',
-                },
-              },
-              color: {
-                mode: 'palette-classic',
-              },
-              mappings: [],
-              thresholds: {
-                mode: 'absolute',
-                steps: [
-                  {
-                    value: null,
-                    color: 'green',
-                  },
-                  {
-                    value: 80,
-                    color: 'red',
-                  },
-                ],
-              },
-              unit: 'short',
-            },
-            overrides: [],
-          },
-          timeFrom: null,
-          timeShift: null,
-        },
-        {
-          id: 8,
-          gridPos: {
-            h: 10,
-            w: 12,
-            x: 12,
-            y: 23,
-          },
-          type: 'timeseries',
-          title: 'Apache CPU load',
-          datasource: {
-            uid: '${prometheus_datasource}',
-          },
-          pluginVersion: '8.4.5',
-          links: [],
-          options: {
-            tooltip: {
-              mode: 'multi',
-              sort: 'none',
-            },
-            legend: {
-              displayMode: 'table',
-              placement: 'bottom',
-              calcs: [
-                'mean',
-                'lastNotNull',
-                'max',
-                'min',
-              ],
-            },
-          },
-          targets: [
-            {
-              expr: 'apache_cpuload{' + matcher + '}',
-              format: 'time_series',
-              intervalFactor: 1,
-              legendFormat: 'Load',
-              refId: 'A',
-              step: 240,
-            },
-          ],
-          fieldConfig: {
-            defaults: {
-              custom: {
-                drawStyle: 'line',
-                lineInterpolation: 'linear',
-                barAlignment: 0,
-                lineWidth: 1,
-                fillOpacity: 10,
-                gradientMode: 'none',
-                spanNulls: true,
-                showPoints: 'never',
-                pointSize: 5,
-                stacking: {
-                  mode: 'none',
-                  group: 'A',
-                },
-                axisPlacement: 'auto',
-                axisLabel: '',
-                scaleDistribution: {
-                  type: 'linear',
-                },
-                hideFrom: {
-                  tooltip: false,
-                  viz: false,
-                  legend: false,
-                },
-                thresholdsStyle: {
-                  mode: 'off',
-                },
-              },
-              color: {
-                mode: 'palette-classic',
-              },
-              mappings: [],
-              thresholds: {
-                mode: 'absolute',
-                steps: [
-                  {
-                    value: null,
-                    color: 'green',
-                  },
-                  {
-                    value: 80,
-                    color: 'red',
-                  },
-                ],
-              },
-              unit: 'short',
-              min: 0,
-            },
-            overrides: [],
-          },
-          timeFrom: null,
-          timeShift: null,
-        },
-      ]),
+        ])
+      ),
 
   },
 }

--- a/apache-http-mixin/dashboards/apache-logs.libsonnet
+++ b/apache-http-mixin/dashboards/apache-logs.libsonnet
@@ -1,0 +1,64 @@
+local grafana = import 'github.com/grafana/grafonnet-lib/grafonnet/grafana.libsonnet';
+local dashboard = grafana.dashboard;
+local template = grafana.template;
+local dashboardUid = 'apache-http-logs';
+local matcher = 'job=~"$job", instance=~"$instance"';
+
+{
+  grafanaDashboards+::
+
+    if $._config.enableLokiLogs then {
+      'apache-http-logs.json':
+        dashboard.new(
+          'Apache HTTP server logs',
+          time_from='%s' % $._config.dashboardPeriod,
+          editable=false,
+          tags=($._config.dashboardTags),
+          timezone='%s' % $._config.dashboardTimezone,
+          refresh='%s' % $._config.dashboardRefresh,
+          uid=dashboardUid,
+        )
+        .addLink(grafana.link.dashboards(
+          asDropdown=false,
+          title='Other Apache HTTP dashboards',
+          includeVars=true,
+          keepTime=true,
+          tags=($._config.dashboardTags),
+        ))
+        .addTemplates(
+          [
+            {
+              hide: 0,
+              label: 'Data source',
+              name: 'prometheus_datasource',
+              query: 'prometheus',
+              refresh: 1,
+              regex: '',
+              type: 'datasource',
+            },
+            template.new(
+              name='job',
+              label='job',
+              datasource='$prometheus_datasource',
+              query='label_values(apache_up, job)',
+              current='',
+              refresh=2,
+              includeAll=true,
+              multi=true,
+              allValues='.+',
+              sort=1
+            ),
+            template.new(
+              name='instance',
+              label='instance',
+              datasource='$prometheus_datasource',
+              query='label_values(apache_up{job=~"$job"}, instance)',
+              current='',
+              refresh=2,
+              includeAll=false,
+              sort=1
+            ),
+          ]
+        ),
+    } else {},
+}

--- a/apache-http-mixin/dashboards/apache-logs.libsonnet
+++ b/apache-http-mixin/dashboards/apache-logs.libsonnet
@@ -20,6 +20,7 @@ local logsByLevel =
     },
     fieldConfig: {
       defaults: {
+        unit: 'short',
         custom: {
           drawStyle: 'bars',
         },
@@ -74,7 +75,7 @@ local logsByLevel =
       legend: {
         displayMode: 'list',
         placement: 'bottom',
-        calcs: ["sum"],
+        calcs: ['sum'],
       },
     },
   };
@@ -89,6 +90,7 @@ local logsByHTTPcodes =
     },
     fieldConfig: {
       defaults: {
+        unit: 'short',
         custom: {
           drawStyle: 'bars',
           lineInterpolation: 'linear',
@@ -99,7 +101,7 @@ local logsByHTTPcodes =
           showPoints: 'never',
           pointSize: 5,
           stacking: {
-            mode: 'percent',
+            mode: 'normal',
             group: 'A',
           },
           axisPlacement: 'auto',
@@ -185,7 +187,12 @@ local logsByHTTPcodes =
     },
     targets: [
       {
-        expr: 'label_replace(\nsum by (le,job, instance) (apache_response_http_codes_bucket{le!="+Inf", ' + matcher + '}),\n  "alias", "HTTP ${1}00-${1}99", "le", "(.).+"\n)',
+        expr: |||
+          label_replace(
+            sum by (le,job, instance) (increase(apache_response_http_codes_bucket{le!="+Inf", %s}[$__rate_interval])),
+            "alias", "HTTP ${1}00-${1}99", "le", "(.).+"
+          )
+        ||| % matcher,
         legendFormat: '{{ alias }}',
         format: 'heatmap',
       },
@@ -198,7 +205,7 @@ local logsByHTTPcodes =
       legend: {
         displayMode: 'list',
         placement: 'bottom',
-        calcs: ["sum"],
+        calcs: ['sum'],
       },
     },
   };

--- a/apache-http-mixin/dashboards/apache-logs.libsonnet
+++ b/apache-http-mixin/dashboards/apache-logs.libsonnet
@@ -4,6 +4,204 @@ local template = grafana.template;
 local dashboardUid = 'apache-http-logs';
 local matcher = 'job=~"$job", instance=~"$instance"';
 
+local errorLogRegex = |||
+  `^\[[^ ]* (?P<timestamp>[^\]]*)\] \[(?:(?P<module>[^:\]]+):)?(?P<level>[^\]]+)\](?: \[pid (?P<pid>[^\]]*)\])?(?: \[client (?P<client>[^\]]*)\])? (?P<message>.*)$`
+|||;
+local accessLogregex = |||
+  `^(?P<ip>[^ ]*) [^ ]* (?P<user>[^ ]*) \[(?P<timestamp>[^\]]*)\] "(?P<method>\S+)(?: +(?P<path>[^ ]*) +\S*)?" (?P<code>[^ ]*) (?P<size>[^ ]*)(?: "(?P<referer>[^\"]*)" "(?P<agent>.*)")?$`
+|||;
+local logsByLevel =
+  {
+    type: 'timeseries',  // barchart vs timeseries
+    title: 'Logs by level',
+    datasource: {
+      uid: '${loki_datasource}',
+      type: 'loki',
+    },
+    fieldConfig: {
+      defaults: {
+        custom: {
+          drawStyle: 'bars',
+        },
+        color: {
+          mode: 'palette-classic',
+        },
+      },
+      overrides: [
+        {
+          matcher: {
+            id: 'byName',
+            options: 'error',
+          },
+          properties: [
+            {
+              id: 'color',
+              value: {
+                mode: 'fixed',
+                fixedColor: 'red',
+              },
+            },
+          ],
+        },
+        {
+          matcher: {
+            id: 'byName',
+            options: 'notice',
+          },
+          properties: [
+            {
+              id: 'color',
+              value: {
+                mode: 'fixed',
+                fixedColor: 'green',
+              },
+            },
+          ],
+        },
+      ],
+    },
+    targets: [
+      {
+        expr: 'sum(count_over_time({' + matcher + ', logtype="error", level!=""}[$__interval])) by (level)',
+        legendFormat: '{{ level }}',
+      },
+    ],
+    options: {
+      tooltip: {
+        mode: 'multi',
+        sort: 'none',
+      },
+      legend: {
+        displayMode: 'list',
+        placement: 'bottom',
+        calcs: ["sum"],
+      },
+    },
+  };
+
+local logsByHTTPcodes =
+  {
+    type: 'timeseries',
+    title: 'Logs by HTTP codes',
+    datasource: {
+      uid: '${prometheus_datasource}',
+      type: 'prometheus',
+    },
+    fieldConfig: {
+      defaults: {
+        custom: {
+          drawStyle: 'bars',
+          lineInterpolation: 'linear',
+          lineWidth: 1,
+          fillOpacity: 60,
+          gradientMode: 'none',
+          spanNulls: false,
+          showPoints: 'never',
+          pointSize: 5,
+          stacking: {
+            mode: 'percent',
+            group: 'A',
+          },
+          axisPlacement: 'auto',
+          axisLabel: '',
+          scaleDistribution: {
+            type: 'linear',
+          },
+          hideFrom: {
+            tooltip: false,
+            viz: false,
+            legend: false,
+          },
+          thresholdsStyle: {
+            mode: 'off',
+          },
+        },
+        color: {
+          mode: 'palette-classic',
+        },
+      },
+      overrides: [
+        {
+          matcher: {
+            id: 'byName',
+            options: 'HTTP 500-599',
+          },
+          properties: [
+            {
+              id: 'color',
+              value: {
+                fixedColor: 'red',
+                mode: 'fixed',
+              },
+            },
+          ],
+        },
+        {
+          matcher: {
+            id: 'byName',
+            options: 'HTTP 200-299',
+          },
+          properties: [
+            {
+              id: 'color',
+              value: {
+                fixedColor: 'green',
+                mode: 'fixed',
+              },
+            },
+          ],
+        },
+        {
+          matcher: {
+            id: 'byName',
+            options: 'HTTP 400-499',
+          },
+          properties: [
+            {
+              id: 'color',
+              value: {
+                mode: 'fixed',
+                fixedColor: 'orange',
+              },
+            },
+          ],
+        },
+        {
+          matcher: {
+            id: 'byName',
+            options: 'HTTP 100-199',
+          },
+          properties: [
+            {
+              id: 'color',
+              value: {
+                mode: 'fixed',
+                fixedColor: 'purple',
+              },
+            },
+          ],
+        },
+      ],
+    },
+    targets: [
+      {
+        expr: 'label_replace(\nsum by (le,job, instance) (apache_response_http_codes_bucket{le!="+Inf", ' + matcher + '}),\n  "alias", "HTTP ${1}00-${1}99", "le", "(.).+"\n)',
+        legendFormat: '{{ alias }}',
+        format: 'heatmap',
+      },
+    ],
+    options: {
+      tooltip: {
+        mode: 'multi',
+        sort: 'none',
+      },
+      legend: {
+        displayMode: 'list',
+        placement: 'bottom',
+        calcs: ["sum"],
+      },
+    },
+  };
 {
   grafanaDashboards+::
 
@@ -29,9 +227,18 @@ local matcher = 'job=~"$job", instance=~"$instance"';
           [
             {
               hide: 0,
-              label: 'Data source',
+              label: 'Metrics datasource',
               name: 'prometheus_datasource',
               query: 'prometheus',
+              refresh: 1,
+              regex: '',
+              type: 'datasource',
+            },
+            {
+              hide: 0,
+              label: 'Loki datasource',
+              name: 'loki_datasource',
+              query: 'loki',
               refresh: 1,
               regex: '',
               type: 'datasource',
@@ -58,6 +265,28 @@ local matcher = 'job=~"$job", instance=~"$instance"';
               includeAll=false,
               sort=1
             ),
+          ]
+        )
+        .addPanels(
+          [
+            grafana.row.new('Error logs') { gridPos: { y: 0 } },
+            logsByLevel { gridPos: { w: 24, y: 0, h: 6 } },
+            grafana.logPanel.new(
+              title='Apache error logs',
+              datasource='$loki_datasource',
+            ).addTarget(grafana.loki.target('{' + matcher + ', logtype="error"}'))
+            // \n| regexp ' + errorLogRegex))
+            + { gridPos: { w: 24, y: 1, h: 8 } },
+
+            grafana.row.new('Access logs') { gridPos: { y: 2 } },
+            logsByHTTPcodes { gridPos: { w: 24, y: 2, h: 6 } },
+            grafana.logPanel.new(
+              title='Apache access logs',
+              datasource='$loki_datasource',
+            )
+            .addTarget(grafana.loki.target('{' + matcher + ', logtype="access"}'))
+            // \n| regexp ' + accessLogregex))
+            + { gridPos: { w: 24, y: 2, h: 8 } },
           ]
         ),
     } else {},

--- a/apache-http-mixin/dashboards/dashboards.libsonnet
+++ b/apache-http-mixin/dashboards/dashboards.libsonnet
@@ -1,0 +1,2 @@
+(import 'apache-exporter-full.libsonnet') +
+(import 'apache-logs.libsonnet')

--- a/apache-http-mixin/mixin.libsonnet
+++ b/apache-http-mixin/mixin.libsonnet
@@ -1,3 +1,3 @@
-(import 'dashboards/apache-exporter-full.libsonnet') +
+(import 'dashboards/dashboards.libsonnet') +
 (import 'alerts/alerts.libsonnet') +
 (import 'config.libsonnet')


### PR DESCRIPTION
- Adds optional dashboards based on apache logs: error log and access log:
- Adds histogram type metric from access log by promtail

![image](https://user-images.githubusercontent.com/14870891/170279623-7aa6cc8f-7928-4d90-9c9b-94c5148b4488.png)

- Adds error rate alert 
<img width="1247" alt="image" src="https://user-images.githubusercontent.com/14870891/170319771-9ee5b86a-5a3d-48c1-8ced-ec679c0251cc.png">
... and error rate panel:

![image](https://user-images.githubusercontent.com/14870891/170320166-91bf48a6-0e21-48fd-873b-2483ee402339.png)
- Updates version metric (use apache_info instead for more detailed output)
<img width="228" alt="image" src="https://user-images.githubusercontent.com/14870891/170482142-13644e1a-979b-4b7d-b434-1098babdcc1a.png">
