### PR TITLE
Evenly spread memcached across nodes

### DIFF
--- a/memcached/memcached.libsonnet
+++ b/memcached/memcached.libsonnet
@@ -31,6 +31,8 @@ k {
       std.ceil((self.memory_limit_mb * self.overprovision_factor) + self.memory_request_overhead_mb) * 1024 * 1024,
     memory_limits_bytes::
       std.max(self.memory_limit_mb * 1.5 * 1024 * 1024, self.memory_request_bytes),
+    use_topology_spread:: false,
+    topology_spread_max_skew:: 1,
 
     local container = $.core.v1.container,
     local containerPort = $.core.v1.containerPort,
@@ -56,6 +58,7 @@ k {
       ]),
 
     local statefulSet = $.apps.v1.statefulSet,
+    local topologySpreadConstraints = k.core.v1.topologySpreadConstraint,
 
     statefulSet:
       statefulSet.new(self.name, $._config.memcached_replicas, [
@@ -63,7 +66,16 @@ k {
         self.memcached_exporter,
       ], []) +
       statefulSet.spec.withServiceName(self.name) +
-      $.util.antiAffinity,
+      if self.use_topology_spread then
+        statefulSet.spec.template.spec.withTopologySpreadConstraints(
+          // Evenly spread pods among available nodes.
+          topologySpreadConstraints.labelSelector.withMatchLabels({ name: 'memcached' }) +
+          topologySpreadConstraints.withTopologyKey('kubernetes.io/hostname') +
+          topologySpreadConstraints.withWhenUnsatisfiable('ScheduleAnyway') +
+          topologySpreadConstraints.withMaxSkew(self.topology_spread_max_skew),
+        )
+      else
+        $.util.antiAffinity,
 
     local service = $.core.v1.service,
 

--- a/memcached/memcached.libsonnet
+++ b/memcached/memcached.libsonnet
@@ -67,9 +67,10 @@ k {
       ], []) +
       statefulSet.spec.withServiceName(self.name) +
       if self.use_topology_spread then
+        local pod_name = self.name;
         statefulSet.spec.template.spec.withTopologySpreadConstraints(
           // Evenly spread pods among available nodes.
-          topologySpreadConstraints.labelSelector.withMatchLabels({ name: 'memcached' }) +
+          topologySpreadConstraints.labelSelector.withMatchLabels({ name: pod_name }) +
           topologySpreadConstraints.withTopologyKey('kubernetes.io/hostname') +
           topologySpreadConstraints.withWhenUnsatisfiable('ScheduleAnyway') +
           topologySpreadConstraints.withMaxSkew(self.topology_spread_max_skew),


### PR DESCRIPTION
This PR adds support for using a [`TopologySpreadConstraints`][1] to configure Memcached pods to evenly spread across nodes but allow to schedule multiple pod per node. This is similar to https://github.com/grafana/loki/pull/6415 and https://github.com/grafana/loki/pull/6964

We have two new options:
- `use_topology_spread`: False by default.
- `topology_spread_max_skew`: 1 by default. 

If `use_topology_spread` is true, Memcached pods can run on nodes already running Memcached but will be
spread through the available nodes using a `TopologySpreadConstraints` with a max skew of `topology_spread_max_skew`.
If `use_topology_spread` is false, Memcached pods will not be scheduled on nodes already running Memcached.

[1]: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/