### PR TITLE
Remove colon from rate intervals for CouchDB dashboards

### DIFF
--- a/apache-couchdb-mixin/dashboards/couchdb-nodes.libsonnet
+++ b/apache-couchdb-mixin/dashboards/couchdb-nodes.libsonnet
@@ -254,7 +254,7 @@ local databaseWritesPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'rate(couchdb_database_writes_total{' + matcher + '}[$__rate_interval:])',
+      'rate(couchdb_database_writes_total{' + matcher + '}[$__rate_interval])',
       datasource=promDatasource,
       legendFormat='{{instance}}',
     ),
@@ -333,7 +333,7 @@ local databaseReadsPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'rate(couchdb_database_reads_total{' + matcher + '}[$__rate_interval:])',
+      'rate(couchdb_database_reads_total{' + matcher + '}[$__rate_interval])',
       datasource=promDatasource,
       legendFormat='{{instance}}',
     ),
@@ -412,7 +412,7 @@ local viewReadsPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'rate(couchdb_httpd_view_reads_total{' + matcher + '}[$__rate_interval:])',
+      'rate(couchdb_httpd_view_reads_total{' + matcher + '}[$__rate_interval])',
       datasource=promDatasource,
       legendFormat='{{instance}}',
     ),
@@ -491,7 +491,7 @@ local viewTimeoutsPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'rate(couchdb_httpd_view_timeouts_total{' + matcher + '}[$__rate_interval:])',
+      'rate(couchdb_httpd_view_timeouts_total{' + matcher + '}[$__rate_interval])',
       datasource=promDatasource,
       legendFormat='{{instance}}',
     ),
@@ -570,7 +570,7 @@ local temporaryViewReadsPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'rate(couchdb_httpd_temporary_view_reads_total{' + matcher + '}[$__rate_interval:])',
+      'rate(couchdb_httpd_temporary_view_reads_total{' + matcher + '}[$__rate_interval])',
       datasource=promDatasource,
       legendFormat='{{instance}}',
     ),
@@ -657,7 +657,7 @@ local requestMethodsPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'rate(couchdb_httpd_request_methods{' + matcher + '}[$__rate_interval:]) != 0',
+      'rate(couchdb_httpd_request_methods{' + matcher + '}[$__rate_interval]) != 0',
       datasource=promDatasource,
       legendFormat='{{instance}} - {{method}}',
     ),
@@ -830,7 +830,7 @@ local bulkRequestsPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'rate(couchdb_httpd_bulk_requests_total{' + matcher + '}[$__rate_interval:])',
+      'rate(couchdb_httpd_bulk_requests_total{' + matcher + '}[$__rate_interval])',
       datasource=promDatasource,
       legendFormat='{{instance}}',
     ),
@@ -973,7 +973,7 @@ local goodResponseStatusesPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'rate(couchdb_httpd_status_codes{' + matcher + ', code=~"[23].*"}[$__rate_interval:]) != 0',
+      'rate(couchdb_httpd_status_codes{' + matcher + ', code=~"[23].*"}[$__rate_interval]) != 0',
       datasource=promDatasource,
       legendFormat='{{instance}} - {{code}}',
     ),
@@ -1052,7 +1052,7 @@ local errorResponseStatusesPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'rate(couchdb_httpd_status_codes{' + matcher + ', code=~"[45].*"}[$__rate_interval:]) != 0',
+      'rate(couchdb_httpd_status_codes{' + matcher + ', code=~"[45].*"}[$__rate_interval]) != 0',
       datasource=promDatasource,
       legendFormat='{{instance}} - {{code}}',
     ),

--- a/apache-couchdb-mixin/dashboards/couchdb-overview.libsonnet
+++ b/apache-couchdb-mixin/dashboards/couchdb-overview.libsonnet
@@ -349,7 +349,7 @@ local databaseWritesPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(job, couchdb_cluster) (rate(couchdb_database_writes_total{' + matcher + '}[$__rate_interval:]))',
+      'sum by(job, couchdb_cluster) (rate(couchdb_database_writes_total{' + matcher + '}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='{{couchdb_cluster}}',
     ),
@@ -428,7 +428,7 @@ local databaseReadsPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(job, couchdb_cluster) (rate(couchdb_database_reads_total{' + matcher + '}[$__rate_interval:]))',
+      'sum by(job, couchdb_cluster) (rate(couchdb_database_reads_total{' + matcher + '}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='{{couchdb_cluster}}',
     ),
@@ -507,7 +507,7 @@ local viewReadsPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(job, couchdb_cluster) (rate(couchdb_httpd_view_reads_total{' + matcher + '}[$__rate_interval:]))',
+      'sum by(job, couchdb_cluster) (rate(couchdb_httpd_view_reads_total{' + matcher + '}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='{{couchdb_cluster}}',
     ),
@@ -586,7 +586,7 @@ local viewTimeoutsPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(job, couchdb_cluster) (rate(couchdb_httpd_view_timeouts_total{' + matcher + '}[$__rate_interval:]))',
+      'sum by(job, couchdb_cluster) (rate(couchdb_httpd_view_timeouts_total{' + matcher + '}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='{{couchdb_cluster}}',
     ),
@@ -665,7 +665,7 @@ local temporaryViewReadsPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(job, couchdb_cluster) (rate(couchdb_httpd_temporary_view_reads_total{' + matcher + '}[$__rate_interval:]))',
+      'sum by(job, couchdb_cluster) (rate(couchdb_httpd_temporary_view_reads_total{' + matcher + '}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='{{couchdb_cluster}}',
     ),
@@ -752,7 +752,7 @@ local requestMethodsPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(job, couchdb_cluster, method) (rate(couchdb_httpd_request_methods{' + matcher + '}[$__rate_interval:])) != 0',
+      'sum by(job, couchdb_cluster, method) (rate(couchdb_httpd_request_methods{' + matcher + '}[$__rate_interval])) != 0',
       datasource=promDatasource,
       legendFormat='{{couchdb_cluster}} - {{method}}',
     ),
@@ -926,7 +926,7 @@ local bulkRequestsPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(job, couchdb_cluster) (rate(couchdb_httpd_bulk_requests_total{' + matcher + '}[$__rate_interval:]))',
+      'sum by(job, couchdb_cluster) (rate(couchdb_httpd_bulk_requests_total{' + matcher + '}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='{{couchdb_cluster}}',
     ),
@@ -1069,7 +1069,7 @@ local goodResponseStatusesPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(job, couchdb_cluster, code) (rate(couchdb_httpd_status_codes{' + matcher + ', code=~"[23].*"}[$__rate_interval:])) != 0',
+      'sum by(job, couchdb_cluster, code) (rate(couchdb_httpd_status_codes{' + matcher + ', code=~"[23].*"}[$__rate_interval])) != 0',
       datasource=promDatasource,
       legendFormat='{{couchdb_cluster}} - {{code}}',
     ),
@@ -1148,7 +1148,7 @@ local errorResponseStatusesPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(job, couchdb_cluster, code) (rate(couchdb_httpd_status_codes{' + matcher + ', code=~"[45].*"}[$__rate_interval:])) != 0',
+      'sum by(job, couchdb_cluster, code) (rate(couchdb_httpd_status_codes{' + matcher + ', code=~"[45].*"}[$__rate_interval])) != 0',
       datasource=promDatasource,
       legendFormat='{{couchdb_cluster}} - {{code}}',
     ),


### PR DESCRIPTION
Remove : from $__rate_intervals in CouchDB dashboard panels as I was seeing gaps when looking at the sample app in the integration. No one else has been doing this yet (only adding the colon to $__interval: with increase functions) so this shouldn't be an issue.