### PR TITLE
MSSQL mixin: Set min & max on "Buffer cache hit percentage" panel.

### DIFF
--- a/mssql-mixin/dashboards/mssql-pages.libsonnet
+++ b/mssql-mixin/dashboards/mssql-pages.libsonnet
@@ -136,6 +136,8 @@ local bufferCacheHitPercentagePanel = {
         },
       },
       mappings: [],
+      max: 100,
+      min: 0,
       thresholds: {
         mode: 'absolute',
         steps: [


### PR DESCRIPTION
* Adds a range of 0-100 on the "Buffer cache hit percentage" panel to make the display match the bounds of the value.

This was already present in the screenshot of the dashboard, but the change seemed to get dropped at some point on my end.