### PR TITLE
Use redis:6.0 images

### DIFF
--- a/redis/images.libsonnet
+++ b/redis/images.libsonnet
@@ -1,7 +1,7 @@
 {
   _images+:: {
-    redis: 'bitnami/redis:6.2',  // https://hub.docker.com/r/bitnami/redis/
-    redis_sentinel: 'bitnami/redis-sentinel:6.2',  // https://hub.docker.com/r/bitnami/redis-sentinel/
+    redis: 'bitnami/redis:6.0-debian-11',  // https://hub.docker.com/r/bitnami/redis/
+    redis_sentinel: 'bitnami/redis-sentinel:6.0-debian-11',  // https://hub.docker.com/r/bitnami/redis-sentinel/
     redis_exporter: 'oliver006/redis_exporter:latest',
   },
 }


### PR DESCRIPTION
When I open-sourced this library I updated redis image to the latest
minor one, 6.2, but that image doesn't have a curl binary anymore, which
makes it impossible to run the init.sh script.

This downgrades the version to a tested 6.0 which runs properly.

Signed-off-by: Oleg Zaytsev <mail@olegzaytsev.com>
