### PR TITLE
traefik-mixin: dashboard fixes for interval and hardcoded service names

### DIFF
--- a/traefik-mixin/dashboards/traefikdash.json
+++ b/traefik-mixin/dashboards/traefikdash.json
@@ -1449,7 +1449,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "sum by (service) (increase(traefik_service_requests_total{job=~\"$job\", instance=~\"$instance\", service=~\".*grafana@.*|prometheus.*|gitea.*\"}[$__interval])) > 0",
+          "expr": "sum by (service) (increase(traefik_service_requests_total{job=~\"$job\", instance=~\"$instance\", service=~\"$service\"}[$__interval])) > 0",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,


### PR DESCRIPTION
This fixes both issues #915 and #916.