### PR TITLE
WSO2 Enterprise Integrator: Removing Compact Link from dashboard

### DIFF
--- a/wso2-enterprise-integrator-mixin/dashboards/Proxy_Service_Metrics.json
+++ b/wso2-enterprise-integrator-mixin/dashboards/Proxy_Service_Metrics.json
@@ -271,16 +271,10 @@
     },
     {
       "datasource": "$datasource",
-      "description": "Displays all time error count occurred within this proxy service. Use below link to visit error logs for this service for this time period",
+      "description": "Displays all time error count occurred within this proxy service.",
       "fieldConfig": {
         "defaults": {
-          "links": [
-            {
-              "targetBlank": false,
-              "title": "View Error logs",
-              "url": "explore?orgId=1&left=[\"${__from}\",\"${__to}\",\"Loki\",{\"expr\":\"{service=\\\"{proxy:FaultProxy}\\\",log_level=\\\"ERROR\\\"}\",\"datasource\":\"Loki\"},{\"mode\":\"Logs\"},{\"ui\":[true,true,true,\"none\"]}]"
-            }
-          ],
+          "links": [],
           "mappings": [
             {
               "options": {


### PR DESCRIPTION
Removing this link since it is a leftover from the community dashboard, and this link format (compact) is not supported anymore.