### PR TITLE
Mongodb-mixin: Fix replication lag panel

### DIFF
--- a/mongodb-mixin/dashboards/MongoDB_ReplicaSet.json
+++ b/mongodb-mixin/dashboards/MongoDB_ReplicaSet.json
@@ -525,41 +525,53 @@
       "type": "row"
     },
     {
+      "id": 14,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 12
+      },
+      "type": "timeseries",
+      "title": "Replication Lag",
       "datasource": {
-        "uid": "${datasource}"
+        "uid": "${datasource}",
+        "type": "prometheus"
       },
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
           "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
             "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "barAlignment": 0,
+            "lineWidth": 1,
             "fillOpacity": 0,
             "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
+            "spanNulls": false,
+            "showPoints": "auto",
             "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "axisLabel": "",
+            "axisColorMode": "text",
             "scaleDistribution": {
               "type": "linear"
             },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
+            "axisCenteredZero": false,
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
             },
             "thresholdsStyle": {
               "mode": "off"
             }
+          },
+          "color": {
+            "mode": "palette-classic"
           },
           "mappings": [],
           "thresholds": {
@@ -575,26 +587,20 @@
         },
         "overrides": []
       },
-      "gridPos": {
-        "h": 8,
-        "w": 24,
-        "x": 0,
-        "y": 12
-      },
-      "id": 14,
       "options": {
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        },
         "legend": {
+          "showLegend": true,
+          "displayMode": "table",
+          "placement": "right",
           "calcs": [
             "max",
             "min",
             "mean"
-          ],
-          "displayMode": "table",
-          "placement": "right"
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
+          ]
         }
       },
       "targets": [
@@ -603,14 +609,14 @@
             "uid": "${datasource}"
           },
           "exemplar": true,
-          "expr": "avg by (service_name) (max(max_over_time(mongodb_mongod_replset_member_replication_lag{set=\"$replset\",service_name=~\"$secondary\", mongodb_cluster=~\"$cluster\"}[$__rate_interval]) > 0) by (service_name,set,mongodb_cluster))",
+          "expr": "avg by (name) (max(max_over_time(mongodb_mongod_replset_member_replication_lag{set=\"$replset\",service_name=~\"$secondary\", mongodb_cluster=~\"$cluster\"}[$__rate_interval])) by (name, service_name,set,mongodb_cluster))",
           "interval": "",
-          "legendFormat": "{{service_name}}",
-          "refId": "A"
+          "legendFormat": "{{name}}",
+          "refId": "A",
+          "editorMode": "code",
+          "range": true
         }
-      ],
-      "title": "Replication Lag",
-      "type": "timeseries"
+      ]
     },
     {
       "datasource": {


### PR DESCRIPTION
Fix mongodb lag panel, as each mongodb secondary node returns metrics  `mongodb_mongod_replset_member_replication_lag` for ALL other secondary nodes, not only for itself. So results should be grouped by internal label `name` which properly identifies secondary node insteadof service_name (which identifies node where metrics were taken, not actual replication set member in case of this metric).

![telegram-cloud-photo-size-2-5222237850760757785-y](https://user-images.githubusercontent.com/14870891/205856036-f0fde8bf-8173-4e2e-bb75-9f38bca2480d.jpg)
