### PR TITLE
Update asterisk logs job matcher regex

### DIFF
--- a/asterisk-mixin/dashboards/asterisk-logs.json
+++ b/asterisk-mixin/dashboards/asterisk-logs.json
@@ -892,7 +892,7 @@
         "options": [],
         "query": "label_values(job)",
         "refresh": 1,
-        "regex": ".*asterisk.+",
+        "regex": "^.*asterisk.*",
         "skipUrlSync": false,
         "sort": 0,
         "type": "query"


### PR DESCRIPTION
Updates regex to match any job containing asterisk in the label.

Required to make the sample app work.
https://github.com/grafana/cloud-onboarding/pull/1812
