### PR TITLE
Add expectation that apache-cassandra mixin logs panel will work with the rest of the matchers

### DIFF
--- a/apache-cassandra/README.md
+++ b/apache-cassandra/README.md
@@ -43,12 +43,25 @@ Cassandra system logs are enabled by default in the `config.libsonnet` and can b
 }
 ```
 
+In order for the selectors to properly work for system logs ingested into your logs datasource, please also include the matching `instance`, `job`, and `cluster` labels onto the [scrape_configs](https://grafana.com/docs/loki/latest/clients/promtail/configuration/#scrape_configs) as to match the labels for ingested metrics.
+
+```yaml
+scrape_configs:
+  - job_name: integrations/apache-cassandra
+    static_configs:
+      - targets: [localhost]
+        labels:
+          job: integrations/apache-cassandra
+          instance: '<your-instance-name>'
+          cluster: '<your-cluster-name>'
+          __path__: /var/log/cassandra/system.log
+```
+
 ## Apache Cassandra Keyspaces
 
 The Apache Cassandra keyspaces dashboard provides details on number and latency of Writes/Reads, Disk space used, number of pending compactions, and size of the largest table partition for a selected keyspace.
 
 ![Screenshot of the Apache Cassandra keyspaces dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-cassandra/screenshots/keyspaces_1.png)
-
 
 ## Extendable Configuration
 
@@ -65,14 +78,14 @@ The configuration for this mixin also supports adding expected `rack` and `datac
 
 ## Alerts Overview
 
-HighReadLatency: There is a high level of read latency within the node.
-HighWriteLatency: There is a high level of write latency within the node.
-HighPendingCompactionTasks: Compaction task queue is filling up.
-BlockedCompactionTasksFound: Compaction task queue is full.
-HintsStoredOnNode: Hints have been recently written to this node.
-UnavailableWriteRequestsFound: Unavailable exceptions have been encountered while performing writes in this cluster.
-HighCpuUsage: A node has a CPU usage higher than the configured threshold.
-HighMemoryUsage: A node has a higher memory utilization than the configured threshold.
+- HighReadLatency: There is a high level of read latency within the node.
+- HighWriteLatency: There is a high level of write latency within the node.
+- HighPendingCompactionTasks: Compaction task queue is filling up.
+- BlockedCompactionTasksFound: Compaction task queue is full.
+- HintsStoredOnNode: Hints have been recently written to this node.
+- UnavailableWriteRequestsFound: Unavailable exceptions have been encountered while performing writes in this cluster.
+- HighCpuUsage: A node has a CPU usage higher than the configured threshold.
+- HighMemoryUsage: A node has a higher memory utilization than the configured threshold.
 
 ## Install tools
 

--- a/apache-cassandra/dashboards/cassandra-nodes.libsonnet
+++ b/apache-cassandra/dashboards/cassandra-nodes.libsonnet
@@ -1312,13 +1312,13 @@ local crossnodeLatencyPanel(matcher) = {
   },
 };
 
-local systemLogsPanel = {
+local systemLogsPanel(matcher) = {
   datasource: lokiDatasource,
   targets: [
     {
       datasource: lokiDatasource,
       editorMode: 'code',
-      expr: '{filename="/var/log/cassandra/system.log", job=~"$job"} |= ``',
+      expr: '{filename="/var/log/cassandra/system.log", ' + matcher + '} |= ``',
       queryType: 'range',
       refId: 'A',
     },
@@ -1464,7 +1464,7 @@ local getMatcher(cfg) = 'job=~"$job", cluster=~"$cluster", instance=~"$instance"
             crossnodeLatencyPanel(getMatcher($._config)) { gridPos: { h: 6, w: 8, x: 16, y: 30 } },
           ],
           if $._config.enableLokiLogs then [
-            systemLogsPanel { gridPos: { h: 6, w: 24, x: 0, y: 36 } },
+            systemLogsPanel(getMatcher($._config)) { gridPos: { h: 6, w: 24, x: 0, y: 36 } },
           ] else [],
         ])
       ),


### PR DESCRIPTION
Expecting people using the integration to have a logs_scrape configuration of this, this was missed when i first implemented the mixin, sorry about that! 

```yaml
 scrape_configs:
    - job_name: integrations/apache-cassandra
      static_configs:
        - targets: [localhost] 
          labels:
            job: integrations/apache-cassandra
            instance: '<your-instance-name>' # <node1>:9000
            cluster: '<your-cluster-name>'
            __path__: /var/log/cassandra/system.log

```