### PR TITLE
Dasomeone/cilium enterprise add missing tags makefile

### DIFF
--- a/cilium-enterprise-mixin/Makefile
+++ b/cilium-enterprise-mixin/Makefile
@@ -1,0 +1,31 @@
+JSONNET_FMT := jsonnetfmt -n 2 --max-blank-lines 1 --string-style s --comment-style s
+
+.PHONY: all
+all: build dashboards_out
+
+vendor: jsonnetfile.json
+	jb install
+
+.PHONY: build
+build: vendor
+
+.PHONY: fmt
+fmt:
+	find . -name 'vendor' -prune -o -name '*.libsonnet' -print -o -name '*.jsonnet' -print | \
+		xargs -n 1 -- $(JSONNET_FMT) -i
+
+.PHONY: lint
+lint: build
+	find . -name 'vendor' -prune -o -name '*.libsonnet' -print -o -name '*.jsonnet' -print | \
+		while read f; do \
+			$(JSONNET_FMT) "$$f" | diff -u "$$f" -; \
+		done
+	mixtool lint mixin.libsonnet
+
+dashboards_out: mixin.libsonnet
+	@mkdir -p dashboards_out
+	jsonnet -J vendor -m dashboards_out -e "(import 'mixin.libsonnet').grafanaDashboards"
+
+.PHONY: clean
+clean:
+	rm -rf dashboards_out

--- a/cilium-enterprise-mixin/dashboards/cilium-agent-overview.json
+++ b/cilium-enterprise-mixin/dashboards/cilium-agent-overview.json
@@ -1519,7 +1519,9 @@
   "refresh": "30s",
   "schemaVersion": 36,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "cilium-overview"
+  ],
   "templating": {
     "list": [
       {

--- a/cilium-enterprise-mixin/dashboards/cilium-agent/cilium-L3-policy.json
+++ b/cilium-enterprise-mixin/dashboards/cilium-agent/cilium-L3-policy.json
@@ -1046,7 +1046,9 @@
   "refresh": "30s",
   "schemaVersion": 36,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "cilium-agent"
+  ],
   "templating": {
     "list": [
       {

--- a/cilium-enterprise-mixin/dashboards/cilium-agent/cilium-L7-proxy.json
+++ b/cilium-enterprise-mixin/dashboards/cilium-agent/cilium-L7-proxy.json
@@ -917,7 +917,9 @@
   "refresh": "30s",
   "schemaVersion": 36,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "cilium-agent"
+  ],
   "templating": {
     "list": [
       {

--- a/cilium-enterprise-mixin/dashboards/cilium-agent/cilium-actionable.json
+++ b/cilium-enterprise-mixin/dashboards/cilium-agent/cilium-actionable.json
@@ -746,7 +746,9 @@
   "refresh": "30s",
   "schemaVersion": 36,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "cilium-agent"
+  ],
   "templating": {
     "list": [
       {

--- a/cilium-enterprise-mixin/dashboards/cilium-agent/cilium-agent.json
+++ b/cilium-enterprise-mixin/dashboards/cilium-agent/cilium-agent.json
@@ -1544,7 +1544,9 @@
   "refresh": "30s",
   "schemaVersion": 36,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "cilium-agent"
+  ],
   "templating": {
     "list": [
       {

--- a/cilium-enterprise-mixin/dashboards/cilium-agent/cilium-api.json
+++ b/cilium-enterprise-mixin/dashboards/cilium-agent/cilium-api.json
@@ -486,7 +486,9 @@
   "refresh": "30s",
   "schemaVersion": 36,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "cilium-agent"
+  ],
   "templating": {
     "list": [
       {

--- a/cilium-enterprise-mixin/dashboards/cilium-agent/cilium-bpf.json
+++ b/cilium-enterprise-mixin/dashboards/cilium-agent/cilium-bpf.json
@@ -621,7 +621,9 @@
   "refresh": "30s",
   "schemaVersion": 36,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "cilium-agent"
+  ],
   "templating": {
     "list": [
       {

--- a/cilium-enterprise-mixin/dashboards/cilium-agent/cilium-conntrack.json
+++ b/cilium-enterprise-mixin/dashboards/cilium-agent/cilium-conntrack.json
@@ -1058,7 +1058,9 @@
   "refresh": "30s",
   "schemaVersion": 36,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "cilium-agent"
+  ],
   "templating": {
     "list": [
       {

--- a/cilium-enterprise-mixin/dashboards/cilium-agent/cilium-datapath.json
+++ b/cilium-enterprise-mixin/dashboards/cilium-agent/cilium-datapath.json
@@ -768,7 +768,9 @@
   "refresh": "30s",
   "schemaVersion": 36,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "cilium-agent"
+  ],
   "templating": {
     "list": [
       {

--- a/cilium-enterprise-mixin/dashboards/cilium-agent/cilium-external-fqdn-proxy.json
+++ b/cilium-enterprise-mixin/dashboards/cilium-agent/cilium-external-fqdn-proxy.json
@@ -1436,7 +1436,9 @@
   "refresh": false,
   "schemaVersion": 36,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "cilium-agent"
+  ],
   "templating": {
     "list": [
       {

--- a/cilium-enterprise-mixin/dashboards/cilium-agent/cilium-fqdn-proxy.json
+++ b/cilium-enterprise-mixin/dashboards/cilium-agent/cilium-fqdn-proxy.json
@@ -911,7 +911,9 @@
   "refresh": "30s",
   "schemaVersion": 36,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "cilium-agent"
+  ],
   "templating": {
     "list": [
       {

--- a/cilium-enterprise-mixin/dashboards/cilium-agent/cilium-identities.json
+++ b/cilium-enterprise-mixin/dashboards/cilium-agent/cilium-identities.json
@@ -246,7 +246,9 @@
   "refresh": "30s",
   "schemaVersion": 36,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "cilium-agent"
+  ],
   "templating": {
     "list": [
       {

--- a/cilium-enterprise-mixin/dashboards/cilium-agent/cilium-kubernetes.json
+++ b/cilium-enterprise-mixin/dashboards/cilium-agent/cilium-kubernetes.json
@@ -1305,7 +1305,9 @@
   "refresh": "30s",
   "schemaVersion": 36,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "cilium-agent"
+  ],
   "templating": {
     "list": [
       {

--- a/cilium-enterprise-mixin/dashboards/cilium-agent/cilium-network.json
+++ b/cilium-enterprise-mixin/dashboards/cilium-agent/cilium-network.json
@@ -262,7 +262,9 @@
   "refresh": "30s",
   "schemaVersion": 36,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "cilium-agent"
+  ],
   "templating": {
     "list": [
       {

--- a/cilium-enterprise-mixin/dashboards/cilium-agent/cilium-nodes.json
+++ b/cilium-enterprise-mixin/dashboards/cilium-agent/cilium-nodes.json
@@ -415,7 +415,9 @@
   "refresh": "30s",
   "schemaVersion": 36,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "cilium-agent"
+  ],
   "templating": {
     "list": [
       {

--- a/cilium-enterprise-mixin/dashboards/cilium-agent/cilium-policy.json
+++ b/cilium-enterprise-mixin/dashboards/cilium-agent/cilium-policy.json
@@ -1580,7 +1580,9 @@
   "refresh": "30s",
   "schemaVersion": 36,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "cilium-agent"
+  ],
   "templating": {
     "list": [
       {

--- a/cilium-enterprise-mixin/dashboards/cilium-agent/cilium-resource-utilization.json
+++ b/cilium-enterprise-mixin/dashboards/cilium-agent/cilium-resource-utilization.json
@@ -981,7 +981,9 @@
   "refresh": "30s",
   "schemaVersion": 36,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "cilium-agent"
+  ],
   "templating": {
     "list": [
       {

--- a/cilium-enterprise-mixin/dashboards/cilium-operator.json
+++ b/cilium-enterprise-mixin/dashboards/cilium-operator.json
@@ -4248,7 +4248,9 @@
   "refresh": "30s",
   "schemaVersion": 37,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "cilium-overview"
+  ],
   "templating": {
     "list": [
       {

--- a/cilium-enterprise-mixin/dashboards/cilium-overview.json
+++ b/cilium-enterprise-mixin/dashboards/cilium-overview.json
@@ -1580,7 +1580,9 @@
   "refresh": "30s",
   "schemaVersion": 36,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "cilium-overview"
+  ],
   "templating": {
     "list": [
       {

--- a/cilium-enterprise-mixin/dashboards/hubble-overview.json
+++ b/cilium-enterprise-mixin/dashboards/hubble-overview.json
@@ -3227,8 +3227,8 @@
   "schemaVersion": 37,
   "style": "dark",
   "tags": [
-    "cilium-enterprise-integration",
-    "cilium-overview"
+    "cilium-overview",
+    "hubble"
   ],
   "templating": {
     "list": [

--- a/cilium-enterprise-mixin/dashboards/hubble/hubble-timescape.json
+++ b/cilium-enterprise-mixin/dashboards/hubble/hubble-timescape.json
@@ -1033,7 +1033,9 @@
   "refresh": false,
   "schemaVersion": 37,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "hubble"
+  ],
   "templating": {
     "list": [
       {


### PR DESCRIPTION
As @stevo-f3 mentioned on the initial PR for adding the Cilium Enterprise mixin, two key aspects were not included:
1) The makefile was missing
2) Dashboard tags were used for navigation, but not included in the mixin

This PR addresses these two concerns.