### PR TITLE
Adjust Discourse mixin alerts duration to be `5m`

### DIFF
--- a/discourse-mixin/alerts/alerts.libsonnet
+++ b/discourse-mixin/alerts/alerts.libsonnet
@@ -9,7 +9,7 @@
             expr: |||
               100 * rate(discourse_http_requests{status="500"}[5m]) / on() group_left() (sum(rate(discourse_http_requests[5m])) by (instance)) > %(alertsCritical5xxResponses)s
             ||| % $._config,
-            'for': '0',
+            'for': '5m',
             labels: {
               severity: 'critical',
             },
@@ -26,7 +26,7 @@
             expr: |||
               100 * rate(discourse_http_requests{status=~"^4.*"}[5m]) / on() group_left() (sum(rate(discourse_http_requests[5m])) by (instance)) > %(alertsWarning4xxResponses)s
             ||| % $._config,
-            'for': '0',
+            'for': '5m',
             labels: {
               severity: 'warning',
             },


### PR DESCRIPTION
Recently we wanted duration of 5m as the standard, similar to #855! 