### PR TITLE
Add a function to remove an alert rule

### DIFF
--- a/mixin-utils/utils.libsonnet
+++ b/mixin-utils/utils.libsonnet
@@ -166,4 +166,15 @@ local g = import 'grafana-builder/grafana.libsonnet';
       groups: std.map(overrideInGroup, super.groups),
     },
   },
+
+  removeAlerts(alerts):: {
+    local removeRule(rule) =
+      if 'alert' in rule && std.objectHas(alerts, rule.alert)
+      then {}
+      else rule,
+    local removeInGroup(group) = group { rules: std.map(removeRule, super.rules) },
+    prometheusAlerts+:: {
+      groups: std.prune(std.map(removeInGroup, super.groups)),
+    },
+  },
 }


### PR DESCRIPTION
Sometimes it's quicker to remove an alert via mutating the alerts groups object than waiting for the removal of that alert to be merged to the OSS mixin.

Signed-off-by: Callum Styan <callumstyan@gmail.com>