### PR TITLE
Decapitalize overview in oracledb-mixin

### DIFF
--- a/oracledb-mixin/README.md
+++ b/oracledb-mixin/README.md
@@ -40,8 +40,7 @@ OracleDB alert logs are enabled by default in the `config.libsonnet` and can be 
 
 Alert logs are generally located at `$ORACLE_HOME/diag/rdbms/*/*/trace/alert_*.log` but please follow [the official documentation](http://www.dba-oracle.com/t_alert_log_location.htm) to determine the location specific to respective installs.
 
-![First screenshot of the overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/oracledb/screenshots/oracledb_overview_1.png)
-![Second screenshot of the overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/oracledb/screenshots/oracledb_overview_2.png)
+![Screenshot of the overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/oracledb/screenshots/oracledb_overview.png)
 
 ## Install tools
 

--- a/oracledb-mixin/dashboards/overview.libsonnet
+++ b/oracledb-mixin/dashboards/overview.libsonnet
@@ -1051,7 +1051,7 @@ local tablespaceSizePanel = {
   grafanaDashboards+:: {
     'oracledb-overview.json':
       dashboard.new(
-        'OracleDB Overview',
+        'OracleDB overview',
         time_from='%s' % $._config.dashboardPeriod,
         editable=true,
         tags=($._config.dashboardTags),


### PR DESCRIPTION
Duplicate of #911 

According to this https://grafana.com/docs/writers-toolkit/style-guide/ux-writing/#use-sentence-case-in-ui-elements the title should be `OracleDB overview`

> Use sentence case in UI elements
Capitalize only the first word in the title, the first word in a subheading after a colon, and any proper nouns