### PR TITLE
gitlab-mixin: Fix GitLabHighRunnerAuthFailure alert not alerting

### DIFF
--- a/gitlab-mixin/alerts/alerts.libsonnet
+++ b/gitlab-mixin/alerts/alerts.libsonnet
@@ -24,8 +24,8 @@
           {
             alert: 'GitLabHighRunnerAuthFailure',
             expr: |||
-              100 * rate(gitlab_ci_runner_authentication_failure_total{}[5m]) / 
-              (rate(gitlab_ci_runner_authentication_success_total{}[5m]) + rate(gitlab_ci_runner_authentication_failure_total{}[5m])) 
+              100 * sum by (instance) (rate(gitlab_ci_runner_authentication_failure_total{}[5m]))  / 
+              (sum by (instance) (rate(gitlab_ci_runner_authentication_success_total{}[5m]))  + sum by (instance) (rate(gitlab_ci_runner_authentication_failure_total{}[5m])))
               > %(alertsWarningRunnerAuthFailures)s
             ||| % $._config,
             'for': '0',


### PR DESCRIPTION
The two metrics used in the query here end up having different labels, so adding them produces an empty set. Summing the failures/successes based on instance allows the alert to function properly.