### PR TITLE
Add timeseriesPanel

### DIFF
--- a/grafana-builder/grafana.libsonnet
+++ b/grafana-builder/grafana.libsonnet
@@ -259,8 +259,8 @@
         showLegend: true,
       },
       tooltip: {
-        mode: 'multi',
-        sort: 'desc',
+        mode: 'single',
+        sort: 'none',
       },
     },
     links: [],

--- a/grafana-builder/grafana.libsonnet
+++ b/grafana-builder/grafana.libsonnet
@@ -178,6 +178,7 @@
     titleSize: 'h6',
   },
 
+  // "graph" type, now deprecated.
   panel(title):: {
     aliasColors: {},
     bars: false,
@@ -226,6 +227,46 @@
       values: [],
     },
     yaxes: $.yaxes('short'),
+  },
+
+  // "timeseries" panel, introduced with Grafana 7.4 and made standard in 8.0.
+  timeseriesPanel(title):: {
+    datasource: '$datasource',
+    fieldConfig: {
+      defaults: {
+        custom: {
+          drawStyle: 'line',
+          fillOpacity: 1,
+          lineWidth: 1,
+          pointSize: 5,
+          showPoints: 'never',
+          spanNulls: false,
+          stacking: {
+            group: 'A',
+            mode: 'none',
+          },
+        },
+        thresholds: {
+          mode: 'absolute',
+          steps: [],
+        },
+        unit: 's',
+      },
+      overrides: [],
+    },
+    options: {
+      legend: {
+        showLegend: true,
+      },
+      tooltip: {
+        mode: 'multi',
+        sort: 'desc',
+      },
+    },
+    links: [],
+    targets: [],
+    title: title,
+    type: 'timeseries',
   },
 
   queryPanel(queries, legends, legendLink=null):: {


### PR DESCRIPTION
["The default and primary way to visualize time series data"](https://grafana.com/docs/grafana/latest/visualizations/time-series/)

Introduced under a new name to avoid breaking all dashboards that use `panel()` and override something.