### PR TITLE
Vault-mixin: Replacing grafana-pie-chart in favor of the core piechart plugin

### DIFF
--- a/vault-mixin/dashboards/vault.json
+++ b/vault-mixin/dashboards/vault.json
@@ -8,9 +8,9 @@
     },
     {
       "type": "panel",
-      "id": "grafana-piechart-panel",
+      "id": "piechart",
       "name": "Pie Chart",
-      "version": "1.5.0"
+      "version": ""
     },
     {
       "type": "panel",
@@ -356,7 +356,7 @@
       "timeFrom": null,
       "timeShift": null,
       "title": "Identity Entities Aliases by Method",
-      "type": "grafana-piechart-panel",
+      "type": "piechart",
       "valueName": "current"
     },
     {


### PR DESCRIPTION
This is for fixing a bug where the user has to install the non-default piechart plugin to avoid a plugin not found error.