### PR TITLE
Fix MongoDB replicaset states panel

### DIFF
--- a/mongodb-mixin/dashboards/MongoDB_Instance.json
+++ b/mongodb-mixin/dashboards/MongoDB_Instance.json
@@ -285,12 +285,23 @@
       "type": "stat"
     },
     {
-      "datasource": "${datasource}",
+      "id": 12,
+      "gridPos": {
+        "h": 2,
+        "w": 5,
+        "x": 19,
+        "y": 1
+      },
+      "type": "stat",
+      "title": "Current ReplSet State",
+      "transformations": [],
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "pluginVersion": "9.1.6",
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
           "mappings": [
             {
               "options": {
@@ -351,53 +362,43 @@
               }
             ]
           },
+          "color": {
+            "mode": "thresholds"
+          },
           "unit": "none"
         },
         "overrides": []
       },
-      "gridPos": {
-        "h": 2,
-        "w": 5,
-        "x": 19,
-        "y": 1
-      },
-      "id": 12,
       "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
         "reduceOptions": {
+          "values": false,
           "calcs": [
             "lastNotNull"
           ],
-          "fields": "/^Value$/",
-          "values": false
+          "fields": "/^Value$/"
         },
-        "text": {},
-        "textMode": "auto"
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "text": {}
       },
-      "pluginVersion": "8.0.4",
       "targets": [
         {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
           "exemplar": true,
           "expr": "mongodb_mongod_replset_my_state{service_name=~\"$service_name\", mongodb_cluster=\"$cluster\"}",
+          "format": "table",
           "instant": true,
           "interval": "",
-          "legendFormat": "",
+          "legendFormat": "{{label_name}}",
           "refId": "A"
         }
-      ],
-      "title": "Current ReplSet State",
-      "transformations": [
-        {
-          "id": "labelsToFields",
-          "options": {
-            "valueLabel": "__name__"
-          }
-        }
-      ],
-      "type": "stat"
+      ]
     },
     {
       "collapsed": false,

--- a/mongodb-mixin/dashboards/MongoDB_ReplicaSet.json
+++ b/mongodb-mixin/dashboards/MongoDB_ReplicaSet.json
@@ -322,21 +322,61 @@
       "type": "table"
     },
     {
+      "id": 10,
+      "gridPos": {
+        "h": 8,
+        "w": 15,
+        "x": 0,
+        "y": 3
+      },
+      "type": "state-timeline",
+      "title": "ReplSet States",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "valueLabel": "service_name",
+            "mode": "columns"
+          }
+        },
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "__name__": true,
+              "agent_hostname": true,
+              "cluster": true,
+              "instance": true,
+              "job": true,
+              "mongodb_cluster": true,
+              "set": true
+            },
+            "indexByName": {},
+            "renameByName": {}
+          }
+        }
+      ],
       "datasource": {
-        "uid": "${datasource}"
+        "uid": "${datasource}",
+        "type": "prometheus"
       },
       "fieldConfig": {
         "defaults": {
+          "custom": {
+            "lineWidth": 0,
+            "fillOpacity": 70,
+            "spanNulls": false
+          },
           "color": {
             "mode": "palette-classic"
           },
-          "custom": {
-            "fillOpacity": 70,
-            "lineWidth": 0,
-            "spanNulls": false
-          },
           "mappings": [
             {
+              "type": "value",
               "options": {
                 "0": {
                   "color": "blue",
@@ -351,7 +391,7 @@
                 "2": {
                   "color": "yellow",
                   "index": 1,
-                  "text": "SECUNDARY"
+                  "text": "SECONDARY"
                 },
                 "3": {
                   "color": "red",
@@ -388,10 +428,10 @@
                   "index": 9,
                   "text": "REMOVED"
                 }
-              },
-              "type": "value"
+              }
             },
             {
+              "type": "special",
               "options": {
                 "match": "empty",
                 "result": {
@@ -399,10 +439,10 @@
                   "index": 10,
                   "text": "NULL"
                 }
-              },
-              "type": "special"
+              }
             },
             {
+              "type": "special",
               "options": {
                 "match": "null+nan",
                 "result": {
@@ -410,8 +450,7 @@
                   "index": 11,
                   "text": "NULL"
                 }
-              },
-              "type": "special"
+              }
             }
           ],
           "thresholds": {
@@ -427,22 +466,16 @@
         },
         "overrides": []
       },
-      "gridPos": {
-        "h": 8,
-        "w": 15,
-        "x": 0,
-        "y": 3
-      },
-      "id": 10,
       "options": {
+        "mergeValues": true,
+        "showValue": "auto",
         "alignValue": "left",
+        "rowHeight": 0.9,
         "legend": {
-          "displayMode": "hidden",
+          "showLegend": false,
+          "displayMode": "list",
           "placement": "bottom"
         },
-        "mergeValues": true,
-        "rowHeight": 0.9,
-        "showValue": "auto",
         "tooltip": {
           "mode": "single",
           "sort": "none"
@@ -454,45 +487,16 @@
             "uid": "${datasource}"
           },
           "exemplar": true,
-          "expr": "mongodb_mongod_replset_my_state{set=~\"$replset\",service_name=~\"$service_name\", mongodb_cluster=~\"$cluster\"}",
+          "expr": "max by (set, mongodb_cluter, service_name) (mongodb_mongod_replset_my_state{set=~\"$replset\",service_name=~\"$service_name\", mongodb_cluster=~\"$cluster\"})",
           "format": "time_series",
           "hide": false,
           "instant": false,
           "interval": "",
           "legendFormat": "",
-          "refId": "A"
+          "refId": "A",
+          "editorMode": "code"
         }
-      ],
-      "title": "ReplSet States",
-      "transformations": [
-        {
-          "id": "labelsToFields",
-          "options": {
-            "valueLabel": "service_name"
-          }
-        },
-        {
-          "id": "merge",
-          "options": {}
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "__name__": true,
-              "agent_hostname": true,
-              "cluster": true,
-              "instance": true,
-              "job": true,
-              "mongodb_cluster": true,
-              "set": true
-            },
-            "indexByName": {},
-            "renameByName": {}
-          }
-        }
-      ],
-      "type": "state-timeline"
+      ]
     },
     {
       "collapsed": false,


### PR DESCRIPTION
1. Mongodb replicaset states panel could have extra rows if external_labels are used on the grafana_agent side. Grouping by only relevant labels fixes this potential problem.
2. Same applies to 'Current ReplSet State' in Mongodb instances dashboard. It is broken if external_labels present. Simplified calculations (removed transformations, changed timeseries to table output) to make it work with extra labels.
3. Also fixes 'SECUNDARY' typo in value mapping
<img width="825" alt="image" src="https://user-images.githubusercontent.com/14870891/205609357-fa731549-4fc0-493e-b210-762a3f0f7785.png">
