### PR TITLE
Add Redis Enterprise Mixin

### DIFF
--- a/redis-enterprise-mixin/.lint
+++ b/redis-enterprise-mixin/.lint
@@ -1,0 +1,18 @@
+exclusions:
+  template-job-rule:
+    reason: Prometheus datasource variable is being named as prometheus_datasource now while linter expects ‘datasource’
+  panel-datasource-rule:
+    reason: "Loki datasource variable is being named as loki_datasource now while linter expects 'datasource'"
+  template-datasource-rule:
+    reason: "Based on new convention we are using variable names prometheus_datasource and loki_datasource where as linter expects 'datasource'"
+  template-instance-rule:
+    reason: Prometheus datasource variable is being named as prometheus_datasource now while linter expects ‘datasource’
+  target-instance-rule:
+    reason: "For Redis enterprise, the instance = cluster, as there's a 1:1 endpoint to cluster relationship. So the instance requirement should be dropped specifically for this instance."
+    entries:
+    - dashboard: "Redis Enterprise overview"
+    - dashboard: "Redis Enterprise node overview"
+    - dashbaord: "Redis Enterprise database overview"
+  panel-units-rule:
+    reason: "Custom units are used for better user experience in these panels"
+    entries:

--- a/redis-enterprise-mixin/Makefile
+++ b/redis-enterprise-mixin/Makefile
@@ -1,0 +1,34 @@
+JSONNET_FMT := jsonnetfmt -n 2 --max-blank-lines 1 --string-style s --comment-style s
+
+.PHONY: all
+all: build dashboards_out prometheus_alerts.yaml
+
+vendor: jsonnetfile.json
+	jb install
+
+.PHONY: build
+build: vendor
+
+.PHONY: fmt
+fmt:
+	find . -name 'vendor' -prune -o -name '*.libsonnet' -print -o -name '*.jsonnet' -print | \
+		xargs -n 1 -- $(JSONNET_FMT) -i
+
+.PHONY: lint
+lint: build
+	find . -name 'vendor' -prune -o -name '*.libsonnet' -print -o -name '*.jsonnet' -print | \
+		while read f; do \
+			$(JSONNET_FMT) "$$f" | diff -u "$$f" -; \
+		done
+	mixtool lint mixin.libsonnet
+
+dashboards_out: mixin.libsonnet config.libsonnet $(wildcard dashboards/*)
+	@mkdir -p dashboards_out
+	mixtool generate dashboards mixin.libsonnet -d dashboards_out
+
+prometheus_alerts.yaml: mixin.libsonnet alerts/*.libsonnet
+	mixtool generate alerts mixin.libsonnet -a prometheus_alerts.yaml
+
+.PHONY: clean
+clean:
+	rm -rf dashboards_out prometheus_alerts.yaml

--- a/redis-enterprise-mixin/README.md
+++ b/redis-enterprise-mixin/README.md
@@ -20,7 +20,7 @@ and the following alerts:
 
 ## Redis Enterprise overview
 
-The Redis Enterprise overview dashboard provides details on the overall status of the Redis Enterprise cluster. Includes visualizations for important KPIs such as , nodes up, databases up, average request latency, node cpu utilization, node memory utilization, and cluster cache hit ratio.
+The Redis Enterprise overview dashboard provides details on the overall status of the Redis Enterprise cluster. Includes visualizations for important KPIs such as nodes up, databases up, average request latency, node cpu utilization, node memory utilization, and cluster cache hit ratio.
 
 ### TODO dashboard screenshots
 

--- a/redis-enterprise-mixin/README.md
+++ b/redis-enterprise-mixin/README.md
@@ -22,27 +22,13 @@ and the following alerts:
 
 The Redis Enterprise overview dashboard provides details on the overall status of the Redis Enterprise cluster. Includes visualizations for important KPIs such as nodes up, databases up, average request latency, node cpu utilization, node memory utilization, and cluster cache hit ratio.
 
-### TODO dashboard screenshots
-
-![First screenshot of the Redis Enterprise overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/redis-enterprise/screenshots/overview_1.png)
-![Second screenshot of the Redis Enterprise overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/redis-enterprise/screenshots/overview_2.png)
-
 ## Redis Enterprise nodes
 
 The Redis Enterprise nodes dashboard provides details on memory/cpu usage, node network ingress/egress, number of requests, storage utilization, connections, and optionally the redis logs panel.
 
-### TODO dashboard screenshots
-
-![First screenshot of the Redis Enterprise nodes dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/redis-enterprise/screenshots/nodes_1.png)
-![Second screenshot of the Redis Enterprise nodes dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/redis-enterprise/screenshots/nodes_2.png)
-
 ## Redis Enterprise databases
 
 The Redis Enterprise databases dashboard provides details on key counts, operations, memory utilization, memory fragmentation ratio, LUA heap size, database evictions/expirations, and database ingress/egress.
-
-### TODO dashboard screenshots
-
-![Screenshot of the Redis Enterprise keyspaces dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-cassandra/screenshots/keyspaces_1.png)
 
 ## Alerts Overview
 

--- a/redis-enterprise-mixin/README.md
+++ b/redis-enterprise-mixin/README.md
@@ -25,7 +25,7 @@ The Redis Enterprise overview dashboard provides details on the overall status o
 ### TODO dashboard screenshots
 
 ![First screenshot of the Redis Enterprise overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/redis-enterprise/screenshots/overview_1.png)
-![Second screenshot of the Redis Enterprise overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-cassandra/screenshots/overview_2.png)
+![Second screenshot of the Redis Enterprise overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/redis-enterprise/screenshots/overview_2.png)
 
 ## Redis Enterprise nodes
 
@@ -38,7 +38,7 @@ The Redis Enterprise nodes dashboard provides details on memory/cpu usage, node 
 
 ## Redis Enterprise databases
 
-The Redis Enterprise databases dashboard provides details on key counts, operations,memory utilization, memory fragmentation ratio, LUA heap size, database evictions/expirations, and database ingress/egress.
+The Redis Enterprise databases dashboard provides details on key counts, operations, memory utilization, memory fragmentation ratio, LUA heap size, database evictions/expirations, and database ingress/egress.
 
 ### TODO dashboard screenshots
 

--- a/redis-enterprise-mixin/README.md
+++ b/redis-enterprise-mixin/README.md
@@ -1,0 +1,86 @@
+# Redis Enterprise Mixin
+
+The Redis Enterprise mixin is a set of configurable Grafana dashboards and alerts.
+
+The mixin contains the following dashboards:
+
+- Redis Enterprise overview
+- Redis Enterprise nodes
+- Redis Enterprise databases
+
+and the following alerts:
+
+- ClusterOutOfMemory
+- NodeNotResponding
+- DatabaseNotResponding
+- ShardNotResponding
+- NodeHighCPUUtilization
+- AverageLatencyIncreasing
+- KeyEvictionsIncreasing
+
+## Redis Enterprise overview
+
+The Redis Enterprise overview dashboard provides details on the overall status of the Redis Enterprise cluster. Includes visualizations for important KPIs such as , nodes up, databases up, average request latency, node cpu utilization, node memory utilization, and cluster cache hit ratio.
+
+### TODO dashboard screenshots
+
+![First screenshot of the Redis Enterprise overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/redis-enterprise/screenshots/overview_1.png)
+![Second screenshot of the Redis Enterprise overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-cassandra/screenshots/overview_2.png)
+
+## Redis Enterprise nodes
+
+The Redis Enterprise nodes dashboard provides details on memory/cpu usage, node network ingress/egress, number of requests, storage utilization, connections, and optionally the redis logs panel.
+
+### TODO dashboard screenshots
+
+![First screenshot of the Apache Cassandra nodes dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/redis-enterprise/screenshots/nodes_1.png)
+![Second screenshot of the Apache Cassandra nodes dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/redis-enterprise/screenshots/nodes_2.png)
+
+## Redis Enterprise databases
+
+The Redis Enterprise databases dashboard provides details on key counts, operations,memory utilization, memory fragmentation ratio, LUA heap size, database evictions/expirations, and database ingress/egress.
+
+### TODO dashboard screenshots
+
+![Screenshot of the Redis Enterprise keyspaces dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-cassandra/screenshots/keyspaces_1.png)
+
+## Alerts Overview
+
+- ClusterOutOfMemory: Cluster has run out of memory.
+- NodeNotResponding: A node in the Redis Enterprise cluster is offline or unreachable.
+- DatabaseNotResponding: A database in the Redis Enterprise cluster is offline or unreachable.
+- ShardNotResponding: A shard in the Redis Enterprise cluster is offline or unreachable.
+- NodeHighCPUUtilization: Node CPU usage is above the configured threshold.
+- DatabaseHighMemoryUtilization: Node memory utilization is above the configured threshold.
+- AverageLatencyIncreasing: Operation latency is above the configured threshold.
+- KeyEvictionsIncreasing: A node has a higher memory utilization than the configured threshold.
+
+## Install tools
+
+```bash
+go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@latest
+go install github.com/monitoring-mixins/mixtool/cmd/mixtool@latest
+```
+
+For linting and formatting, you would also need `jsonnetfmt` installed. If you
+have a working Go development environment, it's easiest to run the following:
+
+```bash
+go install github.com/google/go-jsonnet/cmd/jsonnetfmt@latest
+```
+
+The files in `dashboards_out` need to be imported
+into your Grafana server. The exact details will be depending on your environment.
+
+`prometheus_alerts.yaml` needs to be imported into Prometheus.
+
+## Generate dashboards and alerts
+
+Edit `config.libsonnet` if required and then build JSON dashboard files and prometheus alerts for Grafana:
+
+```bash
+make
+```
+
+For more advanced uses of mixins, see
+https://github.com/monitoring-mixins/docs.

--- a/redis-enterprise-mixin/README.md
+++ b/redis-enterprise-mixin/README.md
@@ -10,13 +10,13 @@ The mixin contains the following dashboards:
 
 and the following alerts:
 
-- ClusterOutOfMemory
-- NodeNotResponding
-- DatabaseNotResponding
-- ShardNotResponding
-- NodeHighCPUUtilization
-- AverageLatencyIncreasing
-- KeyEvictionsIncreasing
+- RedisEnterpriseClusterOutOfMemory
+- RedisEnterpriseNodeNotResponding
+- RedisEnterpriseDatabaseNotResponding
+- RedisEnterpriseShardNotResponding
+- RedisEnterpriseNodeHighCPUUtilization
+- RedisEnterpriseAverageLatencyIncreasing
+- RedisEnterpriseKeyEvictionsIncreasing
 
 ## Redis Enterprise overview
 
@@ -32,14 +32,14 @@ The Redis Enterprise databases dashboard provides details on key counts, operati
 
 ## Alerts Overview
 
-- ClusterOutOfMemory: Cluster has run out of memory.
-- NodeNotResponding: A node in the Redis Enterprise cluster is offline or unreachable.
-- DatabaseNotResponding: A database in the Redis Enterprise cluster is offline or unreachable.
-- ShardNotResponding: A shard in the Redis Enterprise cluster is offline or unreachable.
-- NodeHighCPUUtilization: Node CPU usage is above the configured threshold.
-- DatabaseHighMemoryUtilization: Node memory utilization is above the configured threshold.
-- AverageLatencyIncreasing: Operation latency is above the configured threshold.
-- KeyEvictionsIncreasing: A node has a higher memory utilization than the configured threshold.
+- RedisEnterpriseClusterOutOfMemory: Cluster has run out of memory.
+- RedisEnterpriseNodeNotResponding: A node in the Redis Enterprise cluster is offline or unreachable.
+- RedisEnterpriseDatabaseNotResponding: A database in the Redis Enterprise cluster is offline or unreachable.
+- RedisEnterpriseShardNotResponding: A shard in the Redis Enterprise cluster is offline or unreachable.
+- RedisEnterpriseNodeHighCPUUtilization: Node CPU usage is above the configured threshold.
+- RedisEnterpriseDatabaseHighMemoryUtilization: Node memory utilization is above the configured threshold.
+- RedisEnterpriseAverageLatencyIncreasing: Operation latency is above the configured threshold.
+- RedisEnterpriseKeyEvictionsIncreasing: A node has a higher memory utilization than the configured threshold.
 
 ## Install tools
 

--- a/redis-enterprise-mixin/README.md
+++ b/redis-enterprise-mixin/README.md
@@ -33,8 +33,8 @@ The Redis Enterprise nodes dashboard provides details on memory/cpu usage, node 
 
 ### TODO dashboard screenshots
 
-![First screenshot of the Apache Cassandra nodes dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/redis-enterprise/screenshots/nodes_1.png)
-![Second screenshot of the Apache Cassandra nodes dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/redis-enterprise/screenshots/nodes_2.png)
+![First screenshot of the Redis Enterprise nodes dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/redis-enterprise/screenshots/nodes_1.png)
+![Second screenshot of the Redis Enterprise nodes dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/redis-enterprise/screenshots/nodes_2.png)
 
 ## Redis Enterprise databases
 

--- a/redis-enterprise-mixin/alerts/alerts.libsonnet
+++ b/redis-enterprise-mixin/alerts/alerts.libsonnet
@@ -5,7 +5,7 @@
         name: 'RedisEnterpriseAlerts',
         rules: [
           {
-            alert: 'ClusterOutOfMemory',
+            alert: 'RedisEnterpriseClusterOutOfMemory',
             expr: |||
               sum(redis_used_memory) by (redis_cluster, node) / sum(node_available_memory) by (redis_cluster, node) * 100 > %(alertsClusterOutOfMemoryThreshold)s
             ||| % $._config,
@@ -23,7 +23,7 @@
             },
           },
           {
-            alert: 'NodeNotResponding',
+            alert: 'RedisEnterpriseNodeNotResponding',
             expr: |||
               node_up == 0
             ||| % $._config,
@@ -40,7 +40,7 @@
             },
           },
           {
-            alert: 'DatabaseNotResponding',
+            alert: 'RedisEnterpriseDatabaseNotResponding',
             expr: |||
               bdb_up == 0
             ||| % $._config,
@@ -57,7 +57,7 @@
             },
           },
           {
-            alert: 'ShardNotResponding',
+            alert: 'RedisEnterpriseShardNotResponding',
             expr: |||
               redis_up == 0
             ||| % $._config,
@@ -74,7 +74,7 @@
             },
           },
           {
-            alert: 'NodeHighCPUUtilization',
+            alert: 'RedisEnterpriseNodeHighCPUUtilization',
             expr: |||
               (sum(node_cpu_user) by (node, redis_cluster, job) + sum(node_cpu_system) by (node, redis_cluster, job)) * 100 > %(alertsNodeCPUHighUtilizationThreshold)s
             ||| % $._config,
@@ -92,7 +92,7 @@
             },
           },
           {
-            alert: 'DatabaseHighMemoryUtilization',
+            alert: 'RedisEnterpriseDatabaseHighMemoryUtilization',
             expr: |||
               sum(bdb_used_memory) by (bdb, redis_cluster) / sum(bdb_memory_limit) by (bdb, redis_cluster) * 100 > %(alertsDatabaseHighMemoryUtiliation)s
             ||| % $._config,
@@ -110,7 +110,7 @@
             },
           },
           {
-            alert: 'AverageLatencyIncreasing',
+            alert: 'RedisEnterpriseAverageLatencyIncreasing',
             expr: |||
               bdb_avg_latency / 1000 > %(alertsDatabaseHighLatencyMs)s
             ||| % $._config,
@@ -128,7 +128,7 @@
             },
           },
           {
-            alert: 'KeyEvictionsIncreasing',
+            alert: 'RedisEnterpriseKeyEvictionsIncreasing',
             expr: |||
               bdb_evicted_objects >= %(alertsEvictedObjectsThreshold)s
             ||| % $._config,

--- a/redis-enterprise-mixin/alerts/alerts.libsonnet
+++ b/redis-enterprise-mixin/alerts/alerts.libsonnet
@@ -1,0 +1,170 @@
+{
+  prometheusAlerts+:: {
+    groups+: [
+      {
+        name: 'RedisEnterpriseAlerts',
+        rules: [
+          {
+            alert: 'ClusterOutOfMemory',
+            expr: |||
+              sum(redis_used_memory) by (redis_cluster, node) / sum(node_available_memory) by (redis_cluster, node) * 100 > %(alertsClusterOutOfMemoryThreshold)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              summary: 'There is a high level of read latency within the node.',
+              description:
+                (
+                  'Memory usage is at {{ printf "%%.0f" $value }} percent on the cluster {{$labels.redis_cluster}}, ' +
+                  "which is above the configured threshold of %(alertsClusterOutOfMemoryThreshold)s%% of the cluster's available memory"
+                ) % $._config,
+            },
+          },
+          {
+            alert: 'NodeNotResponding',
+            expr: |||
+              node_up == 0
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              summary: 'A node in the Redis Enterprise cluster is offline or unreachable.',
+              description:
+                (
+                  'The node {{$labels.node}} in {{$labels.redis_cluster}} is offline or unreachable.'
+                ) % $._config,
+            },
+          },
+          {
+            alert: 'DatabaseNotResponding',
+            expr: |||
+              bdb_up == 0
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              summary: 'A database in the Redis Enterprise cluster is offline or unreachable.',
+              description:
+                (
+                  'The database {{$labels.bdb}} in {{$labels.redis_cluster}} is offline or unreachable.'
+                ) % $._config,
+            },
+          },
+          {
+            alert: 'DatabaseNotResponding',
+            expr: |||
+              redis_up == 0
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              summary: 'A database in the Redis Enterprise cluster is offline or unreachable.',
+              description:
+                (
+                  'The shard {{$labels.redis}} on database {{$labels.bdb}} running on node {{$labels.node}} in the cluster {{$labels.redis_cluster}} is offline or unreachable.'
+                ) % $._config,
+            },
+          },
+          {
+            alert: 'NodeHighCPUUtilization',
+            expr: |||
+              (sum(node_cpu_user) by (node, redis_cluster, job) + sum(node_cpu_system) by (node, redis_cluster, job)) * 100 > %(alertsNodeCPUHighUtilizationThreshold)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              summary: 'Node CPU usage is above the configured threshold.',
+              description:
+                (
+                  'The node {{$labels.node}} in cluster {{$labels.redis_cluster}} has a CPU percentage of ${{ printf "%%.0f" $value }}, which exceeds ' +
+                  'the threshold %(alertsNodeCPUHighUtilizationThreshold)s%%.'
+                ) % $._config,
+            },
+          },
+          {
+            alert: 'DatabaseHighMemoryUtilization',
+            expr: |||
+              sum(bdb_used_memory) by (bdb, redis_cluster) / sum(bdb_memory_limit) by (bdb, redis_cluster) * 100 > %(alertsDatabaseHighMemoryUtiliation)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              summary: 'Node CPU usage is above the configured threshold.',
+              description:
+                (
+                  'The database {{$labels.bdb}} in cluster {{$labels.redis_cluster}} has a memory utiliztaion of ${{ printf "%%.0f" $value }}, which exceeds ' +
+                  'the threshold %(alertsDatabaseHighMemoryUtiliation)s%%.'
+                ) % $._config,
+            },
+          },
+          {
+            alert: 'NodeFreeMemoryIsLow',
+            expr: |||
+              sum(bdb_used_memory) by (bdb, redis_cluster) / sum(bdb_memory_limit) by (bdb, redis_cluster) * 100 > %(alertsDatabaseHighMemoryUtiliation)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              summary: 'The Redis Enterprise node has less than the configured threshold of its memory remaining.',
+              description:
+                (
+                  'The database {{$labels.bdb}} in cluster {{$labels.redis_cluster}} has a memory utiliztaion of ${{ printf "%%.0f" $value }}, which exceeds ' +
+                  'the threshold %(alertsDatabaseHighMemoryUtiliation)s%%.'
+                ) % $._config,
+            },
+          },
+          {
+            alert: 'AverageLatencyIncreasing',
+            expr: |||
+              bdb_avg_latency / 1000 > %(alertsDatabaseHighLatencyMs)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              summary: 'Operation latency is above the configured threshold.',
+              description:
+                (
+                  'The database {{$labels.bdb}} in cluster {{$labels.redis_cluster}} has high latency of ${{ printf "%%.0f" $value }}, which exceeds ' +
+                  'the threshold of %(alertsDatabaseHighLatencyMs)s ms.'
+                ) % $._config,
+            },
+          },
+          {
+            alert: 'KeyEvictionsIncreasing',
+            expr: |||
+              bdb_evicted_objects > %(alertsEvictedObjectsThreshold)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              summary: 'Operation latency is above the configured threshold.',
+              description:
+                (
+                  'The database {{$labels.bdb}} in cluster {{$labels.redis_cluster}} is evicting ${{ printf "%%.0f" $value }} objects, which exceeds ' +
+                  'the threshold of %(alertsEvictedObjectsThreshold)s evicted objects.'
+                ) % $._config,
+            },
+          },
+        ],
+      },
+    ],
+  },
+}

--- a/redis-enterprise-mixin/alerts/alerts.libsonnet
+++ b/redis-enterprise-mixin/alerts/alerts.libsonnet
@@ -14,7 +14,7 @@
               severity: 'critical',
             },
             annotations: {
-              summary: 'There is a high level of read latency within the node.',
+              summary: 'Cluster has run out of memory.',
               description:
                 (
                   'Memory usage is at {{ printf "%%.0f" $value }} percent on the cluster {{$labels.redis_cluster}}, ' +
@@ -57,7 +57,7 @@
             },
           },
           {
-            alert: 'DatabaseNotResponding',
+            alert: 'ShardNotResponding',
             expr: |||
               redis_up == 0
             ||| % $._config,
@@ -66,7 +66,7 @@
               severity: 'critical',
             },
             annotations: {
-              summary: 'A database in the Redis Enterprise cluster is offline or unreachable.',
+              summary: 'A shard in the Redis Enterprise cluster is offline or unreachable.',
               description:
                 (
                   'The shard {{$labels.redis}} on database {{$labels.bdb}} running on node {{$labels.node}} in the cluster {{$labels.redis_cluster}} is offline or unreachable.'
@@ -80,7 +80,7 @@
             ||| % $._config,
             'for': '5m',
             labels: {
-              severity: 'critical',
+              severity: 'warning',
             },
             annotations: {
               summary: 'Node CPU usage is above the configured threshold.',
@@ -98,28 +98,10 @@
             ||| % $._config,
             'for': '5m',
             labels: {
-              severity: 'critical',
+              severity: 'warning',
             },
             annotations: {
-              summary: 'Node CPU usage is above the configured threshold.',
-              description:
-                (
-                  'The database {{$labels.bdb}} in cluster {{$labels.redis_cluster}} has a memory utiliztaion of ${{ printf "%%.0f" $value }}, which exceeds ' +
-                  'the threshold %(alertsDatabaseHighMemoryUtiliation)s%%.'
-                ) % $._config,
-            },
-          },
-          {
-            alert: 'NodeFreeMemoryIsLow',
-            expr: |||
-              sum(bdb_used_memory) by (bdb, redis_cluster) / sum(bdb_memory_limit) by (bdb, redis_cluster) * 100 > %(alertsDatabaseHighMemoryUtiliation)s
-            ||| % $._config,
-            'for': '5m',
-            labels: {
-              severity: 'critical',
-            },
-            annotations: {
-              summary: 'The Redis Enterprise node has less than the configured threshold of its memory remaining.',
+              summary: 'Node memory utilization is above the configured threshold.',
               description:
                 (
                   'The database {{$labels.bdb}} in cluster {{$labels.redis_cluster}} has a memory utiliztaion of ${{ printf "%%.0f" $value }}, which exceeds ' +
@@ -148,14 +130,14 @@
           {
             alert: 'KeyEvictionsIncreasing',
             expr: |||
-              bdb_evicted_objects > %(alertsEvictedObjectsThreshold)s
+              bdb_evicted_objects >= %(alertsEvictedObjectsThreshold)s
             ||| % $._config,
             'for': '5m',
             labels: {
               severity: 'warning',
             },
             annotations: {
-              summary: 'Operation latency is above the configured threshold.',
+              summary: 'The number of evicted objects is greater than or equal to the configured threshold.',
               description:
                 (
                   'The database {{$labels.bdb}} in cluster {{$labels.redis_cluster}} is evicting ${{ printf "%%.0f" $value }} objects, which exceeds ' +

--- a/redis-enterprise-mixin/config.libsonnet
+++ b/redis-enterprise-mixin/config.libsonnet
@@ -1,0 +1,17 @@
+{
+  _config+:: {
+    dashboardTags: ['redis-enterprise-mixin'],
+    dashboardPeriod: 'now-1h',
+    dashboardTimezone: 'default',
+    dashboardRefresh: '1m',
+
+    //alert thresholds
+    alertsClusterOutOfMemoryThreshold: 80,  // %
+    alertsNodeCPUHighUtilizationThreshold: 80,  // %
+    alertsDatabaseHighMemoryUtiliation: 80,  // %
+    alertsDatabaseHighLatencyMs: 1000,  // ms
+    alertsEvictedObjectsThreshold: 1,
+
+    enableLokiLogs: true,
+  },
+}

--- a/redis-enterprise-mixin/dashboards/dashboards.libsonnet
+++ b/redis-enterprise-mixin/dashboards/dashboards.libsonnet
@@ -1,0 +1,3 @@
+(import 'redis-enterprise-overview.libsonnet') +
+(import 'redis-enterprise-nodes.libsonnet') +
+(import 'redis-enterprise-database.libsonnet')

--- a/redis-enterprise-mixin/dashboards/redis-enterprise-database.libsonnet
+++ b/redis-enterprise-mixin/dashboards/redis-enterprise-database.libsonnet
@@ -12,7 +12,8 @@ local promDatasource = {
   uid: '${%s}' % promDatasourceName,
 };
 
-local matcher = 'redis_cluster=~"$redis_cluster", job=~"$job", bdb=~"$database"';
+local nodeMatcher = 'redis_cluster=~"$redis_cluster", job=~"$job"';
+local matcher = nodeMatcher + ', bdb=~"$database"';
 
 local databaseUpPanel = {
   datasource: promDatasource,
@@ -20,7 +21,7 @@ local databaseUpPanel = {
     prometheus.target(
       'bdb_up{' + matcher + '}',
       datasource=promDatasource,
-      legendFormat='{{ bdb }}',
+      legendFormat='node: {{ node }} - {{ bdb }}',
     ),
   ],
   type: 'timeseries',
@@ -154,7 +155,7 @@ local nodesUpPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'node_up{' + matcher + '}',
+      'node_up{' + nodeMatcher + ', node=~"$node"}',
       datasource=promDatasource,
       legendFormat='{{ node }}',
     ),
@@ -1125,7 +1126,7 @@ local syncStatusPanel = {
     prometheus.target(
       'bdb_crdt_syncer_status{' + matcher + '}',
       datasource=promDatasource,
-      legendFormat='{{ bdb }}',
+      legendFormat='{{ bdb }} - repl_id: {{ crdt_replica_id }}',
     ),
   ],
   type: 'timeseries',

--- a/redis-enterprise-mixin/dashboards/redis-enterprise-database.libsonnet
+++ b/redis-enterprise-mixin/dashboards/redis-enterprise-database.libsonnet
@@ -1,0 +1,1536 @@
+local g = (import 'grafana-builder/grafana.libsonnet');
+local grafana = (import 'grafonnet/grafana.libsonnet');
+local dashboard = grafana.dashboard;
+local template = grafana.template;
+local prometheus = grafana.prometheus;
+
+local dashboardUid = 'redis-enterprise-database-overview';
+
+local promDatasourceName = 'prometheus_datasource';
+
+local promDatasource = {
+  uid: '${%s}' % promDatasourceName,
+};
+
+local matcher = 'redis_cluster=~"$redis_cluster", job=~"$job", bdb=~"$database"';
+
+local databaseUpPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'bdb_up{' + matcher + '}',
+      datasource=promDatasource,
+      legendFormat='{{ bdb }}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Database up',
+  description: 'Displays up/down status for the selected database.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local shardsUpPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'redis_up{redis_cluster=~"$redis_cluster", job=~"$job", node=~"$node"}',
+      datasource=promDatasource,
+      legendFormat='{{ bdb }} - redis: {{ redis }}',
+    ),
+  ],
+  type: 'bargauge',
+  title: 'Shards up',
+  description: 'Displays up/down status for each shard related to the database.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      displayName: '${__series.name}',
+      mappings: [],
+      max: 1,
+      min: 0,
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 0,
+          },
+          {
+            color: 'green',
+            value: 1,
+          },
+        ],
+      },
+    },
+    overrides: [],
+  },
+  options: {
+    displayMode: 'basic',
+    minVizHeight: 10,
+    minVizWidth: 0,
+    orientation: 'horizontal',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    showUnfilled: true,
+  },
+  pluginVersion: '9.4.7',
+};
+
+local nodesUpPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'node_up{' + matcher + '}',
+      datasource=promDatasource,
+      legendFormat='{{ node }}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Nodes up',
+  description: 'Displays up/down status for each node related to the database.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local databaseOperationsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'bdb_read_req{' + matcher + '}',
+      datasource=promDatasource,
+      legendFormat='{{ bdb }} - read',
+    ),
+    prometheus.target(
+      'bdb_write_req{' + matcher + '}',
+      datasource=promDatasource,
+      legendFormat='{{bdb}} - write',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Database operations',
+  description: 'Rate of read and write requests.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local databaseAverageLatencyPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'bdb_avg_read_latency{' + matcher + '}',
+      datasource=promDatasource,
+      legendFormat='{{ bdb }} - read',
+    ),
+    prometheus.target(
+      'bdb_avg_write_latency{' + matcher + '}',
+      datasource=promDatasource,
+      legendFormat='{{bdb }} - write',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Database average latency',
+  description: 'Average rate of read and write latency',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'seconds',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local databaseKeyCountPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'bdb_no_of_keys{' + matcher + '}',
+      datasource=promDatasource,
+      legendFormat='{{ bdb }}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Database key count',
+  description: 'Number of keys in the database.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local databaseCacheHitRatioPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'bdb_read_hits{' + matcher + '} / clamp_min(bdb_read_misses{' + matcher + '} + bdb_read_hits{' + matcher + '}, 1) * 100',
+      datasource=promDatasource,
+      legendFormat='{{ bdb }}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Database cache hit ratio',
+  description: 'Percentage of read operations that result in a cache hit.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'percent',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local databaseEvictionsVsExpirationsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'bdb_expired_objects{' + matcher + '}',
+      datasource=promDatasource,
+      legendFormat='{{ bdb }} - expired',
+    ),
+    prometheus.target(
+      'bdb_evicted_objects{' + matcher + '}',
+      datasource=promDatasource,
+      legendFormat='{{ bdb }} - evicted',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Database evictions vs expirations',
+  description: 'Rate of object expiration and eviction',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'ops',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local databaseMemoryUtilizationPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'bdb_used_memory{' + matcher + '} / bdb_memory_limit{' + matcher + '} * 100',
+      datasource=promDatasource,
+      legendFormat='{{ bdb }}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Database memory utilization',
+  description: 'Calculated memory utilization % of the database compared to the limit.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'percent',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local databaseMemoryFragmentationRatioPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'bdb_mem_frag_ratio{' + matcher + '}',
+      datasource=promDatasource,
+      legendFormat='{{ bdb }}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Database memory fragmentation ratio',
+  description: 'RAM fragmentation ratio between RSS and allocated RAM.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'percent',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local databaseLUAHeapSizePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'bdb_mem_size_lua{' + matcher + '}',
+      datasource=promDatasource,
+      legendFormat='{{ bdb }}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Database LUA heap size',
+  description: 'LUA scripting heap size',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'bytes',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local databaseNetworkIngressPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'bdb_ingress_bytes{' + matcher + '}',
+      datasource=promDatasource,
+      legendFormat='{{ bdb }}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Database network ingress',
+  description: 'Rate of incoming network traffic.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'binBps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local databaseNetworkEgressPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'bdb_egress_bytes{' + matcher + '}',
+      datasource=promDatasource,
+      legendFormat='{{ bdb }}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Database network egress',
+  description: 'Rate of outgoing network traffic.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'binBps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local databaseConnectionsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'bdb_conns{' + matcher + '}',
+      datasource=promDatasource,
+      legendFormat='{{ bdb }}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Database connections',
+  description: 'Number of client connections',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local activeactiveRow = {
+  datasource: promDatasource,
+  targets: [],
+  type: 'row',
+  title: 'Active-active',
+  collapsed: false,
+};
+
+local syncStatusPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'bdb_crdt_syncer_status{' + matcher + '}',
+      datasource=promDatasource,
+      legendFormat='{{ bdb }}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Sync status',
+  description: 'Sync status for CRDB traffic.\n- 0=in-sync\n- 1=syncing\n- 2=out of sync',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local localLagPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'bdb_crdt_syncer_local_ingress_lag_time{' + matcher + '}',
+      datasource=promDatasource,
+      legendFormat='{{ bdb }}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Local lag',
+  description: 'Lag between source and destination for CRDB traffic.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'ms',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local crdbIngressCompressedPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'bdb_crdt_syncer_ingress_bytes{' + matcher + '}',
+      datasource=promDatasource,
+      legendFormat='{{ bdb }}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'CRDB ingress compressed',
+  description: 'Rate of compressed network traffic to the CRDB.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'binBps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local crdbIngressDecompressedPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'bdb_crdt_ingress_bytes_decompressed{' + matcher + '}',
+      datasource=promDatasource,
+      legendFormat='{{ bdb }}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'CRDB ingress decompressed',
+  description: 'Rate of decompressed network traffic to the CRDB.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'binBps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+{
+  grafanaDashboards+:: {
+    'redis-enterprise-database-overview.json':
+      dashboard.new(
+        'Redis Enterprise database overview',
+        time_from='%s' % $._config.dashboardPeriod,
+        tags=($._config.dashboardTags),
+        timezone='%s' % $._config.dashboardTimezone,
+        refresh='%s' % $._config.dashboardRefresh,
+        description='',
+        uid=dashboardUid,
+      )
+      .addLink(grafana.link.dashboards(
+        asDropdown=false,
+        title='Other Redis Enterprise dashboards',
+        includeVars=true,
+        keepTime=true,
+        tags=($._config.dashboardTags),
+      ))
+      .addTemplates(
+        [
+          template.datasource(
+            promDatasourceName,
+            'prometheus',
+            null,
+            label='Data Source',
+            refresh='load'
+          ),
+          template.new(
+            'job',
+            promDatasource,
+            'label_values(bdb_up, job)',
+            label='job',
+            refresh=1,
+            includeAll=true,
+            multi=true,
+            allValues='',
+            sort=0
+          ),
+          template.new(
+            'redis_cluster',
+            promDatasource,
+            'label_values(bdb_up, redis_cluster)',
+            label='Redis Cluster',
+            refresh=1,
+            includeAll=true,
+            multi=true,
+            allValues='',
+            sort=0
+          ),
+          template.new(
+            'database',
+            promDatasource,
+            'label_values(bdb_up, bdb)',
+            label='Database',
+            refresh=1,
+            includeAll=true,
+            multi=true,
+            allValues='',
+            sort=0
+          ),
+          template.new(
+            'node',
+            promDatasource,
+            'label_values(redis_up, node)',
+            label='Node',
+            refresh=1,
+            includeAll=true,
+            multi=true,
+            allValues='',
+            sort=0
+          ),
+        ]
+      )
+      .addPanels(
+        [
+          databaseUpPanel { gridPos: { h: 6, w: 8, x: 0, y: 0 } },
+          shardsUpPanel { gridPos: { h: 6, w: 8, x: 8, y: 0 } },
+          nodesUpPanel { gridPos: { h: 6, w: 8, x: 16, y: 0 } },
+          databaseOperationsPanel { gridPos: { h: 6, w: 12, x: 0, y: 6 } },
+          databaseAverageLatencyPanel { gridPos: { h: 6, w: 12, x: 12, y: 6 } },
+          databaseKeyCountPanel { gridPos: { h: 6, w: 8, x: 0, y: 12 } },
+          databaseCacheHitRatioPanel { gridPos: { h: 6, w: 8, x: 8, y: 12 } },
+          databaseEvictionsVsExpirationsPanel { gridPos: { h: 6, w: 8, x: 16, y: 12 } },
+          databaseMemoryUtilizationPanel { gridPos: { h: 6, w: 8, x: 0, y: 18 } },
+          databaseMemoryFragmentationRatioPanel { gridPos: { h: 6, w: 8, x: 8, y: 18 } },
+          databaseLUAHeapSizePanel { gridPos: { h: 6, w: 8, x: 16, y: 18 } },
+          databaseNetworkIngressPanel { gridPos: { h: 6, w: 8, x: 0, y: 24 } },
+          databaseNetworkEgressPanel { gridPos: { h: 6, w: 8, x: 8, y: 24 } },
+          databaseConnectionsPanel { gridPos: { h: 6, w: 8, x: 16, y: 24 } },
+          activeactiveRow { gridPos: { h: 1, w: 24, x: 0, y: 30 } },
+          syncStatusPanel { gridPos: { h: 6, w: 6, x: 0, y: 31 } },
+          localLagPanel { gridPos: { h: 6, w: 6, x: 6, y: 31 } },
+          crdbIngressCompressedPanel { gridPos: { h: 6, w: 6, x: 12, y: 31 } },
+          crdbIngressDecompressedPanel { gridPos: { h: 6, w: 6, x: 18, y: 31 } },
+        ]
+      ),
+  },
+}

--- a/redis-enterprise-mixin/dashboards/redis-enterprise-database.libsonnet
+++ b/redis-enterprise-mixin/dashboards/redis-enterprise-database.libsonnet
@@ -1,4 +1,3 @@
-local g = (import 'grafana-builder/grafana.libsonnet');
 local grafana = (import 'grafonnet/grafana.libsonnet');
 local dashboard = grafana.dashboard;
 local template = grafana.template;

--- a/redis-enterprise-mixin/dashboards/redis-enterprise-database.libsonnet
+++ b/redis-enterprise-mixin/dashboards/redis-enterprise-database.libsonnet
@@ -1486,10 +1486,10 @@ local crdbIngressDecompressedPanel = {
             sort=0
           ),
           template.new(
-            'database',
+            'node',
             promDatasource,
-            'label_values(bdb_up, bdb)',
-            label='Database',
+            'label_values(redis_up, node)',
+            label='Node',
             refresh=1,
             includeAll=true,
             multi=true,
@@ -1497,10 +1497,10 @@ local crdbIngressDecompressedPanel = {
             sort=0
           ),
           template.new(
-            'node',
+            'database',
             promDatasource,
-            'label_values(redis_up, node)',
-            label='Node',
+            'label_values(bdb_up, bdb)',
+            label='Database',
             refresh=1,
             includeAll=true,
             multi=true,

--- a/redis-enterprise-mixin/dashboards/redis-enterprise-nodes.libsonnet
+++ b/redis-enterprise-mixin/dashboards/redis-enterprise-nodes.libsonnet
@@ -1,0 +1,1050 @@
+local g = (import 'grafana-builder/grafana.libsonnet');
+local grafana = (import 'grafonnet/grafana.libsonnet');
+local dashboard = grafana.dashboard;
+local template = grafana.template;
+local prometheus = grafana.prometheus;
+
+local dashboardUid = 'redis-enterprise-node-overview';
+
+local promDatasourceName = 'prometheus_datasource';
+local lokiDatasourceName = 'loki_datasource';
+
+local promDatasource = {
+  uid: '${%s}' % promDatasourceName,
+};
+
+local lokiDatasource = {
+  uid: '${%s}' % lokiDatasourceName,
+};
+
+local matcher = 'redis_cluster=~"$redis_cluster", job=~"$job", node=~"$node"';
+
+local nodesUpPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'node_up{' + matcher + '}',
+      datasource=promDatasource,
+      legendFormat='{{ node }}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Nodes up',
+  description: 'Displays up/down status for the selected node',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local databaseUpPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'bdb_up{redis_cluster=~"$redis_cluster", job=~"$job"}',
+      datasource=promDatasource,
+      legendFormat='db: {{ bdb }}',
+    ),
+  ],
+  type: 'bargauge',
+  title: 'Database up',
+  description: 'Displays up/down status for the databases of the selected node(s).',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      displayName: '${__series.name}',
+      mappings: [],
+      min: 0,
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'transparent',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 0,
+          },
+          {
+            color: 'green',
+            value: 1,
+          },
+        ],
+      },
+    },
+    overrides: [],
+  },
+  options: {
+    displayMode: 'basic',
+    minVizHeight: 10,
+    minVizWidth: 0,
+    orientation: 'horizontal',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    showUnfilled: true,
+  },
+  pluginVersion: '9.4.7',
+};
+
+local shardsUpPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'redis_up{' + matcher + '}',
+      datasource=promDatasource,
+      legendFormat='redis: {{redis}}',
+    ),
+  ],
+  type: 'bargauge',
+  title: 'Shards up',
+  description: 'Displays up/down status for the shards on the selected node.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      displayName: '${__series.name}',
+      mappings: [],
+      min: 0,
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'transparent',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 0,
+          },
+          {
+            color: 'green',
+            value: 1,
+          },
+        ],
+      },
+    },
+    overrides: [],
+  },
+  options: {
+    displayMode: 'basic',
+    minVizHeight: 10,
+    minVizWidth: 0,
+    orientation: 'horizontal',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    showUnfilled: true,
+  },
+  pluginVersion: '9.4.7',
+};
+
+local nodeRequestsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'node_total_req{' + matcher + '}',
+      datasource=promDatasource,
+      legendFormat='{{ node }}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Node requests',
+  description: 'Total endpoint request rate for the selected node.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'reqps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local nodeAverageLatencyPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'node_avg_latency{' + matcher + '}',
+      datasource=promDatasource,
+      legendFormat='{{ node }}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Node average latency',
+  description: 'Average request latency for the selected node.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 's',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local nodeCPUUtilizationPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'node_cpu_system{' + matcher + '} * 100',
+      datasource=promDatasource,
+      legendFormat='{{ node }} - system',
+    ),
+    prometheus.target(
+      'node_cpu_user{' + matcher + '} * 100',
+      datasource=promDatasource,
+      legendFormat='{{node}} - user',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Node CPU utilization',
+  description: 'CPU utilization for idle, main, and user threads.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'percent',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local nodeMemoryUtilizationPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      '(sum(redis_used_memory{' + matcher + '}) by (redis_cluster, job, node) / clamp_min(sum(node_available_memory{' + matcher + '}) by (redis_cluster, job, node) + sum(redis_used_memory{' + matcher + '}) by (redis_cluster, job, node), 1)) * 100',
+      datasource=promDatasource,
+      legendFormat='{{node}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Node memory utilization',
+  description: 'Node memory utilization %.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'percent',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local nodeEphemeralFreeStoragePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'node_ephemeral_storage_free{' + matcher + '}',
+      datasource=promDatasource,
+      legendFormat='{{ node }}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Node ephemeral free storage',
+  description: 'Ephemeral storage available for the selected node.\n',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'bytes',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local nodePersistentFreeStoragePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'node_persistent_storage_free{' + matcher + '}',
+      datasource=promDatasource,
+      legendFormat='{{ node }}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Node persistent free storage',
+  description: 'Persistent storage available for the selected node',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'bytes',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local nodeNetworkIngressPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'node_ingress_bytes{' + matcher + '}',
+      datasource=promDatasource,
+      legendFormat='{{ node }}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Node network ingress',
+  description: 'Rate of incoming network traffic to the selected node',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'binBps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local nodeNetworkEgressPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'node_egress_bytes{' + matcher + '}',
+      datasource=promDatasource,
+      legendFormat='{{ node }}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Node network egress',
+  description: 'Rate of outgoing network traffic to the selected node.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'binBps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local nodeClientConnectionsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'node_conns{' + matcher + '}',
+      datasource=promDatasource,
+      legendFormat='{{ node }}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Node client connections',
+  description: 'Number of client connections to each node.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local redisLogsPanel = {
+  datasource: lokiDatasource,
+  targets: [
+    {
+      datasource: lokiDatasource,
+      editorMode: 'code',
+      expr: '{filename="/var/opt/redislabs/log/redis.log", job=~"$job", redis_cluster=~"$redis_cluster"} |= ``',
+      queryType: 'range',
+      refId: 'A',
+    },
+  ],
+  type: 'logs',
+  title: 'Redis logs',
+  description: 'Recent logs outputted from the Redis server.',
+  options: {
+    dedupStrategy: 'none',
+    enableLogDetails: true,
+    prettifyLogMessage: false,
+    showCommonLabels: false,
+    showLabels: false,
+    showTime: false,
+    sortOrder: 'Descending',
+    wrapLogMessage: false,
+  },
+};
+
+{
+  grafanaDashboards+:: {
+    'redis-enterprise-node-overview.json':
+      dashboard.new(
+        'Redis Enterprise node overview',
+        time_from='%s' % $._config.dashboardPeriod,
+        tags=($._config.dashboardTags),
+        timezone='%s' % $._config.dashboardTimezone,
+        refresh='%s' % $._config.dashboardRefresh,
+        description='',
+        uid=dashboardUid,
+      )
+
+      .addTemplates(
+        std.flattenArrays([
+          [
+            template.datasource(
+              promDatasourceName,
+              'prometheus',
+              null,
+              label='Data Source',
+              refresh='load'
+            ),
+          ],
+          if $._config.enableLokiLogs then [
+            template.datasource(
+              lokiDatasourceName,
+              'loki',
+              null,
+              label='Loki Datasource',
+              refresh='load'
+            ),
+          ] else [],
+          [
+            template.new(
+              'job',
+              promDatasource,
+              'label_values(node_up, job)',
+              label='Job',
+              refresh=1,
+              includeAll=true,
+              multi=true,
+              allValues='',
+              sort=0
+            ),
+            template.new(
+              'redis_cluster',
+              promDatasource,
+              'label_values(node_up, redis_cluster)',
+              label='Redis Cluster',
+              refresh=1,
+              includeAll=true,
+              multi=true,
+              allValues='',
+              sort=0
+            ),
+            template.new(
+              'node',
+              promDatasource,
+              'label_values(node_up, node)\n',
+              label='Node',
+              refresh=1,
+              includeAll=true,
+              multi=true,
+              allValues='',
+              sort=0
+            ),
+          ],
+        ])
+      )
+      .addPanels(
+        std.flattenArrays([
+          [
+            nodesUpPanel { gridPos: { h: 6, w: 8, x: 0, y: 0 } },
+            databaseUpPanel { gridPos: { h: 6, w: 8, x: 8, y: 0 } },
+            shardsUpPanel { gridPos: { h: 6, w: 8, x: 16, y: 0 } },
+            nodeRequestsPanel { gridPos: { h: 6, w: 8, x: 0, y: 6 } },
+            nodeAverageLatencyPanel { gridPos: { h: 6, w: 8, x: 8, y: 6 } },
+            nodeCPUUtilizationPanel { gridPos: { h: 6, w: 8, x: 16, y: 6 } },
+            nodeMemoryUtilizationPanel { gridPos: { h: 6, w: 8, x: 0, y: 12 } },
+            nodeEphemeralFreeStoragePanel { gridPos: { h: 6, w: 8, x: 8, y: 12 } },
+            nodePersistentFreeStoragePanel { gridPos: { h: 6, w: 8, x: 16, y: 12 } },
+            nodeNetworkIngressPanel { gridPos: { h: 6, w: 8, x: 0, y: 18 } },
+            nodeNetworkEgressPanel { gridPos: { h: 6, w: 8, x: 8, y: 18 } },
+            nodeClientConnectionsPanel { gridPos: { h: 6, w: 8, x: 16, y: 18 } },
+          ],
+          if $._config.enableLokiLogs then [
+            redisLogsPanel { gridPos: { h: 8, w: 24, x: 0, y: 24 } },
+          ] else [],
+          [
+          ],
+        ])
+      ),
+  },
+}

--- a/redis-enterprise-mixin/dashboards/redis-enterprise-nodes.libsonnet
+++ b/redis-enterprise-mixin/dashboards/redis-enterprise-nodes.libsonnet
@@ -1,4 +1,3 @@
-local g = (import 'grafana-builder/grafana.libsonnet');
 local grafana = (import 'grafonnet/grafana.libsonnet');
 local dashboard = grafana.dashboard;
 local template = grafana.template;

--- a/redis-enterprise-mixin/dashboards/redis-enterprise-nodes.libsonnet
+++ b/redis-enterprise-mixin/dashboards/redis-enterprise-nodes.libsonnet
@@ -965,7 +965,13 @@ local redisLogsPanel = {
         description='',
         uid=dashboardUid,
       )
-
+      .addLink(grafana.link.dashboards(
+        asDropdown=false,
+        title='Other Redis Enterprise dashboards',
+        includeVars=true,
+        keepTime=true,
+        tags=($._config.dashboardTags),
+      ))
       .addTemplates(
         std.flattenArrays([
           [

--- a/redis-enterprise-mixin/dashboards/redis-enterprise-overview.libsonnet
+++ b/redis-enterprise-mixin/dashboards/redis-enterprise-overview.libsonnet
@@ -1,0 +1,1383 @@
+local g = (import 'grafana-builder/grafana.libsonnet');
+local grafana = (import 'grafonnet/grafana.libsonnet');
+local dashboard = grafana.dashboard;
+local template = grafana.template;
+local prometheus = grafana.prometheus;
+
+local dashboardUid = 'redis-enterprise-overview';
+
+local promDatasourceName = 'prometheus_datasource';
+
+local promDatasource = {
+  uid: '${%s}' % promDatasourceName,
+};
+
+local matcher = 'redis_cluster=~"$redis_cluster", job=~"$job"';
+
+local nodesUpPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'node_up{' + matcher + '}',
+      datasource=promDatasource,
+      legendFormat='{{ redis_cluster }} - {{ node }}',
+    ),
+  ],
+  type: 'bargauge',
+  title: 'Nodes up',
+  description: 'Up/down status for each node in the cluster.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      displayName: '${__series.name}',
+      mappings: [],
+      min: 0,
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'red',
+            value: 0,
+          },
+          {
+            color: 'green',
+            value: 1,
+          },
+        ],
+      },
+    },
+    overrides: [],
+  },
+  options: {
+    displayMode: 'basic',
+    minVizHeight: 10,
+    minVizWidth: 0,
+    orientation: 'horizontal',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    showUnfilled: true,
+  },
+  pluginVersion: '9.4.7',
+};
+
+local databasesUpPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'bdb_up{' + matcher + '}',
+      datasource=promDatasource,
+      legendFormat='{{ redis_cluster }} - bdb={{bdb}}',
+    ),
+  ],
+  type: 'bargauge',
+  title: 'Databases up',
+  description: 'Up/down status for each database in the cluster.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      displayName: '${__series.name}',
+      mappings: [],
+      max: 1,
+      min: 0,
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'red',
+            value: 0,
+          },
+          {
+            color: 'green',
+            value: 1,
+          },
+        ],
+      },
+    },
+    overrides: [],
+  },
+  options: {
+    displayMode: 'basic',
+    minVizHeight: 10,
+    minVizWidth: 0,
+    orientation: 'horizontal',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    showUnfilled: true,
+  },
+  pluginVersion: '9.4.7',
+};
+
+local shardsUpPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'redis_up{' + matcher + '}',
+      datasource=promDatasource,
+      legendFormat='{{ redis_cluster }} - redis: {{ redis }} ',
+    ),
+  ],
+  type: 'bargauge',
+  title: 'Shards up',
+  description: 'Up/down status for each shard in the cluster.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      displayName: '${__series.name}',
+      mappings: [],
+      min: 0,
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'red',
+            value: 0,
+          },
+          {
+            color: 'green',
+            value: 1,
+          },
+        ],
+      },
+    },
+    overrides: [],
+  },
+  options: {
+    displayMode: 'basic',
+    minVizHeight: 10,
+    minVizWidth: 0,
+    orientation: 'horizontal',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    showUnfilled: true,
+  },
+  pluginVersion: '9.4.7',
+};
+
+local clusterTotalRequestsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum(node_total_req{redis_cluster=~"$redis_cluster", job=~"$job"}) by (redis_cluster, job)',
+      datasource=promDatasource,
+      legendFormat='{{ redis_cluster }}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Cluster total requests',
+  description: 'Total requests handled by endpoints aggregated across all nodes.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local clusterTotalMemoryUsedPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum(bdb_used_memory{redis_cluster=~"$redis_cluster", job=~"$job"}) by (job, bdb, redis_cluster)',
+      datasource=promDatasource,
+      legendFormat='{{ redis_cluster }} - db: {{ bdb }}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Cluster total memory used',
+  description: 'Total memory used by each across each database in the cluster',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'bytes',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local clusterTotalConnectionsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum(bdb_conns{redis_cluster=~"$redis_cluster",  job=~"$job"}) by (bdb, redis_cluster, job)',
+      datasource=promDatasource,
+      legendFormat='{{ redis_cluster }} - db: {{ bdb }}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Cluster total connections',
+  description: 'Total connections to each database in the cluster.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local clusterTotalKeysPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum(bdb_no_of_keys{' + matcher + '}) by (redis_cluster, bdb, job)',
+      datasource=promDatasource,
+      legendFormat='{{ redis_cluster }} - db: {{ bdb }}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Cluster total keys',
+  description: 'Total cluster key count for each database in the cluster.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local clusterCacheHitRatioPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'bdb_read_hits{' + matcher + '} / (clamp_min(bdb_read_hits{' + matcher + '} + bdb_read_misses{' + matcher + '}, 1)) * 100',
+      datasource=promDatasource,
+      legendFormat='{{ redis_cluster }} - db: {{ bdb }}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Cluster cache hit ratio',
+  description: 'Ratio of database cache key hits against hits and misses.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'percent',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local clusterEvictionsVsExpiredObjectsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'bdb_evicted_objects{' + matcher + '}',
+      datasource=promDatasource,
+      legendFormat='{{ redis_cluster }} - db: {{ bdb }} - evicted',
+    ),
+    prometheus.target(
+      'bdb_expired_objects{' + matcher + '}',
+      datasource=promDatasource,
+      legendFormat='{{ redis_cluster }} - db: {{ bdb }} - expired',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Cluster evictions vs expired objects',
+  description: 'Sum of key evictions and expirations in the cluster by database.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'percent',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local nodesKPIsRow = {
+  datasource: promDatasource,
+  targets: [],
+  type: 'row',
+  title: 'Nodes KPIs',
+  collapsed: false,
+};
+
+local nodeRequestsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'rate(node_total_req{' + matcher + '}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='{{ redis_cluster }} - node: {{ node }} ',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Node requests',
+  description: 'Endpoint request rate for each node in the cluster.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'reqps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local nodeAverageLatencyPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'node_avg_latency{' + matcher + ' }',
+      datasource=promDatasource,
+      legendFormat='{{ redis_cluster }} - node: {{ node }} ',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Node average latency',
+  description: 'Average latency for each node in the cluster.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 's',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local nodeMemoryUtilizationPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      '(sum(redis_used_memory{' + matcher + '}) by (redis_cluster, node, job) / clamp_min(sum(node_available_memory{' + matcher + '}) by (redis_cluster,node, job), 1)) * 100',
+      datasource=promDatasource,
+      legendFormat='{{ redis_cluster }} - node: {{ node }} ',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Node memory utilization',
+  description: 'Memory utilization % for each node in the cluster.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'percent',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local nodeCPUUtilizationPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'node_cpu_system{' + matcher + '} * 100',
+      datasource=promDatasource,
+      legendFormat='node: {{ node }} - system',
+    ),
+    prometheus.target(
+      'node_cpu_user{' + matcher + '} * 100',
+      datasource=promDatasource,
+      legendFormat='node: {{ node }} - user',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Node CPU utilization',
+  description: 'CPU utilization for each node in the cluster.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'percent',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local databaseKPIsRow = {
+  datasource: promDatasource,
+  targets: [],
+  type: 'row',
+  title: 'Database KPIs',
+  collapsed: false,
+};
+
+local databaseOperationsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum(bdb_instantaneous_ops_per_sec{' + matcher + '}) by (redis_cluster, bdb, job)',
+      datasource=promDatasource,
+      legendFormat='{{ redis_cluster }} - db: {{ bdb }} ',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Database operations',
+  description: 'Rate of request handled by each database in the cluster.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'ops',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local databaseAverageLatencyPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum(bdb_avg_latency{' + matcher + '}) by (redis_cluster, job, bdb)',
+      datasource=promDatasource,
+      legendFormat='{{ redis_cluster }} - db: {{ bdb }} ',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Database average latency',
+  description: 'Average latency for each database in the cluster.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 's',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local databaseMemoryUtilizationPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum(bdb_used_memory{' + matcher + '}) by (job, redis_cluster, bdb) / clamp_min(sum(bdb_memory_limit{' + matcher + '}) by (job, redis_cluster, bdb), 1) * 100 ',
+      datasource=promDatasource,
+      legendFormat='{{ redis_cluster }} - db: {{ bdb }} ',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Database memory utilization',
+  description: 'Calculated memory utilization % for each database in the cluster.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'percent',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local databaseCacheHitRatioPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum(bdb_read_hits{' + matcher + '}) by (job, redis_cluster, bdb) / clamp_min(sum(bdb_read_hits{' + matcher + '}) by (job, redis_cluster, bdb) + sum(bdb_read_misses{' + matcher + '}) by (job, redis_cluster, bdb),1) * 100',
+      datasource=promDatasource,
+      legendFormat='{{ redis_cluster }} - db: {{ bdb }} ',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Database cache hit ratio',
+  description: 'Calculated cache hit rate for each database in the cluster',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'percent',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+{
+  grafanaDashboards+:: {
+    'redis-enterprise-overview.json':
+      dashboard.new(
+        'Redis Enterprise overview',
+        time_from='%s' % $._config.dashboardPeriod,
+        tags=($._config.dashboardTags),
+        timezone='%s' % $._config.dashboardTimezone,
+        refresh='%s' % $._config.dashboardRefresh,
+        description='',
+        uid=dashboardUid,
+      )
+      .addLink(grafana.link.dashboards(
+        asDropdown=false,
+        title='Other Redis Enterprise dashboards',
+        includeVars=true,
+        keepTime=true,
+        tags=($._config.dashboardTags),
+      ))
+      .addTemplates(
+        [
+          template.datasource(
+            promDatasourceName,
+            'prometheus',
+            null,
+            label='Data Source',
+            refresh='load'
+          ),
+          template.new(
+            'job',
+            promDatasource,
+            'label_values(node_up, job)',
+            label='Job',
+            refresh=2,
+            includeAll=true,
+            multi=true,
+            allValues='',
+            sort=0
+          ),
+          template.new(
+            'redis_cluster',
+            promDatasource,
+            'label_values(node_up, redis_cluster)\n',
+            label='Redis Cluster',
+            refresh=1,
+            includeAll=true,
+            multi=true,
+            allValues='',
+            sort=0
+          ),
+        ]
+      )
+      .addPanels(
+        [
+          nodesUpPanel { gridPos: { h: 6, w: 8, x: 0, y: 0 } },
+          databasesUpPanel { gridPos: { h: 6, w: 8, x: 8, y: 0 } },
+          shardsUpPanel { gridPos: { h: 6, w: 8, x: 16, y: 0 } },
+          clusterTotalRequestsPanel { gridPos: { h: 6, w: 8, x: 0, y: 6 } },
+          clusterTotalMemoryUsedPanel { gridPos: { h: 6, w: 8, x: 8, y: 6 } },
+          clusterTotalConnectionsPanel { gridPos: { h: 6, w: 8, x: 16, y: 6 } },
+          clusterTotalKeysPanel { gridPos: { h: 6, w: 8, x: 0, y: 12 } },
+          clusterCacheHitRatioPanel { gridPos: { h: 6, w: 8, x: 8, y: 12 } },
+          clusterEvictionsVsExpiredObjectsPanel { gridPos: { h: 6, w: 8, x: 16, y: 12 } },
+          nodesKPIsRow { gridPos: { h: 1, w: 24, x: 0, y: 18 } },
+          nodeRequestsPanel { gridPos: { h: 6, w: 6, x: 0, y: 19 } },
+          nodeAverageLatencyPanel { gridPos: { h: 6, w: 6, x: 6, y: 19 } },
+          nodeMemoryUtilizationPanel { gridPos: { h: 6, w: 6, x: 12, y: 19 } },
+          nodeCPUUtilizationPanel { gridPos: { h: 6, w: 6, x: 18, y: 19 } },
+          databaseKPIsRow { gridPos: { h: 1, w: 24, x: 0, y: 25 } },
+          databaseOperationsPanel { gridPos: { h: 6, w: 6, x: 0, y: 26 } },
+          databaseAverageLatencyPanel { gridPos: { h: 6, w: 6, x: 6, y: 26 } },
+          databaseMemoryUtilizationPanel { gridPos: { h: 6, w: 6, x: 12, y: 26 } },
+          databaseCacheHitRatioPanel { gridPos: { h: 6, w: 6, x: 18, y: 26 } },
+        ]
+      ),
+  },
+}

--- a/redis-enterprise-mixin/dashboards/redis-enterprise-overview.libsonnet
+++ b/redis-enterprise-mixin/dashboards/redis-enterprise-overview.libsonnet
@@ -1,4 +1,3 @@
-local g = (import 'grafana-builder/grafana.libsonnet');
 local grafana = (import 'grafonnet/grafana.libsonnet');
 local dashboard = grafana.dashboard;
 local template = grafana.template;

--- a/redis-enterprise-mixin/jsonnetfile.json
+++ b/redis-enterprise-mixin/jsonnetfile.json
@@ -1,0 +1,15 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/grafonnet-lib.git",
+          "subdir": "grafonnet"
+        }
+      },
+      "version": "master"
+    }
+  ],
+  "legacyImports": true
+}

--- a/redis-enterprise-mixin/mixin.libsonnet
+++ b/redis-enterprise-mixin/mixin.libsonnet
@@ -1,0 +1,3 @@
+(import 'dashboards/dashboards.libsonnet') +
+(import 'alerts/alerts.libsonnet') +
+(import 'config.libsonnet')


### PR DESCRIPTION
Adds 3 new dashboards and several new alerts for [Redis-Enterprise](https://docs.redis.com/latest/rs/clusters/monitoring/prometheus-metrics-definitions/). Hoping this provides users with a monitoring toolkit OOTB that helps them monitor and manage their Redis Enterprise Deployments.


Metric Definitions: https://docs.redis.com/latest/rs/clusters/monitoring/prometheus-metrics-definitions/


<details>
<summary> Screenshots </summary>
<img width="1739" alt="Screen Shot 2023-04-12 at 11 10 50 AM" src="https://user-images.githubusercontent.com/32067685/231532974-aa3f6f37-3487-4fe9-89cc-8091253147c3.png">
<img width="1718" alt="Screen Shot 2023-04-12 at 11 10 30 AM" src="https://user-images.githubusercontent.com/32067685/231532982-dcdc469e-7d79-428b-b1e0-64eb76524a9d.png">
<img width="1720" alt="Screen Shot 2023-04-12 at 10 57 11 AM" src="https://user-images.githubusercontent.com/32067685/231532990-14f3e8d8-fb91-45e7-8b0d-9d6a6c9ab8ef.png">
<img width="1722" alt="Screen Shot 2023-04-12 at 10 56 49 AM" src="https://user-images.githubusercontent.com/32067685/231532994-4f22eaa3-2d8e-4e94-8139-2910032d0673.png">
<img width="1723" alt="Screen Shot 2023-04-12 at 10 56 33 AM" src="https://user-images.githubusercontent.com/32067685/231533000-8372d16e-c3d4-461c-a16f-593bd715cffd.png">
</details>




