### PR TITLE
Extend apache alert description

### DIFF
--- a/apache-http-mixin/alerts/alerts.libsonnet
+++ b/apache-http-mixin/alerts/alerts.libsonnet
@@ -24,7 +24,7 @@
                    },
                    annotations: {
                      summary: 'Apache restart.',
-                     description: 'Apache has just been restarted.',
+                     description: 'Apache has just been restarted on {{ $labels.instance }}.',
                    },
                    'for': '0',
                  },


### PR DESCRIPTION
Extended description of apache restart alert, to pass mixtool linter.