### PR TITLE
 Fix ElasticSearch Dashboard `Thread Pool threads active` expr

### DIFF
--- a/elasticsearch-mixin/dashboards/elasticsearch-overview.json
+++ b/elasticsearch-mixin/dashboards/elasticsearch-overview.json
@@ -4463,7 +4463,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "elasticsearch_thread_pool_active_count{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}",
+              "expr": "elasticsearch_thread_pool_queue_count{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{name}}: {{ type }}",


### PR DESCRIPTION

panel `Thread Pool operations queued`  should use  `elasticsearch_thread_pool_queue_count`   , but now is `elasticsearch_thread_pool_active_count`  .



