### PR TITLE
Allow including "All" for single template var

### DIFF
--- a/grafana-builder/grafana.libsonnet
+++ b/grafana-builder/grafana.libsonnet
@@ -13,7 +13,7 @@
       rows+: [row { panels: panels }],
     },
 
-    addTemplate(name, metric_name, label_name, hide=0, allValue=null):: self {
+    addTemplate(name, metric_name, label_name, hide=0, allValue=null, includeAll=false):: self {
       templating+: {
         list+: [{
           allValue: allValue,
@@ -23,7 +23,7 @@
           },
           datasource: '$datasource',
           hide: hide,
-          includeAll: false,
+          includeAll: includeAll,
           label: name,
           multi: false,
           name: name,


### PR DESCRIPTION
Sometimes it makes sense to be able to select the "all" value for single-valued template vars. This function actually accepts the "allValue" param, but it doesn't allow vars with "all" option.

Signed-off-by: Oleg Zaytsev <mail@olegzaytsev.com>
