### PR TITLE
Grafana Agent: correct overview dashboard queries

### DIFF
--- a/grafana-agent-mixin/dashboards/grafana-agent.libsonnet
+++ b/grafana-agent-mixin/dashboards/grafana-agent.libsonnet
@@ -89,7 +89,7 @@ local instance_template = grafana.template.new(
           span=6,
         )
         .addTarget(prometheus.target(
-          'sum(rate(prometheus_target_sync_length_seconds_sum{' + host_matcher + '}[$__rate_interval])) by (instance, scrape_job) * 1e3',
+          'sum(rate(prometheus_target_sync_length_seconds_sum{' + host_matcher + '}[$__rate_interval])) by (instance, scrape_job)',
           legendFormat='{{instance}}/{{scrape_job}}',
         )) +
         utils.timeSeriesOverride(unit='s');
@@ -114,7 +114,7 @@ local instance_template = grafana.template.new(
           span=6,
         )
         .addTarget(prometheus.target(
-          'rate(prometheus_target_interval_length_seconds_sum{' + host_matcher + '}[$__rate_interval]) / rate(prometheus_target_interval_length_seconds_count{' + host_matcher + '}[$__rate_interval]) * 1e3',
+          'rate(prometheus_target_interval_length_seconds_sum{' + host_matcher + '}[$__rate_interval]) / rate(prometheus_target_interval_length_seconds_count{' + host_matcher + '}[$__rate_interval])',
           legendFormat='{{instance}} {{interval}} configured',
         )) +
         utils.timeSeriesOverride(unit='s');


### PR DESCRIPTION
The queries use metrics that are in seconds, but multiply by a 1000. The panels still have the unit as seconds. I removed the multiplication instead of changing the units, as it reduces complexity.

You can see in the screenshot from [the docs](https://grafana.com/docs/grafana-cloud/data-configuration/integrations/integration-reference/integration-grafana-agent/#dashboards) that the current 'average scrape interval duration' says hours, while it should be talking about seconds.

![overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/grafana-agent/screenshots/grafana-agent-overview.png)

After the change, scrape interval is 15s
![image](https://user-images.githubusercontent.com/6214906/188856554-fb6685d9-bddc-44eb-bf5c-6fd04d1a0252.png)

(The target-sync panel is always 0 for me, I'll have to dig into that separately, so I cannot test that. But I think the same logic holds: The metric is already in seconds, multiplying changes that, and the unit should match)