### PR TITLE
fix(ksonnet-util): provide fallback for manifestYaml

### DIFF
--- a/ksonnet-util/util.libsonnet
+++ b/ksonnet-util/util.libsonnet
@@ -226,7 +226,9 @@ local util(k) = {
 
   manifestYaml(value):: (
     local f = std.native('manifestYamlFromJson');
-    f(std.toString(value))
+    if f != null
+    then f(std.toString(value))
+    else std.manifestYamlDoc(value)
   ),
 
   resourcesRequests(cpu, memory)::


### PR DESCRIPTION
`std.manifestYamlDoc` implements the same feature but has a slightly different output,
this change maintains the old Tanka functionality but provides a compatible fallback that
works with plain jsonnet.