### PR TITLE
gitlab-mixin: Use technology specific metric to populate job/instance templates

### DIFF
--- a/gitlab-mixin/dashboards/gitlab-overview.libsonnet
+++ b/gitlab-mixin/dashboards/gitlab-overview.libsonnet
@@ -664,7 +664,7 @@ local buildTraceOperationsPanel = {
           template.new(
             'job',
             promDatasource,
-            'label_values(up{}, job)',
+            'label_values(gitlab_rails_boot_time_seconds{}, job)',
             label='Job',
             refresh='time',
             includeAll=true,
@@ -675,7 +675,7 @@ local buildTraceOperationsPanel = {
           template.new(
             'instance',
             promDatasource,
-            'label_values(up{job=~"$job"}, instance)',
+            'label_values(gitlab_rails_boot_time_seconds{job=~"$job"}, instance)',
             label='Instance',
             refresh='time'
           ),

--- a/gitlab-mixin/dashboards/gitlab-overview.libsonnet
+++ b/gitlab-mixin/dashboards/gitlab-overview.libsonnet
@@ -1,4 +1,5 @@
-local grafana = import 'github.com/grafana/grafonnet-lib/grafonnet/grafana.libsonnet';
+local g = (import 'grafana-builder/grafana.libsonnet');
+local grafana = (import 'grafonnet/grafana.libsonnet');
 local dashboard = grafana.dashboard;
 local template = grafana.template;
 local prometheus = grafana.prometheus;

--- a/gitlab-mixin/jsonnetfile.json
+++ b/gitlab-mixin/jsonnetfile.json
@@ -11,5 +11,5 @@
       "version": "master"
     }
   ],
-  "legacyImports": false
+  "legacyImports": true
 }


### PR DESCRIPTION
When populating job/instance templates, it's much nicer for the user when irrelevant jobs/instances aren't selectable; In order to only display jobs/instances that are gitlab instances, we should use a technology-specific metric (`gitlab_rails_boot_time_seconds`) to determine the jobs/instances available, as opposed to the generic `up` metric.