### PR TITLE
Fixed CODEOWNERS because cortex-team doesn't exist anymore at Grafana Labs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,8 @@
 # https://help.github.com/articles/about-codeowners/
 # https://git-scm.com/docs/gitignore#_pattern_format
 
-/consul*/ @grafana/cortex-team @grafana/loki-team
-/etcd-operator/ @grafana/cortex-team
-/memcached*/ @grafana/cortex-team @grafana/loki-team
-/prometheus-ksonnet/ @grafana/cortex-team @grafana/cloud-platform
+/consul*/ @grafana/mimir-maintainers @grafana/loki-team
+/etcd-operator/ @grafana/mimir-maintainers
+/memcached*/ @grafana/mimir-maintainers @grafana/loki-team
+/prometheus-ksonnet/ @grafana/mimir-maintainers @grafana/cloud-platform
 /enterprise-metrics/ @grafana/backend-enterprise


### PR DESCRIPTION
Fixed CODEOWNERS because coretx-team doesn't exist anymore at Grafana Labs.