### PR TITLE
Remove extensions/v1beta1 patches deprecated with k8s 1.22

### DIFF
--- a/ksonnet-util/grafana.libsonnet
+++ b/ksonnet-util/grafana.libsonnet
@@ -60,10 +60,6 @@
     },
   },
 
-  extensions+: {
-    v1beta1+: appsExtentions,
-  },
-
   apps+: {
     v1beta1+: appsExtentions,
     v1+: appsExtentions,

--- a/ksonnet-util/legacy-custom.libsonnet
+++ b/ksonnet-util/legacy-custom.libsonnet
@@ -144,10 +144,6 @@
     },
   },
 
-  extensions+: {
-    v1beta1+: appsExtentions,
-  },
-
   apps+: {
     v1beta1+: appsExtentions,
     v1+: appsExtentions,

--- a/ksonnet-util/legacy-noname.libsonnet
+++ b/ksonnet-util/legacy-noname.libsonnet
@@ -5,11 +5,6 @@ function(noNewEmptyNameMixin) {
   core+: { v1+: {
     persistentVolumeClaim+: noNewEmptyNameMixin,
   } },
-  extensions+: {
-    v1beta1+: {
-      ingress+: noNewEmptyNameMixin,
-    },
-  },
   networking+: {
     v1beta1+: {
       ingress+: noNewEmptyNameMixin,

--- a/ksonnet-util/legacy-subtypes.libsonnet
+++ b/ksonnet-util/legacy-subtypes.libsonnet
@@ -79,17 +79,6 @@
     v1+: appsPatch,
     v1beta1+: appsPatch,
   },
-  extensions+: {
-    v1beta1+: appsPatch {
-      ingress+: {
-        spec+: {
-          rulesType: $.extensions.v1beta1.ingressRule {
-            httpType+: { pathsType: $.extensions.v1beta1.httpIngressPath },
-          },
-        },
-      },
-    },
-  },
 
   batch+: {
     local patch = {


### PR DESCRIPTION
This is a rather drastic measure, removing deprecated and finally removed API extensions.
It came up in another context here https://github.com/jsonnet-libs/k8s/issues/171.

I've triple checked it and the issue persists in our internal code-base as well - this deprecation would be very handy!
Obviously, as Grafana is the owner of this lib, feel free to take all the time you need.
