### PR TITLE
Migrating from old container registry (k8s.gcr.io) to new GA Container registry (registry.k8s.io)

### DIFF
--- a/k8s-node-termination-handler/gke.libsonnet
+++ b/k8s-node-termination-handler/gke.libsonnet
@@ -3,7 +3,7 @@ local k = import 'k.libsonnet';
 {
   namespace:: 'kube-system',
   slack_webhook:: '',
-  image:: 'k8s.gcr.io/gke-node-termination-handler@sha256:aca12d17b222dfed755e28a44d92721e477915fb73211d0a0f8925a1fa847cca',
+  image:: 'registry.k8s.io/gke-node-termination-handler@sha256:aca12d17b222dfed755e28a44d92721e477915fb73211d0a0f8925a1fa847cca',
 
   local container = k.core.v1.container,
   local envVar = k.core.v1.envVar,

--- a/kube-state-metrics/main.libsonnet
+++ b/kube-state-metrics/main.libsonnet
@@ -3,7 +3,7 @@ local kausal = import 'github.com/grafana/jsonnet-libs/ksonnet-util/kausal.libso
 {
   new(
     namespace,
-    image='k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.1.0',
+    image='registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.1.0',
   ):: {
     local k = kausal {
       _config+: {

--- a/prometheus-ksonnet/images.libsonnet
+++ b/prometheus-ksonnet/images.libsonnet
@@ -7,7 +7,7 @@ local prometheus_images = import 'prometheus/images.libsonnet';
     alertmanager_images +
     {
       watch: 'weaveworks/watch:master-0c44bf6',
-      kubeStateMetrics: 'k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.1.0',
+      kubeStateMetrics: 'registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.1.0',
       nodeExporter: 'prom/node-exporter:v1.3.1',
       nginx: 'nginx:1.15.1-alpine',
     },


### PR DESCRIPTION
As part of the effort to migrate off of the old container registry, we are replacing all of the `k8s.gcr.io` references with `registry.k8s.io`.