### PR TITLE
nginx-directory: don't accept gzip when subfiltering

### DIFF
--- a/nginx-directory/configfile.libsonnet
+++ b/nginx-directory/configfile.libsonnet
@@ -33,13 +33,14 @@ function(services) {
     + (
       if service.subfilter
       then |||
+        proxy_set_header Accept-Encoding "";
         sub_filter 'href="/' 'href="/%(path)s/';
         sub_filter 'src="/' 'src="/%(path)s/';
         sub_filter 'action="/' 'action="/%(path)s/';
         sub_filter 'endpoint:"/' 'endpoint:"/%(path)s/';  # for XHRs.
         sub_filter 'href:"/v1/' 'href:"/%(path)s/v1/';
         sub_filter_once off;
-        sub_filter_types %(rendered_subfilter_content_types)s;
+        sub_filter_types %(rendered_subfilter_content_types)s';
         proxy_redirect   "/" "/%(path)s/";
       ||| % (service { rendered_subfilter_content_types: std.join(' ', self.subfilter_content_types) })
       else ''

--- a/nginx-directory/configfile.libsonnet
+++ b/nginx-directory/configfile.libsonnet
@@ -40,7 +40,7 @@ function(services) {
         sub_filter 'endpoint:"/' 'endpoint:"/%(path)s/';  # for XHRs.
         sub_filter 'href:"/v1/' 'href:"/%(path)s/v1/';
         sub_filter_once off;
-        sub_filter_types %(rendered_subfilter_content_types)s';
+        sub_filter_types %(rendered_subfilter_content_types)s;
         proxy_redirect   "/" "/%(path)s/";
       ||| % (service { rendered_subfilter_content_types: std.join(' ', self.subfilter_content_types) })
       else ''


### PR DESCRIPTION
When using subfilter, we need the response to be non-gzipped in order to
be able to inspect the body.

Ref: https://til.hashrocket.com/posts/7ktzgumkmp-subfilter-proxypass-requires-no-gzip-encoding

Signed-off-by: Oleg Zaytsev <mail@olegzaytsev.com>
