### PR TITLE
TensorFlow mixin adds name filter to expression

### DIFF
--- a/tensorflow-mixin/dashboards/tensorflow-overview.libsonnet
+++ b/tensorflow-mixin/dashboards/tensorflow-overview.libsonnet
@@ -637,7 +637,7 @@ local containerLogsPanel = {
     {
       datasource: lokiDatasource,
       editorMode: 'code',
-      expr: '{job=~"$job",instance=~"$instance"}',
+      expr: '{name="tensorflow",job=~"$job",instance=~"$instance"}',
       legendFormat: '',
       queryType: 'range',
       refId: 'A',


### PR DESCRIPTION
Adds name to TensorFlow Container logs dashboard expression.

This is because when the job and instance selectors are set to all, the loki datasource can pick up unexpected logs. So a 3rd identifier is needed to differentiate only the TensorFlow logs.