### PR TITLE
nginx-directory: Add optional help text

### DIFF
--- a/nginx-directory/files/help.html
+++ b/nginx-directory/files/help.html
@@ -1,0 +1,1 @@
+<span class="help" title="%(help)s">?</span>

--- a/nginx-directory/files/index.html
+++ b/nginx-directory/files/index.html
@@ -1,5 +1,16 @@
 <html>
-  <head><title>%(title)s</title></head>
+  <head>
+    <style>
+      .help {
+        color: grey;
+        font-size: 50%%; 
+        text-decoration-line: underline;
+        text-decoration-style: dashed;
+        vertical-align: super;
+      }
+    </style>
+    <title>%(title)s</title>
+  </head>
   <body>
     <h1>%(title)s</h1>
     <ul>

--- a/nginx-directory/files/link.html
+++ b/nginx-directory/files/link.html
@@ -1,1 +1,1 @@
-<li><a href="/%(path)s%(params)s">%(title)s</a></li>
+<li><a href="/%(path)s%(params)s">%(title)s</a>%(helptext)s</li>

--- a/nginx-directory/link_data.libsonnet
+++ b/nginx-directory/link_data.libsonnet
@@ -1,6 +1,7 @@
 function(services, sorted=false) {
   link_stanzas: [
-    (importstr 'files/link.html') % (service)
+    local help = if std.objectHas(service, 'help') then (importstr 'files/help.html') % service else '';
+    (importstr 'files/link.html') % (service { helptext: help })
     for service in (if sorted then std.sort(services, function(s) s.title) else services)
     // adding a "hidden" field set to true will cause the link to not be rendered in HTML
     if !(std.objectHas(service, 'hidden') && service.hidden == true)


### PR DESCRIPTION
Sometimes you might want to add additonal information beyond the link text to tell people what a service is. Let services specify a `help` element and render that as a superscript "?" tooltip, if present.