### PR TITLE
Use nodejs_version_info for alert NodejsDown.

### DIFF
--- a/nodejs-mixin/alerts/alerts.yaml
+++ b/nodejs-mixin/alerts/alerts.yaml
@@ -2,8 +2,8 @@ groups:
   - name: NodejsAlerts
     rules:
       - alert: NodejsDown
-        expr: process_start_time_seconds != 1
-        for: 5m
+        expr: absent(nodejs_version_info) or (sum by (version) (nodejs_version_info) < 1)
+        for: 0m
         labels:
           severity: critical
         annotations:


### PR DESCRIPTION
Fix NodejsDown firing even when the application is up.