### PR TITLE
Fix nginx queryType bug

### DIFF
--- a/nginx-mixin/dashboards/nginx-overview.json
+++ b/nginx-mixin/dashboards/nginx-overview.json
@@ -1466,6 +1466,7 @@
           "expr": "topk(300, sum by (request_uri) (count_over_time({$label_name=~\"$label_value\", job=~\"$job\", instance=~\"$instance\"} !~ `\\.ico|\\.svg|\\.css|\\.png|\\.txt|\\.js|\\.xml` | json | status = 200 and request_uri != \"/\" | __error__=\"\" [$__interval])))",
           "instant": true,
           "legendFormat": "{{request_uri}}",
+          "queryType": "instant",
           "range": false,
           "refId": "A"
         }


### PR DESCRIPTION
when try to edit the dashboard and not specified queryType, the default value is range, but the true value is instant
![image](https://user-images.githubusercontent.com/50474995/205222524-5ec00a05-5556-4d70-a928-f8f61b9db2f0.png)
