### PR TITLE
Add OracleDB Mixin

### DIFF
--- a/oracledb-mixin/.lint
+++ b/oracledb-mixin/.lint
@@ -1,0 +1,9 @@
+exclusions:
+  template-job-rule:
+    reason: "Prometheus datasource variable is being named as prometheus_datasource now while linter expects 'datasource'"
+  panel-datasource-rule:
+    reason: "Loki datasource variable is being named as loki_datasource now while linter expects 'datasource'"
+  template-datasource-rule:
+    reason: "Based on new convention we are using variable names prometheus_datasource and loki_datasource where as linter expects 'datasource'"
+  template-instance-rule:
+    reason: "Based on new convention we are using variable names prometheus_datasource and loki_datasource where as linter expects 'datasource'"

--- a/oracledb-mixin/Makefile
+++ b/oracledb-mixin/Makefile
@@ -1,0 +1,34 @@
+JSONNET_FMT := jsonnetfmt -n 2 --max-blank-lines 1 --string-style s --comment-style s
+
+.PHONY: all
+all: build dashboards_out prometheus_alerts.yaml
+
+vendor: jsonnetfile.json
+	jb install
+
+.PHONY: build
+build: vendor
+
+.PHONY: fmt
+fmt:
+	find . -name 'vendor' -prune -o -name '*.libsonnet' -print -o -name '*.jsonnet' -print | \
+		xargs -n 1 -- $(JSONNET_FMT) -i
+
+.PHONY: lint
+lint: build
+	find . -name 'vendor' -prune -o -name '*.libsonnet' -print -o -name '*.jsonnet' -print | \
+		while read f; do \
+			$(JSONNET_FMT) "$$f" | diff -u "$$f" -; \
+		done
+	mixtool lint mixin.libsonnet
+
+dashboards_out: mixin.libsonnet config.libsonnet $(wildcard dashboards/*)
+	@mkdir -p dashboards_out
+	mixtool generate dashboards mixin.libsonnet -d dashboards_out
+
+prometheus_alerts.yaml: mixin.libsonnet alerts/*.libsonnet
+	mixtool generate alerts mixin.libsonnet -a prometheus_alerts.yaml
+
+.PHONY: clean
+clean:
+	rm -rf dashboards_out prometheus_alerts.yaml

--- a/oracledb-mixin/README.md
+++ b/oracledb-mixin/README.md
@@ -1,0 +1,1 @@
+# OracleDB Mixin

--- a/oracledb-mixin/README.md
+++ b/oracledb-mixin/README.md
@@ -1,1 +1,71 @@
 # OracleDB Mixin
+
+OracleDB mixin is a set of configurable alerts and dashboards that use the third party [OracleDB Exporter](https://github.com/iamseth/oracledb_exporter) using Prometheus and Loki for logs (optional).
+
+## Alerts
+
+| Alert                              | Description                                                           | Default Threshold |
+| ---------------------------------- | --------------------------------------------------------------------- | ----------------- |
+| OracledbReachingSessionLimit       | number of processess being utilized exceeded a theshold.              | 85%               |
+| OracledbReachingProcessLimit       | The number of processess being utilized exceeded the threshold.       | 85%               |
+| OracledbTablespaceReachingCapacity | A Tablespace is exceeded its threshold of its maximum allotted space. | 85%               |
+| OracledbFileDescriptorLimit        | File descriptors usage is reaching its threshold.                     | 85%               |
+
+Default thresholds can be configured in `config.libsonnet`.
+
+```js
+{
+  _config+:: {
+    alertsFileDescriptorThreshold: '85',  // %
+    alertsProcessThreshold: '85',  // %
+    alertsSessionThreshold: '85',  // %
+    alertsTablespaceThreshold: '85',  // %
+  },
+}
+```
+
+## Dashboards
+
+This mixin includes one dashboard: `OracleDB Overview` which includes a variety of metrics and a panel for alert logs.
+
+OracleDB alert logs are enabled by default in the `config.libsonnet` and can be remoed by setting `enableLokiLogs` to `false` and generating the dashboards again.
+
+```js
+{
+  _config+:: {
+    enableLokiLogs: true,
+  },
+}
+```
+
+Alert logs are located generally located at `$ORACLE_HOME/diag/rdbms/*/*/trace/alert_*.log` but please follow [this documentation](http://www.dba-oracle.com/t_alert_log_location.htm) to determine the location specific to respective installs.
+
+## Install tools
+
+```bash
+go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@latest
+go install github.com/monitoring-mixins/mixtool/cmd/mixtool@latest
+```
+
+For linting and formatting, you would also need and `jsonnetfmt` installed. If you
+have a working Go development environment, it's easiest to run the following:
+
+```bash
+go install github.com/google/go-jsonnet/cmd/jsonnetfmt@latest
+```
+
+The files in `dashboards_out` need to be imported
+into your Grafana server. The exact details will be depending on your environment.
+
+`prometheus_alerts.yaml` needs to be imported into Prometheus.
+
+## Generate dashboards and alerts
+
+Edit `config.libsonnet` if required and then build JSON dashboard files for Grafana:
+
+```bash
+make
+```
+
+For more advanced uses of mixins, see
+<https://github.com/monitoring-mixins/docs>.

--- a/oracledb-mixin/README.md
+++ b/oracledb-mixin/README.md
@@ -40,6 +40,9 @@ OracleDB alert logs are enabled by default in the `config.libsonnet` and can be 
 
 Alert logs are generally located at `$ORACLE_HOME/diag/rdbms/*/*/trace/alert_*.log` but please follow [the official documentation](http://www.dba-oracle.com/t_alert_log_location.htm) to determine the location specific to respective installs.
 
+![First screenshot of the overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/oracledb/screenshots/oracledb_overview_1.png)
+![Second screenshot of the overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/oracledb/screenshots/oracledb_overview_2.png)
+
 ## Install tools
 
 ```bash

--- a/oracledb-mixin/README.md
+++ b/oracledb-mixin/README.md
@@ -38,7 +38,7 @@ OracleDB alert logs are enabled by default in the `config.libsonnet` and can be 
 }
 ```
 
-Alert logs are located generally located at `$ORACLE_HOME/diag/rdbms/*/*/trace/alert_*.log` but please follow [this documentation](http://www.dba-oracle.com/t_alert_log_location.htm) to determine the location specific to respective installs.
+Alert logs are generally located at `$ORACLE_HOME/diag/rdbms/*/*/trace/alert_*.log` but please follow [the official documentation](http://www.dba-oracle.com/t_alert_log_location.htm) to determine the location specific to respective installs.
 
 ## Install tools
 

--- a/oracledb-mixin/alerts/alerts.libsonnet
+++ b/oracledb-mixin/alerts/alerts.libsonnet
@@ -1,5 +1,76 @@
 {
   prometheusAlerts+:: {
-    groups+: [],
+    groups+: [
+      {
+        name: 'OracleDBAlerts',
+        rules: [
+          {
+            alert: 'OracledbReachingSessionLimit',
+            expr: |||
+              oracledb_resource_current_utilization{resource_name="sessions"} / oracledb_resource_limit_value{resource_name="sessions"} * 100 > %(alertsSessionThreshold)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              summary: 'The number of processess being utilized exceeded %(alertsSessionThreshold)s%%.' % $._config,
+              description:
+                ('{{ printf "%%.2f" $value }}%% of sessions are being utilized which is above the ' +
+                 'threshold %(alertsSessionThreshold)s%%. This could mean that {{$labels.instance}} is being overutilized.') % $._config,
+            },
+          },
+          {
+            alert: 'OracledbReachingProcessLimit',
+            expr: |||
+              oracledb_resource_current_utilization{resource_name="processes"} / oracledb_resource_limit_value{resource_name="processes"} * 100 > %(alertsProcessThreshold)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              summary: 'The number of processess being utilized exceeded the threshold of %(alertsProcessThreshold)s%%.' % $._config,
+              description:
+                ('{{ printf "%%.2f" $value }} of processes are being utilized which is above the' +
+                 'threshold %(alertsProcessThreshold)s%%. This could potentially mean that ' +
+                 '{{$labels.instance}} runs out of processes it can spin up.') % $._config,
+            },
+          },
+          {
+            alert: 'OracledbTablespaceReachingCapacity',
+            expr: |||
+              oracledb_tablespace_bytes / oracledb_tablespace_max_bytes * 100 > %(alertsTablespaceThreshold)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              summary: 'A Tablespace is exceeding more than %(alertsTablespaceThreshold)s%% of its maximum allotted space.' % $._config,
+              description:
+                ('{{ printf "%%.2f" $value }}%% of bytes are being utilized by the tablespace {{$labels.tablespace}} on the instance {{$labels.instance}}, ' +
+                 'which is above the threshold %(alertsTablespaceThreshold)s%%.') % $._config,
+            },
+          },
+          {
+            alert: 'OracledbFileDescriptorLimit',
+            expr: |||
+              process_open_fds / process_max_fds * 100 > %(alertsFileDescriptorThreshold)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              summary: 'File descriptors usage is reaching its threshold of %(alertsFileDescriptorThreshold)s%%.' % $._config,
+              description:
+                ('{{ printf "%%.2f" $value }}%% of file descriptors are open on {{$labels.instance}}, which is above the ' +
+                 'threshold %(alertsFileDescriptorThreshold)s%%.') % $._config,
+            },
+          },
+        ],
+      },
+    ],
   },
 }

--- a/oracledb-mixin/alerts/alerts.libsonnet
+++ b/oracledb-mixin/alerts/alerts.libsonnet
@@ -47,7 +47,7 @@
               severity: 'critical',
             },
             annotations: {
-              summary: 'A Tablespace is exceeding more than %(alertsTablespaceThreshold)s%% of its maximum allotted space.' % $._config,
+              summary: 'A tablespace is exceeding more than %(alertsTablespaceThreshold)s%% of its maximum allotted space.' % $._config,
               description:
                 ('{{ printf "%%.2f" $value }}%% of bytes are being utilized by the tablespace {{$labels.tablespace}} on the instance {{$labels.instance}}, ' +
                  'which is above the threshold %(alertsTablespaceThreshold)s%%.') % $._config,

--- a/oracledb-mixin/alerts/alerts.libsonnet
+++ b/oracledb-mixin/alerts/alerts.libsonnet
@@ -1,0 +1,5 @@
+{
+  prometheusAlerts+:: {
+    groups+: [],
+  },
+}

--- a/oracledb-mixin/config.libsonnet
+++ b/oracledb-mixin/config.libsonnet
@@ -1,0 +1,11 @@
+{
+  _config+:: {
+    dashboardTags: ['oracledb-mixin'],
+    dashboardPeriod: 'now-1h',
+    dashboardTimezone: 'default',
+    dashboardRefresh: '1m',
+
+    // enable Loki logs
+    enableLokiLogs: true,
+  },
+}

--- a/oracledb-mixin/config.libsonnet
+++ b/oracledb-mixin/config.libsonnet
@@ -5,6 +5,11 @@
     dashboardTimezone: 'default',
     dashboardRefresh: '1m',
 
+    alertsFileDescriptorThreshold: '85',  // %
+    alertsProcessThreshold: '85',  // %
+    alertsSessionThreshold: '85',  // %
+    alertsTablespaceThreshold: '85',  // %
+
     // enable Loki logs
     enableLokiLogs: true,
   },

--- a/oracledb-mixin/dashboards/dashboards.libsonnet
+++ b/oracledb-mixin/dashboards/dashboards.libsonnet
@@ -1,0 +1,1 @@
+(import 'overview.libsonnet')

--- a/oracledb-mixin/dashboards/overview.libsonnet
+++ b/oracledb-mixin/dashboards/overview.libsonnet
@@ -71,7 +71,7 @@ local databaseStatusPanel = {
     {
       datasource: promDatasource,
       editorMode: 'code',
-      expr: 'oracledb_up{job=~"$job", instance=~"$instance"}',
+      expr: 'oracledb_up{' + matcher + '}',
       legendFormat: '__auto',
       range: true,
       refId: 'A',
@@ -151,7 +151,7 @@ local cpuSecondsPanel = {
     {
       datasource: promDatasource,
       editorMode: 'code',
-      expr: 'increase(process_cpu_seconds_total{instance=~"$instance",job=~"$job"}[$__rate_interval])',
+      expr: 'increase(process_cpu_seconds_total{' + matcher + '}[$__rate_interval])',
       legendFormat: '{{instance}}',
       range: true,
       refId: 'A',
@@ -232,7 +232,7 @@ local virtualMemoryPanel = {
     {
       datasource: promDatasource,
       editorMode: 'code',
-      expr: 'process_virtual_memory_bytes{instance=~"$instance",job=~"$job"}',
+      expr: 'process_virtual_memory_bytes{' + matcher + '}',
       legendFormat: '{{instance}}',
       range: true,
       refId: 'A',
@@ -312,7 +312,7 @@ local openFdsPanel = {
     {
       datasource: promDatasource,
       editorMode: 'code',
-      expr: 'process_open_fds{instance=~"$instance",job=~"$job"}',
+      expr: 'process_open_fds{' + matcher + '}',
       legendFormat: '{{instance}} - open',
       range: true,
       refId: 'OPEN',
@@ -320,7 +320,7 @@ local openFdsPanel = {
     {
       datasource: promDatasource,
       editorMode: 'code',
-      expr: 'process_max_fds{instance=~"$instance",job=~"$job"}',
+      expr: 'process_max_fds{' + matcher + '}',
       hide: false,
       legendFormat: '{{instance}} - limit',
       range: true,
@@ -403,7 +403,7 @@ local sessionsPanel = {
     {
       datasource: promDatasource,
       editorMode: 'code',
-      expr: 'oracledb_resource_current_utilization{instance=~"$instance",job=~"$job",resource_name="sessions"}',
+      expr: 'oracledb_resource_current_utilization{' + matcher + ',resource_name="sessions"}',
       legendFormat: '{{instance}} - open',
       range: true,
       refId: 'Open',
@@ -411,7 +411,7 @@ local sessionsPanel = {
     {
       datasource: promDatasource,
       editorMode: 'code',
-      expr: 'oracledb_resource_limit_value{instance=~"$instance",job=~"$job",resource_name="sessions"}',
+      expr: 'oracledb_resource_limit_value{' + matcher + ',resource_name="sessions"}',
       hide: false,
       legendFormat: '{{instance}} - limit',
       range: true,
@@ -494,7 +494,7 @@ local processPanel = {
     {
       datasource: promDatasource,
       editorMode: 'code',
-      expr: 'oracledb_resource_current_utilization{instance=~"$instance",job=~"$job",resource_name="processes"}',
+      expr: 'oracledb_resource_current_utilization{' + matcher + ',resource_name="processes"}',
       legendFormat: '{{instance}} - current',
       range: true,
       refId: 'Current',
@@ -502,7 +502,7 @@ local processPanel = {
     {
       datasource: promDatasource,
       editorMode: 'code',
-      expr: 'oracledb_resource_limit_value{instance=~"$instance",job=~"$job",resource_name="processes"}',
+      expr: 'oracledb_resource_limit_value{' + matcher + ',resource_name="processes"}',
       hide: false,
       legendFormat: '{{instance}} - limit',
       range: true,
@@ -555,7 +555,7 @@ local alertLogPanel = {
     {
       datasource: lokiDatasource,
       editorMode: 'builder',
-      expr: '{filename=~"/u01/base/diag/rdbms/*/*/trace/alert_*.log", instance=~"$instance", job=~"$job"}',
+      expr: '{filename=~"/u01/base/diag/rdbms/.*/.*/trace/alert_.*log",' + matcher + '}',
       queryType: 'range',
       refId: 'A',
     },
@@ -641,8 +641,8 @@ local applicationWaitTimePanel = {
     {
       datasource: promDatasource,
       editorMode: 'code',
-      expr: 'oracledb_wait_time_application{job=~"$job", instance=~"$instance"}',
-      legendFormat: '__auto',
+      expr: 'oracledb_wait_time_application{' + matcher + '}',
+      legendFormat: '{{instance}}',
       range: true,
       refId: 'A',
     },
@@ -722,8 +722,8 @@ local commitTimePanel = {
     {
       datasource: promDatasource,
       editorMode: 'code',
-      expr: 'oracledb_wait_time_commit{instance=~"$instance",job=~"$job"}',
-      legendFormat: '__auto',
+      expr: 'oracledb_wait_time_commit{' + matcher + '}',
+      legendFormat: '{{instance}}',
       range: true,
       refId: 'A',
     },
@@ -803,8 +803,8 @@ local concurrencyWaitTime = {
     {
       datasource: promDatasource,
       editorMode: 'code',
-      expr: 'oracledb_wait_time_concurrency{instance=~"$instance",job=~"$job"}',
-      legendFormat: '__auto',
+      expr: 'oracledb_wait_time_concurrency{' + matcher + '}',
+      legendFormat: '{{instance}}',
       range: true,
       refId: 'A',
     },
@@ -884,8 +884,8 @@ local configurationWaitTime = {
     {
       datasource: promDatasource,
       editorMode: 'code',
-      expr: 'oracledb_wait_time_configuration{instance=~"$instance",job=~"$job"}',
-      legendFormat: '__auto',
+      expr: 'oracledb_wait_time_configuration{' + matcher + '}',
+      legendFormat: '{{instance}}',
       range: true,
       refId: 'A',
     },
@@ -965,8 +965,8 @@ local networkWaitTime = {
     {
       datasource: promDatasource,
       editorMode: 'code',
-      expr: 'oracledb_wait_time_network{instance=~"$instance",job=~"$job"}',
-      legendFormat: '__auto',
+      expr: 'oracledb_wait_time_network{' + matcher + '}',
+      legendFormat: '{{instance}}',
       range: true,
       refId: 'A',
     },
@@ -1046,8 +1046,8 @@ local schedulerWaitTime = {
     {
       datasource: promDatasource,
       editorMode: 'code',
-      expr: 'oracledb_wait_time_scheduler{instance=~"$instance",job=~"$job"}',
-      legendFormat: '__auto',
+      expr: 'oracledb_wait_time_scheduler{' + matcher + '}',
+      legendFormat: '{{instance}}',
       range: true,
       refId: 'A',
     },
@@ -1127,8 +1127,8 @@ local systemIOWaitTime = {
     {
       datasource: promDatasource,
       editorMode: 'code',
-      expr: 'oracledb_wait_time_system_io{instance=~"$instance",job=~"$job"}',
-      legendFormat: '__auto',
+      expr: 'oracledb_wait_time_system_io{' + matcher + '}',
+      legendFormat: '{{instance}}',
       range: true,
       refId: 'A',
     },
@@ -1208,8 +1208,8 @@ local userIOWaitTime = {
     {
       datasource: promDatasource,
       editorMode: 'code',
-      expr: 'oracledb_wait_time_user_io{instance=~"$instance",job=~"$job"}',
-      legendFormat: '__auto',
+      expr: 'oracledb_wait_time_user_io{' + matcher + '}',
+      legendFormat: '{{instance}}',
       range: true,
       refId: 'A',
     },
@@ -1295,7 +1295,7 @@ local tablespaceSizePanel = {
     {
       datasource: promDatasource,
       editorMode: 'code',
-      expr: 'oracledb_tablespace_bytes{instance=~"$instance",job=~"$job",tablespace=~"$tablespace"}',
+      expr: 'oracledb_tablespace_bytes{' + matcher + ',tablespace=~"$tablespace"}',
       legendFormat: '{{instance}} - {{tablespace}} - used',
       range: true,
       refId: 'Used Bytes',
@@ -1303,7 +1303,7 @@ local tablespaceSizePanel = {
     {
       datasource: promDatasource,
       editorMode: 'code',
-      expr: 'oracledb_tablespace_free{instance=~"$instance",job=~"$job",tablespace=~"$tablespace"}',
+      expr: 'oracledb_tablespace_free{' + matcher + ',tablespace=~"$tablespace"}',
       hide: false,
       legendFormat: '{{instance}} - {{tablespace}} - free',
       range: true,
@@ -1312,7 +1312,7 @@ local tablespaceSizePanel = {
     {
       datasource: promDatasource,
       editorMode: 'code',
-      expr: 'oracledb_tablespace_max_bytes{instance=~"$instance",job=~"$job",tablespace=~"$tablespace"}',
+      expr: 'oracledb_tablespace_max_bytes{' + matcher + ',tablespace=~"$tablespace"}',
       hide: false,
       legendFormat: '{{instance}} - {{tablespace}} - max',
       range: true,
@@ -1336,12 +1336,6 @@ local tablespaceSizePanel = {
         graphTooltip='shared_crosshair',
         uid=dashboardUid,
       )
-      .addLink(grafana.link.dashboards(
-        title='Other OracleDB dashboards',
-        includeVars=true,
-        keepTime=true,
-        tags=($._config.dashboardTags),
-      ))
       .addTemplates(
         [
           {

--- a/oracledb-mixin/dashboards/overview.libsonnet
+++ b/oracledb-mixin/dashboards/overview.libsonnet
@@ -1356,7 +1356,7 @@ local tablespaceSizePanel = {
           template.new(
             'tablespace',
             promDatasource,
-            query='label_values(oracledb_tablespace_bytes, tablespace)',
+            query='label_values(oracledb_tablespace_bytes{' + matcher + '}, tablespace)',
             label='Tablespace',
             refresh='time',
             includeAll=true,

--- a/oracledb-mixin/dashboards/overview.libsonnet
+++ b/oracledb-mixin/dashboards/overview.libsonnet
@@ -1410,9 +1410,9 @@ local tablespaceSizePanel = {
             sessionsPanel { gridPos: { h: 6, w: 8, x: 8, y: 4 } },
             processPanel { gridPos: { h: 6, w: 8, x: 16, y: 4 } },
           ],
-          [
+          if $._config.enableLokiLogs then [
             alertLogPanel { gridPos: { h: 7, w: 24, x: 0, y: 10 } },
-          ],
+          ] else [],
           [
             waitTimerow { gridPos: { h: 1, w: 24, x: 0, y: 17 } },
           ],

--- a/oracledb-mixin/dashboards/overview.libsonnet
+++ b/oracledb-mixin/dashboards/overview.libsonnet
@@ -564,6 +564,12 @@ local alertLogPanel = {
   type: 'table',
 };
 
+local waitTimerow = {
+  collapsed: false,
+  title: 'Wait Time',
+  type: 'row',
+};
+
 local applicationWaitTimePanel = {
   datasource: promDatasource,
   description: 'Application wait time, in seconds, waiting for wait events.',
@@ -1212,6 +1218,12 @@ local userIOWaitTime = {
   type: 'timeseries',
 };
 
+local tablespaceRow = {
+  collapsed: false,
+  title: 'Tablespace',
+  type: 'row',
+};
+
 local tablespaceSizePanel = {
   datasource: promDatasource,
   description: 'Shows the size overtime for the tablespace.',
@@ -1374,10 +1386,10 @@ local tablespaceSizePanel = {
             sort=1
           ),
           template.new(
-            'job',
+            'tablespace',
             promDatasource,
             query='label_values(oracledb_tablespace_bytes, tablespace)',
-            label='Job',
+            label='Tablespace',
             refresh='time',
             includeAll=true,
             multi=true,
@@ -1402,19 +1414,25 @@ local tablespaceSizePanel = {
             alertLogPanel { gridPos: { h: 7, w: 24, x: 0, y: 10 } },
           ],
           [
-            applicationWaitTimePanel { gridPos: { h: 6, w: 6, x: 0, y: 12 } },
-            commitTimePanel { gridPos: { h: 6, w: 6, x: 6, y: 12 } },
-            concurrencyWaitTime { gridPos: { h: 6, w: 6, x: 12, y: 12 } },
-            configurationWaitTime { gridPos: { h: 6, w: 6, x: 18, y: 12 } },
+            waitTimerow { gridPos: { h: 1, w: 24, x: 0, y: 17 } },
           ],
           [
-            networkWaitTime { gridPos: { h: 6, w: 6, x: 0, y: 18 } },
-            schedulerWaitTime { gridPos: { h: 6, w: 6, x: 6, y: 18 } },
-            systemIOWaitTime { gridPos: { h: 6, w: 6, x: 12, y: 18 } },
-            userIOWaitTime { gridPos: { h: 6, w: 6, x: 18, y: 18 } },
+            applicationWaitTimePanel { gridPos: { h: 6, w: 6, x: 0, y: 18 } },
+            commitTimePanel { gridPos: { h: 6, w: 6, x: 6, y: 18 } },
+            concurrencyWaitTime { gridPos: { h: 6, w: 6, x: 12, y: 18 } },
+            configurationWaitTime { gridPos: { h: 6, w: 6, x: 18, y: 18 } },
           ],
           [
-            tablespaceSizePanel { gridPos: { h: 6, w: 24, x: 0, y: 25 } },
+            networkWaitTime { gridPos: { h: 6, w: 6, x: 0, y: 24 } },
+            schedulerWaitTime { gridPos: { h: 6, w: 6, x: 6, y: 24 } },
+            systemIOWaitTime { gridPos: { h: 6, w: 6, x: 12, y: 24 } },
+            userIOWaitTime { gridPos: { h: 6, w: 6, x: 18, y: 24 } },
+          ],
+          [
+            tablespaceRow { gridPos: { h: 1, w: 24, x: 0, y: 30 } },
+          ],
+          [
+            tablespaceSizePanel { gridPos: { h: 6, w: 24, x: 0, y: 31 } },
           ],
         ])
       ),

--- a/oracledb-mixin/dashboards/overview.libsonnet
+++ b/oracledb-mixin/dashboards/overview.libsonnet
@@ -77,7 +77,7 @@ local databaseStatusPanel = {
       refId: 'A',
     },
   ],
-  title: 'Database Status',
+  title: 'Database status',
   type: 'stat',
 };
 
@@ -157,7 +157,7 @@ local cpuSecondsPanel = {
       refId: 'A',
     },
   ],
-  title: 'CPU Seconds',
+  title: 'CPU seconds',
   type: 'timeseries',
 };
 
@@ -238,7 +238,7 @@ local virtualMemoryPanel = {
       refId: 'A',
     },
   ],
-  title: 'Virtual Memory',
+  title: 'Virtual memory',
   type: 'timeseries',
 };
 
@@ -327,7 +327,7 @@ local openFdsPanel = {
       refId: 'MAX',
     },
   ],
-  title: 'Open File Descriptors',
+  title: 'Open file descriptors',
   type: 'timeseries',
 };
 
@@ -383,7 +383,6 @@ local sessionsPanel = {
           },
         ],
       },
-      unit: 'sessions',
     },
     overrides: [],
   },
@@ -474,7 +473,6 @@ local processPanel = {
           },
         ],
       },
-      unit: 'processes',
     },
     overrides: [],
   },
@@ -516,39 +514,15 @@ local processPanel = {
 local alertLogPanel = {
   datasource: lokiDatasource,
   description: 'Recent logs from alert log file',
-  fieldConfig: {
-    defaults: {
-      custom: {
-        align: 'auto',
-        displayMode: 'auto',
-        inspect: false,
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-          {
-            color: 'red',
-            value: 80,
-          },
-        ],
-      },
-    },
-    overrides: [],
-  },
   options: {
-    footer: {
-      fields: '',
-      reducer: [
-        'sum',
-      ],
-      show: false,
-    },
-    showHeader: true,
+    dedupStrategy: 'none',
+    enableLogDetails: true,
+    prettifyLogMessage: false,
+    showCommonLabels: false,
+    showLabels: false,
+    showTime: false,
+    sortOrder: 'Descending',
+    wrapLogMessage: false,
   },
   pluginVersion: '9.1.8',
   targets: [
@@ -560,13 +534,13 @@ local alertLogPanel = {
       refId: 'A',
     },
   ],
-  title: 'Alert Logs',
-  type: 'table',
+  title: 'Alert logs',
+  type: 'logs',
 };
 
 local waitTimerow = {
   collapsed: false,
-  title: 'Wait Time',
+  title: 'Wait time',
   type: 'row',
 };
 
@@ -647,7 +621,7 @@ local applicationWaitTimePanel = {
       refId: 'A',
     },
   ],
-  title: 'Application Wait Time',
+  title: 'Application wait time',
   type: 'timeseries',
 };
 
@@ -728,7 +702,7 @@ local commitTimePanel = {
       refId: 'A',
     },
   ],
-  title: 'Commit Wait Time',
+  title: 'Commit wait time',
   type: 'timeseries',
 };
 
@@ -809,7 +783,7 @@ local concurrencyWaitTime = {
       refId: 'A',
     },
   ],
-  title: 'Concurrency Wait Time',
+  title: 'Concurrency wait time',
   type: 'timeseries',
 };
 
@@ -890,7 +864,7 @@ local configurationWaitTime = {
       refId: 'A',
     },
   ],
-  title: 'Configuration Wait Time',
+  title: 'Configuration wait time',
   type: 'timeseries',
 };
 
@@ -971,7 +945,7 @@ local networkWaitTime = {
       refId: 'A',
     },
   ],
-  title: 'Network Wait Time',
+  title: 'Network wait time',
   type: 'timeseries',
 };
 
@@ -1052,13 +1026,13 @@ local schedulerWaitTime = {
       refId: 'A',
     },
   ],
-  title: 'Scheduler Wait Time',
+  title: 'Scheduler wait time',
   type: 'timeseries',
 };
 
 local systemIOWaitTime = {
   datasource: promDatasource,
-  description: 'System IO wait time, in seconds, waiting for wait events.',
+  description: 'System I/O wait time, in seconds, waiting for wait events.',
   fieldConfig: {
     defaults: {
       color: {
@@ -1133,13 +1107,13 @@ local systemIOWaitTime = {
       refId: 'A',
     },
   ],
-  title: 'System IO Wait TIme',
+  title: 'System I/O wait time',
   type: 'timeseries',
 };
 
 local userIOWaitTime = {
   datasource: promDatasource,
-  description: 'User IO wait time, in seconds, waiting for wait events.',
+  description: 'User I/O wait time, in seconds, waiting for wait events.',
   fieldConfig: {
     defaults: {
       color: {
@@ -1214,7 +1188,7 @@ local userIOWaitTime = {
       refId: 'A',
     },
   ],
-  title: 'User IO Wait TIme',
+  title: 'User I/O wait time',
   type: 'timeseries',
 };
 
@@ -1319,7 +1293,7 @@ local tablespaceSizePanel = {
       refId: 'Max',
     },
   ],
-  title: 'Tablespace Size',
+  title: 'Tablespace size',
   type: 'timeseries',
 };
 
@@ -1357,23 +1331,23 @@ local tablespaceSizePanel = {
             type: 'datasource',
           },
           template.new(
-            name='instance',
-            label='Instance',
-            datasource='$prometheus_datasource',
-            query='label_values(oracledb_up, instance)',
-            current='',
-            refresh=2,
+            'job',
+            promDatasource,
+            query='label_values(oracledb_up, job)',
+            label='Job',
+            refresh='time',
             includeAll=true,
             multi=true,
             allValues='.+',
             sort=1
           ),
           template.new(
-            'job',
-            promDatasource,
-            query='label_values(oracledb_up, job)',
-            label='Job',
-            refresh='time',
+            name='instance',
+            label='Instance',
+            datasource='$prometheus_datasource',
+            query='label_values(oracledb_up, instance)',
+            current='',
+            refresh=2,
             includeAll=true,
             multi=true,
             allValues='.+',

--- a/oracledb-mixin/dashboards/overview.libsonnet
+++ b/oracledb-mixin/dashboards/overview.libsonnet
@@ -1,0 +1,1422 @@
+local grafana = (import 'grafonnet/grafana.libsonnet');
+local dashboard = grafana.dashboard;
+local template = grafana.template;
+local dashboardUid = 'oracledb-overview';
+
+local prometheus = grafana.prometheus;
+local promDatasourceName = 'prometheus_datasource';
+local matcher = 'job=~"$job", instance=~"$instance"';
+
+local promDatasource = {
+  uid: '${%s}' % promDatasourceName,
+};
+
+local lokiDatasource = {
+  uid: '$loki_datasource',
+};
+
+local databaseStatusPanel = {
+  description: 'Database status either Up or Down. Colored to be green when Up or red when Down',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [
+        {
+          options: {
+            '0': {
+              index: 0,
+              text: 'Down',
+            },
+            '1': {
+              index: 1,
+              text: 'OK',
+            },
+          },
+          type: 'value',
+        },
+      ],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'red',
+          },
+          {
+            color: 'green',
+            value: 1,
+          },
+        ],
+      },
+    },
+    overrides: [],
+  },
+  options: {
+    colorMode: 'value',
+    graphMode: 'none',
+    justifyMode: 'auto',
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    textMode: 'auto',
+  },
+  pluginVersion: '9.1.8',
+  targets: [
+    {
+      datasource: promDatasource,
+      editorMode: 'code',
+      expr: 'oracledb_up{job=~"$job", instance=~"$instance"}',
+      legendFormat: '__auto',
+      range: true,
+      refId: 'A',
+    },
+  ],
+  title: 'Database Status',
+  type: 'stat',
+};
+
+local cpuSecondsPanel = {
+  datasource: promDatasource,
+  description: 'Amount of CPU time, in seconds, used by OracleDB over a window.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+  targets: [
+    {
+      datasource: promDatasource,
+      editorMode: 'code',
+      expr: 'increase(process_cpu_seconds_total{instance=~"$instance",job=~"$job"}[$__rate_interval])',
+      legendFormat: '{{instance}}',
+      range: true,
+      refId: 'A',
+    },
+  ],
+  title: 'CPU Seconds',
+  type: 'timeseries',
+};
+
+local virtualMemoryPanel = {
+  datasource: promDatasource,
+  description: 'Used virtual memory overtime.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'bytes',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+  targets: [
+    {
+      datasource: promDatasource,
+      editorMode: 'code',
+      expr: 'process_virtual_memory_bytes{instance=~"$instance",job=~"$job"}',
+      legendFormat: '{{instance}}',
+      range: true,
+      refId: 'A',
+    },
+  ],
+  title: 'Virtual Memory',
+  type: 'timeseries',
+};
+
+local openFdsPanel = {
+  datasource: promDatasource,
+  description: 'Number of open file descriptors and the limit overtime.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+  targets: [
+    {
+      datasource: promDatasource,
+      editorMode: 'code',
+      expr: 'process_open_fds{instance=~"$instance",job=~"$job"}',
+      legendFormat: '{{instance}} - open',
+      range: true,
+      refId: 'OPEN',
+    },
+    {
+      datasource: promDatasource,
+      editorMode: 'code',
+      expr: 'process_max_fds{instance=~"$instance",job=~"$job"}',
+      hide: false,
+      legendFormat: '{{instance}} - limit',
+      range: true,
+      refId: 'MAX',
+    },
+  ],
+  title: 'Open File Descriptors',
+  type: 'timeseries',
+};
+
+local sessionsPanel = {
+  datasource: promDatasource,
+  description: 'Number of sessions and the limit overtime.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'sessions',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+  targets: [
+    {
+      datasource: promDatasource,
+      editorMode: 'code',
+      expr: 'oracledb_resource_current_utilization{instance=~"$instance",job=~"$job",resource_name="sessions"}',
+      legendFormat: '{{instance}} - open',
+      range: true,
+      refId: 'Open',
+    },
+    {
+      datasource: promDatasource,
+      editorMode: 'code',
+      expr: 'oracledb_resource_limit_value{instance=~"$instance",job=~"$job",resource_name="sessions"}',
+      hide: false,
+      legendFormat: '{{instance}} - limit',
+      range: true,
+      refId: 'Limit',
+    },
+  ],
+  title: 'Sessions',
+  type: 'timeseries',
+};
+
+local processPanel = {
+  datasource: promDatasource,
+  description: 'Number of processes and the limit overtime.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'processes',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+  targets: [
+    {
+      datasource: promDatasource,
+      editorMode: 'code',
+      expr: 'oracledb_resource_current_utilization{instance=~"$instance",job=~"$job",resource_name="processes"}',
+      legendFormat: '{{instance}} - current',
+      range: true,
+      refId: 'Current',
+    },
+    {
+      datasource: promDatasource,
+      editorMode: 'code',
+      expr: 'oracledb_resource_limit_value{instance=~"$instance",job=~"$job",resource_name="processes"}',
+      hide: false,
+      legendFormat: '{{instance}} - limit',
+      range: true,
+      refId: 'Limit',
+    },
+  ],
+  title: 'Processes',
+  type: 'timeseries',
+};
+
+local alertLogPanel = {
+  datasource: lokiDatasource,
+  description: 'Recent logs from alert log file',
+  fieldConfig: {
+    defaults: {
+      custom: {
+        align: 'auto',
+        displayMode: 'auto',
+        inspect: false,
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+    },
+    overrides: [],
+  },
+  options: {
+    footer: {
+      fields: '',
+      reducer: [
+        'sum',
+      ],
+      show: false,
+    },
+    showHeader: true,
+  },
+  pluginVersion: '9.1.8',
+  targets: [
+    {
+      datasource: lokiDatasource,
+      editorMode: 'builder',
+      expr: '{filename=~"/u01/base/diag/rdbms/*/*/trace/alert_*.log", instance=~"$instance", job=~"$job"}',
+      queryType: 'range',
+      refId: 'A',
+    },
+  ],
+  title: 'Alert Logs',
+  type: 'table',
+};
+
+local applicationWaitTimePanel = {
+  datasource: promDatasource,
+  description: 'Application wait time, in seconds, waiting for wait events.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 's',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+  targets: [
+    {
+      datasource: promDatasource,
+      editorMode: 'code',
+      expr: 'oracledb_wait_time_application{job=~"$job", instance=~"$instance"}',
+      legendFormat: '__auto',
+      range: true,
+      refId: 'A',
+    },
+  ],
+  title: 'Application Wait Time',
+  type: 'timeseries',
+};
+
+local commitTimePanel = {
+  datasource: promDatasource,
+  description: 'Commit wait time, in seconds, waiting for wait events.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 's',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+  targets: [
+    {
+      datasource: promDatasource,
+      editorMode: 'code',
+      expr: 'oracledb_wait_time_commit{instance=~"$instance",job=~"$job"}',
+      legendFormat: '__auto',
+      range: true,
+      refId: 'A',
+    },
+  ],
+  title: 'Commit Wait Time',
+  type: 'timeseries',
+};
+
+local concurrencyWaitTime = {
+  datasource: promDatasource,
+  description: 'Concurrency wait time, in seconds, waiting for wait events.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 's',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+  targets: [
+    {
+      datasource: promDatasource,
+      editorMode: 'code',
+      expr: 'oracledb_wait_time_concurrency{instance=~"$instance",job=~"$job"}',
+      legendFormat: '__auto',
+      range: true,
+      refId: 'A',
+    },
+  ],
+  title: 'Concurrency Wait Time',
+  type: 'timeseries',
+};
+
+local configurationWaitTime = {
+  datasource: promDatasource,
+  description: 'Configuration wait time, in seconds waiting for wait events.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 's',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+  targets: [
+    {
+      datasource: promDatasource,
+      editorMode: 'code',
+      expr: 'oracledb_wait_time_configuration{instance=~"$instance",job=~"$job"}',
+      legendFormat: '__auto',
+      range: true,
+      refId: 'A',
+    },
+  ],
+  title: 'Configuration Wait Time',
+  type: 'timeseries',
+};
+
+local networkWaitTime = {
+  datasource: promDatasource,
+  description: 'Network wait time, in seconds, waiting for wait events.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 's',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+  targets: [
+    {
+      datasource: promDatasource,
+      editorMode: 'code',
+      expr: 'oracledb_wait_time_network{instance=~"$instance",job=~"$job"}',
+      legendFormat: '__auto',
+      range: true,
+      refId: 'A',
+    },
+  ],
+  title: 'Network Wait Time',
+  type: 'timeseries',
+};
+
+local schedulerWaitTime = {
+  datasource: promDatasource,
+  description: 'Scheduler wait time, in seconds, waiting for wait events.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 's',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+  targets: [
+    {
+      datasource: promDatasource,
+      editorMode: 'code',
+      expr: 'oracledb_wait_time_scheduler{instance=~"$instance",job=~"$job"}',
+      legendFormat: '__auto',
+      range: true,
+      refId: 'A',
+    },
+  ],
+  title: 'Scheduler Wait Time',
+  type: 'timeseries',
+};
+
+local systemIOWaitTime = {
+  datasource: promDatasource,
+  description: 'System IO wait time, in seconds, waiting for wait events.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 's',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+  targets: [
+    {
+      datasource: promDatasource,
+      editorMode: 'code',
+      expr: 'oracledb_wait_time_system_io{instance=~"$instance",job=~"$job"}',
+      legendFormat: '__auto',
+      range: true,
+      refId: 'A',
+    },
+  ],
+  title: 'System IO Wait TIme',
+  type: 'timeseries',
+};
+
+local userIOWaitTime = {
+  datasource: promDatasource,
+  description: 'User IO wait time, in seconds, waiting for wait events.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 's',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+  targets: [
+    {
+      datasource: promDatasource,
+      editorMode: 'code',
+      expr: 'oracledb_wait_time_user_io{instance=~"$instance",job=~"$job"}',
+      legendFormat: '__auto',
+      range: true,
+      refId: 'A',
+    },
+  ],
+  title: 'User IO Wait TIme',
+  type: 'timeseries',
+};
+
+local tablespaceSizePanel = {
+  datasource: promDatasource,
+  description: 'Shows the size overtime for the tablespace.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'bytes',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+  targets: [
+    {
+      datasource: promDatasource,
+      editorMode: 'code',
+      expr: 'oracledb_tablespace_bytes{instance=~"$instance",job=~"$job",tablespace=~"$tablespace"}',
+      legendFormat: '{{instance}} - {{tablespace}} - used',
+      range: true,
+      refId: 'Used Bytes',
+    },
+    {
+      datasource: promDatasource,
+      editorMode: 'code',
+      expr: 'oracledb_tablespace_free{instance=~"$instance",job=~"$job",tablespace=~"$tablespace"}',
+      hide: false,
+      legendFormat: '{{instance}} - {{tablespace}} - free',
+      range: true,
+      refId: 'Free',
+    },
+    {
+      datasource: promDatasource,
+      editorMode: 'code',
+      expr: 'oracledb_tablespace_max_bytes{instance=~"$instance",job=~"$job",tablespace=~"$tablespace"}',
+      hide: false,
+      legendFormat: '{{instance}} - {{tablespace}} - max',
+      range: true,
+      refId: 'Max',
+    },
+  ],
+  title: 'Tablespace Size',
+  type: 'timeseries',
+};
+
+{
+  grafanaDashboards+:: {
+    'oracledb-overview.json':
+      dashboard.new(
+        'OracleDB Overview',
+        time_from='%s' % $._config.dashboardPeriod,
+        editable=true,
+        tags=($._config.dashboardTags),
+        timezone='%s' % $._config.dashboardTimezone,
+        refresh='%s' % $._config.dashboardRefresh,
+        graphTooltip='shared_crosshair',
+        uid=dashboardUid,
+      )
+      .addLink(grafana.link.dashboards(
+        title='Other OracleDB dashboards',
+        includeVars=true,
+        keepTime=true,
+        tags=($._config.dashboardTags),
+      ))
+      .addTemplates(
+        [
+          {
+            hide: 0,
+            label: 'Data source',
+            name: promDatasourceName,
+            query: 'prometheus',
+            refresh: 1,
+            regex: '',
+            type: 'datasource',
+          },
+          {
+            hide: 0,
+            label: 'Loki datasource',
+            name: 'loki_datasource',
+            query: 'loki',
+            refresh: 1,
+            regex: '',
+            type: 'datasource',
+          },
+          template.new(
+            name='instance',
+            label='Instance',
+            datasource='$prometheus_datasource',
+            query='label_values(oracledb_up, instance)',
+            current='',
+            refresh=2,
+            includeAll=true,
+            multi=true,
+            allValues='.+',
+            sort=1
+          ),
+          template.new(
+            'job',
+            promDatasource,
+            query='label_values(oracledb_up, job)',
+            label='Job',
+            refresh='time',
+            includeAll=true,
+            multi=true,
+            allValues='.+',
+            sort=1
+          ),
+          template.new(
+            'job',
+            promDatasource,
+            query='label_values(oracledb_tablespace_bytes, tablespace)',
+            label='Job',
+            refresh='time',
+            includeAll=true,
+            multi=true,
+            allValues='.+',
+            sort=1
+          ),
+        ],
+      )
+      .addPanels(
+        std.flattenArrays([
+          [
+            databaseStatusPanel { gridPos: { h: 4, w: 4, x: 0, y: 0 } },
+            cpuSecondsPanel { gridPos: { h: 4, w: 12, x: 4, y: 0 } },
+            virtualMemoryPanel { gridPos: { h: 4, w: 8, x: 16, y: 0 } },
+          ],
+          [
+            openFdsPanel { gridPos: { h: 6, w: 8, x: 0, y: 4 } },
+            sessionsPanel { gridPos: { h: 6, w: 8, x: 8, y: 4 } },
+            processPanel { gridPos: { h: 6, w: 8, x: 16, y: 4 } },
+          ],
+          [
+            alertLogPanel { gridPos: { h: 7, w: 24, x: 0, y: 10 } },
+          ],
+          [
+            applicationWaitTimePanel { gridPos: { h: 6, w: 6, x: 0, y: 12 } },
+            commitTimePanel { gridPos: { h: 6, w: 6, x: 6, y: 12 } },
+            concurrencyWaitTime { gridPos: { h: 6, w: 6, x: 12, y: 12 } },
+            configurationWaitTime { gridPos: { h: 6, w: 6, x: 18, y: 12 } },
+          ],
+          [
+            networkWaitTime { gridPos: { h: 6, w: 6, x: 0, y: 18 } },
+            schedulerWaitTime { gridPos: { h: 6, w: 6, x: 6, y: 18 } },
+            systemIOWaitTime { gridPos: { h: 6, w: 6, x: 12, y: 18 } },
+            userIOWaitTime { gridPos: { h: 6, w: 6, x: 18, y: 18 } },
+          ],
+          [
+            tablespaceSizePanel { gridPos: { h: 6, w: 24, x: 0, y: 25 } },
+          ],
+        ])
+      ),
+  },
+}

--- a/oracledb-mixin/jsonnetfile.json
+++ b/oracledb-mixin/jsonnetfile.json
@@ -1,0 +1,15 @@
+{
+    "version": 1,
+    "dependencies": [
+        {
+            "source": {
+                "git": {
+                    "remote": "https://github.com/grafana/grafonnet-lib.git",
+                    "subdir": "grafonnet"
+                }
+            },
+            "version": "master"
+        }
+    ],
+    "legacyImports": true
+}

--- a/oracledb-mixin/mixin.libsonnet
+++ b/oracledb-mixin/mixin.libsonnet
@@ -1,0 +1,3 @@
+(import 'alerts/alerts.libsonnet') +
+(import 'dashboards/dashboards.libsonnet') +
+(import 'config.libsonnet')


### PR DESCRIPTION
This adds the following Dashboards for a third party [OracleDB Exporter](https://github.com/iamseth/oracledb_exporter).

### Dashboards

- OracleDB Overview
  - 3 sections
    - General Row (no row  title)
      - Status Panel, CPU Seconds, Virtual Memory Usage
      - Open FDs, Sessions, Processes
      - Alert Logs
    - Wait Time
      - Panels that relate to the impacted wait times of the OracleDB instance  
    - Tablespace
      - Tablespace size related metrics 
 

### Alerts


| Alert                              | Description                                                           | Default Threshold |
| ---------------------------------- | --------------------------------------------------------------------- | ----------------- |
| OracledbReachingSessionLimit       | number of processess being utilized exceeded a theshold.              | 85%               |
| OracledbReachingProcessLimit       | The number of processess being utilized exceeded the threshold.       | 85%               |
| OracledbTablespaceReachingCapacity | A Tablespace is exceeded its threshold of its maximum allotted space. | 85%               |
| OracledbFileDescriptorLimit        | File descriptors usage is reaching its threshold.                     | 85%               |


<details>
<summary> Screenshots </summary>

![image](https://user-images.githubusercontent.com/32067685/210402397-eaa72a1a-dba4-4d61-9f53-120d1fc1e790.png)
![image](https://user-images.githubusercontent.com/32067685/210402482-9841fc0a-afa1-4383-8e98-569a56b3243d.png)

</details>
