### PR TITLE
Adds the Apache CouchDB mixin

### DIFF
--- a/apache-couchdb-mixin/.lint
+++ b/apache-couchdb-mixin/.lint
@@ -1,0 +1,13 @@
+exclusions:
+  template-job-rule:
+    reason: "Prometheus datasource variable is being named as prometheus_datasource now while linter expects 'datasource'"
+  panel-datasource-rule:
+    reason: "Loki datasource variable is being named as loki_datasource now while linter expects 'datasource'"
+  template-datasource-rule:
+    reason: "Based on new convention we are using variable names prometheus_datasource and loki_datasource where as linter expects 'datasource'"
+  template-instance-rule:
+    reason: "Based on new convention we are using variable names prometheus_datasource and loki_datasource where as linter expects 'datasource'"
+  target-instance-rule:
+    reason: "The dashboard is a 'cluster' dashboard where the instance refers to nodes, this dashboard focuses only on the cluster view."
+    entries:
+    - dashboard: "Apache CouchDB overview"

--- a/apache-couchdb-mixin/.lint
+++ b/apache-couchdb-mixin/.lint
@@ -11,3 +11,19 @@ exclusions:
     reason: "The dashboard is a 'cluster' dashboard where the instance refers to nodes, this dashboard focuses only on the cluster view."
     entries:
     - dashboard: "Apache CouchDB overview"
+  panel-units-rule:
+    reason: "Custom units are used for better user experience in these panels"
+    entries:
+    - panel: "Number of clusters"
+    - panel: "Number of nodes"
+    - panel: "Cluster health"
+    - panel: "Open OS files"
+    - panel: "Open databases"
+    - panel: "Replicator changes manager deaths"
+    - panel: "Replicator changes queue deaths"
+    - panel: "Replicator changes reader deaths"
+    - panel: "Replicator connection owner crashes"
+    - panel: "Replicator connection worker crashes"
+    - panel: "Replicator job crashes"
+    - panel: "Replicator jobs pending"
+    - panel: "Log types"

--- a/apache-couchdb-mixin/Makefile
+++ b/apache-couchdb-mixin/Makefile
@@ -1,0 +1,34 @@
+JSONNET_FMT := jsonnetfmt -n 2 --max-blank-lines 1 --string-style s --comment-style s
+
+.PHONY: all
+all: build dashboards_out prometheus_alerts.yaml
+
+vendor: jsonnetfile.json
+	jb install
+
+.PHONY: build
+build: vendor
+
+.PHONY: fmt
+fmt:
+	find . -name 'vendor' -prune -o -name '*.libsonnet' -print -o -name '*.jsonnet' -print | \
+		xargs -n 1 -- $(JSONNET_FMT) -i
+
+.PHONY: lint
+lint: build
+	find . -name 'vendor' -prune -o -name '*.libsonnet' -print -o -name '*.jsonnet' -print | \
+		while read f; do \
+			$(JSONNET_FMT) "$$f" | diff -u "$$f" -; \
+		done
+	mixtool lint mixin.libsonnet
+
+dashboards_out: mixin.libsonnet config.libsonnet $(wildcard dashboards/*)
+	@mkdir -p dashboards_out
+	mixtool generate dashboards mixin.libsonnet -d dashboards_out
+
+prometheus_alerts.yaml: mixin.libsonnet alerts/*.libsonnet
+	mixtool generate alerts mixin.libsonnet -a prometheus_alerts.yaml
+
+.PHONY: clean
+clean:
+	rm -rf dashboards_out prometheus_alerts.yaml

--- a/apache-couchdb-mixin/README.md
+++ b/apache-couchdb-mixin/README.md
@@ -1,4 +1,4 @@
-# Apache Cassandra Mixin
+# Apache CouchDB Mixin
 
 The Apache CouchDB mixin is a set of configurable Grafana dashboards and alerts.
 
@@ -29,7 +29,7 @@ The Apache CouchDB overview dashboard provides details on number of clusters and
 
 ## Apache CouchDB Nodes
 
-The Apache CouchDB nodes dashboard provides details on memory usage, open OS files, open databases, database reads and writes, view info, request info (rate, latency, status code info), log type breakdown, and logs for a specific node in the cluster. To get CouchDB system logs, [Promtail and Loki needs to be installed](https://grafana.com/docs/loki/latest/installation/) and provisioned for logs with your Grafana instance. The default Cassandra system log path is `/var/log/couchdb/couchdb.log` on Linux.
+The Apache CouchDB nodes dashboard provides details on memory usage, open OS files, open databases, database reads and writes, view info, request info (rate, latency, status code info), log type breakdown, and logs for a specific node in the cluster. To get CouchDB system logs, [Promtail and Loki needs to be installed](https://grafana.com/docs/loki/latest/installation/) and provisioned for logs with your Grafana instance. The default CouchDB system log path is `/var/log/couchdb/couchdb.log` on Linux.
 
 ![First screenshot of the Apache CouchDB nodes dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-couchdb/screenshots/nodes_1.png)
 ![Second screenshot of the Apache CouchDB nodes dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-couchdb/screenshots/nodes_2.png)

--- a/apache-couchdb-mixin/README.md
+++ b/apache-couchdb-mixin/README.md
@@ -9,15 +9,15 @@ The Apache CouchDB mixin contains the following dashboards:
 
 and the following alerts:
 
-- CouchDbHigh4xxResponseCodes
-- CouchDbHigh5xxResponseCodes
-- CouchDbModerateRequestLatency
-- CouchDbHighRequestLatency
-- CouchDbManyReplicatorJobsPending
-- CouchDbReplicatorJobsCrashing
-- CouchDbReplicatorChangesQueuesDying
-- CouchDbReplicatorConnectionOwnersCrashing
-- CouchDbReplicatorConnectionWorkersCrashing
+- CouchDBHigh4xxResponseCodes
+- CouchDBHigh5xxResponseCodes
+- CouchDBModerateRequestLatency
+- CouchDBHighRequestLatency
+- CouchDBManyReplicatorJobsPending
+- CouchDBReplicatorJobsCrashing
+- CouchDBReplicatorChangesQueuesDying
+- CouchDBReplicatorConnectionOwnersCrashing
+- CouchDBReplicatorConnectionWorkersCrashing
 
 ## Apache CouchDB Overview
 
@@ -60,15 +60,15 @@ scrape_configs:
 
 ## Alerts Overview
 
-- CouchDbHigh4xxResponseCodes: There are a high number of 4xx responses for incoming requests to a node.
-- CouchDbHigh5xxResponseCodes: There are a high number of 5xx responses for incoming requests to a node.
-- CouchDbModerateRequestLatency: There is a moderate level of request latency for a node.
-- CouchDbHighRequestLatency: There is a high level of request latency for a node.
-- CouchDbManyReplicatorJobsPending: There is a high number of replicator jobs pending for a node.
-- CouchDbReplicatorJobsCrashing: There are replicator jobs crashing for a node.
-- CouchDbReplicatorChangesQueuesDying: There are replicator changes queue process deaths for a node.
-- CouchDbReplicatorConnectionOwnersCrashing: There are replicator connection owner process crashes for a node.
-- CouchDbReplicatorConnectionWorkersCrashing: There are replicator connection worker process crashes for a node.
+- CouchDBHigh4xxResponseCodes: There are a high number of 4xx responses for incoming requests to a node.
+- CouchDBHigh5xxResponseCodes: There are a high number of 5xx responses for incoming requests to a node.
+- CouchDBModerateRequestLatency: There is a moderate level of request latency for a node.
+- CouchDBHighRequestLatency: There is a high level of request latency for a node.
+- CouchDBManyReplicatorJobsPending: There is a high number of replicator jobs pending for a node.
+- CouchDBReplicatorJobsCrashing: There are replicator jobs crashing for a node.
+- CouchDBReplicatorChangesQueuesDying: There are replicator changes queue process deaths for a node.
+- CouchDBReplicatorConnectionOwnersCrashing: There are replicator connection owner process crashes for a node.
+- CouchDBReplicatorConnectionWorkersCrashing: There are replicator connection worker process crashes for a node.
 
 ## Install tools
 

--- a/apache-couchdb-mixin/README.md
+++ b/apache-couchdb-mixin/README.md
@@ -1,0 +1,101 @@
+# Apache Cassandra Mixin
+
+The Apache CouchDB mixin is a set of configurable Grafana dashboards and alerts.
+
+The Apache CouchDB mixin contains the following dashboards:
+
+- Apache CouchDB overview
+- Apache CouchDB nodes
+
+and the following alerts:
+
+- CouchDbHigh4xxResponseCodes
+- CouchDbHigh5xxResponseCodes
+- CouchDbModerateRequestLatency
+- CouchDbHighRequestLatency
+- CouchDbManyReplicatorJobsPending
+- CouchDbReplicatorJobsCrashing
+- CouchDbReplicatorChangesQueuesDying
+- CouchDbReplicatorConnectionOwnersCrashing
+- CouchDbReplicatorConnectionWorkersCrashing
+
+## Apache CouchDB Overview
+
+The Apache CouchDB overview dashboard provides details on number of clusters and nodes per cluster, open OS files, open databases, database reads and writes, view info, request info (rate, latency, status code info), and replicator failure info for a CouchDB cluster.
+
+![First screenshot of the Apache CouchDB overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-couchdb/screenshots/overview_1.png)
+![Second screenshot of the Apache CouchDB overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-couchdb/screenshots/overview_2.png)
+![Third screenshot of the Apache CouchDB overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-couchdb/screenshots/overview_3.png)
+
+## Apache CouchDB Nodes
+
+The Apache CouchDB nodes dashboard provides details on memory usage, open OS files, open databases, database reads and writes, view info, request info (rate, latency, status code info), log type breakdown, and logs for a specific node in the cluster. To get CouchDB system logs, [Promtail and Loki needs to be installed](https://grafana.com/docs/loki/latest/installation/) and provisioned for logs with your Grafana instance. The default Cassandra system log path is `/var/log/couchdb/couchdb.log` on Linux.
+
+![First screenshot of the Apache CouchDB nodes dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-couchdb/screenshots/nodes_1.png)
+![Second screenshot of the Apache CouchDB nodes dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-couchdb/screenshots/nodes_2.png)
+
+CouchDB system logs are enabled by default in the `config.libsonnet` and can be removed by setting `enableLokiLogs` to `false`. Then run `make` again to regenerate the dashboard:
+
+```
+{
+  _config+:: {
+    enableLokiLogs: false,
+  },
+}
+```
+
+In order for the selectors to properly work for system logs ingested into your logs datasource, please also include the matching `instance`, `job`, and `cluster` labels onto the [scrape_configs](https://grafana.com/docs/loki/latest/clients/promtail/configuration/#scrape_configs) as to match the labels for ingested metrics.
+
+```yaml
+scrape_configs:
+  - job_name: integrations/apache-couchdb
+    static_configs:
+      - targets: [localhost]
+        labels:
+          job: integrations/apache-couchdb
+          instance: '<your-instance-name>'
+          cluster: '<your-cluster-name>'
+          __path__: /var/log/couchdb/couchdb.log
+```
+
+## Alerts Overview
+
+- CouchDbHigh4xxResponseCodes: There are a high number of 4xx responses for incoming requests to a node.
+- CouchDbHigh5xxResponseCodes: There are a high number of 5xx responses for incoming requests to a node.
+- CouchDbModerateRequestLatency: There is a moderate level of request latency for a node.
+- CouchDbHighRequestLatency: There is a high level of request latency for a node.
+- CouchDbManyReplicatorJobsPending: There is a high number of replicator jobs pending for a node.
+- CouchDbReplicatorJobsCrashing: There are replicator jobs crashing for a node.
+- CouchDbReplicatorChangesQueuesDying: There are replicator changes queue process deaths for a node.
+- CouchDbReplicatorConnectionOwnersCrashing: There are replicator connection owner process crashes for a node.
+- CouchDbReplicatorConnectionWorkersCrashing: There are replicator connection worker process crashes for a node.
+
+## Install tools
+
+```bash
+go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@latest
+go install github.com/monitoring-mixins/mixtool/cmd/mixtool@latest
+```
+
+For linting and formatting, you would also need `jsonnetfmt` installed. If you
+have a working Go development environment, it's easiest to run the following:
+
+```bash
+go install github.com/google/go-jsonnet/cmd/jsonnetfmt@latest
+```
+
+The files in `dashboards_out` need to be imported
+into your Grafana server. The exact details will be depending on your environment.
+
+`prometheus_alerts.yaml` needs to be imported into Prometheus.
+
+## Generate dashboards and alerts
+
+Edit `config.libsonnet` if required and then build JSON dashboard files for Grafana:
+
+```bash
+make
+```
+
+For more advanced uses of mixins, see
+https://github.com/monitoring-mixins/docs.

--- a/apache-couchdb-mixin/README.md
+++ b/apache-couchdb-mixin/README.md
@@ -9,6 +9,7 @@ The Apache CouchDB mixin contains the following dashboards:
 
 and the following alerts:
 
+- CouchDBUnhealthyCluster
 - CouchDBHigh4xxResponseCodes
 - CouchDBHigh5xxResponseCodes
 - CouchDBModerateRequestLatency
@@ -60,6 +61,7 @@ scrape_configs:
 
 ## Alerts Overview
 
+- CouchDBUnhealthyCluster: At least one of the nodes in a cluster is reporting the cluster as being unstable.
 - CouchDBHigh4xxResponseCodes: There are a high number of 4xx responses for incoming requests to a node.
 - CouchDBHigh5xxResponseCodes: There are a high number of 5xx responses for incoming requests to a node.
 - CouchDBModerateRequestLatency: There is a moderate level of request latency for a node.

--- a/apache-couchdb-mixin/README.md
+++ b/apache-couchdb-mixin/README.md
@@ -24,16 +24,15 @@ and the following alerts:
 
 The Apache CouchDB overview dashboard provides details on number of clusters and nodes per cluster, open OS files, open databases, database reads and writes, view info, request info (rate, latency, status code info), and replicator failure info for a CouchDB cluster.
 
-![First screenshot of the Apache CouchDB overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-couchdb/screenshots/overview_1.png)
-![Second screenshot of the Apache CouchDB overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-couchdb/screenshots/overview_2.png)
-![Third screenshot of the Apache CouchDB overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-couchdb/screenshots/overview_3.png)
+![First screenshot of the Apache CouchDB overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-couchdb/screenshots/couchdb_overview_1.png)
+![Second screenshot of the Apache CouchDB overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-couchdb/screenshots/couchdb_overview_2.png)
 
 ## Apache CouchDB Nodes
 
 The Apache CouchDB nodes dashboard provides details on memory usage, open OS files, open databases, database reads and writes, view info, request info (rate, latency, status code info), log type breakdown, and logs for a specific node in the cluster. To get CouchDB system logs, [Promtail and Loki needs to be installed](https://grafana.com/docs/loki/latest/installation/) and provisioned for logs with your Grafana instance. The default CouchDB system log path is `/var/log/couchdb/couchdb.log` on Linux.
 
-![First screenshot of the Apache CouchDB nodes dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-couchdb/screenshots/nodes_1.png)
-![Second screenshot of the Apache CouchDB nodes dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-couchdb/screenshots/nodes_2.png)
+![First screenshot of the Apache CouchDB nodes dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-couchdb/screenshots/couchdb_nodes_1.png)
+![Second screenshot of the Apache CouchDB nodes dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-couchdb/screenshots/couchdb_nodes_2.png)
 
 CouchDB system logs are enabled by default in the `config.libsonnet` and can be removed by setting `enableLokiLogs` to `false`. Then run `make` again to regenerate the dashboard:
 

--- a/apache-couchdb-mixin/alerts/alerts.libsonnet
+++ b/apache-couchdb-mixin/alerts/alerts.libsonnet
@@ -5,6 +5,24 @@
         name: 'ApacheCouchDBAlerts',
         rules: [
           {
+            alert: 'CouchDBUnhealthyCluster',
+            expr: |||
+              min by(job, cluster) (couchdb_couch_replicator_cluster_is_stable) < %(alertsCriticalClusterIsUnstable5m)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              summary: 'At least one of the nodes in a cluster is reporting the cluster as being unstable.',
+              description:
+                (
+                  '{{$labels.cluster}} has reported a value of {{ printf "%%.0f" $value }} for its stability over the last 5 minutes, ' +
+                  'which is below the threshold of %(alertsCriticalClusterIsUnstable5m)s.'
+                ) % $._config,
+            },
+          },
+          {
             alert: 'CouchDBHigh4xxResponseCodes',
             expr: |||
               sum by(job, instance) (increase(couchdb_httpd_status_codes{code=~"4.*"}[5m])) > %(alertsWarning4xxResponseCodes5m)s

--- a/apache-couchdb-mixin/alerts/alerts.libsonnet
+++ b/apache-couchdb-mixin/alerts/alerts.libsonnet
@@ -1,0 +1,173 @@
+{
+  prometheusAlerts+:: {
+    groups+: [
+      {
+        name: 'ApacheCouchDbAlerts',
+        rules: [
+          {
+            alert: 'CouchDbHigh4xxResponseCodes',
+            expr: |||
+              sum by(job, instance) (increase(couchdb_httpd_status_codes{code=~"4.*"}[5m])) > %(alertsWarning4xxResponseCodes5m)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              summary: 'There are a high number of 4xx responses for incoming requests to a node.',
+              description:
+                (
+                  '{{ printf "%%.0f" $value }} 4xx responses have been detected over the last 5 minutes on {{$labels.instance}}, ' +
+                  'which is above the threshold of %(alertsWarning4xxResponseCodes5m)s.'
+                ) % $._config,
+            },
+          },
+          {
+            alert: 'CouchDbHigh5xxResponseCodes',
+            expr: |||
+              sum by(job, instance) (increase(couchdb_httpd_status_codes{code=~"5.*"}[5m])) > %(alertsCritical5xxResponseCodes5m)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              summary: 'There are a high number of 5xx responses for incoming requests to a node.',
+              description:
+                (
+                  '{{ printf "%%.0f" $value }} 5xx responses have been detected over the last 5 minutes on {{$labels.instance}}, ' +
+                  'which is above the threshold of %(alertsCritical5xxResponseCodes5m)s.'
+                ) % $._config,
+            },
+          },
+          {
+            alert: 'CouchDbModerateRequestLatency',
+            expr: |||
+              sum by(job, instance) (increase(couchdb_request_time_seconds_sum[5m]) / increase(couchdb_request_time_seconds_count[5m])) * 1000 > %(alertsWarningRequestLatency5m)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              summary: 'There is a moderate level of request latency for a node.',
+              description:
+                (
+                  'An average of {{ printf "%%.0f" $value }}ms of request latency has occurred over the last 5 minutes on {{$labels.instance}}, ' +
+                  'which is above the threshold of %(alertsWarningRequestLatency5m)sms. '
+                ) % $._config,
+            },
+          },
+          {
+            alert: 'CouchDbHighRequestLatency',
+            expr: |||
+              sum by(job, instance) (increase(couchdb_request_time_seconds_sum[5m]) / increase(couchdb_request_time_seconds_count[5m])) * 1000 > %(alertsCriticalRequestLatency5m)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              summary: 'There is a high level of request latency for a node.',
+              description:
+                (
+                  'An average of {{ printf "%%.0f" $value }}ms of request latency has occurred over the last 5 minutes on {{$labels.instance}}, ' +
+                  'which is above the threshold of %(alertsCriticalRequestLatency5m)sms. '
+                ) % $._config,
+            },
+          },
+          {
+            alert: 'CouchDbManyReplicatorJobsPending',
+            expr: |||
+              sum by(job, instance) (couchdb_couch_replicator_jobs_pending) > %(alertsWarningPendingReplicatorJobs5m)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              summary: 'There is a high number of replicator jobs pending for a node.',
+              description:
+                (
+                  '{{ printf "%%.0f" $value }} replicator jobs are pending on {{$labels.instance}}, ' +
+                  'which is above the threshold of %(alertsWarningPendingReplicatorJobs5m)s. '
+                ) % $._config,
+            },
+          },
+          {
+            alert: 'CouchDbReplicatorJobsCrashing',
+            expr: |||
+              sum by(job, instance) (increase(couchdb_couch_replicator_jobs_crashes_total[5m])) > %(alertsCriticalCrashingReplicatorJobs5m)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              summary: 'There are replicator jobs crashing for a node.',
+              description:
+                (
+                  '{{ printf "%%.0f" $value }} replicator jobs have crashed over the last 5 minutes on {{$labels.instance}}, ' +
+                  'which is above the threshold of %(alertsCriticalCrashingReplicatorJobs5m)s. '
+                ) % $._config,
+            },
+          },
+          {
+            alert: 'CouchDbReplicatorChangesQueuesDying',
+            expr: |||
+              sum by(job, instance) (increase(couchdb_couch_replicator_changes_queue_deaths_total[5m])) > %(alertsWarningDyingReplicatorChangesQueues5m)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              summary: 'There are replicator changes queue process deaths for a node.',
+              description:
+                (
+                  '{{ printf "%%.0f" $value }} replicator changes queue processes have died over the last 5 minutes on {{$labels.instance}}, ' +
+                  'which is above the threshold of %(alertsWarningDyingReplicatorChangesQueues5m)s. '
+                ) % $._config,
+            },
+          },
+          {
+            alert: 'CouchDbReplicatorConnectionOwnersCrashing',
+            expr: |||
+              sum by(job, instance) (increase(couchdb_couch_replicator_connection_owner_crashes_total[5m])) > %(alertsWarningCrashingReplicatorConnectionOwners5m)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              summary: 'There are replicator connection owner process crashes for a node.',
+              description:
+                (
+                  '{{ printf "%%.0f" $value }} replicator connection owner processes have crashed over the last 5 minutes on {{$labels.instance}}, ' +
+                  'which is above the threshold of %(alertsWarningCrashingReplicatorConnectionOwners5m)s. '
+                ) % $._config,
+            },
+          },
+          {
+            alert: 'CouchDbReplicatorConnectionWorkersCrashing',
+            expr: |||
+              sum by(job, instance) (increase(couchdb_couch_replicator_connection_worker_crashes_total[5m])) > %(alertsWarningCrashingReplicatorConnectionWorkers5m)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              summary: 'There are replicator connection worker process crashes for a node.',
+              description:
+                (
+                  '{{ printf "%%.0f" $value }} replicator connection worker processes have crashed over the last 5 minutes on {{$labels.instance}}, ' +
+                  'which is above the threshold of %(alertsWarningCrashingReplicatorConnectionWorkers5m)s. '
+                ) % $._config,
+            },
+          },
+        ],
+      },
+    ],
+  },
+}

--- a/apache-couchdb-mixin/alerts/alerts.libsonnet
+++ b/apache-couchdb-mixin/alerts/alerts.libsonnet
@@ -2,10 +2,10 @@
   prometheusAlerts+:: {
     groups+: [
       {
-        name: 'ApacheCouchDbAlerts',
+        name: 'ApacheCouchDBAlerts',
         rules: [
           {
-            alert: 'CouchDbHigh4xxResponseCodes',
+            alert: 'CouchDBHigh4xxResponseCodes',
             expr: |||
               sum by(job, instance) (increase(couchdb_httpd_status_codes{code=~"4.*"}[5m])) > %(alertsWarning4xxResponseCodes5m)s
             ||| % $._config,
@@ -23,7 +23,7 @@
             },
           },
           {
-            alert: 'CouchDbHigh5xxResponseCodes',
+            alert: 'CouchDBHigh5xxResponseCodes',
             expr: |||
               sum by(job, instance) (increase(couchdb_httpd_status_codes{code=~"5.*"}[5m])) > %(alertsCritical5xxResponseCodes5m)s
             ||| % $._config,
@@ -41,7 +41,7 @@
             },
           },
           {
-            alert: 'CouchDbModerateRequestLatency',
+            alert: 'CouchDBModerateRequestLatency',
             expr: |||
               sum by(job, instance) (increase(couchdb_request_time_seconds_sum[5m]) / increase(couchdb_request_time_seconds_count[5m])) * 1000 > %(alertsWarningRequestLatency5m)s
             ||| % $._config,
@@ -59,7 +59,7 @@
             },
           },
           {
-            alert: 'CouchDbHighRequestLatency',
+            alert: 'CouchDBHighRequestLatency',
             expr: |||
               sum by(job, instance) (increase(couchdb_request_time_seconds_sum[5m]) / increase(couchdb_request_time_seconds_count[5m])) * 1000 > %(alertsCriticalRequestLatency5m)s
             ||| % $._config,
@@ -77,7 +77,7 @@
             },
           },
           {
-            alert: 'CouchDbManyReplicatorJobsPending',
+            alert: 'CouchDBManyReplicatorJobsPending',
             expr: |||
               sum by(job, instance) (couchdb_couch_replicator_jobs_pending) > %(alertsWarningPendingReplicatorJobs5m)s
             ||| % $._config,
@@ -95,7 +95,7 @@
             },
           },
           {
-            alert: 'CouchDbReplicatorJobsCrashing',
+            alert: 'CouchDBReplicatorJobsCrashing',
             expr: |||
               sum by(job, instance) (increase(couchdb_couch_replicator_jobs_crashes_total[5m])) > %(alertsCriticalCrashingReplicatorJobs5m)s
             ||| % $._config,
@@ -113,7 +113,7 @@
             },
           },
           {
-            alert: 'CouchDbReplicatorChangesQueuesDying',
+            alert: 'CouchDBReplicatorChangesQueuesDying',
             expr: |||
               sum by(job, instance) (increase(couchdb_couch_replicator_changes_queue_deaths_total[5m])) > %(alertsWarningDyingReplicatorChangesQueues5m)s
             ||| % $._config,
@@ -131,7 +131,7 @@
             },
           },
           {
-            alert: 'CouchDbReplicatorConnectionOwnersCrashing',
+            alert: 'CouchDBReplicatorConnectionOwnersCrashing',
             expr: |||
               sum by(job, instance) (increase(couchdb_couch_replicator_connection_owner_crashes_total[5m])) > %(alertsWarningCrashingReplicatorConnectionOwners5m)s
             ||| % $._config,
@@ -149,7 +149,7 @@
             },
           },
           {
-            alert: 'CouchDbReplicatorConnectionWorkersCrashing',
+            alert: 'CouchDBReplicatorConnectionWorkersCrashing',
             expr: |||
               sum by(job, instance) (increase(couchdb_couch_replicator_connection_worker_crashes_total[5m])) > %(alertsWarningCrashingReplicatorConnectionWorkers5m)s
             ||| % $._config,

--- a/apache-couchdb-mixin/config.libsonnet
+++ b/apache-couchdb-mixin/config.libsonnet
@@ -6,6 +6,7 @@
     dashboardRefresh: '1m',
 
     //alert thresholds
+    alertsCriticalClusterIsUnstable5m: 1,  //1 is stable
     alertsWarning4xxResponseCodes5m: 5,
     alertsCritical5xxResponseCodes5m: 0,
     alertsWarningRequestLatency5m: 500,  //ms

--- a/apache-couchdb-mixin/config.libsonnet
+++ b/apache-couchdb-mixin/config.libsonnet
@@ -1,0 +1,21 @@
+{
+  _config+:: {
+    dashboardTags: ['apache-couchdb-mixin'],
+    dashboardPeriod: 'now-1h',
+    dashboardTimezone: 'default',
+    dashboardRefresh: '1m',
+
+    //alert thresholds
+    alertsWarning4xxResponseCodes5m: 5,
+    alertsCritical5xxResponseCodes5m: 0,
+    alertsWarningRequestLatency5m: 500,  //ms
+    alertsCriticalRequestLatency5m: 1000,  //ms
+    alertsWarningPendingReplicatorJobs5m: 10,
+    alertsCriticalCrashingReplicatorJobs5m: 0,
+    alertsWarningDyingReplicatorChangesQueues5m: 0,
+    alertsWarningCrashingReplicatorConnectionOwners5m: 0,
+    alertsWarningCrashingReplicatorConnectionWorkers5m: 0,
+
+    enableLokiLogs: true,
+  },
+}

--- a/apache-couchdb-mixin/dashboards/couchdb-nodes.libsonnet
+++ b/apache-couchdb-mixin/dashboards/couchdb-nodes.libsonnet
@@ -905,19 +905,9 @@ local bulkRequestsPanel = {
   },
 };
 
-local responseStatusOverviewPanel = {
+local responseStatusErrorOverviewPanel = {
   datasource: promDatasource,
   targets: [
-    prometheus.target(
-      'sum by(instance, cluster) (increase(couchdb_httpd_status_codes{' + matcher + ', code=~"2.*"}[$__interval])) != 0',
-      datasource=promDatasource,
-      legendFormat='{{cluster}} - {{instance}} - 2xx',
-    ),
-    prometheus.target(
-      'sum by(instance, cluster) (increase(couchdb_httpd_status_codes{' + matcher + ', code=~"3.*"}[$__interval])) != 0',
-      datasource=promDatasource,
-      legendFormat='{{cluster}} - {{instance}} - 3xx',
-    ),
     prometheus.target(
       'sum by(instance, cluster) (increase(couchdb_httpd_status_codes{' + matcher + ', code=~"4.*"}[$__interval])) != 0',
       datasource=promDatasource,
@@ -930,8 +920,8 @@ local responseStatusOverviewPanel = {
     ),
   ],
   type: 'piechart',
-  title: 'Response status overview',
-  description: 'The responses grouped by HTTP status type (2xx, 3xx, 4xx, 5xx) for a node.',
+  title: 'Response status error overview',
+  description: 'The responses grouped by HTTP error status type (4xx and 5xx) for a node.',
   fieldConfig: {
     defaults: {
       color: {
@@ -1341,8 +1331,8 @@ local systemLogsPanel = {
             requestsRow { gridPos: { h: 1, w: 24, x: 0, y: 18 } },
             bulkRequestsPanel { gridPos: { h: 6, w: 12, x: 0, y: 19 } },
             requestLatencyPanel { gridPos: { h: 6, w: 12, x: 12, y: 19 } },
-            responseStatusOverviewPanel { gridPos: { h: 6, w: 12, x: 0, y: 25 } },
-            requestMethodsPanel { gridPos: { h: 6, w: 12, x: 12, y: 25 } },
+            requestMethodsPanel { gridPos: { h: 6, w: 12, x: 0, y: 25 } },
+            responseStatusErrorOverviewPanel { gridPos: { h: 6, w: 12, x: 12, y: 25 } },
             goodResponseStatusesPanel { gridPos: { h: 6, w: 12, x: 0, y: 31 } },
             errorResponseStatusesPanel { gridPos: { h: 6, w: 12, x: 12, y: 31 } },
             logsRow { gridPos: { h: 1, w: 24, x: 0, y: 37 } },

--- a/apache-couchdb-mixin/dashboards/couchdb-nodes.libsonnet
+++ b/apache-couchdb-mixin/dashboards/couchdb-nodes.libsonnet
@@ -24,7 +24,7 @@ local erlangMemoryUsagePanel = {
     prometheus.target(
       'couchdb_erlang_memory_bytes{' + matcher + ', memory_type="total"}',
       datasource=promDatasource,
-      legendFormat='{{cluster}} - {{instance}}',
+      legendFormat='{{instance}}',
     ),
   ],
   type: 'timeseries',
@@ -103,7 +103,7 @@ local openOSFilesPanel = {
     prometheus.target(
       'increase(couchdb_open_os_files_total{' + matcher + '}[$__interval])',
       datasource=promDatasource,
-      legendFormat='{{cluster}} - {{instance}}',
+      legendFormat='{{instance}}',
     ),
   ],
   type: 'timeseries',
@@ -178,7 +178,7 @@ local openDatabasesPanel = {
     prometheus.target(
       'couchdb_open_databases_total{' + matcher + '}',
       datasource=promDatasource,
-      legendFormat='{{cluster}} - {{instance}}',
+      legendFormat='{{instance}}',
     ),
   ],
   type: 'timeseries',
@@ -256,7 +256,7 @@ local databaseWritesPanel = {
     prometheus.target(
       'rate(couchdb_database_writes_total{' + matcher + '}[$__rate_interval])',
       datasource=promDatasource,
-      legendFormat='{{cluster}} - {{instance}}',
+      legendFormat='{{instance}}',
     ),
   ],
   type: 'timeseries',
@@ -335,7 +335,7 @@ local databaseReadsPanel = {
     prometheus.target(
       'rate(couchdb_database_reads_total{' + matcher + '}[$__rate_interval])',
       datasource=promDatasource,
-      legendFormat='{{cluster}} - {{instance}}',
+      legendFormat='{{instance}}',
     ),
   ],
   type: 'timeseries',
@@ -414,7 +414,7 @@ local viewReadsPanel = {
     prometheus.target(
       'rate(couchdb_httpd_view_reads_total{' + matcher + '}[$__rate_interval])',
       datasource=promDatasource,
-      legendFormat='{{cluster}} - {{instance}}',
+      legendFormat='{{instance}}',
     ),
   ],
   type: 'timeseries',
@@ -493,7 +493,7 @@ local viewTimeoutsPanel = {
     prometheus.target(
       'rate(couchdb_httpd_view_timeouts_total{' + matcher + '}[$__rate_interval])',
       datasource=promDatasource,
-      legendFormat='{{cluster}} - {{instance}}',
+      legendFormat='{{instance}}',
     ),
   ],
   type: 'timeseries',
@@ -572,7 +572,7 @@ local temporaryViewReadsPanel = {
     prometheus.target(
       'rate(couchdb_httpd_temporary_view_reads_total{' + matcher + '}[$__rate_interval])',
       datasource=promDatasource,
-      legendFormat='{{cluster}} - {{instance}}',
+      legendFormat='{{instance}}',
     ),
   ],
   type: 'timeseries',
@@ -659,7 +659,7 @@ local requestMethodsPanel = {
     prometheus.target(
       'rate(couchdb_httpd_request_methods{' + matcher + '}[$__rate_interval]) != 0',
       datasource=promDatasource,
-      legendFormat='{{cluster}} - {{instance}} - {{method}}',
+      legendFormat='{{instance}} - {{method}}',
     ),
   ],
   type: 'timeseries',
@@ -738,22 +738,22 @@ local requestLatencyPanel = {
     prometheus.target(
       'couchdb_request_time_seconds{' + matcher + ', quantile="0.5"}',
       datasource=promDatasource,
-      legendFormat='{{cluster}} - {{instance}} - p50',
+      legendFormat='{{instance}} - p50',
     ),
     prometheus.target(
       'couchdb_request_time_seconds{' + matcher + ', quantile="0.75"}',
       datasource=promDatasource,
-      legendFormat='{{cluster}} - {{instance}} - p75',
+      legendFormat='{{instance}} - p75',
     ),
     prometheus.target(
       'couchdb_request_time_seconds{' + matcher + ', quantile="0.95"}',
       datasource=promDatasource,
-      legendFormat='{{cluster}} - {{instance}} - p95',
+      legendFormat='{{instance}} - p95',
     ),
     prometheus.target(
       'couchdb_request_time_seconds{' + matcher + ', quantile="0.99"}',
       datasource=promDatasource,
-      legendFormat='{{cluster}} - {{instance}} - p99',
+      legendFormat='{{instance}} - p99',
     ),
   ],
   type: 'timeseries',
@@ -832,7 +832,7 @@ local bulkRequestsPanel = {
     prometheus.target(
       'rate(couchdb_httpd_bulk_requests_total{' + matcher + '}[$__rate_interval])',
       datasource=promDatasource,
-      legendFormat='{{cluster}} - {{instance}}',
+      legendFormat='{{instance}}',
     ),
   ],
   type: 'timeseries',
@@ -905,23 +905,33 @@ local bulkRequestsPanel = {
   },
 };
 
-local responseStatusErrorOverviewPanel = {
+local responseStatusOverviewPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
+      'sum by(instance, cluster) (increase(couchdb_httpd_status_codes{' + matcher + ', code=~"2.*"}[$__interval])) != 0',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - 2xx',
+    ),
+    prometheus.target(
+      'sum by(instance, cluster) (increase(couchdb_httpd_status_codes{' + matcher + ', code=~"3.*"}[$__interval])) != 0',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - 3xx',
+    ),
+    prometheus.target(
       'sum by(instance, cluster) (increase(couchdb_httpd_status_codes{' + matcher + ', code=~"4.*"}[$__interval])) != 0',
       datasource=promDatasource,
-      legendFormat='{{cluster}} - {{instance}} - 4xx',
+      legendFormat='{{instance}} - 4xx',
     ),
     prometheus.target(
       'sum by(instance, cluster) (increase(couchdb_httpd_status_codes{' + matcher + ', code=~"5.*"}[$__interval])) != 0',
       datasource=promDatasource,
-      legendFormat='{{cluster}} - {{instance}} - 5xx',
+      legendFormat='{{instance}} - 5xx',
     ),
   ],
   type: 'piechart',
-  title: 'Response status error overview',
-  description: 'The responses grouped by HTTP error status type (4xx and 5xx) for a node.',
+  title: 'Response status overview',
+  description: 'The responses grouped by HTTP status type (2xx, 3xx, 4xx, and 5xx) for a node.',
   fieldConfig: {
     defaults: {
       color: {
@@ -953,7 +963,7 @@ local responseStatusErrorOverviewPanel = {
       values: false,
     },
     tooltip: {
-      mode: 'single',
+      mode: 'multi',
       sort: 'none',
     },
   },
@@ -965,7 +975,7 @@ local goodResponseStatusesPanel = {
     prometheus.target(
       'rate(couchdb_httpd_status_codes{' + matcher + ', code=~"[23].*"}[$__rate_interval]) != 0',
       datasource=promDatasource,
-      legendFormat='{{cluster}} - {{instance}} - {{code}}',
+      legendFormat='{{instance}} - {{code}}',
     ),
   ],
   type: 'timeseries',
@@ -1044,7 +1054,7 @@ local errorResponseStatusesPanel = {
     prometheus.target(
       'rate(couchdb_httpd_status_codes{' + matcher + ', code=~"[45].*"}[$__rate_interval]) != 0',
       datasource=promDatasource,
-      legendFormat='{{cluster}} - {{instance}} - {{code}}',
+      legendFormat='{{instance}} - {{code}}',
     ),
   ],
   type: 'timeseries',
@@ -1131,7 +1141,7 @@ local logTypesPanel = {
     prometheus.target(
       'increase(couchdb_couch_log_requests_total{' + matcher + ', level=~"$log_level"}[$__interval]) != 0',
       datasource=promDatasource,
-      legendFormat='{{cluster}} - {{instance}} - {{level}}',
+      legendFormat='{{instance}} - {{level}}',
     ),
   ],
   type: 'timeseries',
@@ -1332,7 +1342,7 @@ local systemLogsPanel = {
             bulkRequestsPanel { gridPos: { h: 6, w: 12, x: 0, y: 19 } },
             requestLatencyPanel { gridPos: { h: 6, w: 12, x: 12, y: 19 } },
             requestMethodsPanel { gridPos: { h: 6, w: 12, x: 0, y: 25 } },
-            responseStatusErrorOverviewPanel { gridPos: { h: 6, w: 12, x: 12, y: 25 } },
+            responseStatusOverviewPanel { gridPos: { h: 6, w: 12, x: 12, y: 25 } },
             goodResponseStatusesPanel { gridPos: { h: 6, w: 12, x: 0, y: 31 } },
             errorResponseStatusesPanel { gridPos: { h: 6, w: 12, x: 12, y: 31 } },
             logsRow { gridPos: { h: 1, w: 24, x: 0, y: 37 } },

--- a/apache-couchdb-mixin/dashboards/couchdb-nodes.libsonnet
+++ b/apache-couchdb-mixin/dashboards/couchdb-nodes.libsonnet
@@ -24,7 +24,7 @@ local erlangMemoryUsagePanel = {
     prometheus.target(
       'couchdb_erlang_memory_bytes{' + matcher + ', memory_type="total"}',
       datasource=promDatasource,
-      legendFormat='cluster="{{cluster}}",instance="{{instance}}"',
+      legendFormat='{{cluster}} - {{instance}}',
     ),
   ],
   type: 'timeseries',
@@ -91,7 +91,7 @@ local erlangMemoryUsagePanel = {
       showLegend: true,
     },
     tooltip: {
-      mode: 'single',
+      mode: 'multi',
       sort: 'none',
     },
   },
@@ -101,9 +101,9 @@ local openOSFilesPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'increase(couchdb_open_os_files_total{' + matcher + '}[$__rate_interval])',
+      'increase(couchdb_open_os_files_total{' + matcher + '}[$__interval])',
       datasource=promDatasource,
-      legendFormat='cluster="{{cluster}}",instance="{{instance}}"',
+      legendFormat='{{cluster}} - {{instance}}',
     ),
   ],
   type: 'timeseries',
@@ -166,7 +166,7 @@ local openOSFilesPanel = {
       showLegend: true,
     },
     tooltip: {
-      mode: 'single',
+      mode: 'multi',
       sort: 'none',
     },
   },
@@ -178,7 +178,7 @@ local openDatabasesPanel = {
     prometheus.target(
       'couchdb_open_databases_total{' + matcher + '}',
       datasource=promDatasource,
-      legendFormat='cluster="{{cluster}}",instance="{{instance}}"',
+      legendFormat='{{cluster}} - {{instance}}',
     ),
   ],
   type: 'timeseries',
@@ -244,7 +244,7 @@ local openDatabasesPanel = {
       showLegend: true,
     },
     tooltip: {
-      mode: 'single',
+      mode: 'multi',
       sort: 'none',
     },
   },
@@ -256,7 +256,7 @@ local databaseWritesPanel = {
     prometheus.target(
       'rate(couchdb_database_writes_total{' + matcher + '}[$__rate_interval])',
       datasource=promDatasource,
-      legendFormat='cluster="{{cluster}}",instance="{{instance}}"',
+      legendFormat='{{cluster}} - {{instance}}',
     ),
   ],
   type: 'timeseries',
@@ -323,7 +323,7 @@ local databaseWritesPanel = {
       showLegend: true,
     },
     tooltip: {
-      mode: 'single',
+      mode: 'multi',
       sort: 'none',
     },
   },
@@ -335,7 +335,7 @@ local databaseReadsPanel = {
     prometheus.target(
       'rate(couchdb_database_reads_total{' + matcher + '}[$__rate_interval])',
       datasource=promDatasource,
-      legendFormat='cluster="{{cluster}}",instance="{{instance}}"',
+      legendFormat='{{cluster}} - {{instance}}',
     ),
   ],
   type: 'timeseries',
@@ -402,7 +402,7 @@ local databaseReadsPanel = {
       showLegend: true,
     },
     tooltip: {
-      mode: 'single',
+      mode: 'multi',
       sort: 'none',
     },
   },
@@ -414,7 +414,7 @@ local viewReadsPanel = {
     prometheus.target(
       'rate(couchdb_httpd_view_reads_total{' + matcher + '}[$__rate_interval])',
       datasource=promDatasource,
-      legendFormat='cluster="{{cluster}}",instance="{{instance}}"',
+      legendFormat='{{cluster}} - {{instance}}',
     ),
   ],
   type: 'timeseries',
@@ -481,7 +481,7 @@ local viewReadsPanel = {
       showLegend: true,
     },
     tooltip: {
-      mode: 'single',
+      mode: 'multi',
       sort: 'none',
     },
   },
@@ -493,7 +493,7 @@ local viewTimeoutsPanel = {
     prometheus.target(
       'rate(couchdb_httpd_view_timeouts_total{' + matcher + '}[$__rate_interval])',
       datasource=promDatasource,
-      legendFormat='cluster="{{cluster}}",instance="{{instance}}"',
+      legendFormat='{{cluster}} - {{instance}}',
     ),
   ],
   type: 'timeseries',
@@ -560,7 +560,7 @@ local viewTimeoutsPanel = {
       showLegend: true,
     },
     tooltip: {
-      mode: 'single',
+      mode: 'multi',
       sort: 'none',
     },
   },
@@ -572,7 +572,7 @@ local temporaryViewReadsPanel = {
     prometheus.target(
       'rate(couchdb_httpd_temporary_view_reads_total{' + matcher + '}[$__rate_interval])',
       datasource=promDatasource,
-      legendFormat='cluster="{{cluster}}",instance="{{instance}}"',
+      legendFormat='{{cluster}} - {{instance}}',
     ),
   ],
   type: 'timeseries',
@@ -639,7 +639,7 @@ local temporaryViewReadsPanel = {
       showLegend: true,
     },
     tooltip: {
-      mode: 'single',
+      mode: 'multi',
       sort: 'none',
     },
   },
@@ -657,9 +657,9 @@ local requestMethodsPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'rate(couchdb_httpd_request_methods{' + matcher + '}[$__rate_interval])',
+      'rate(couchdb_httpd_request_methods{' + matcher + '}[$__rate_interval]) != 0',
       datasource=promDatasource,
-      legendFormat='cluster="{{cluster}}",instance="{{instance}}",method="{{method}}"',
+      legendFormat='{{cluster}} - {{instance}} - {{method}}',
     ),
   ],
   type: 'timeseries',
@@ -721,12 +721,12 @@ local requestMethodsPanel = {
   options: {
     legend: {
       calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
+      displayMode: 'table',
+      placement: 'right',
       showLegend: true,
     },
     tooltip: {
-      mode: 'single',
+      mode: 'multi',
       sort: 'none',
     },
   },
@@ -738,27 +738,27 @@ local requestLatencyPanel = {
     prometheus.target(
       'couchdb_request_time_seconds{' + matcher + ', quantile="0.5"}',
       datasource=promDatasource,
-      legendFormat='cluster="{{cluster}}",instance="{{instance}}",quantile="{{quantile}}"',
+      legendFormat='{{cluster}} - {{instance}} - p50',
     ),
     prometheus.target(
       'couchdb_request_time_seconds{' + matcher + ', quantile="0.75"}',
       datasource=promDatasource,
-      legendFormat='cluster="{{cluster}}",instance="{{instance}}",quantile="{{quantile}}"',
+      legendFormat='{{cluster}} - {{instance}} - p75',
     ),
     prometheus.target(
       'couchdb_request_time_seconds{' + matcher + ', quantile="0.95"}',
       datasource=promDatasource,
-      legendFormat='cluster="{{cluster}}",instance="{{instance}}",quantile="{{quantile}}"',
+      legendFormat='{{cluster}} - {{instance}} - p95',
     ),
     prometheus.target(
       'couchdb_request_time_seconds{' + matcher + ', quantile="0.99"}',
       datasource=promDatasource,
-      legendFormat='cluster="{{cluster}}",instance="{{instance}}",quantile="{{quantile}}"',
+      legendFormat='{{cluster}} - {{instance}} - p99',
     ),
   ],
   type: 'timeseries',
-  title: 'Request latency',
-  description: 'The request latency for a node.',
+  title: 'Request latency quantiles',
+  description: 'The request latency quantiles for a node.',
   fieldConfig: {
     defaults: {
       color: {
@@ -815,12 +815,12 @@ local requestLatencyPanel = {
   options: {
     legend: {
       calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
+      displayMode: 'table',
+      placement: 'right',
       showLegend: true,
     },
     tooltip: {
-      mode: 'single',
+      mode: 'multi',
       sort: 'none',
     },
   },
@@ -832,7 +832,7 @@ local bulkRequestsPanel = {
     prometheus.target(
       'rate(couchdb_httpd_bulk_requests_total{' + matcher + '}[$__rate_interval])',
       datasource=promDatasource,
-      legendFormat='cluster="{{cluster}}",instance="{{instance}}"',
+      legendFormat='{{cluster}} - {{instance}}',
     ),
   ],
   type: 'timeseries',
@@ -899,7 +899,7 @@ local bulkRequestsPanel = {
       showLegend: true,
     },
     tooltip: {
-      mode: 'single',
+      mode: 'multi',
       sort: 'none',
     },
   },
@@ -909,24 +909,24 @@ local responseStatusOverviewPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(instance, cluster) (increase(couchdb_httpd_status_codes{' + matcher + ', code=~"2.*"}[$__rate_interval]))',
+      'sum by(instance, cluster) (increase(couchdb_httpd_status_codes{' + matcher + ', code=~"2.*"}[$__interval])) != 0',
       datasource=promDatasource,
-      legendFormat='cluster="{{cluster}}",instance="{{instance}}",status="2xx"',
+      legendFormat='{{cluster}} - {{instance}} - 2xx',
     ),
     prometheus.target(
-      'sum by(instance, cluster) (increase(couchdb_httpd_status_codes{' + matcher + ', code=~"3.*"}[$__rate_interval]))',
+      'sum by(instance, cluster) (increase(couchdb_httpd_status_codes{' + matcher + ', code=~"3.*"}[$__interval])) != 0',
       datasource=promDatasource,
-      legendFormat='cluster="{{cluster}}",instance="{{instance}}",status="3xx"',
+      legendFormat='{{cluster}} - {{instance}} - 3xx',
     ),
     prometheus.target(
-      'sum by(instance, cluster) (increase(couchdb_httpd_status_codes{' + matcher + ', code=~"4.*"}[$__rate_interval]))',
+      'sum by(instance, cluster) (increase(couchdb_httpd_status_codes{' + matcher + ', code=~"4.*"}[$__interval])) != 0',
       datasource=promDatasource,
-      legendFormat='cluster="{{cluster}}",instance="{{instance}}",status="4xx"',
+      legendFormat='{{cluster}} - {{instance}} - 4xx',
     ),
     prometheus.target(
-      'sum by(instance, cluster) (increase(couchdb_httpd_status_codes{' + matcher + ', code=~"5.*"}[$__rate_interval]))',
+      'sum by(instance, cluster) (increase(couchdb_httpd_status_codes{' + matcher + ', code=~"5.*"}[$__interval])) != 0',
       datasource=promDatasource,
-      legendFormat='cluster="{{cluster}}",instance="{{instance}}",status="5xx"',
+      legendFormat='{{cluster}} - {{instance}} - 5xx',
     ),
   ],
   type: 'piechart',
@@ -950,8 +950,8 @@ local responseStatusOverviewPanel = {
   },
   options: {
     legend: {
-      displayMode: 'list',
-      placement: 'bottom',
+      displayMode: 'table',
+      placement: 'right',
       showLegend: true,
     },
     pieType: 'pie',
@@ -969,18 +969,18 @@ local responseStatusOverviewPanel = {
   },
 };
 
-local responseStatusesPanel = {
+local goodResponseStatusesPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'rate(couchdb_httpd_status_codes{' + matcher + '}[$__rate_interval])',
+      'rate(couchdb_httpd_status_codes{' + matcher + ', code=~"[23].*"}[$__rate_interval]) != 0',
       datasource=promDatasource,
-      legendFormat='cluster="{{cluster}}",instance="{{instance}}",code="{{code}}"',
+      legendFormat='{{cluster}} - {{instance}} - {{code}}',
     ),
   ],
   type: 'timeseries',
-  title: 'Response statuses',
-  description: 'The response rate split by HTTP statuses for a node.',
+  title: 'Good response statuses',
+  description: 'The response rate split by good HTTP statuses for a node.',
   fieldConfig: {
     defaults: {
       color: {
@@ -1037,12 +1037,91 @@ local responseStatusesPanel = {
   options: {
     legend: {
       calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
+      displayMode: 'table',
+      placement: 'right',
       showLegend: true,
     },
     tooltip: {
-      mode: 'single',
+      mode: 'multi',
+      sort: 'none',
+    },
+  },
+};
+
+local errorResponseStatusesPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'rate(couchdb_httpd_status_codes{' + matcher + ', code=~"[45].*"}[$__rate_interval]) != 0',
+      datasource=promDatasource,
+      legendFormat='{{cluster}} - {{instance}} - {{code}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Error response statuses',
+  description: 'The response rate split by error HTTP statuses for a node.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'reqps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'table',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
       sort: 'none',
     },
   },
@@ -1060,9 +1139,9 @@ local logTypesPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'increase(couchdb_couch_log_requests_total{' + matcher + '}[$__rate_interval])',
+      'increase(couchdb_couch_log_requests_total{' + matcher + ', level=~"$log_level"}[$__interval]) != 0',
       datasource=promDatasource,
-      legendFormat='cluster="{{cluster}}",instance="{{instance}}",level="{{level}}"',
+      legendFormat='{{cluster}} - {{instance}} - {{level}}',
     ),
   ],
   type: 'timeseries',
@@ -1124,12 +1203,12 @@ local logTypesPanel = {
   options: {
     legend: {
       calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
+      displayMode: 'table',
+      placement: 'right',
       showLegend: true,
     },
     tooltip: {
-      mode: 'single',
+      mode: 'multi',
       sort: 'none',
     },
   },
@@ -1141,7 +1220,7 @@ local systemLogsPanel = {
     {
       datasource: lokiDatasource,
       editorMode: 'code',
-      expr: '{' + matcher + ', filename="/var/log/couchdb/couchdb.log"} |= ""',
+      expr: '{' + matcher + ', filename="/var/log/couchdb/couchdb.log"} |~ "$log_level"',
       queryType: 'range',
       refId: 'A',
     },
@@ -1234,31 +1313,43 @@ local systemLogsPanel = {
               allValues='',
               sort=0
             ),
+            template.new(
+              'log_level',
+              promDatasource,
+              'label_values(couchdb_couch_log_requests_total{instance=~"$instance"}, level)',
+              label='Log Level',
+              refresh=1,
+              includeAll=true,
+              multi=true,
+              allValues='',
+              sort=0
+            ),
           ],
         ])
       )
       .addPanels(
         std.flattenArrays([
           [
-            erlangMemoryUsagePanel { gridPos: { h: 8, w: 8, x: 0, y: 0 } },
-            openOSFilesPanel { gridPos: { h: 8, w: 8, x: 8, y: 0 } },
-            openDatabasesPanel { gridPos: { h: 8, w: 8, x: 16, y: 0 } },
-            databaseWritesPanel { gridPos: { h: 8, w: 12, x: 0, y: 8 } },
-            databaseReadsPanel { gridPos: { h: 8, w: 12, x: 12, y: 8 } },
-            viewReadsPanel { gridPos: { h: 8, w: 8, x: 0, y: 16 } },
-            viewTimeoutsPanel { gridPos: { h: 8, w: 8, x: 8, y: 16 } },
-            temporaryViewReadsPanel { gridPos: { h: 8, w: 8, x: 16, y: 16 } },
-            requestsRow { gridPos: { h: 1, w: 24, x: 0, y: 24 } },
-            requestMethodsPanel { gridPos: { h: 8, w: 8, x: 0, y: 25 } },
-            requestLatencyPanel { gridPos: { h: 8, w: 8, x: 8, y: 25 } },
-            bulkRequestsPanel { gridPos: { h: 8, w: 8, x: 16, y: 25 } },
-            responseStatusOverviewPanel { gridPos: { h: 8, w: 12, x: 0, y: 33 } },
-            responseStatusesPanel { gridPos: { h: 8, w: 12, x: 12, y: 33 } },
-            logsRow { gridPos: { h: 1, w: 24, x: 0, y: 41 } },
-            logTypesPanel { gridPos: { h: 8, w: 24, x: 0, y: 42 } },
+            erlangMemoryUsagePanel { gridPos: { h: 6, w: 8, x: 0, y: 0 } },
+            openOSFilesPanel { gridPos: { h: 6, w: 8, x: 8, y: 0 } },
+            openDatabasesPanel { gridPos: { h: 6, w: 8, x: 16, y: 0 } },
+            databaseWritesPanel { gridPos: { h: 6, w: 12, x: 0, y: 6 } },
+            databaseReadsPanel { gridPos: { h: 6, w: 12, x: 12, y: 6 } },
+            viewReadsPanel { gridPos: { h: 6, w: 8, x: 0, y: 12 } },
+            viewTimeoutsPanel { gridPos: { h: 6, w: 8, x: 8, y: 12 } },
+            temporaryViewReadsPanel { gridPos: { h: 6, w: 8, x: 16, y: 12 } },
+            requestsRow { gridPos: { h: 1, w: 24, x: 0, y: 18 } },
+            bulkRequestsPanel { gridPos: { h: 6, w: 12, x: 0, y: 19 } },
+            requestLatencyPanel { gridPos: { h: 6, w: 12, x: 12, y: 19 } },
+            responseStatusOverviewPanel { gridPos: { h: 6, w: 12, x: 0, y: 25 } },
+            requestMethodsPanel { gridPos: { h: 6, w: 12, x: 12, y: 25 } },
+            goodResponseStatusesPanel { gridPos: { h: 6, w: 12, x: 0, y: 31 } },
+            errorResponseStatusesPanel { gridPos: { h: 6, w: 12, x: 12, y: 31 } },
+            logsRow { gridPos: { h: 1, w: 24, x: 0, y: 37 } },
+            logTypesPanel { gridPos: { h: 6, w: 24, x: 0, y: 38 } },
           ],
           if $._config.enableLokiLogs then [
-            systemLogsPanel { gridPos: { h: 8, w: 24, x: 0, y: 50 } },
+            systemLogsPanel { gridPos: { h: 6, w: 24, x: 0, y: 44 } },
           ] else [],
           [
           ],

--- a/apache-couchdb-mixin/dashboards/couchdb-nodes.libsonnet
+++ b/apache-couchdb-mixin/dashboards/couchdb-nodes.libsonnet
@@ -1141,7 +1141,7 @@ local systemLogsPanel = {
     {
       datasource: lokiDatasource,
       editorMode: 'code',
-      expr: '{' + matcher + ', filename=~"/var/log/couchdb/couchdb\\.log"} |= ""',
+      expr: '{' + matcher + ', filename="/var/log/couchdb/couchdb.log"} |= ""',
       queryType: 'range',
       refId: 'A',
     },

--- a/apache-couchdb-mixin/dashboards/couchdb-nodes.libsonnet
+++ b/apache-couchdb-mixin/dashboards/couchdb-nodes.libsonnet
@@ -1,0 +1,1268 @@
+local g = (import 'grafana-builder/grafana.libsonnet');
+local grafana = (import 'grafonnet/grafana.libsonnet');
+local dashboard = grafana.dashboard;
+local template = grafana.template;
+local prometheus = grafana.prometheus;
+
+local dashboardUid = 'couchdb-nodes';
+
+local promDatasourceName = 'prometheus_datasource';
+local lokiDatasourceName = 'loki_datasource';
+local matcher = 'job=~"$job", cluster=~"$cluster", instance=~"$instance"';
+
+local promDatasource = {
+  uid: '${%s}' % promDatasourceName,
+};
+
+local lokiDatasource = {
+  uid: '${%s}' % lokiDatasourceName,
+};
+
+local erlangMemoryUsagePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'couchdb_erlang_memory_bytes{' + matcher + ', memory_type="total"}',
+      datasource=promDatasource,
+      legendFormat='cluster="{{cluster}}",instance="{{instance}}"',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Erlang memory usage',
+  description: "The amount of memory used by a node's Erlang Virtual Machine.",
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'decbytes',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local openOSFilesPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'increase(couchdb_open_os_files_total{' + matcher + '}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='cluster="{{cluster}}",instance="{{instance}}"',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Open OS files',
+  description: 'The total number of file descriptors open on a node',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local openDatabasesPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'couchdb_open_databases_total{' + matcher + '}',
+      datasource=promDatasource,
+      legendFormat='cluster="{{cluster}}",instance="{{instance}}"',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Open databases',
+  description: 'The total number of open databases on a node.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local databaseWritesPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'rate(couchdb_database_writes_total{' + matcher + '}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='cluster="{{cluster}}",instance="{{instance}}"',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Database writes',
+  description: 'The number of database writes on a node.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'wps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local databaseReadsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'rate(couchdb_database_reads_total{' + matcher + '}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='cluster="{{cluster}}",instance="{{instance}}"',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Database reads',
+  description: 'The number of database reads on a node.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'rps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local viewReadsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'rate(couchdb_httpd_view_reads_total{' + matcher + '}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='cluster="{{cluster}}",instance="{{instance}}"',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'View reads',
+  description: 'The number of view reads on a node.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'rps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local viewTimeoutsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'rate(couchdb_httpd_view_timeouts_total{' + matcher + '}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='cluster="{{cluster}}",instance="{{instance}}"',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'View timeouts',
+  description: 'The number of view requests that timed out on a node.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'reqps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local temporaryViewReadsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'rate(couchdb_httpd_temporary_view_reads_total{' + matcher + '}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='cluster="{{cluster}}",instance="{{instance}}"',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Temporary view reads',
+  description: 'The number of temporary view reads on a node.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'rps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local requestsRow = {
+  datasource: promDatasource,
+  targets: [],
+  type: 'row',
+  title: 'Requests',
+  collapsed: false,
+};
+
+local requestMethodsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'rate(couchdb_httpd_request_methods{' + matcher + '}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='cluster="{{cluster}}",instance="{{instance}}",method="{{method}}"',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Request methods',
+  description: 'The request rate split by HTTP Method for a node.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'reqps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local requestLatencyPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'couchdb_request_time_seconds{' + matcher + ', quantile="0.5"}',
+      datasource=promDatasource,
+      legendFormat='cluster="{{cluster}}",instance="{{instance}}",quantile="{{quantile}}"',
+    ),
+    prometheus.target(
+      'couchdb_request_time_seconds{' + matcher + ', quantile="0.75"}',
+      datasource=promDatasource,
+      legendFormat='cluster="{{cluster}}",instance="{{instance}}",quantile="{{quantile}}"',
+    ),
+    prometheus.target(
+      'couchdb_request_time_seconds{' + matcher + ', quantile="0.95"}',
+      datasource=promDatasource,
+      legendFormat='cluster="{{cluster}}",instance="{{instance}}",quantile="{{quantile}}"',
+    ),
+    prometheus.target(
+      'couchdb_request_time_seconds{' + matcher + ', quantile="0.99"}',
+      datasource=promDatasource,
+      legendFormat='cluster="{{cluster}}",instance="{{instance}}",quantile="{{quantile}}"',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Request latency',
+  description: 'The request latency for a node.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 's',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local bulkRequestsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'rate(couchdb_httpd_bulk_requests_total{' + matcher + '}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='cluster="{{cluster}}",instance="{{instance}}"',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Bulk requests',
+  description: 'The number of bulk requests for a node.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'reqps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local responseStatusOverviewPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by(instance, cluster) (increase(couchdb_httpd_status_codes{' + matcher + ', code=~"2.*"}[$__rate_interval]))',
+      datasource=promDatasource,
+      legendFormat='cluster="{{cluster}}",instance="{{instance}}",status="2xx"',
+    ),
+    prometheus.target(
+      'sum by(instance, cluster) (increase(couchdb_httpd_status_codes{' + matcher + ', code=~"3.*"}[$__rate_interval]))',
+      datasource=promDatasource,
+      legendFormat='cluster="{{cluster}}",instance="{{instance}}",status="3xx"',
+    ),
+    prometheus.target(
+      'sum by(instance, cluster) (increase(couchdb_httpd_status_codes{' + matcher + ', code=~"4.*"}[$__rate_interval]))',
+      datasource=promDatasource,
+      legendFormat='cluster="{{cluster}}",instance="{{instance}}",status="4xx"',
+    ),
+    prometheus.target(
+      'sum by(instance, cluster) (increase(couchdb_httpd_status_codes{' + matcher + ', code=~"5.*"}[$__rate_interval]))',
+      datasource=promDatasource,
+      legendFormat='cluster="{{cluster}}",instance="{{instance}}",status="5xx"',
+    ),
+  ],
+  type: 'piechart',
+  title: 'Response status overview',
+  description: 'The responses grouped by HTTP status type (2xx, 3xx, 4xx, 5xx) for a node.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+      },
+      mappings: [],
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    pieType: 'pie',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local responseStatusesPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'rate(couchdb_httpd_status_codes{' + matcher + '}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='cluster="{{cluster}}",instance="{{instance}}",code="{{code}}"',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Response statuses',
+  description: 'The response rate split by HTTP statuses for a node.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'reqps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local logsRow = {
+  datasource: promDatasource,
+  targets: [],
+  type: 'row',
+  title: 'Logs',
+  collapsed: false,
+};
+
+local logTypesPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'increase(couchdb_couch_log_requests_total{' + matcher + '}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='cluster="{{cluster}}",instance="{{instance}}",level="{{level}}"',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Log types',
+  description: 'The number of logged messages for a node.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local systemLogsPanel = {
+  datasource: lokiDatasource,
+  targets: [
+    {
+      datasource: lokiDatasource,
+      editorMode: 'code',
+      expr: '{' + matcher + ', filename=~"/var/log/couchdb/couchdb\\.log"} |= ""',
+      queryType: 'range',
+      refId: 'A',
+    },
+  ],
+  type: 'logs',
+  title: 'System logs',
+  description: 'Recent logs from the Apache CouchDB logs file for a node.',
+  options: {
+    dedupStrategy: 'none',
+    enableLogDetails: true,
+    prettifyLogMessage: false,
+    showCommonLabels: false,
+    showLabels: false,
+    showTime: false,
+    sortOrder: 'Descending',
+    wrapLogMessage: false,
+  },
+};
+
+{
+  grafanaDashboards+:: {
+    'couchdb-nodes.json':
+      dashboard.new(
+        'Apache CouchDB nodes',
+        time_from='%s' % $._config.dashboardPeriod,
+        tags=($._config.dashboardTags),
+        timezone='%s' % $._config.dashboardTimezone,
+        refresh='%s' % $._config.dashboardRefresh,
+        description='',
+        uid=dashboardUid,
+      )
+      .addLink(grafana.link.dashboards(
+        asDropdown=false,
+        title='Other Apache CouchDB dashboards',
+        includeVars=true,
+        keepTime=true,
+        tags=($._config.dashboardTags),
+      ))
+      .addTemplates(
+        std.flattenArrays([
+          [
+            template.datasource(
+              promDatasourceName,
+              'prometheus',
+              null,
+              label='Data Source',
+              refresh='load'
+            ),
+          ],
+          if $._config.enableLokiLogs then [
+            template.datasource(
+              lokiDatasourceName,
+              'loki',
+              null,
+              label='Loki Datasource',
+              refresh='load'
+            ),
+          ] else [],
+          [
+            template.new(
+              'job',
+              promDatasource,
+              'label_values(couchdb_couch_replicator_cluster_is_stable, job)',
+              label='Job',
+              refresh=1,
+              includeAll=true,
+              multi=true,
+              allValues='',
+              sort=0
+            ),
+            template.new(
+              'cluster',
+              promDatasource,
+              'label_values(couchdb_couch_replicator_cluster_is_stable{job=~"$job"}, cluster)',
+              label='Cluster',
+              refresh=1,
+              includeAll=true,
+              multi=true,
+              allValues='',
+              sort=0
+            ),
+            template.new(
+              'instance',
+              promDatasource,
+              'label_values(couchdb_couch_replicator_cluster_is_stable{cluster=~"$cluster"}, instance)',
+              label='Instance',
+              refresh=1,
+              includeAll=true,
+              multi=true,
+              allValues='',
+              sort=0
+            ),
+          ],
+        ])
+      )
+      .addPanels(
+        std.flattenArrays([
+          [
+            erlangMemoryUsagePanel { gridPos: { h: 8, w: 8, x: 0, y: 0 } },
+            openOSFilesPanel { gridPos: { h: 8, w: 8, x: 8, y: 0 } },
+            openDatabasesPanel { gridPos: { h: 8, w: 8, x: 16, y: 0 } },
+            databaseWritesPanel { gridPos: { h: 8, w: 12, x: 0, y: 8 } },
+            databaseReadsPanel { gridPos: { h: 8, w: 12, x: 12, y: 8 } },
+            viewReadsPanel { gridPos: { h: 8, w: 8, x: 0, y: 16 } },
+            viewTimeoutsPanel { gridPos: { h: 8, w: 8, x: 8, y: 16 } },
+            temporaryViewReadsPanel { gridPos: { h: 8, w: 8, x: 16, y: 16 } },
+            requestsRow { gridPos: { h: 1, w: 24, x: 0, y: 24 } },
+            requestMethodsPanel { gridPos: { h: 8, w: 8, x: 0, y: 25 } },
+            requestLatencyPanel { gridPos: { h: 8, w: 8, x: 8, y: 25 } },
+            bulkRequestsPanel { gridPos: { h: 8, w: 8, x: 16, y: 25 } },
+            responseStatusOverviewPanel { gridPos: { h: 8, w: 12, x: 0, y: 33 } },
+            responseStatusesPanel { gridPos: { h: 8, w: 12, x: 12, y: 33 } },
+            logsRow { gridPos: { h: 1, w: 24, x: 0, y: 41 } },
+            logTypesPanel { gridPos: { h: 8, w: 24, x: 0, y: 42 } },
+          ],
+          if $._config.enableLokiLogs then [
+            systemLogsPanel { gridPos: { h: 8, w: 24, x: 0, y: 50 } },
+          ] else [],
+          [
+          ],
+        ])
+      ),
+  },
+}

--- a/apache-couchdb-mixin/dashboards/couchdb-overview.libsonnet
+++ b/apache-couchdb-mixin/dashboards/couchdb-overview.libsonnet
@@ -1030,19 +1030,9 @@ local bulkRequestsPanel = {
   },
 };
 
-local responseStatusOverviewPanel = {
+local responseStatusErrorOverviewPanel = {
   datasource: promDatasource,
   targets: [
-    prometheus.target(
-      'sum by(job, cluster) (increase(couchdb_httpd_status_codes{' + matcher + ', code=~"2.*"}[$__interval])) != 0',
-      datasource=promDatasource,
-      legendFormat='{{cluster}} - 2xx',
-    ),
-    prometheus.target(
-      'sum by(job, cluster) (increase(couchdb_httpd_status_codes{' + matcher + ', code=~"3.*"}[$__interval])) != 0',
-      datasource=promDatasource,
-      legendFormat='{{cluster}} - 3xx',
-    ),
     prometheus.target(
       'sum by(job, cluster) (increase(couchdb_httpd_status_codes{' + matcher + ', code=~"4.*"}[$__interval])) != 0',
       datasource=promDatasource,
@@ -1055,8 +1045,8 @@ local responseStatusOverviewPanel = {
     ),
   ],
   type: 'piechart',
-  title: 'Response status overview',
-  description: 'The responses grouped by HTTP status type (2xx, 3xx, 4xx, 5xx) aggregated across all nodes.',
+  title: 'Response status error overview',
+  description: 'The responses grouped by HTTP error status type (4xx and 5xx) aggregated across all nodes.',
   fieldConfig: {
     defaults: {
       color: {
@@ -1800,7 +1790,7 @@ local replicatorJobsPendingPanel = {
           requestsRow { gridPos: { h: 1, w: 24, x: 0, y: 24 } },
           bulkRequestsPanel { gridPos: { h: 6, w: 8, x: 0, y: 25 } },
           averageRequestLatencyPanel { gridPos: { h: 6, w: 8, x: 8, y: 25 } },
-          responseStatusOverviewPanel { gridPos: { h: 6, w: 8, x: 16, y: 25 } },
+          responseStatusErrorOverviewPanel { gridPos: { h: 6, w: 8, x: 16, y: 25 } },
           requestMethodsPanel { gridPos: { h: 6, w: 12, x: 0, y: 31 } },
           responseStatusesPanel { gridPos: { h: 6, w: 12, x: 12, y: 31 } },
           replicationRow { gridPos: { h: 1, w: 24, x: 0, y: 37 } },

--- a/apache-couchdb-mixin/dashboards/couchdb-overview.libsonnet
+++ b/apache-couchdb-mixin/dashboards/couchdb-overview.libsonnet
@@ -862,27 +862,27 @@ local averageRequestLatencyPanel = {
     prometheus.target(
       'avg by(job, cluster, quantile) (couchdb_request_time_seconds{' + matcher + ', quantile=~"0.5"})',
       datasource=promDatasource,
-      legendFormat='{{cluster}} - 0.5',
+      legendFormat='{{cluster}} - p50',
     ),
     prometheus.target(
       'avg by(job, cluster, quantile) (couchdb_request_time_seconds{' + matcher + ', quantile=~"0.75"})',
       datasource=promDatasource,
-      legendFormat='{{cluster}} - 0.75',
+      legendFormat='{{cluster}} - p75',
     ),
     prometheus.target(
       'avg by(job, cluster, quantile) (couchdb_request_time_seconds{' + matcher + ', quantile=~"0.95"})',
       datasource=promDatasource,
-      legendFormat='{{cluster}} - 0.95',
+      legendFormat='{{cluster}} - p95',
     ),
     prometheus.target(
       'avg by(job, cluster, quantile) (couchdb_request_time_seconds{' + matcher + ', quantile=~"0.99"})',
       datasource=promDatasource,
-      legendFormat='{{cluster}} - 0.99',
+      legendFormat='{{cluster}} - p99',
     ),
   ],
   type: 'timeseries',
-  title: 'Average request latency',
-  description: 'The average request latency aggregated across all nodes.',
+  title: 'Request latency quantiles',
+  description: 'The average request latency quantiles aggregated across all nodes.',
   fieldConfig: {
     defaults: {
       color: {

--- a/apache-couchdb-mixin/dashboards/couchdb-overview.libsonnet
+++ b/apache-couchdb-mixin/dashboards/couchdb-overview.libsonnet
@@ -1,0 +1,1817 @@
+local g = (import 'grafana-builder/grafana.libsonnet');
+local grafana = (import 'grafonnet/grafana.libsonnet');
+local dashboard = grafana.dashboard;
+local template = grafana.template;
+local prometheus = grafana.prometheus;
+
+local dashboardUid = 'couchdb-overview';
+
+local promDatasourceName = 'prometheus_datasource';
+local matcher = 'job=~"$job", cluster=~"$cluster"';
+
+local promDatasource = {
+  uid: '${%s}' % promDatasourceName,
+};
+
+local numberOfClustersPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'count(count by(cluster, job) (couchdb_request_time_seconds_count{' + matcher + '}))',
+      datasource=promDatasource,
+      legendFormat='cluster="{{ cluster }}"',
+      format='time_series',
+    ),
+  ],
+  type: 'stat',
+  title: 'Number of clusters',
+  description: 'The number of clusters being reported.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'yellow',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 0,
+          },
+          {
+            color: 'green',
+            value: 1,
+          },
+        ],
+      },
+    },
+    overrides: [],
+  },
+  options: {
+    colorMode: 'value',
+    graphMode: 'none',
+    justifyMode: 'auto',
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    textMode: 'auto',
+  },
+  pluginVersion: '9.2.3',
+};
+
+local numberOfNodesPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum(count by(cluster, job) (couchdb_request_time_seconds_count{' + matcher + '}))',
+      datasource=promDatasource,
+      legendFormat='cluster="{{ cluster }}"',
+      format='time_series',
+    ),
+  ],
+  type: 'stat',
+  title: 'Number of nodes',
+  description: 'The number of nodes being reported.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'red',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 0,
+          },
+          {
+            color: 'green',
+            value: 1,
+          },
+        ],
+      },
+    },
+    overrides: [],
+  },
+  options: {
+    colorMode: 'value',
+    graphMode: 'none',
+    justifyMode: 'auto',
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    textMode: 'auto',
+  },
+  pluginVersion: '9.2.3',
+};
+
+local clusterHealthPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'min(min by(cluster, job) (couchdb_couch_replicator_cluster_is_stable{' + matcher + '}))',
+      datasource=promDatasource,
+      legendFormat='cluster="{{ cluster }}"',
+      format='time_series',
+    ),
+  ],
+  type: 'stat',
+  title: 'Cluster health',
+  description: 'Either Healthy or Unhealthy based on whether all nodes are reported as healthy within the cluster.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [
+        {
+          options: {
+            '0': {
+              color: 'red',
+              index: 0,
+              text: 'Unhealthy',
+            },
+            '1': {
+              color: 'green',
+              index: 1,
+              text: 'Healthy',
+            },
+          },
+          type: 'value',
+        },
+      ],
+      max: 1,
+      min: 0,
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'yellow',
+            value: null,
+          },
+        ],
+      },
+    },
+    overrides: [],
+  },
+  options: {
+    colorMode: 'value',
+    graphMode: 'none',
+    justifyMode: 'auto',
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    textMode: 'auto',
+  },
+  pluginVersion: '9.2.3',
+};
+
+local openOSFilesPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by(cluster, job) (increase(couchdb_open_os_files_total{' + matcher + '}[$__rate_interval]))',
+      datasource=promDatasource,
+      legendFormat='cluster="{{cluster}}"',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Open OS files',
+  description: 'The total number of file descriptors open aggregated across all nodes.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [
+      {
+        __systemRef: 'hideSeriesFrom',
+        matcher: {
+          id: 'byNames',
+          options: {
+            mode: 'exclude',
+            names: [
+              'Value',
+            ],
+            prefix: 'All except:',
+            readOnly: true,
+          },
+        },
+        properties: [
+          {
+            id: 'custom.hideFrom',
+            value: {
+              legend: false,
+              tooltip: false,
+              viz: true,
+            },
+          },
+        ],
+      },
+    ],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local openDatabasesPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by(job, cluster) (couchdb_open_databases_total{' + matcher + '})',
+      datasource=promDatasource,
+      legendFormat='cluster="{{cluster}}"',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Open databases',
+  description: 'The total number of open databases aggregated across all nodes.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local databaseWritesPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by(job, cluster) (rate(couchdb_database_writes_total{' + matcher + '}[$__rate_interval]))',
+      datasource=promDatasource,
+      legendFormat='cluster="{{cluster}}"',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Database writes',
+  description: 'The number of database writes aggregated across all nodes.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'wps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local databaseReadsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by(job, cluster) (rate(couchdb_database_reads_total{' + matcher + '}[$__rate_interval]))',
+      datasource=promDatasource,
+      legendFormat='cluster="{{cluster}}"',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Database reads',
+  description: 'The number of database reads aggregated across all nodes.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'rps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local viewReadsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by(job, cluster) (rate(couchdb_httpd_view_reads_total{' + matcher + '}[$__rate_interval]))',
+      datasource=promDatasource,
+      legendFormat='cluster="{{cluster}}"',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'View reads',
+  description: 'The number of view reads aggregated across all nodes.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'rps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local viewTimeoutsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by(job, cluster) (rate(couchdb_httpd_view_timeouts_total{' + matcher + '}[$__rate_interval]))',
+      datasource=promDatasource,
+      legendFormat='cluster="{{cluster}}"',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'View timeouts',
+  description: 'The number of view requests that timed out aggregated across all nodes.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'reqps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local temporaryViewReadsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by(job, cluster) (rate(couchdb_httpd_temporary_view_reads_total{' + matcher + '}[$__rate_interval]))',
+      datasource=promDatasource,
+      legendFormat='cluster="{{cluster}}"',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Temporary view reads',
+  description: 'The number of temporary view reads aggregated across all nodes.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'rps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local requestsRow = {
+  datasource: promDatasource,
+  targets: [],
+  type: 'row',
+  title: 'Requests',
+  collapsed: false,
+};
+
+local requestMethodsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by(job, cluster, method) (rate(couchdb_httpd_request_methods{' + matcher + '}[$__rate_interval]))',
+      datasource=promDatasource,
+      legendFormat='cluster="{{cluster}}",method="{{method}}"',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Request methods',
+  description: 'The request rate split by HTTP Method aggregated across all nodes.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'reqps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local averageRequestLatencyPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'avg by(job, cluster, quantile) (couchdb_request_time_seconds{' + matcher + ', quantile=~"0.5"})',
+      datasource=promDatasource,
+      legendFormat='cluster="{{cluster}}",quantile="{{quantile}}"',
+    ),
+    prometheus.target(
+      'avg by(job, cluster, quantile) (couchdb_request_time_seconds{' + matcher + ', quantile=~"0.75"})',
+      datasource=promDatasource,
+      legendFormat='cluster="{{cluster}}",quantile="{{quantile}}"',
+    ),
+    prometheus.target(
+      'avg by(job, cluster, quantile) (couchdb_request_time_seconds{' + matcher + ', quantile=~"0.95"})',
+      datasource=promDatasource,
+      legendFormat='cluster="{{cluster}}",quantile="{{quantile}}"',
+    ),
+    prometheus.target(
+      'avg by(job, cluster, quantile) (couchdb_request_time_seconds{' + matcher + ', quantile=~"0.99"})',
+      datasource=promDatasource,
+      legendFormat='cluster="{{cluster}}",quantile="{{quantile}}"',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Average request latency',
+  description: 'The average request latency aggregated across all nodes.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 's',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+  pluginVersion: '9.2.3',
+};
+
+local bulkRequestsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by(job, cluster) (rate(couchdb_httpd_bulk_requests_total{' + matcher + '}[$__rate_interval]))',
+      datasource=promDatasource,
+      legendFormat='cluster="{{cluster}}"',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Bulk requests',
+  description: 'The number of bulk requests aggregated across all nodes.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'reqps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local responseStatusOverviewPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by(job, cluster) (increase(couchdb_httpd_status_codes{' + matcher + ', code=~"2.*"}[$__rate_interval]))',
+      datasource=promDatasource,
+      legendFormat='cluster="{{cluster}}",status="2xx"',
+    ),
+    prometheus.target(
+      'sum by(job, cluster) (increase(couchdb_httpd_status_codes{' + matcher + ', code=~"3.*"}[$__rate_interval]))',
+      datasource=promDatasource,
+      legendFormat='cluster="{{cluster}}",status="3xx"',
+    ),
+    prometheus.target(
+      'sum by(job, cluster) (increase(couchdb_httpd_status_codes{' + matcher + ', code=~"4.*"}[$__rate_interval]))',
+      datasource=promDatasource,
+      legendFormat='cluster="{{cluster}}",status="4xx"',
+    ),
+    prometheus.target(
+      'sum by(job, cluster) (increase(couchdb_httpd_status_codes{' + matcher + ', code=~"5.*"}[$__rate_interval]))',
+      datasource=promDatasource,
+      legendFormat='cluster="{{cluster}}",status="5xx"',
+    ),
+  ],
+  type: 'piechart',
+  title: 'Response status overview',
+  description: 'The responses grouped by HTTP status type (2xx, 3xx, 4xx, 5xx) aggregated across all nodes.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+      },
+      mappings: [],
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    pieType: 'pie',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local responseStatusesPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by(job, cluster, code) (rate(couchdb_httpd_status_codes{' + matcher + '}[$__rate_interval]))',
+      datasource=promDatasource,
+      legendFormat='cluster="{{cluster}}",status="{{code}}"',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Response statuses',
+  description: 'The response rate split by HTTP statuses aggregated across all nodes.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'reqps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local replicationRow = {
+  datasource: promDatasource,
+  targets: [],
+  type: 'row',
+  title: 'Replication',
+  collapsed: false,
+};
+
+local replicatorChangesManagerDeathsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by(job, cluster) (increase(couchdb_couch_replicator_changes_manager_deaths_total{' + matcher + '}[$__rate_interval]))',
+      datasource=promDatasource,
+      legendFormat='cluster="{{cluster}}"',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Replicator changes manager deaths',
+  description: 'Number of replicator changes manager processor deaths across all nodes.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local replicatorChangesQueueDeathsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by(job, cluster) (increase(couchdb_couch_replicator_changes_queue_deaths_total{' + matcher + '}[$__rate_interval]))',
+      datasource=promDatasource,
+      legendFormat='cluster="{{cluster}}"',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Replicator changes queue deaths',
+  description: 'Number of replicator changes queue processor deaths across all nodes.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local replicatorChangesReaderDeathsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by(job, cluster) (increase(couchdb_couch_replicator_changes_reader_deaths_total{' + matcher + '}[$__rate_interval]))',
+      datasource=promDatasource,
+      legendFormat='cluster="{{cluster}}"',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Replicator changes reader deaths',
+  description: 'Number of replicator changes reader processor deaths across all nodes.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local replicatorConnectionOwnerCrashesPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by(job, cluster) (increase(couchdb_couch_replicator_connection_owner_crashes_total{' + matcher + '}[$__rate_interval]))',
+      datasource=promDatasource,
+      legendFormat='cluster="{{cluster}}"',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Replicator connection owner crashes',
+  description: 'Number of replicator connection owner crashes across all nodes.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local replicatorConnectionWorkerCrashesPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by(job, cluster) (increase(couchdb_couch_replicator_connection_worker_crashes_total{' + matcher + '}[$__rate_interval]))',
+      datasource=promDatasource,
+      legendFormat='cluster="{{cluster}}"',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Replicator connection worker crashes',
+  description: 'Number of replicator connection worker crashes across all nodes.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local replicatorJobCrashesPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by(job, cluster) (increase(couchdb_couch_replicator_jobs_crashes_total{' + matcher + '}[$__rate_interval]))',
+      datasource=promDatasource,
+      legendFormat='cluster="{{cluster}}"',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Replicator job crashes',
+  description: 'Number of replicator job crashes across all nodes.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local replicatorJobsPendingPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by(job, cluster) (couchdb_couch_replicator_jobs_pending{' + matcher + '})',
+      datasource=promDatasource,
+      legendFormat='cluster="{{cluster}}"',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Replicator jobs pending',
+  description: 'Number of replicator jobs pending across all nodes.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+{
+  grafanaDashboards+:: {
+    'couchdb-overview.json':
+      dashboard.new(
+        'Apache CouchDB overview',
+        time_from='%s' % $._config.dashboardPeriod,
+        tags=($._config.dashboardTags),
+        timezone='%s' % $._config.dashboardTimezone,
+        refresh='%s' % $._config.dashboardRefresh,
+        description='',
+        uid=dashboardUid,
+      )
+      .addLink(grafana.link.dashboards(
+        asDropdown=false,
+        title='Other Apache CouchDB dashboards',
+        includeVars=true,
+        keepTime=true,
+        tags=($._config.dashboardTags),
+      ))
+      .addTemplates(
+        [
+          template.datasource(
+            promDatasourceName,
+            'prometheus',
+            null,
+            label='Data Source',
+            refresh='load'
+          ),
+          template.new(
+            'job',
+            promDatasource,
+            'label_values(couchdb_couch_replicator_cluster_is_stable, job)',
+            label='Job',
+            refresh=1,
+            includeAll=true,
+            multi=true,
+            allValues='',
+            sort=0
+          ),
+          template.new(
+            'cluster',
+            promDatasource,
+            'label_values(couchdb_couch_replicator_cluster_is_stable{job=~"$job"}, cluster)',
+            label='Cluster',
+            refresh=1,
+            includeAll=true,
+            multi=true,
+            allValues='',
+            sort=0
+          ),
+        ]
+      )
+      .addPanels(
+        [
+          numberOfClustersPanel { gridPos: { h: 8, w: 8, x: 0, y: 0 } },
+          numberOfNodesPanel { gridPos: { h: 8, w: 8, x: 8, y: 0 } },
+          clusterHealthPanel { gridPos: { h: 8, w: 8, x: 16, y: 0 } },
+          openOSFilesPanel { gridPos: { h: 8, w: 12, x: 0, y: 8 } },
+          openDatabasesPanel { gridPos: { h: 8, w: 12, x: 12, y: 8 } },
+          databaseWritesPanel { gridPos: { h: 8, w: 12, x: 0, y: 16 } },
+          databaseReadsPanel { gridPos: { h: 8, w: 12, x: 12, y: 16 } },
+          viewReadsPanel { gridPos: { h: 8, w: 8, x: 0, y: 24 } },
+          viewTimeoutsPanel { gridPos: { h: 8, w: 8, x: 8, y: 24 } },
+          temporaryViewReadsPanel { gridPos: { h: 8, w: 8, x: 16, y: 24 } },
+          requestsRow { gridPos: { h: 1, w: 24, x: 0, y: 32 } },
+          requestMethodsPanel { gridPos: { h: 8, w: 8, x: 0, y: 33 } },
+          averageRequestLatencyPanel { gridPos: { h: 8, w: 8, x: 8, y: 33 } },
+          bulkRequestsPanel { gridPos: { h: 8, w: 8, x: 16, y: 33 } },
+          responseStatusOverviewPanel { gridPos: { h: 8, w: 12, x: 0, y: 41 } },
+          responseStatusesPanel { gridPos: { h: 8, w: 12, x: 12, y: 41 } },
+          replicationRow { gridPos: { h: 1, w: 24, x: 0, y: 49 } },
+          replicatorChangesManagerDeathsPanel { gridPos: { h: 8, w: 8, x: 0, y: 50 } },
+          replicatorChangesQueueDeathsPanel { gridPos: { h: 8, w: 8, x: 8, y: 50 } },
+          replicatorChangesReaderDeathsPanel { gridPos: { h: 8, w: 8, x: 16, y: 50 } },
+          replicatorConnectionOwnerCrashesPanel { gridPos: { h: 8, w: 12, x: 0, y: 58 } },
+          replicatorConnectionWorkerCrashesPanel { gridPos: { h: 8, w: 12, x: 12, y: 58 } },
+          replicatorJobCrashesPanel { gridPos: { h: 8, w: 12, x: 0, y: 66 } },
+          replicatorJobsPendingPanel { gridPos: { h: 8, w: 12, x: 12, y: 66 } },
+        ]
+      ),
+  },
+}

--- a/apache-couchdb-mixin/dashboards/couchdb-overview.libsonnet
+++ b/apache-couchdb-mixin/dashboards/couchdb-overview.libsonnet
@@ -129,7 +129,7 @@ local clusterHealthPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'min(min by(cluster, job) (couchdb_couch_replicator_cluster_is_stable{' + matcher + '}))',
+      'min by(cluster, job) (couchdb_couch_replicator_cluster_is_stable{' + matcher + '})',
       datasource=promDatasource,
       legendFormat='{{ cluster }}',
       format='time_series',
@@ -137,37 +137,27 @@ local clusterHealthPanel = {
   ],
   type: 'stat',
   title: 'Cluster health',
-  description: 'Either Healthy or Unhealthy based on whether all nodes are reported as healthy within the cluster.',
+  description: 'Each cluster shows green for healthy or red for unhealthy if all nodes in cluster are reporting healthy.',
   fieldConfig: {
     defaults: {
       color: {
-        mode: 'thresholds',
+        mode: 'continuous-GrYlRd',
       },
-      mappings: [
-        {
-          options: {
-            '0': {
-              color: 'red',
-              index: 0,
-              text: 'Unhealthy',
-            },
-            '1': {
-              color: 'green',
-              index: 1,
-              text: 'Healthy',
-            },
-          },
-          type: 'value',
-        },
-      ],
-      max: 1,
-      min: 0,
+      mappings: [],
       thresholds: {
         mode: 'absolute',
         steps: [
           {
+            color: 'green',
+            value: 1,
+          },
+          {
             color: 'yellow',
             value: null,
+          },
+          {
+            color: 'red',
+            value: 0,
           },
         ],
       },
@@ -175,7 +165,7 @@ local clusterHealthPanel = {
     overrides: [],
   },
   options: {
-    colorMode: 'value',
+    colorMode: 'background',
     graphMode: 'none',
     justifyMode: 'auto',
     orientation: 'auto',
@@ -186,7 +176,8 @@ local clusterHealthPanel = {
       fields: '',
       values: false,
     },
-    textMode: 'auto',
+    text: {},
+    textMode: 'name',
   },
   pluginVersion: '9.2.3',
 };

--- a/apache-couchdb-mixin/dashboards/couchdb-overview.libsonnet
+++ b/apache-couchdb-mixin/dashboards/couchdb-overview.libsonnet
@@ -19,7 +19,7 @@ local numberOfClustersPanel = {
     prometheus.target(
       'count(count by(cluster, job) (couchdb_request_time_seconds_count{' + matcher + '}))',
       datasource=promDatasource,
-      legendFormat='cluster="{{ cluster }}"',
+      legendFormat='{{ cluster }}',
       format='time_series',
     ),
   ],
@@ -75,7 +75,7 @@ local numberOfNodesPanel = {
     prometheus.target(
       'sum(count by(cluster, job) (couchdb_request_time_seconds_count{' + matcher + '}))',
       datasource=promDatasource,
-      legendFormat='cluster="{{ cluster }}"',
+      legendFormat='{{ cluster }}',
       format='time_series',
     ),
   ],
@@ -131,7 +131,7 @@ local clusterHealthPanel = {
     prometheus.target(
       'min(min by(cluster, job) (couchdb_couch_replicator_cluster_is_stable{' + matcher + '}))',
       datasource=promDatasource,
-      legendFormat='cluster="{{ cluster }}"',
+      legendFormat='{{ cluster }}',
       format='time_series',
     ),
   ],
@@ -195,9 +195,9 @@ local openOSFilesPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(cluster, job) (increase(couchdb_open_os_files_total{' + matcher + '}[$__rate_interval]))',
+      'sum by(cluster, job) (increase(couchdb_open_os_files_total{' + matcher + '}[$__interval]))',
       datasource=promDatasource,
-      legendFormat='cluster="{{cluster}}"',
+      legendFormat='{{cluster}}',
     ),
   ],
   type: 'timeseries',
@@ -301,7 +301,7 @@ local openDatabasesPanel = {
     prometheus.target(
       'sum by(job, cluster) (couchdb_open_databases_total{' + matcher + '})',
       datasource=promDatasource,
-      legendFormat='cluster="{{cluster}}"',
+      legendFormat='{{cluster}}',
     ),
   ],
   type: 'timeseries',
@@ -380,7 +380,7 @@ local databaseWritesPanel = {
     prometheus.target(
       'sum by(job, cluster) (rate(couchdb_database_writes_total{' + matcher + '}[$__rate_interval]))',
       datasource=promDatasource,
-      legendFormat='cluster="{{cluster}}"',
+      legendFormat='{{cluster}}',
     ),
   ],
   type: 'timeseries',
@@ -459,7 +459,7 @@ local databaseReadsPanel = {
     prometheus.target(
       'sum by(job, cluster) (rate(couchdb_database_reads_total{' + matcher + '}[$__rate_interval]))',
       datasource=promDatasource,
-      legendFormat='cluster="{{cluster}}"',
+      legendFormat='{{cluster}}',
     ),
   ],
   type: 'timeseries',
@@ -538,7 +538,7 @@ local viewReadsPanel = {
     prometheus.target(
       'sum by(job, cluster) (rate(couchdb_httpd_view_reads_total{' + matcher + '}[$__rate_interval]))',
       datasource=promDatasource,
-      legendFormat='cluster="{{cluster}}"',
+      legendFormat='{{cluster}}',
     ),
   ],
   type: 'timeseries',
@@ -617,7 +617,7 @@ local viewTimeoutsPanel = {
     prometheus.target(
       'sum by(job, cluster) (rate(couchdb_httpd_view_timeouts_total{' + matcher + '}[$__rate_interval]))',
       datasource=promDatasource,
-      legendFormat='cluster="{{cluster}}"',
+      legendFormat='{{cluster}}',
     ),
   ],
   type: 'timeseries',
@@ -696,7 +696,7 @@ local temporaryViewReadsPanel = {
     prometheus.target(
       'sum by(job, cluster) (rate(couchdb_httpd_temporary_view_reads_total{' + matcher + '}[$__rate_interval]))',
       datasource=promDatasource,
-      legendFormat='cluster="{{cluster}}"',
+      legendFormat='{{cluster}}',
     ),
   ],
   type: 'timeseries',
@@ -781,9 +781,9 @@ local requestMethodsPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(job, cluster, method) (rate(couchdb_httpd_request_methods{' + matcher + '}[$__rate_interval]))',
+      'sum by(job, cluster, method) (rate(couchdb_httpd_request_methods{' + matcher + '}[$__rate_interval])) != 0',
       datasource=promDatasource,
-      legendFormat='cluster="{{cluster}}",method="{{method}}"',
+      legendFormat='{{cluster}} - {{method}}',
     ),
   ],
   type: 'timeseries',
@@ -845,12 +845,12 @@ local requestMethodsPanel = {
   options: {
     legend: {
       calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
+      displayMode: 'table',
+      placement: 'right',
       showLegend: true,
     },
     tooltip: {
-      mode: 'single',
+      mode: 'multi',
       sort: 'none',
     },
   },
@@ -862,22 +862,22 @@ local averageRequestLatencyPanel = {
     prometheus.target(
       'avg by(job, cluster, quantile) (couchdb_request_time_seconds{' + matcher + ', quantile=~"0.5"})',
       datasource=promDatasource,
-      legendFormat='cluster="{{cluster}}",quantile="{{quantile}}"',
+      legendFormat='{{cluster}} - 0.5',
     ),
     prometheus.target(
       'avg by(job, cluster, quantile) (couchdb_request_time_seconds{' + matcher + ', quantile=~"0.75"})',
       datasource=promDatasource,
-      legendFormat='cluster="{{cluster}}",quantile="{{quantile}}"',
+      legendFormat='{{cluster}} - 0.75',
     ),
     prometheus.target(
       'avg by(job, cluster, quantile) (couchdb_request_time_seconds{' + matcher + ', quantile=~"0.95"})',
       datasource=promDatasource,
-      legendFormat='cluster="{{cluster}}",quantile="{{quantile}}"',
+      legendFormat='{{cluster}} - 0.95',
     ),
     prometheus.target(
       'avg by(job, cluster, quantile) (couchdb_request_time_seconds{' + matcher + ', quantile=~"0.99"})',
       datasource=promDatasource,
-      legendFormat='cluster="{{cluster}}",quantile="{{quantile}}"',
+      legendFormat='{{cluster}} - 0.99',
     ),
   ],
   type: 'timeseries',
@@ -939,12 +939,12 @@ local averageRequestLatencyPanel = {
   options: {
     legend: {
       calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
+      displayMode: 'table',
+      placement: 'right',
       showLegend: true,
     },
     tooltip: {
-      mode: 'single',
+      mode: 'multi',
       sort: 'none',
     },
   },
@@ -957,7 +957,7 @@ local bulkRequestsPanel = {
     prometheus.target(
       'sum by(job, cluster) (rate(couchdb_httpd_bulk_requests_total{' + matcher + '}[$__rate_interval]))',
       datasource=promDatasource,
-      legendFormat='cluster="{{cluster}}"',
+      legendFormat='{{cluster}}',
     ),
   ],
   type: 'timeseries',
@@ -1034,24 +1034,24 @@ local responseStatusOverviewPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(job, cluster) (increase(couchdb_httpd_status_codes{' + matcher + ', code=~"2.*"}[$__rate_interval]))',
+      'sum by(job, cluster) (increase(couchdb_httpd_status_codes{' + matcher + ', code=~"2.*"}[$__interval])) != 0',
       datasource=promDatasource,
-      legendFormat='cluster="{{cluster}}",status="2xx"',
+      legendFormat='{{cluster}} - 2xx',
     ),
     prometheus.target(
-      'sum by(job, cluster) (increase(couchdb_httpd_status_codes{' + matcher + ', code=~"3.*"}[$__rate_interval]))',
+      'sum by(job, cluster) (increase(couchdb_httpd_status_codes{' + matcher + ', code=~"3.*"}[$__interval])) != 0',
       datasource=promDatasource,
-      legendFormat='cluster="{{cluster}}",status="3xx"',
+      legendFormat='{{cluster}} - 3xx',
     ),
     prometheus.target(
-      'sum by(job, cluster) (increase(couchdb_httpd_status_codes{' + matcher + ', code=~"4.*"}[$__rate_interval]))',
+      'sum by(job, cluster) (increase(couchdb_httpd_status_codes{' + matcher + ', code=~"4.*"}[$__interval])) != 0',
       datasource=promDatasource,
-      legendFormat='cluster="{{cluster}}",status="4xx"',
+      legendFormat='{{cluster}} - 4xx',
     ),
     prometheus.target(
-      'sum by(job, cluster) (increase(couchdb_httpd_status_codes{' + matcher + ', code=~"5.*"}[$__rate_interval]))',
+      'sum by(job, cluster) (increase(couchdb_httpd_status_codes{' + matcher + ', code=~"5.*"}[$__interval])) != 0',
       datasource=promDatasource,
-      legendFormat='cluster="{{cluster}}",status="5xx"',
+      legendFormat='{{cluster}} - 5xx',
     ),
   ],
   type: 'piechart',
@@ -1075,8 +1075,8 @@ local responseStatusOverviewPanel = {
   },
   options: {
     legend: {
-      displayMode: 'list',
-      placement: 'bottom',
+      displayMode: 'table',
+      placement: 'right',
       showLegend: true,
     },
     pieType: 'pie',
@@ -1098,9 +1098,9 @@ local responseStatusesPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(job, cluster, code) (rate(couchdb_httpd_status_codes{' + matcher + '}[$__rate_interval]))',
+      'sum by(job, cluster, code) (rate(couchdb_httpd_status_codes{' + matcher + '}[$__rate_interval])) != 0',
       datasource=promDatasource,
-      legendFormat='cluster="{{cluster}}",status="{{code}}"',
+      legendFormat='{{cluster}} - {{code}}',
     ),
   ],
   type: 'timeseries',
@@ -1162,12 +1162,12 @@ local responseStatusesPanel = {
   options: {
     legend: {
       calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
+      displayMode: 'table',
+      placement: 'right',
       showLegend: true,
     },
     tooltip: {
-      mode: 'single',
+      mode: 'multi',
       sort: 'none',
     },
   },
@@ -1185,9 +1185,9 @@ local replicatorChangesManagerDeathsPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(job, cluster) (increase(couchdb_couch_replicator_changes_manager_deaths_total{' + matcher + '}[$__rate_interval]))',
+      'sum by(job, cluster) (increase(couchdb_couch_replicator_changes_manager_deaths_total{' + matcher + '}[$__interval]))',
       datasource=promDatasource,
-      legendFormat='cluster="{{cluster}}"',
+      legendFormat='{{cluster}}',
     ),
   ],
   type: 'timeseries',
@@ -1264,9 +1264,9 @@ local replicatorChangesQueueDeathsPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(job, cluster) (increase(couchdb_couch_replicator_changes_queue_deaths_total{' + matcher + '}[$__rate_interval]))',
+      'sum by(job, cluster) (increase(couchdb_couch_replicator_changes_queue_deaths_total{' + matcher + '}[$__interval]))',
       datasource=promDatasource,
-      legendFormat='cluster="{{cluster}}"',
+      legendFormat='{{cluster}}',
     ),
   ],
   type: 'timeseries',
@@ -1343,9 +1343,9 @@ local replicatorChangesReaderDeathsPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(job, cluster) (increase(couchdb_couch_replicator_changes_reader_deaths_total{' + matcher + '}[$__rate_interval]))',
+      'sum by(job, cluster) (increase(couchdb_couch_replicator_changes_reader_deaths_total{' + matcher + '}[$__interval]))',
       datasource=promDatasource,
-      legendFormat='cluster="{{cluster}}"',
+      legendFormat='{{cluster}}',
     ),
   ],
   type: 'timeseries',
@@ -1422,9 +1422,9 @@ local replicatorConnectionOwnerCrashesPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(job, cluster) (increase(couchdb_couch_replicator_connection_owner_crashes_total{' + matcher + '}[$__rate_interval]))',
+      'sum by(job, cluster) (increase(couchdb_couch_replicator_connection_owner_crashes_total{' + matcher + '}[$__interval]))',
       datasource=promDatasource,
-      legendFormat='cluster="{{cluster}}"',
+      legendFormat='{{cluster}}',
     ),
   ],
   type: 'timeseries',
@@ -1501,9 +1501,9 @@ local replicatorConnectionWorkerCrashesPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(job, cluster) (increase(couchdb_couch_replicator_connection_worker_crashes_total{' + matcher + '}[$__rate_interval]))',
+      'sum by(job, cluster) (increase(couchdb_couch_replicator_connection_worker_crashes_total{' + matcher + '}[$__interval]))',
       datasource=promDatasource,
-      legendFormat='cluster="{{cluster}}"',
+      legendFormat='{{cluster}}',
     ),
   ],
   type: 'timeseries',
@@ -1580,9 +1580,9 @@ local replicatorJobCrashesPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(job, cluster) (increase(couchdb_couch_replicator_jobs_crashes_total{' + matcher + '}[$__rate_interval]))',
+      'sum by(job, cluster) (increase(couchdb_couch_replicator_jobs_crashes_total{' + matcher + '}[$__interval]))',
       datasource=promDatasource,
-      legendFormat='cluster="{{cluster}}"',
+      legendFormat='{{cluster}}',
     ),
   ],
   type: 'timeseries',
@@ -1661,7 +1661,7 @@ local replicatorJobsPendingPanel = {
     prometheus.target(
       'sum by(job, cluster) (couchdb_couch_replicator_jobs_pending{' + matcher + '})',
       datasource=promDatasource,
-      legendFormat='cluster="{{cluster}}"',
+      legendFormat='{{cluster}}',
     ),
   ],
   type: 'timeseries',
@@ -1787,30 +1787,30 @@ local replicatorJobsPendingPanel = {
       )
       .addPanels(
         [
-          numberOfClustersPanel { gridPos: { h: 8, w: 8, x: 0, y: 0 } },
-          numberOfNodesPanel { gridPos: { h: 8, w: 8, x: 8, y: 0 } },
-          clusterHealthPanel { gridPos: { h: 8, w: 8, x: 16, y: 0 } },
-          openOSFilesPanel { gridPos: { h: 8, w: 12, x: 0, y: 8 } },
-          openDatabasesPanel { gridPos: { h: 8, w: 12, x: 12, y: 8 } },
-          databaseWritesPanel { gridPos: { h: 8, w: 12, x: 0, y: 16 } },
-          databaseReadsPanel { gridPos: { h: 8, w: 12, x: 12, y: 16 } },
-          viewReadsPanel { gridPos: { h: 8, w: 8, x: 0, y: 24 } },
-          viewTimeoutsPanel { gridPos: { h: 8, w: 8, x: 8, y: 24 } },
-          temporaryViewReadsPanel { gridPos: { h: 8, w: 8, x: 16, y: 24 } },
-          requestsRow { gridPos: { h: 1, w: 24, x: 0, y: 32 } },
-          requestMethodsPanel { gridPos: { h: 8, w: 8, x: 0, y: 33 } },
-          averageRequestLatencyPanel { gridPos: { h: 8, w: 8, x: 8, y: 33 } },
-          bulkRequestsPanel { gridPos: { h: 8, w: 8, x: 16, y: 33 } },
-          responseStatusOverviewPanel { gridPos: { h: 8, w: 12, x: 0, y: 41 } },
-          responseStatusesPanel { gridPos: { h: 8, w: 12, x: 12, y: 41 } },
-          replicationRow { gridPos: { h: 1, w: 24, x: 0, y: 49 } },
-          replicatorChangesManagerDeathsPanel { gridPos: { h: 8, w: 8, x: 0, y: 50 } },
-          replicatorChangesQueueDeathsPanel { gridPos: { h: 8, w: 8, x: 8, y: 50 } },
-          replicatorChangesReaderDeathsPanel { gridPos: { h: 8, w: 8, x: 16, y: 50 } },
-          replicatorConnectionOwnerCrashesPanel { gridPos: { h: 8, w: 12, x: 0, y: 58 } },
-          replicatorConnectionWorkerCrashesPanel { gridPos: { h: 8, w: 12, x: 12, y: 58 } },
-          replicatorJobCrashesPanel { gridPos: { h: 8, w: 12, x: 0, y: 66 } },
-          replicatorJobsPendingPanel { gridPos: { h: 8, w: 12, x: 12, y: 66 } },
+          numberOfClustersPanel { gridPos: { h: 6, w: 8, x: 0, y: 0 } },
+          numberOfNodesPanel { gridPos: { h: 6, w: 8, x: 8, y: 0 } },
+          clusterHealthPanel { gridPos: { h: 6, w: 8, x: 16, y: 0 } },
+          openOSFilesPanel { gridPos: { h: 6, w: 12, x: 0, y: 6 } },
+          openDatabasesPanel { gridPos: { h: 6, w: 12, x: 12, y: 6 } },
+          databaseWritesPanel { gridPos: { h: 6, w: 12, x: 0, y: 12 } },
+          databaseReadsPanel { gridPos: { h: 6, w: 12, x: 12, y: 12 } },
+          viewReadsPanel { gridPos: { h: 6, w: 8, x: 0, y: 18 } },
+          viewTimeoutsPanel { gridPos: { h: 6, w: 8, x: 8, y: 18 } },
+          temporaryViewReadsPanel { gridPos: { h: 6, w: 8, x: 16, y: 18 } },
+          requestsRow { gridPos: { h: 1, w: 24, x: 0, y: 24 } },
+          bulkRequestsPanel { gridPos: { h: 6, w: 8, x: 0, y: 25 } },
+          averageRequestLatencyPanel { gridPos: { h: 6, w: 8, x: 8, y: 25 } },
+          responseStatusOverviewPanel { gridPos: { h: 6, w: 8, x: 16, y: 25 } },
+          requestMethodsPanel { gridPos: { h: 6, w: 12, x: 0, y: 31 } },
+          responseStatusesPanel { gridPos: { h: 6, w: 12, x: 12, y: 31 } },
+          replicationRow { gridPos: { h: 1, w: 24, x: 0, y: 37 } },
+          replicatorChangesManagerDeathsPanel { gridPos: { h: 6, w: 8, x: 0, y: 38 } },
+          replicatorChangesQueueDeathsPanel { gridPos: { h: 6, w: 8, x: 8, y: 38 } },
+          replicatorChangesReaderDeathsPanel { gridPos: { h: 6, w: 8, x: 16, y: 38 } },
+          replicatorConnectionOwnerCrashesPanel { gridPos: { h: 6, w: 12, x: 0, y: 44 } },
+          replicatorConnectionWorkerCrashesPanel { gridPos: { h: 6, w: 12, x: 12, y: 44 } },
+          replicatorJobCrashesPanel { gridPos: { h: 6, w: 12, x: 0, y: 50 } },
+          replicatorJobsPendingPanel { gridPos: { h: 6, w: 12, x: 12, y: 50 } },
         ]
       ),
   },

--- a/apache-couchdb-mixin/dashboards/couchdb-overview.libsonnet
+++ b/apache-couchdb-mixin/dashboards/couchdb-overview.libsonnet
@@ -1090,18 +1090,97 @@ local responseStatusOverviewPanel = {
   },
 };
 
-local responseStatusesPanel = {
+local goodResponseStatusesPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(job, cluster, code) (rate(couchdb_httpd_status_codes{' + matcher + '}[$__rate_interval])) != 0',
+      'sum by(job, cluster, code) (rate(couchdb_httpd_status_codes{' + matcher + ', code=~"[23].*"}[$__rate_interval])) != 0',
       datasource=promDatasource,
       legendFormat='{{cluster}} - {{code}}',
     ),
   ],
   type: 'timeseries',
   title: 'Response statuses',
-  description: 'The response rate split by HTTP statuses aggregated across all nodes.',
+  description: 'The response rate split by good HTTP statuses aggregated across all nodes.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'reqps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'table',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'none',
+    },
+  },
+};
+
+local errorResponseStatusesPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by(job, cluster, code) (rate(couchdb_httpd_status_codes{' + matcher + ', code=~"[45].*"}[$__rate_interval])) != 0',
+      datasource=promDatasource,
+      legendFormat='{{cluster}} - {{code}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Error response statuses',
+  description: 'The response rate split by error HTTP statuses aggregated across all nodes.',
   fieldConfig: {
     defaults: {
       color: {
@@ -1794,19 +1873,20 @@ local replicatorJobsPendingPanel = {
           viewTimeoutsPanel { gridPos: { h: 6, w: 8, x: 8, y: 18 } },
           temporaryViewReadsPanel { gridPos: { h: 6, w: 8, x: 16, y: 18 } },
           requestsRow { gridPos: { h: 1, w: 24, x: 0, y: 24 } },
-          bulkRequestsPanel { gridPos: { h: 6, w: 8, x: 0, y: 25 } },
-          averageRequestLatencyPanel { gridPos: { h: 6, w: 8, x: 8, y: 25 } },
-          responseStatusOverviewPanel { gridPos: { h: 6, w: 8, x: 16, y: 25 } },
+          bulkRequestsPanel { gridPos: { h: 6, w: 12, x: 0, y: 25 } },
+          averageRequestLatencyPanel { gridPos: { h: 6, w: 12, x: 12, y: 25 } },
           requestMethodsPanel { gridPos: { h: 6, w: 12, x: 0, y: 31 } },
-          responseStatusesPanel { gridPos: { h: 6, w: 12, x: 12, y: 31 } },
-          replicationRow { gridPos: { h: 1, w: 24, x: 0, y: 37 } },
-          replicatorChangesManagerDeathsPanel { gridPos: { h: 6, w: 8, x: 0, y: 38 } },
-          replicatorChangesQueueDeathsPanel { gridPos: { h: 6, w: 8, x: 8, y: 38 } },
-          replicatorChangesReaderDeathsPanel { gridPos: { h: 6, w: 8, x: 16, y: 38 } },
-          replicatorConnectionOwnerCrashesPanel { gridPos: { h: 6, w: 12, x: 0, y: 44 } },
-          replicatorConnectionWorkerCrashesPanel { gridPos: { h: 6, w: 12, x: 12, y: 44 } },
-          replicatorJobCrashesPanel { gridPos: { h: 6, w: 12, x: 0, y: 50 } },
-          replicatorJobsPendingPanel { gridPos: { h: 6, w: 12, x: 12, y: 50 } },
+          responseStatusOverviewPanel { gridPos: { h: 6, w: 12, x: 12, y: 31 } },
+          goodResponseStatusesPanel { gridPos: { h: 6, w: 12, x: 0, y: 37 } },
+          errorResponseStatusesPanel { gridPos: { h: 6, w: 12, x: 12, y: 37 } },
+          replicationRow { gridPos: { h: 1, w: 24, x: 0, y: 43 } },
+          replicatorChangesManagerDeathsPanel { gridPos: { h: 6, w: 8, x: 0, y: 44 } },
+          replicatorChangesQueueDeathsPanel { gridPos: { h: 6, w: 8, x: 8, y: 44 } },
+          replicatorChangesReaderDeathsPanel { gridPos: { h: 6, w: 8, x: 16, y: 44 } },
+          replicatorConnectionOwnerCrashesPanel { gridPos: { h: 6, w: 12, x: 0, y: 50 } },
+          replicatorConnectionWorkerCrashesPanel { gridPos: { h: 6, w: 12, x: 12, y: 50 } },
+          replicatorJobCrashesPanel { gridPos: { h: 6, w: 12, x: 0, y: 56 } },
+          replicatorJobsPendingPanel { gridPos: { h: 6, w: 12, x: 12, y: 56 } },
         ]
       ),
   },

--- a/apache-couchdb-mixin/dashboards/dashboards.libsonnet
+++ b/apache-couchdb-mixin/dashboards/dashboards.libsonnet
@@ -1,0 +1,2 @@
+(import 'couchdb-overview.libsonnet') +
+(import 'couchdb-nodes.libsonnet')

--- a/apache-couchdb-mixin/jsonnetfile.json
+++ b/apache-couchdb-mixin/jsonnetfile.json
@@ -1,0 +1,15 @@
+{
+    "version": 1,
+    "dependencies": [
+        {
+            "source": {
+                "git": {
+                    "remote": "https://github.com/grafana/grafonnet-lib.git",
+                    "subdir": "grafonnet"
+                }
+            },
+            "version": "master"
+        }
+    ],
+    "legacyImports": true
+}

--- a/apache-couchdb-mixin/mixin.libsonnet
+++ b/apache-couchdb-mixin/mixin.libsonnet
@@ -1,0 +1,3 @@
+(import 'dashboards/dashboards.libsonnet') +
+(import 'alerts/alerts.libsonnet') +
+(import 'config.libsonnet')


### PR DESCRIPTION
Adding a mixin for [Apache CouchDB](https://couchdb.apache.org/)

This includes 2 dashboards `Apache CouchDB overview` and `Apache CouchDB nodes`

It also adds alerts

- `CouchDbHigh4xxResponseCodes`: There are a high number of 4xx responses for incoming requests to a node.
- `CouchDbHigh5xxResponseCodes`: There are a high number of 5xx responses for incoming requests to a node.
- `CouchDbModerateRequestLatency`: There is a moderate level of request latency for a node.
- `CouchDbHighRequestLatency`: There is a high level of request latency for a node.
- `CouchDbManyReplicatorJobsPending`: There is a high number of replicator jobs pending for a node.
- `CouchDbReplicatorJobsCrashing`: There are replicator jobs crashing for a node.
- `CouchDbReplicatorChangesQueuesDying`: There are replicator changes queue process deaths for a node.
- `CouchDbReplicatorConnectionOwnersCrashing`: There are replicator connection owner process crashes for a node.
- `CouchDbReplicatorConnectionWorkersCrashing`: There are replicator connection worker process crashes for a node.

Currently setup in Keith's shared instance https://keithschmitty.grafana.net/dashboards/f/bYIXT0aVk/apache-couchdb-mixin

# Overview
<img width="2547" alt="couchdb_overview_1" src="https://user-images.githubusercontent.com/12396806/225912536-15d10f9f-5291-438c-bab8-207786b19a67.png">
<img width="2542" alt="couchdb_overview_2" src="https://user-images.githubusercontent.com/12396806/225912562-9ebe88f7-c260-4bb5-a3b0-a0d5b1cd4f16.png">

# Nodes
<img width="2547" alt="couchdb_nodes_1" src="https://user-images.githubusercontent.com/12396806/225912600-a4620988-2642-40da-8bcf-e328ac0654d1.png">
<img width="2547" alt="couchdb_nodes_2" src="https://user-images.githubusercontent.com/12396806/225912617-0e82040f-1303-4685-bfd8-19f97ce513cd.png">

