### PR TITLE
Aligned alert timeframes with Grafana standard

### DIFF
--- a/cilium-enterprise-mixin/alerts/ciliumAlerts.libsonnet
+++ b/cilium-enterprise-mixin/alerts/ciliumAlerts.libsonnet
@@ -70,7 +70,7 @@
             labels: {
               severity: 'critical',
             },
-            'for': '2m',
+            'for': '5m',
           },
           {
             // Should be relative time range of 600-0
@@ -163,7 +163,7 @@
             labels: {
               severity: 'critical',
             },
-            'for': '2m',
+            'for': '5m',
           },
           {
             // TODO: According to alert dump this should have two conditions/time ranges


### PR DESCRIPTION
Anything below or equal to 5m : Updated to 5m
15minute alerts are kept with the justification that they may take longer to recover on their own, but aren't important enough to alert on unless it's been firing for 15 minutes