### PR TITLE
Redis: make resources configurable

### DIFF
--- a/redis/config.libsonnet
+++ b/redis/config.libsonnet
@@ -8,6 +8,14 @@
       replicas: 3,
       down_after_milliseconds: 15000,
       diskSize: '50Gi',
+      requests: {
+        cpu: '100m',
+        memory: '512Mi',
+      },
+      limits: {
+        cpu: null,
+        memory: '2Gi',
+      },
       timeout: 0,
       clientOutputBufferLimits: {
         normal: {

--- a/redis/statefulset.libsonnet
+++ b/redis/statefulset.libsonnet
@@ -91,14 +91,8 @@ local k = import 'ksonnet-util/kausal.libsonnet';
       '-c',
       'redis-cli -p %(port)d ping' % $._config.redis,
     ]) +
-    container.mixin.resources.withLimitsMixin({
-      memory: '2Gi',
-      cpu: '500m',
-    }) +
-    container.mixin.resources.withRequestsMixin({
-      memory: '1Gi',
-      cpu: '100m',
-    }),
+    container.mixin.resources.withLimitsMixin($._config.redis.limits) +
+    container.mixin.resources.withRequestsMixin($._config.redis.requests),
 
   redis_sentinel_container::
     container.new('redis-sentinel', $._images.redis_sentinel) +


### PR DESCRIPTION
Instead of having to manually override the container requests, this
makes the resources manually configurable.

Also lowers the default requests/limits to some more conservative
numbers.
Signed-off-by: Oleg Zaytsev <mail@olegzaytsev.com>
