### PR TITLE
memcached: Use bytes/sec for y axes instead of bits/sec

### DIFF
--- a/memcached-mixin/dashboards.libsonnet
+++ b/memcached-mixin/dashboards.libsonnet
@@ -82,12 +82,12 @@ local g = (import 'grafana-builder/grafana.libsonnet');
         .addPanel(
           g.panel('Bytes received') +
           g.queryPanel('sum by(instance) (rate(memcached_read_bytes_total{' + $._config.clusterLabel + '=~"$cluster", job=~"$job", instance=~"$instance"}[$__rate_interval]))', '{{instance}}') +
-          { yaxes: g.yaxes('bps') },
+          { yaxes: g.yaxes('Bps') },
         )
         .addPanel(
           g.panel('Bytes transmitted') +
           g.queryPanel('sum by(instance) (rate(memcached_written_bytes_total{' + $._config.clusterLabel + '=~"$cluster", job=~"$job", instance=~"$instance"}[$__rate_interval]))', '{{instance}}') +
-          { yaxes: g.yaxes('bps') },
+          { yaxes: g.yaxes('Bps') },
         )
       )
       .addRow(


### PR DESCRIPTION
The metric being used is `memcached_(read|written)_bytes_total`