### PR TITLE
memcached: Relabel Reads/Writes to Received/Transmitted

### DIFF
--- a/memcached-mixin/dashboards.libsonnet
+++ b/memcached-mixin/dashboards.libsonnet
@@ -80,12 +80,12 @@ local g = (import 'grafana-builder/grafana.libsonnet');
           ])
         )
         .addPanel(
-          g.panel('Reads') +
+          g.panel('Bytes received') +
           g.queryPanel('sum by(instance) (rate(memcached_read_bytes_total{' + $._config.clusterLabel + '=~"$cluster", job=~"$job", instance=~"$instance"}[$__rate_interval]))', '{{instance}}') +
           { yaxes: g.yaxes('bps') },
         )
         .addPanel(
-          g.panel('Writes') +
+          g.panel('Bytes transmitted') +
           g.queryPanel('sum by(instance) (rate(memcached_written_bytes_total{' + $._config.clusterLabel + '=~"$cluster", job=~"$job", instance=~"$instance"}[$__rate_interval]))', '{{instance}}') +
           { yaxes: g.yaxes('bps') },
         )


### PR DESCRIPTION
When talking about a cache server, creating panels based on the number of bytes read from and written to the network is deceptive since:

* When an application reads from the cache, the cache writes bytes to the network.
* When an application writes to the cache, the cache reads bytes from the network.

Changing the panels to "received" and "transmitted" avoids this ambiguity.

Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>