### PR TITLE
Remove compact URL usage

### DIFF
--- a/wso2-enterprise-integrator-mixin/dashboards/Proxy_Service_Metrics.json
+++ b/wso2-enterprise-integrator-mixin/dashboards/Proxy_Service_Metrics.json
@@ -278,7 +278,7 @@
             {
               "targetBlank": false,
               "title": "View Error logs",
-              "url": "explore?orgId=1&left=[\"${__from}\",\"${__to}\",\"Loki\",{\"expr\":\"{service=\\\"{proxy:FaultProxy}\\\",log_level=\\\"ERROR\\\"}\",\"datasource\":\"Loki\"},{\"mode\":\"Logs\"},{\"ui\":[true,true,true,\"none\"]}]"
+              "url": "explore?orgId=1&left={\"datasource\":\"Loki\",\"queries\":[{\"expr\":\"{service=\\\"{proxy:FaultProxy}\\\",log_level=\\\"ERROR\\\"}\",\"datasource\":\"Loki\",\"refId\":\"A\"}],\"range\":{\"from\":\"${__from}\",\"to\":\"${__to}\"}}"
             }
           ],
           "mappings": [


### PR DESCRIPTION
The Explore team is seeking to deprecate the compact URL format. That format allowed parameters to be passed into the explore URL as an array in a specific order. Due to the increasing number of parameters, this was not going to be a workable, future forward format. This removes the one use of compact URLs from this repository. Search parameters were `orgId=1&left=%5B` and `orgId=1&left=[`