### PR TITLE
Fix node-exporter-full dashboard name conflict

### DIFF
--- a/prometheus-ksonnet/mixins.libsonnet
+++ b/prometheus-ksonnet/mixins.libsonnet
@@ -81,7 +81,7 @@
 
     // A more complete view than the node_exporter
     node_exporter_full: {
-      grafanaDashboardFolder: 'node_exporter_full',
+      grafanaDashboardFolder: 'node_exporter',
       grafanaDashboards+:: {
         'node-exporter-full.json': (import 'github.com/rfrail3/grafana-dashboards/prometheus/node-exporter-full.json'),
       },


### PR DESCRIPTION
Dashboard is currently failing to load on our Grafana instances due to a naming conflict:
> logger=provisioning.dashboard type=file name=dashboards-node-exporter-full t=2023-03-10T00:26:34.785401393Z level=error msg="failed to save dashboard" file=/grafana/dashboards-node-exporter-full/dashboards-node-exporter-full-0/node-exporter-full.json error="**Dashboard name cannot be the same as folder**"

Lets move the dashboard into the same `node_exporter` folder as the other node-exporter dashboards.

I've confirmed this works as expected:
<img width="1184" alt="Screenshot 2023-03-09 at 4 44 10 PM" src="https://user-images.githubusercontent.com/23463959/224194332-5695255e-5b57-44bc-a33a-1c8b39ac98e2.png">
