### PR TITLE
Update graph to timeseries panel

### DIFF
--- a/grafana-builder/grafana.libsonnet
+++ b/grafana-builder/grafana.libsonnet
@@ -217,7 +217,7 @@
       sort: 2,
       value_type: 'individual',
     },
-    type: 'graph',
+    type: 'timeseries',
     xaxis: {
       buckets: null,
       mode: 'time',


### PR DESCRIPTION
Dashboards defined via jsonnet use the old Graph.
This commit updates them to timeseries panel.

Relates to: https://github.com/grafana/mimir/issues/1953

Signed-off-by: Wilfried Roset <wilfriedroset@users.noreply.github.com>