### PR TITLE
Fixes latency alerts for CouchDB mixin

### DIFF
--- a/apache-couchdb-mixin/alerts/alerts.libsonnet
+++ b/apache-couchdb-mixin/alerts/alerts.libsonnet
@@ -61,7 +61,7 @@
           {
             alert: 'CouchDBModerateRequestLatency',
             expr: |||
-              sum by(job, instance) (increase(couchdb_request_time_seconds_sum[5m]) / increase(couchdb_request_time_seconds_count[5m])) * 1000 > %(alertsWarningRequestLatency5m)s
+              sum by(job, instance) (couchdb_request_time_seconds_sum / couchdb_request_time_seconds_count) > %(alertsWarningRequestLatency5m)s
             ||| % $._config,
             'for': '5m',
             labels: {
@@ -79,7 +79,7 @@
           {
             alert: 'CouchDBHighRequestLatency',
             expr: |||
-              sum by(job, instance) (increase(couchdb_request_time_seconds_sum[5m]) / increase(couchdb_request_time_seconds_count[5m])) * 1000 > %(alertsCriticalRequestLatency5m)s
+              sum by(job, instance) (couchdb_request_time_seconds_sum / couchdb_request_time_seconds_count) > %(alertsCriticalRequestLatency5m)s
             ||| % $._config,
             'for': '5m',
             labels: {


### PR DESCRIPTION
I noticed two things wrong with the calculations for the latency related alerts for CouchDB.
1. I assumed that the metric `couchdb_request_time_seconds_sum` would be in seconds, but it appears to actually report in milliseconds (I was seeing unexpected values by a factor of 1000).
2. I also assumed that both `couchdb_request_time_seconds_sum` and `couchdb_request_time_seconds_count` would be monotonic counters, but instead they appear to be gauges (they are not marked properly in the prometheus exporter). 

I fixed the calculation and now my alerts aren't firing when I have low (<50ms) latency in the integration.