### PR TITLE
Disable actionable dashboard for Cilium Enterprise

### DIFF
--- a/cilium-enterprise-mixin/README.md
+++ b/cilium-enterprise-mixin/README.md
@@ -7,7 +7,6 @@ This integration includes the following dashboards.
 - Cilium / Overview
 - Cilium / Operator
 - Cilium / Agent Overview
-- Cilium / Components / Actionable
 - Cilium / Components / Agent
 - Cilium / Components / API
 - Cilium / Components / BPF

--- a/cilium-enterprise-mixin/mixin.libsonnet
+++ b/cilium-enterprise-mixin/mixin.libsonnet
@@ -6,7 +6,7 @@
     'cilium-operator.json': (import 'dashboards/cilium-operator.json'),
     'hubble-overview.json': (import 'dashboards/hubble-overview.json'),
     'hubble-timescape.json': (import 'dashboards/hubble/hubble-timescape.json'),
-    'cilium-actionable.json': (import 'dashboards/cilium-agent/cilium-actionable.json'),
+    // 'cilium-actionable.json': (import 'dashboards/cilium-agent/cilium-actionable.json'),
     'cilium-agent.json': (import 'dashboards/cilium-agent/cilium-agent.json'),
     'cilium-api.json': (import 'dashboards/cilium-agent/cilium-api.json'),
     'cilium-bpf.json': (import 'dashboards/cilium-agent/cilium-bpf.json'),


### PR DESCRIPTION
@tommyp1ckles suggested this dashboard be disabled for now, and later iterated on to contain endpoint information