### PR TITLE
Fix lint issues with ElasticSearch mixin

### DIFF
--- a/elasticsearch-mixin/.lint
+++ b/elasticsearch-mixin/.lint
@@ -1,0 +1,5 @@
+exclusions:
+  panel-units-rule:
+    reason: Stat panels have no unit, and some panels use custom unit or text
+  panel-title-description-rule:
+    reason: Suppress noisy linting rule until we can address minor tech debt like this

--- a/elasticsearch-mixin/dashboards/elasticsearch-overview.json
+++ b/elasticsearch-mixin/dashboards/elasticsearch-overview.json
@@ -149,7 +149,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "elasticsearch_cluster_health_status{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",color=\"red\"}==1 or (elasticsearch_cluster_health_status{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",color=\"green\"}==1)+4 or (elasticsearch_cluster_health_status{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",color=\"yellow\"}==1)+22",
+          "expr": "elasticsearch_cluster_health_status{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",color=\"red\"}==1 or (elasticsearch_cluster_health_status{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",color=\"green\"}==1)+4 or (elasticsearch_cluster_health_status{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",color=\"yellow\"}==1)+22",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -255,7 +255,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "count(elasticsearch_breakers_tripped{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}>0)",
+          "expr": "count(elasticsearch_breakers_tripped{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}>0)",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 2,
@@ -356,7 +356,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum (elasticsearch_process_cpu_percent{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"} ) / count (elasticsearch_process_cpu_percent{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"} )",
+          "expr": "sum (elasticsearch_process_cpu_percent{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"} ) / count (elasticsearch_process_cpu_percent{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"} )",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -450,7 +450,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum (elasticsearch_jvm_memory_used_bytes{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}) / sum (elasticsearch_jvm_memory_max_bytes{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}) * 100",
+          "expr": "sum (elasticsearch_jvm_memory_used_bytes{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}) / sum (elasticsearch_jvm_memory_max_bytes{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}) * 100",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -545,7 +545,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "elasticsearch_cluster_health_number_of_nodes{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\"}",
+          "expr": "elasticsearch_cluster_health_number_of_nodes{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\"}",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -640,7 +640,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "elasticsearch_cluster_health_number_of_data_nodes{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\"}",
+          "expr": "elasticsearch_cluster_health_number_of_data_nodes{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\"}",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -736,7 +736,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "elasticsearch_cluster_health_number_of_pending_tasks{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\"}",
+          "expr": "elasticsearch_cluster_health_number_of_pending_tasks{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\"}",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -830,7 +830,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum (elasticsearch_process_open_files_count{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"})",
+          "expr": "sum (elasticsearch_process_open_files_count{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"})",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -936,7 +936,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "elasticsearch_cluster_health_active_primary_shards{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\"}",
+          "expr": "elasticsearch_cluster_health_active_primary_shards{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\"}",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 2,
@@ -1030,7 +1030,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "elasticsearch_cluster_health_active_shards{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\"}",
+          "expr": "elasticsearch_cluster_health_active_shards{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\"}",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 2,
@@ -1124,7 +1124,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "elasticsearch_cluster_health_initializing_shards{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\"}",
+          "expr": "elasticsearch_cluster_health_initializing_shards{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\"}",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -1219,7 +1219,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "elasticsearch_cluster_health_relocating_shards{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\"}",
+          "expr": "elasticsearch_cluster_health_relocating_shards{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\"}",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 2,
@@ -1313,7 +1313,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "elasticsearch_cluster_health_delayed_unassigned_shards{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\"} ",
+          "expr": "elasticsearch_cluster_health_delayed_unassigned_shards{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\"} ",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 2,
@@ -1407,7 +1407,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "elasticsearch_cluster_health_unassigned_shards{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\"} ",
+          "expr": "elasticsearch_cluster_health_unassigned_shards{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\"} ",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 2,
@@ -1499,7 +1499,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "irate(elasticsearch_jvm_gc_collection_seconds_count{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$__rate_interval])",
+              "expr": "irate(elasticsearch_jvm_gc_collection_seconds_count{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}[$__rate_interval])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -1610,7 +1610,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "irate(elasticsearch_jvm_gc_collection_seconds_sum{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$__rate_interval])",
+              "expr": "irate(elasticsearch_jvm_gc_collection_seconds_sum{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}[$__rate_interval])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -1729,7 +1729,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "irate(elasticsearch_indices_translog_operations{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$__rate_interval])",
+              "expr": "irate(elasticsearch_indices_translog_operations{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{name}}",
@@ -1828,7 +1828,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "irate(elasticsearch_indices_translog_size_in_bytes{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$__rate_interval])",
+              "expr": "irate(elasticsearch_indices_translog_size_in_bytes{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{name}}",
@@ -1945,7 +1945,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "elasticsearch_breakers_tripped{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}",
+              "expr": "elasticsearch_breakers_tripped{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{name}}: {{breaker}}",
@@ -2046,14 +2046,14 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "elasticsearch_breakers_estimated_size_bytes{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}",
+              "expr": "elasticsearch_breakers_estimated_size_bytes{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{name}}: {{breaker}}",
               "refId": "A"
             },
             {
-              "expr": "elasticsearch_breakers_limit_size_bytes{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}",
+              "expr": "elasticsearch_breakers_limit_size_bytes{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{name}}: limit for {{breaker}}",
@@ -2180,7 +2180,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "elasticsearch_os_load1{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}",
+          "expr": "elasticsearch_os_load1{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -2191,7 +2191,7 @@
           "step": 20
         },
         {
-          "expr": "elasticsearch_os_load5{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}",
+          "expr": "elasticsearch_os_load5{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -2202,7 +2202,7 @@
           "step": 20
         },
         {
-          "expr": "elasticsearch_os_load15{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}",
+          "expr": "elasticsearch_os_load15{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -2314,7 +2314,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "elasticsearch_process_cpu_percent{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}",
+          "expr": "elasticsearch_process_cpu_percent{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -2426,7 +2426,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "elasticsearch_jvm_memory_used_bytes{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}",
+          "expr": "elasticsearch_jvm_memory_used_bytes{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -2436,7 +2436,7 @@
           "step": 20
         },
         {
-          "expr": "elasticsearch_jvm_memory_max_bytes{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}",
+          "expr": "elasticsearch_jvm_memory_max_bytes{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{name}} max: {{area}}",
@@ -2444,7 +2444,7 @@
           "step": 20
         },
         {
-          "expr": "elasticsearch_jvm_memory_pool_peak_used_bytes{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}",
+          "expr": "elasticsearch_jvm_memory_pool_peak_used_bytes{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{name}} peak used pool: {{pool}}",
@@ -2553,7 +2553,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "elasticsearch_jvm_memory_committed_bytes{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}",
+          "expr": "elasticsearch_jvm_memory_committed_bytes{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{name}} committed: {{area}}",
@@ -2561,7 +2561,7 @@
           "step": 20
         },
         {
-          "expr": "elasticsearch_jvm_memory_max_bytes{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}",
+          "expr": "elasticsearch_jvm_memory_max_bytes{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{name}} max: {{area}}",
@@ -2681,7 +2681,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "1-(elasticsearch_filesystem_data_available_bytes{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}/elasticsearch_filesystem_data_size_bytes{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"})",
+              "expr": "1-(elasticsearch_filesystem_data_available_bytes{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}/elasticsearch_filesystem_data_size_bytes{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"})",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -2812,7 +2812,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "irate(elasticsearch_transport_tx_size_bytes_total{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$__rate_interval])",
+              "expr": "irate(elasticsearch_transport_tx_size_bytes_total{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}[$__rate_interval])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -2821,7 +2821,7 @@
               "step": 20
             },
             {
-              "expr": "-irate(elasticsearch_transport_rx_size_bytes_total{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$__rate_interval])",
+              "expr": "-irate(elasticsearch_transport_rx_size_bytes_total{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{name}}: received",
@@ -2951,7 +2951,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "elasticsearch_indices_docs{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}",
+          "expr": "elasticsearch_indices_docs{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -3061,7 +3061,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(elasticsearch_indices_indexing_index_total{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$__rate_interval])",
+          "expr": "irate(elasticsearch_indices_indexing_index_total{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}[$__rate_interval])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -3173,7 +3173,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(elasticsearch_indices_docs_deleted{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$__rate_interval])",
+          "expr": "irate(elasticsearch_indices_docs_deleted{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}[$__rate_interval])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -3283,7 +3283,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(elasticsearch_indices_merges_docs_total{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$__rate_interval])",
+          "expr": "rate(elasticsearch_indices_merges_docs_total{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}[$__rate_interval])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -3393,7 +3393,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(elasticsearch_indices_merges_total_size_bytes_total{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$__rate_interval])",
+          "expr": "irate(elasticsearch_indices_merges_total_size_bytes_total{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}[$__rate_interval])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -3514,7 +3514,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "irate(elasticsearch_indices_search_query_time_seconds{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$__rate_interval]) ",
+              "expr": "irate(elasticsearch_indices_search_query_time_seconds{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}[$__rate_interval]) ",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -3623,7 +3623,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "irate(elasticsearch_indices_indexing_index_time_seconds_total{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$__rate_interval])",
+              "expr": "irate(elasticsearch_indices_indexing_index_time_seconds_total{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}[$__rate_interval])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -3734,7 +3734,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "irate(elasticsearch_indices_merges_total_time_seconds_total{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$__rate_interval])",
+              "expr": "irate(elasticsearch_indices_merges_total_time_seconds_total{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}[$__rate_interval])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -3845,7 +3845,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "irate(elasticsearch_indices_store_throttle_time_seconds_total{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$__rate_interval])",
+              "expr": "irate(elasticsearch_indices_store_throttle_time_seconds_total{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}[$__rate_interval])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -3972,7 +3972,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(elasticsearch_indices_indexing_index_total{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$__rate_interval])",
+              "expr": "rate(elasticsearch_indices_indexing_index_total{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}[$__rate_interval])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -3982,7 +3982,7 @@
               "step": 10
             },
             {
-              "expr": "rate(elasticsearch_indices_search_query_total{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$__rate_interval])",
+              "expr": "rate(elasticsearch_indices_search_query_total{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{name}}: query",
@@ -3990,7 +3990,7 @@
               "step": 10
             },
             {
-              "expr": "rate(elasticsearch_indices_search_fetch_total{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$__rate_interval])",
+              "expr": "rate(elasticsearch_indices_search_fetch_total{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{name}}: fetch",
@@ -3998,7 +3998,7 @@
               "step": 10
             },
             {
-              "expr": "rate(elasticsearch_indices_merges_total{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$__rate_interval])",
+              "expr": "rate(elasticsearch_indices_merges_total{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{name}}: merges",
@@ -4006,7 +4006,7 @@
               "step": 10
             },
             {
-              "expr": "rate(elasticsearch_indices_refresh_total{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$__rate_interval])",
+              "expr": "rate(elasticsearch_indices_refresh_total{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{name}}: refresh",
@@ -4014,7 +4014,7 @@
               "step": 10
             },
             {
-              "expr": "rate(elasticsearch_indices_flush_total{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$__rate_interval])",
+              "expr": "rate(elasticsearch_indices_flush_total{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{name}}: flush",
@@ -4022,7 +4022,7 @@
               "step": 10
             },
             {
-              "expr": "rate(elasticsearch_indices_get_exists_total{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$__rate_interval])",
+              "expr": "rate(elasticsearch_indices_get_exists_total{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{name}}: get_exists",
@@ -4030,7 +4030,7 @@
               "step": 10
             },
             {
-              "expr": "rate(elasticsearch_indices_get_missing_total{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$__rate_interval])",
+              "expr": "rate(elasticsearch_indices_get_missing_total{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{name}}: get_missing",
@@ -4038,7 +4038,7 @@
               "step": 10
             },
             {
-              "expr": "rate(elasticsearch_indices_get_tota{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$__rate_interval])",
+              "expr": "rate(elasticsearch_indices_get_tota{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{name}}: get",
@@ -4046,7 +4046,7 @@
               "step": 10
             },
             {
-              "expr": "rate(elasticsearch_indices_indexing_delete_total{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$__rate_interval])",
+              "expr": "rate(elasticsearch_indices_indexing_delete_total{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{name}}: indexing_delete",
@@ -4155,7 +4155,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "irate(elasticsearch_indices_indexing_index_time_seconds_total{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$__rate_interval])",
+              "expr": "irate(elasticsearch_indices_indexing_index_time_seconds_total{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}[$__rate_interval])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -4165,7 +4165,7 @@
               "step": 10
             },
             {
-              "expr": "irate(elasticsearch_indices_search_query_time_seconds{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$__rate_interval])",
+              "expr": "irate(elasticsearch_indices_search_query_time_seconds{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{name}}: query",
@@ -4173,7 +4173,7 @@
               "step": 10
             },
             {
-              "expr": "irate(elasticsearch_indices_search_fetch_time_seconds{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$__rate_interval])",
+              "expr": "irate(elasticsearch_indices_search_fetch_time_seconds{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{name}}: fetch",
@@ -4181,7 +4181,7 @@
               "step": 10
             },
             {
-              "expr": "irate(elasticsearch_indices_merges_total_time_seconds_total{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$__rate_interval])",
+              "expr": "irate(elasticsearch_indices_merges_total_time_seconds_total{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{name}}: merges",
@@ -4189,7 +4189,7 @@
               "step": 10
             },
             {
-              "expr": "irate(elasticsearch_indices_refresh_time_seconds_total{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$__rate_interval])",
+              "expr": "irate(elasticsearch_indices_refresh_time_seconds_total{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{name}}: refresh",
@@ -4197,7 +4197,7 @@
               "step": 10
             },
             {
-              "expr": "irate(elasticsearch_indices_flush_time_seconds{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$__rate_interval])",
+              "expr": "irate(elasticsearch_indices_flush_time_seconds{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{name}}: flush",
@@ -4205,7 +4205,7 @@
               "step": 10
             },
             {
-              "expr": "irate(elasticsearch_indices_get_exists_time_seconds{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$__rate_interval])",
+              "expr": "irate(elasticsearch_indices_get_exists_time_seconds{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{name}}: get_exists",
@@ -4213,7 +4213,7 @@
               "step": 10
             },
             {
-              "expr": "irate(elasticsearch_indices_get_time_seconds{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$__rate_interval])",
+              "expr": "irate(elasticsearch_indices_get_time_seconds{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{name}}: get_time",
@@ -4221,7 +4221,7 @@
               "step": 10
             },
             {
-              "expr": "irate(elasticsearch_indices_get_missing_time_seconds{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$__rate_interval])",
+              "expr": "irate(elasticsearch_indices_get_missing_time_seconds{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{name}}: get_missing",
@@ -4229,7 +4229,7 @@
               "step": 10
             },
             {
-              "expr": "irate(elasticsearch_indices_indexing_delete_time_seconds_total{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$__rate_interval])",
+              "expr": "irate(elasticsearch_indices_indexing_delete_time_seconds_total{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{name}}: indexing_delete",
@@ -4237,7 +4237,7 @@
               "step": 10
             },
             {
-              "expr": "irate(elasticsearch_indices_get_time_seconds{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$__rate_interval])",
+              "expr": "irate(elasticsearch_indices_get_time_seconds{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{name}}: get",
@@ -4358,7 +4358,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "irate(elasticsearch_thread_pool_rejected_count{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$__rate_interval])",
+              "expr": "irate(elasticsearch_thread_pool_rejected_count{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{name}}: {{ type }}",
@@ -4463,7 +4463,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "elasticsearch_thread_pool_queue_count{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}",
+              "expr": "elasticsearch_thread_pool_active_count{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{name}}: {{ type }}",
@@ -4569,7 +4569,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "elasticsearch_thread_pool_active_count{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}",
+              "expr": "elasticsearch_thread_pool_active_count{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{name}}: {{ type }}",
@@ -4674,7 +4674,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "irate(elasticsearch_thread_pool_completed_count{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$__rate_interval])",
+              "expr": "irate(elasticsearch_thread_pool_completed_count{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{name}}: {{ type }}",
@@ -4799,7 +4799,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "elasticsearch_indices_fielddata_memory_size_bytes{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}",
+              "expr": "elasticsearch_indices_fielddata_memory_size_bytes{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -4910,7 +4910,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(elasticsearch_indices_fielddata_evictions{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$__rate_interval])",
+              "expr": "rate(elasticsearch_indices_fielddata_evictions{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}[$__rate_interval])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -5021,7 +5021,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "elasticsearch_indices_query_cache_memory_size_bytes{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}",
+              "expr": "elasticsearch_indices_query_cache_memory_size_bytes{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -5132,7 +5132,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(elasticsearch_indices_query_cache_evictions{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$__rate_interval])",
+              "expr": "rate(elasticsearch_indices_query_cache_evictions{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}[$__rate_interval])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -5243,7 +5243,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(elasticsearch_indices_filter_cache_evictions{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$__rate_interval])",
+              "expr": "rate(elasticsearch_indices_filter_cache_evictions{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}[$__rate_interval])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -5364,7 +5364,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "elasticsearch_indices_segments_count{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}",
+              "expr": "elasticsearch_indices_segments_count{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{name}}",
@@ -5465,7 +5465,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "elasticsearch_indices_segments_memory_bytes{job=\"$job\",instance=~\"$instance\",cluster=\"$cluster\",name=~\"$name\"}",
+              "expr": "elasticsearch_indices_segments_memory_bytes{job=~\"$job\",instance=~\"$instance\",cluster=~\"$cluster\",name=~\"$name\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{name}}",
@@ -5582,7 +5582,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "elasticsearch_indices_docs_primary{job=\"$job\",instance=~\"$instance\"}",
+              "expr": "elasticsearch_indices_docs_primary{job=~\"$job\",instance=~\"$instance\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -5684,7 +5684,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "elasticsearch_indices_store_size_bytes_primary{job=\"$job\",instance=~\"$instance\"}",
+              "expr": "elasticsearch_indices_store_size_bytes_primary{job=~\"$job\",instance=~\"$instance\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -5786,7 +5786,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "elasticsearch_indices_store_size_bytes_total{job=\"$job\",instance=~\"$instance\"}",
+              "expr": "elasticsearch_indices_store_size_bytes_total{job=~\"$job\",instance=~\"$instance\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -5892,7 +5892,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "elasticsearch_indices_segment_doc_values_memory_bytes_primary{job=\"$job\",instance=~\"$instance\"}",
+              "expr": "elasticsearch_indices_segment_doc_values_memory_bytes_primary{job=~\"$job\",instance=~\"$instance\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{index}}",
@@ -5976,7 +5976,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "elasticsearch_indices_segment_doc_values_memory_bytes_total{job=\"$job\",instance=~\"$instance\"}",
+              "expr": "elasticsearch_indices_segment_doc_values_memory_bytes_total{job=~\"$job\",instance=~\"$instance\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{index}}",
@@ -6088,7 +6088,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "elasticsearch_indices_segment_fields_memory_bytes_primary{job=\"$job\",instance=~\"$instance\"}",
+              "expr": "elasticsearch_indices_segment_fields_memory_bytes_primary{job=~\"$job\",instance=~\"$instance\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{index}}",
@@ -6189,7 +6189,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "elasticsearch_indices_segment_fields_memory_bytes_total{job=\"$job\",instance=~\"$instance\"}",
+              "expr": "elasticsearch_indices_segment_fields_memory_bytes_total{job=~\"$job\",instance=~\"$instance\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{index}}",
@@ -6268,14 +6268,14 @@
         "type": "datasource"
       },
       {
-        "allValue": null,
+        "allValue": ".+",
         "datasource": "$datasource",
         "definition": "label_values(elasticsearch_cluster_health_status, job)",
         "error": null,
         "hide": 0,
         "includeAll": false,
-        "label": null,
-        "multi": false,
+        "label": "job",
+        "multi": true,
         "name": "job",
         "options": [],
         "query": "label_values(elasticsearch_cluster_health_status, job)",
@@ -6290,17 +6290,17 @@
         "useTags": false
       },
       {
-        "allValue": null,
+        "allValue": ".+",
         "datasource": "$datasource",
-        "definition": "label_values(elasticsearch_indices_docs{job=\"$job\"},cluster)",
+        "definition": "label_values(elasticsearch_indices_docs{job=~\"$job\"},cluster)",
         "error": null,
         "hide": 0,
         "includeAll": false,
-        "label": "",
-        "multi": false,
+        "label": "cluster",
+        "multi": true,
         "name": "cluster",
         "options": [],
-        "query": "label_values(elasticsearch_indices_docs{job=\"$job\"},cluster)",
+        "query": "label_values(elasticsearch_indices_docs{job=~\"$job\"},cluster)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -6312,17 +6312,17 @@
         "useTags": false
       },
       {
-        "allValue": null,
+        "allValue": ".+",
         "datasource": "$datasource",
-        "definition": "label_values(elasticsearch_indices_docs{job=\"$job\", cluster=\"$cluster\", name!=\"\"},name)",
+        "definition": "label_values(elasticsearch_indices_docs{job=~\"$job\", cluster=~\"$cluster\", name!=\"\"},name)",
         "error": null,
         "hide": 0,
         "includeAll": true,
-        "label": "",
+        "label": "name",
         "multi": true,
         "name": "name",
         "options": [],
-        "query": "label_values(elasticsearch_indices_docs{job=\"$job\", cluster=\"$cluster\", name!=\"\"},name)",
+        "query": "label_values(elasticsearch_indices_docs{job=~\"$job\", cluster=~\"$cluster\", name!=\"\"},name)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -6334,17 +6334,17 @@
         "useTags": false
       },
       {
-        "allValue": null,
+        "allValue": ".+",
         "datasource": "$datasource",
-        "definition": "label_values(elasticsearch_indices_docs{job=\"$job\",job=\"$job\", cluster=\"$cluster\", name!=\"\"},instance)",
+        "definition": "label_values(elasticsearch_indices_docs{job=~\"$job\",job=~\"$job\", cluster=~\"$cluster\", name!=\"\"},instance)",
         "error": null,
         "hide": 0,
         "includeAll": false,
-        "label": "",
-        "multi": false,
+        "label": "instance",
+        "multi": true,
         "name": "instance",
         "options": [],
-        "query": "label_values(elasticsearch_indices_docs{job=\"$job\", cluster=\"$cluster\", name!=\"\"},instance)",
+        "query": "label_values(elasticsearch_indices_docs{job=~\"$job\", cluster=~\"$cluster\", name!=\"\"},instance)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,


### PR DESCRIPTION
This PR introduces a lint config file and addresses some lint warnings raised by Mixtool:
- Ensure all references to template variables are inclusive regexes rather than exact matches
- Fix allValue for templated vars
- Fix labels for templated vars
- Allow templated vars to be multiselect
