### PR TITLE
Grafana: Allow bigger configmaps

### DIFF
--- a/grafana/config.libsonnet
+++ b/grafana/config.libsonnet
@@ -9,6 +9,15 @@
     provisioningDir: '/etc/grafana/provisioning',
     port: 80,
     containerPort: 3000,
+
+    // Split configmaps into multiple files
+    // 100000 is a good default, because a `kubectl` client-side apply cannot exceed 256kB,
+    //   and the size of the request is doubled when setting the last-applied configuration
+    //   https://github.com/kubernetes/kubectl/issues/712
+    // For serverside applies, it can be increased, but keep in mind the 1MB limit of etcd
+    //   https://github.com/kubernetes/kubernetes/issues/19781
+    configmap_shard_size: 100000,
+
     labels+: {
       dashboards: {},
       datasources: {},

--- a/grafana/configmaps.libsonnet
+++ b/grafana/configmaps.libsonnet
@@ -74,7 +74,7 @@ local deployment = k.apps.v1.deployment;
 
     // Shard configmaps at around 100kB per shard
     local totalCharacters = std.foldl(function(x, y) x + y, [std.length(d.content) for d in dashboards], 0);
-    local shardCount = std.min(count, std.ceil(totalCharacters / 100000));
+    local shardCount = std.min(count, std.ceil(totalCharacters / $._config.configmap_shard_size));
     {
       // Calculate the number of dashboards per shard
       // This is skewed towards tail dashboards (smallest ones)


### PR DESCRIPTION
With kubectl server-side applies, we can apply much bigger resources