### PR TITLE
nginx-directory: configurable subfilter content types

### DIFF
--- a/nginx-directory/configfile.libsonnet
+++ b/nginx-directory/configfile.libsonnet
@@ -39,9 +39,9 @@ function(services) {
         sub_filter 'endpoint:"/' 'endpoint:"/%(path)s/';  # for XHRs.
         sub_filter 'href:"/v1/' 'href:"/%(path)s/v1/';
         sub_filter_once off;
-        sub_filter_types text/css application/xml application/json application/javascript;
+        sub_filter_types %(rendered_subfilter_content_types)s';
         proxy_redirect   "/" "/%(path)s/";
-      ||| % service
+      ||| % (service { rendered_subfilter_content_types: std.join(' ', self.subfilter_content_types) })
       else ''
     ),
 

--- a/nginx-directory/directory.libsonnet
+++ b/nginx-directory/directory.libsonnet
@@ -25,6 +25,8 @@ local link_data = import 'link_data.libsonnet';
       redirect: false,
       allowWebsockets: false,
       subfilter: false,
+      // subfilter_content_types configures the content types handled by the subfilter (nginx sub_filter_types directive).
+      subfilter_content_types: ['text/css', 'application/xml', 'application/json', 'application/javascript'],
       custom: [],
 
       // backwards compatible, service level config allows for more granular configuration


### PR DESCRIPTION
For some reason these types don't include text/html, which is the obvious one for me.

Changing that is a huge change, so I just made it configurable so everyone can add and/or override their types.

Signed-off-by: Oleg Zaytsev <mail@olegzaytsev.com>
