### PR TITLE
Ubiquiti Edge Router Mixin

### DIFF
--- a/ubnt-edgerouter-mixin/dashboards/overview.jsonnet
+++ b/ubnt-edgerouter-mixin/dashboards/overview.jsonnet
@@ -782,7 +782,7 @@ local stack = {
   grafanaDashboards+:: {
     'ubnt-edgrouterx-overview.json':
       dashboard.new(
-        'UBNT EdgeRouter X Overview',
+        'Ubiquiti EdgeRouter Overview',
         time_from='now-1h',
         uid=std.md5('ubnt-edgrouterx-overview.json'),
       ).addTemplates([


### PR DESCRIPTION
The dashboard title was moderately confusing. This makes it a bit more clear by replacing the acronym with the full company name, and removing the specific model from the title of the dashboard.