### PR TITLE
day of week calculation

### DIFF
--- a/time/date.jsonnet
+++ b/time/date.jsonnet
@@ -39,14 +39,15 @@ local common_year_month_offset = [0, 3, 3, 6, 1, 4, 6, 2, 5, 0, 3, 5];
 local leap_year_month_offset = [0, 3, 4, 0, 2, 5, 0, 3, 6, 1, 4, 6];
 
 // month_offset looks up the month offset for day of week calculations based on weather the year is common or leap
-local month_offset(year, month) = if is_leap(year) then leap_year_month_offset[month-1] else common_year_month_offset[month-1];
+local month_offset(year, month) = if is_leap(year) then leap_year_month_offset[month - 1] else common_year_month_offset[month - 1];
 
 {
   // to_unix_timestamp transforms a date into a unix timestamp.
   to_unix_timestamp(year, month, day, hour, minute, second)::
     years_seconds(year) + months_seconds(year, month) + days_seconds(day) + hour * 3600 + minute * 60 + second,
-  
+
+
   // day_of_week calculates the day of the week for a given date using Gauss's algorithm (0=Sunday, 1=Monday, etc.)
   day_of_week(year, month, day)::
-    (day + month_offset(year, month) + 5*((year-1)%4) + 4*((year-1)%100) + 6*((year-1)%400))%7
+    (day + month_offset(year, month) + 5 * ((year - 1) % 4) + 4 * ((year - 1) % 100) + 6 * ((year - 1) % 400)) % 7,
 }

--- a/time/date.jsonnet
+++ b/time/date.jsonnet
@@ -34,8 +34,19 @@ local months_seconds(year, month) = std.foldl(
 // days_seconds returns the number of seconds in all days up to day-1.
 local days_seconds(day) = (day - 1) * 24 * 3600;
 
+// month offset lookup tables for day of week calculation
+local common_year_month_offset = [0, 3, 3, 6, 1, 4, 6, 2, 5, 0, 3, 5];
+local leap_year_month_offset = [0, 3, 4, 0, 2, 5, 0, 3, 6, 1, 4, 6];
+
+// month_offset looks up the month offset for day of week calculations based on weather the year is common or leap
+local month_offset(year, month) = if is_leap(year) then leap_year_month_offset[month-1] else common_year_month_offset[month-1];
+
 {
-  // date_to_unix_timestamp transforms a date into a unix timestamp.
+  // to_unix_timestamp transforms a date into a unix timestamp.
   to_unix_timestamp(year, month, day, hour, minute, second)::
     years_seconds(year) + months_seconds(year, month) + days_seconds(day) + hour * 3600 + minute * 60 + second,
+  
+  // day_of_week calculates the day of the week for a given date using Gauss's algorithm (0=Sunday, 1=Monday, etc.)
+  day_of_week(year, month, day)::
+    (day + month_offset(year, month) + 5*((year-1)%4) + 4*((year-1)%100) + 6*((year-1)%400))%7
 }

--- a/time/date_test.jsonnet
+++ b/time/date_test.jsonnet
@@ -4,28 +4,52 @@ local test = import 'github.com/yugui/jsonnetunit/jsonnetunit/test.libsonnet';
 // Run this test suite by running:
 // jsonnet -J vendor date_test.jsonnet
 test.suite({
-  'test 1970-01-01 00:00:00 (zero)': {
+  'test [to_unix_timestamp] 1970-01-01 00:00:00 (zero)': {
     actual: date.to_unix_timestamp(1970, 1, 1, 0, 0, 0),
     expect: 0,
   },
-  'test 1970-01-02 00:00:00 (one day)': {
+  'test [to_unix_timestamp] 1970-01-02 00:00:00 (one day)': {
     actual: date.to_unix_timestamp(1970, 1, 2, 0, 0, 0),
     expect: 86400,
   },
-  'test 1971-01-01 00:00:00 (one year)': {
+  'test [to_unix_timestamp] 1971-01-01 00:00:00 (one year)': {
     actual: date.to_unix_timestamp(1971, 1, 1, 0, 0, 0),
     expect: 365 * 24 * 3600,
   },
-  'test 1972-03-01 00:00:00 (month of leap year)': {
+  'test [to_unix_timestamp] 1972-03-01 00:00:00 (month of leap year)': {
     actual: date.to_unix_timestamp(1972, 3, 1, 0, 0, 0),
     expect: 2 * 365 * 24 * 3600 + 31 * 24 * 3600 + 29 * 24 * 3600,
   },
-  'test 1974-01-01 00:00:00 (incl leap year)': {
+  'test [to_unix_timestamp] 1974-01-01 00:00:00 (incl leap year)': {
     actual: date.to_unix_timestamp(1974, 1, 1, 0, 0, 0),
     expect: (4 * 365 + 1) * 24 * 3600,
   },
-  'test 2020-01-02 03:04:05 (full date)': {
+  'test [to_unix_timestamp] 2020-01-02 03:04:05 (full date)': {
     actual: date.to_unix_timestamp(2020, 1, 2, 3, 4, 5),
     expect: 1577934245,
+  },
+  'test [day_of_week] 2000-01-01 (leap year start)': {
+    actual: date.day_of_week(2000, 1, 1),
+    expect: 6,
+  },
+  'test [day_of_week] 2000-12-31 (leap year end)': {
+    actual: date.day_of_week(2000, 12, 31),
+    expect: 0,
+  },
+  'test [day_of_week] 1995-01-01 (common year start)': {
+    actual: date.day_of_week(1995, 1, 1),
+    expect: 0,
+  },
+  'test [day_of_week] 2003-12-31 (common year end)': {
+    actual: date.day_of_week(2003, 12, 31),
+    expect: 3,
+  },
+  'test [day_of_week] 2024-07-19 (leap year mid)': {
+    actual: date.day_of_week(2024, 7, 19),
+    expect: 5,
+  },
+  'test [day_of_week] 2023-06-15 (common year mid)': {
+    actual: date.day_of_week(2023, 6, 15),
+    expect: 4,
   },
 })


### PR DESCRIPTION
I was going through this repo yesterday and realized that it would be useful to have some day of week calculations (specifying actions by day of week, filtering output by day of week, etc). This PR does the following:

- adds a `day_of_week(year, month, day)` function to `date.libsonnet`, which returns a day of the week as an integer (0=Sunday, 1=Monday, etc).
- adds unit tests to verify correctness
- since there are now unit tests for two different functions, I added a `[function_name]` label to each unit test.