### PR TITLE
Fix redis by using official image

### DIFF
--- a/redis/files/init.sh
+++ b/redis/files/init.sh
@@ -193,6 +193,8 @@ get_pod_ip() {
 }
 
 install_kubectl() {
+  echo "Installing curl"
+  apt update && apt install -y curl
   echo "Installing kubectl"
   curl -L https://storage.googleapis.com/kubernetes-release/release/v"$KUBECTL_VERSION"/bin/linux/amd64/kubectl -o /k8s/kubectl
   chmod +x /k8s/kubectl

--- a/redis/images.libsonnet
+++ b/redis/images.libsonnet
@@ -1,7 +1,8 @@
 {
   _images+:: {
-    redis: 'bitnami/redis:6.2',  // https://hub.docker.com/r/bitnami/redis/
-    redis_sentinel: 'bitnami/redis-sentinel:6.2',  // https://hub.docker.com/r/bitnami/redis-sentinel/
+    // We use a bullseye image so we can install a curl in init.sh.
+    // We use the same image for redis-sentinel by running `redis-server --sentinal`
+    redis: 'redis:6.2-bullseye',
     redis_exporter: 'oliver006/redis_exporter:latest',
   },
 }

--- a/redis/statefulset.libsonnet
+++ b/redis/statefulset.libsonnet
@@ -101,7 +101,7 @@ local k = import 'ksonnet-util/kausal.libsonnet';
     }),
 
   redis_sentinel_container::
-    container.new('redis-sentinel', $._images.redis_sentinel) +
+    container.new('redis-sentinel', $._images.redis) +
     container.withVolumeMounts(
       [
         mount.new('etcredis', '/etc/redis'),
@@ -119,7 +119,7 @@ local k = import 'ksonnet-util/kausal.libsonnet';
     container.withEnvMixin([
       envVar.fromSecretRef('REDIS_PASSWORD', $.redis_secrets_name, $.redis_secrets_key),
     ]) +
-    container.withCommand(['redis-sentinel', '/etc/redis/sentinel.conf']) +
+    container.withCommand(['redis-server', '/etc/redis/sentinel.conf', '--sentinel']) +
     container.mixin.livenessProbe.exec.withCommand([
       '/bin/sh',
       '-c',


### PR DESCRIPTION
The official redis:6.2-bullseye library allows us to install `curl`, opposed to bitnami/redis. There's no redis-sentinel image, but as docs say, you can run redis-sentinel by just running `redis-server --sentinel`.

This is a better approach than #927 as we don't have to rely on an outdated version.

Signed-off-by: Oleg Zaytsev <mail@olegzaytsev.com>
