### PR TITLE
awx-mixin: Linting fixes

### DIFF
--- a/awx-mixin/.lint
+++ b/awx-mixin/.lint
@@ -1,0 +1,11 @@
+---
+exclusions:
+  target-promql-rule:
+    reason: The linter does not yet support panel reference targets. See grafana/dashboard-linter#59
+    entries:
+    - dashboard: AWX
+      panel: License Type
+    - dashboard: AWX
+      panel: License Expiry
+    - dashboard: AWX
+      panel: Tower Base URL

--- a/awx-mixin/dashboards/awx.libsonnet
+++ b/awx-mixin/dashboards/awx.libsonnet
@@ -10,7 +10,7 @@ local ct = import 'clustertable.libsonnet';
 
 local dashboardUid = 'eqcdR8HDA';
 
-local matcher = 'job=~"$job", instance="$instance"';
+local matcher = 'job=~"$job", instance=~"$instance"';
 
 local queries = {
   awx_system_info: 'awx_system_info{' + matcher + '}',
@@ -80,9 +80,11 @@ local instance_template =
     'instance',
     '$datasource',
     'label_values(awx_system_info{job=~"$job"}, instance)',
+    label='instance',
     refresh='load',
-    multi=false,
-    includeAll=false,
+    multi=true,
+    includeAll=true,
+    allValues='.+',
     sort=1,
   );
 

--- a/awx-mixin/dashboards/clustertable.libsonnet
+++ b/awx-mixin/dashboards/clustertable.libsonnet
@@ -35,7 +35,7 @@
               value: [
                 {
                   title: '',
-                  url: 'd/' + dashboardUid + '/var-datasource=${datasource}&var-job=${job}&var-instance=${__data.fields.Instance}',
+                  url: 'd/' + dashboardUid + '/var-datasource=${datasource}&var-job=${job}&var-instance=~${__data.fields.Instance}',
                 },
               ],
             },
@@ -55,7 +55,7 @@
     },
     targets: [
       {
-        expr: 'awx_organizations_total{job=~"$job", instance="$instance"}',
+        expr: 'awx_organizations_total{job=~"$job", instance=~"$instance"}',
         legendFormat: 'Orgs',
         interval: '',
         exemplar: false,
@@ -65,7 +65,7 @@
         instant: true,
       },
       {
-        expr: 'awx_teams_total{job=~"$job", instance="$instance"}',
+        expr: 'awx_teams_total{job=~"$job", instance=~"$instance"}',
         legendFormat: 'Teams',
         interval: '',
         exemplar: false,
@@ -75,7 +75,7 @@
         instant: true,
       },
       {
-        expr: 'awx_users_total{job=~"$job", instance="$instance"}',
+        expr: 'awx_users_total{job=~"$job", instance=~"$instance"}',
         legendFormat: 'Users',
         interval: '',
         exemplar: false,
@@ -85,7 +85,7 @@
         instant: true,
       },
       {
-        expr: 'awx_inventories_total{job=~"$job", instance="$instance"}',
+        expr: 'awx_inventories_total{job=~"$job", instance=~"$instance"}',
         legendFormat: 'Inventories',
         interval: '',
         exemplar: false,
@@ -95,7 +95,7 @@
         instant: true,
       },
       {
-        expr: 'awx_projects_total{job=~"$job", instance="$instance"}',
+        expr: 'awx_projects_total{job=~"$job", instance=~"$instance"}',
         legendFormat: 'Projects',
         interval: '',
         exemplar: false,
@@ -105,7 +105,7 @@
         instant: true,
       },
       {
-        expr: 'awx_schedules_total{job=~"$job", instance="$instance"}',
+        expr: 'awx_schedules_total{job=~"$job", instance=~"$instance"}',
         legendFormat: 'Schedules',
         interval: '',
         exemplar: false,


### PR DESCRIPTION
Allow multiselect of instance variable
Ignore lint error about panel references which are currently unsupported in linter