### PR TITLE
Windows Mixin - Correct thresholds for C:// Free

### DIFF
--- a/windows-mixin/dashboards/windows_exporter.libsonnet
+++ b/windows-mixin/dashboards/windows_exporter.libsonnet
@@ -222,16 +222,16 @@ local hostname_template = grafana.template.new(
     .hideColumn('volume')
     .addThreshold('C:\\ free %', [
       {
-        color: 'dark-green',
-        value: 80,
+        color: 'dark-red',
+        value: null,
       },
       {
         color: 'dark-yellow',
         value: 20,
       },
       {
-        color: 'dark-red',
-        value: 0,
+        color: 'dark-green',
+        value: 80,
       },
     ], 'absolute'),
 


### PR DESCRIPTION
Thresholds for the available disk space on `C://` were correct, but rendering incorrectly.

It turns out that when thresholds are provided, the "first" entry in the `steps` becomes the base, even if it's value is set. I.E. Grafana overrides it's value with `null`.

This resulted in `dark-green` being the base color, and any utilization between 20-0 % would appear as green.

This PR simply changes the order, so that Grafana does not override the value on import.