### PR TITLE
Discourse Mixin: Minor Usability Improvements

### DIFF
--- a/discourse-mixin/dashboards/discourse-jobs.libsonnet
+++ b/discourse-mixin/dashboards/discourse-jobs.libsonnet
@@ -244,6 +244,7 @@ local usedRSSMemoryPanel = {
     prometheus.target(
       'sum(discourse_rss{instance=~"$instance",job=~"$job"}) by (pid)',
       datasource=promDatasource,
+      legendFormat='pid: {{pid}}',
     ),
   ],
   title: 'Used RSS Memory',
@@ -322,6 +323,7 @@ local v8HeapSizePanel = {
     prometheus.target(
       'sum(discourse_v8_used_heap_size{instance=~"$instance",job=~"$job"}) by (type)',
       datasource=promDatasource,
+      legendFormat='{{type}}',
     ),
   ],
   title: 'V8 Heap Size',

--- a/discourse-mixin/dashboards/discourse-overview.libsonnet
+++ b/discourse-mixin/dashboards/discourse-overview.libsonnet
@@ -86,8 +86,9 @@ local trafficPanel = {
   },
   targets: [
     prometheus.target(
-      'sum(rate(discourse_http_requests{instance=~"$instance",job=~"$job"}[$__rate_interval])) by (api,status,verb)',
+      'sum(rate(discourse_http_requests{instance=~"$instance",job=~"$job"}[$__rate_interval])) by (status)',
       datasource=promDatasource,
+      legendFormat='{{status}}'
     ),
   ],
   title: 'Traffic by Response Code',
@@ -414,6 +415,7 @@ local medianLatencyPanel = {
     prometheus.target(
       'sum(discourse_http_duration_seconds{quantile="0.5",action="latest",instance=~"$instance",job=~"$job"}) by (controller)',
       datasource=promDatasource,
+      legendFormat='{{controller}}',
     ),
   ],
   title: 'Latest Median Request Time',
@@ -491,7 +493,8 @@ local topicMedianPanel = {
   targets: [
     prometheus.target(
       'sum(discourse_http_duration_seconds{quantile="0.5",controller="topics",instance=~"$instance",job=~"$job"}) by (controller)',
-      datasource=promDatasource
+      datasource=promDatasource,
+      legendFormat='{{controller}}',
     ),
   ],
   title: 'Topic Show Median Request Time',
@@ -566,14 +569,11 @@ local ninetyNinthPercentileRequestLatency = {
     },
   },
   targets: [
-    {
-      datasource: promDatasource,
-      editorMode: 'code',
-      expr: 'sum(discourse_http_duration_seconds{quantile="0.99",action="latest",instance=~"$instance",job=~"$job"}) by (controller)',
-      legendFormat: '__auto',
-      range: true,
-      refId: 'A',
-    },
+    prometheus.target(
+      'sum(discourse_http_duration_seconds{quantile="0.99",action="latest",instance=~"$instance",job=~"$job"}) by (controller)',
+      datasource=promDatasource,
+      legendFormat='{{controller}}',
+    ),
   ],
   title: 'Latest 99th percentile Request Time',
   type: 'timeseries',
@@ -650,6 +650,7 @@ local ninetyNinthTopicShowPercentileRequestLatency = {
     prometheus.target(
       'discourse_http_duration_seconds{quantile="0.99",controller="topics",instance=~"$instance",job=~"$job"}',
       datasource=promDatasource,
+      legendFormat='{{controller}}',
     ),
   ],
   title: 'Topic Show 99th percentile Request Time',


### PR DESCRIPTION
During internal review we found some improvements in legends and presentation that we figured we should do.

- Improve legend for `Used RSS Memory` dashboard
- Improve legend by just using `type` in `V8 Heap Size` dashboard
- `Traffic by response code` is desired to just be grouped by response code
- Add consistency to `Request Latency` legends. 


<details>

<summary>Screenshots </summary>

![image](https://user-images.githubusercontent.com/32067685/203641259-d05dba52-08b2-489b-b4a1-3533b1401279.png)

![image](https://user-images.githubusercontent.com/32067685/203641365-4ab88320-08f2-474c-9083-1642bc036375.png)

![image](https://user-images.githubusercontent.com/32067685/203641435-e371932a-f6be-4d67-a53d-c93ea91b6ac1.png)


</details>