### PR TITLE
Remove the usage of RBAC v1beta1 APIs.

### DIFF
--- a/etcd-operator/operator.libsonnet
+++ b/etcd-operator/operator.libsonnet
@@ -5,7 +5,7 @@
 
   local kausal = import 'ksonnet-util/kausal.libsonnet',
   local k = kausal { _config+:: $._config },
-  local policyRule = k.rbac.v1beta1.policyRule,
+  local policyRule = k.rbac.v1.policyRule,
 
   operator_rbac:
     k.util.rbac('etcd-operator', [

--- a/ksonnet-util/legacy-subtypes.libsonnet
+++ b/ksonnet-util/legacy-subtypes.libsonnet
@@ -111,13 +111,13 @@
 
   local rbacPatch = {
     local role = {
-      rulesType: $.rbac.v1beta1.policyRule,
+      rulesType: $.rbac.v1.policyRule,
     },
     role+: role,
     clusterRole+: role,
 
     local binding = {
-      subjectsType: $.rbac.v1beta1.subject,
+      subjectsType: $.rbac.v1.subject,
     },
     roleBinding+: binding,
     clusterRoleBinding+: binding,

--- a/ksonnet-util/legacy-subtypes.libsonnet
+++ b/ksonnet-util/legacy-subtypes.libsonnet
@@ -130,6 +130,7 @@
   },
   rbac+: {
     v1+: rbacPatch,
+    // TODO: the v1beta1 RBAC API has been removed in Kubernetes 1.22 and should get removed once 1.22 is the oldest supported version
     v1beta1+: rbacPatch,
   },
 

--- a/ksonnet-util/legacy-types.libsonnet
+++ b/ksonnet-util/legacy-types.libsonnet
@@ -18,6 +18,7 @@
       policyRule:: $.rbac.v1.clusterRole.rulesType,
       subject:: $.rbac.v1.clusterRoleBinding.subjectsType,
     },
+    // TODO: the v1beta1 RBAC API has been removed in Kubernetes 1.22 and should get removed once 1.22 is the oldest supported version
     v1beta1+: {
       policyRule:: $.rbac.v1.clusterRole.rulesType,
       subject:: $.rbac.v1.clusterRoleBinding.subjectsType,

--- a/ksonnet-util/legacy-types.libsonnet
+++ b/ksonnet-util/legacy-types.libsonnet
@@ -15,12 +15,12 @@
   },
   rbac+: {
     v1+: {
-      policyRule:: $.rbac.v1beta1.clusterRole.rulesType,
-      subject:: $.rbac.v1beta1.clusterRoleBinding.subjectsType,
+      policyRule:: $.rbac.v1.clusterRole.rulesType,
+      subject:: $.rbac.v1.clusterRoleBinding.subjectsType,
     },
     v1beta1+: {
-      policyRule:: $.rbac.v1beta1.clusterRole.rulesType,
-      subject:: $.rbac.v1beta1.clusterRoleBinding.subjectsType,
+      policyRule:: $.rbac.v1.clusterRole.rulesType,
+      subject:: $.rbac.v1.clusterRoleBinding.subjectsType,
     },
   },
 }

--- a/prometheus/prometheus.libsonnet
+++ b/prometheus/prometheus.libsonnet
@@ -18,7 +18,7 @@ local kausal = import 'ksonnet-util/kausal.libsonnet';
           servicePort: kausal.core.v1.service.mixin.spec.portsType,
         } },
         rbac+: { v1+: {
-          policyRule: kausal.rbac.v1beta1.clusterRole.rulesType,
+          policyRule: kausal.rbac.v1.clusterRole.rulesType,
         } },
       }
     else {}


### PR DESCRIPTION
IIUC these have been deprecated since k8s 1.17 and have been removed in
1.22 . The changelog mentions no significant API changes, apart from the
versuin change itself.

This PR right now keeps some references to v1beta1 -- those seem to be
mostly wrappers. I'll be happy to extend this PR with removal of these
-- currently we're well beyond any officially supported k8s version that
doesn't support the v1 RBAC API.

Signed-off-by: Milan Plzik <milan.plzik@grafana.com>
