### PR TITLE
Enable GO runtime scheduler latency signal

### DIFF
--- a/cilium-enterprise-mixin/Makefile
+++ b/cilium-enterprise-mixin/Makefile
@@ -1,7 +1,7 @@
 JSONNET_FMT := jsonnetfmt -n 2 --max-blank-lines 1 --string-style s --comment-style s
 
 .PHONY: all
-all: build dashboards_out
+all: build dashboards_out prometheus_alerts.yaml
 
 vendor: jsonnetfile.json
 	jb install
@@ -25,6 +25,9 @@ lint: build
 dashboards_out: mixin.libsonnet
 	@mkdir -p dashboards_out
 	jsonnet -J vendor -m dashboards_out -e "(import 'mixin.libsonnet').grafanaDashboards"
+
+prometheus_alerts.yaml: mixin.libsonnet alerts/*.libsonnet
+	mixtool generate alerts mixin.libsonnet -a prometheus_alerts.yaml
 
 .PHONY: clean
 clean:

--- a/cilium-enterprise-mixin/README.md
+++ b/cilium-enterprise-mixin/README.md
@@ -1,6 +1,6 @@
 # Cilium Mixin
 
-The Cilium Mixin is a set of configurable, reusable, and extensible alerts as well as dashboards based on the metrics exported by [Cilium's internal Prometheus exporter](https://docs.cilium.io/en/stable/operations/metrics/#installation). 
+The Cilium Mixin is a set of configurable, reusable, and extensible alerts as well as dashboards based on the metrics exported by [Cilium's internal Prometheus exporter](https://docs.cilium.io/en/stable/operations/metrics/#installation).
 
 This integration includes the following dashboards.
 
@@ -25,9 +25,9 @@ This integration includes the following dashboards.
 - Hubble / Overview
 - Hubble / Timescape
 
-
 ## Cilium Overview & Cilium Agent Overview
-These two dashboards give a general overview of the state of the Cilium deployment, as reported by the Cilium Agent. 
+
+These two dashboards give a general overview of the state of the Cilium deployment, as reported by the Cilium Agent.
 
 ***Cilium Overview***
 
@@ -45,8 +45,8 @@ These two dashboards give a general overview of the state of the Cilium deployme
 
 ![image](https://storage.googleapis.com/grafanalabs-integration-assets/cilium-enterprise/screenshots/cilium_agent_overview_2.png)
 
-
 ## Cilium Operator Overview
+
 This dashboard provides information on the state of the Cilium Operator; its resource utilization and IPAM status.
 
 ***Cilium Operator Overview***
@@ -69,28 +69,30 @@ The Hubble Overview and Hubble Timescape dashboards provide detailed insights in
 
 ![image](https://storage.googleapis.com/grafanalabs-integration-assets/cilium-enterprise/screenshots/hubble/hubble_timescape_1.png)
 
-
 ## Dashboard Links
 
 On the top right of dashboards, you will find dropdowns to quickly switch between the dashboards while keeping the time range and variable selection the same.
 
 ## How to use this mixin
-The mixin creates recording and alerting rules for Prometheus and suitable 
+
+The mixin creates recording and alerting rules for Prometheus and suitable
 dashboards for Grafana.
 
 To use them, you need to have `mixtool` and `jsonnetfmt` installed. If you
 have a working Go development environment, it's easiest to run the following:
-```bash
-$ go get github.com/monitoring-mixins/mixtool/cmd/mixtool
-$ go get github.com/google/go-jsonnet/cmd/jsonnetfmt
+
+```shell
+go install -a github.com/monitoring-mixins/mixtool/cmd/mixtool@latest
+go install -a github.com/google/go-jsonnet/cmd/jsonnetfmt@latest
+go install -a github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@latest
 ```
 
 You can then build the Prometheus rules files `alerts.yaml` and
 `rules.yaml` and a directory `dashboard_out` with the JSON dashboard files
 for Grafana:
+
 ```bash
-$ make build
+make build
 ```
 
-For more advanced uses of mixins, see
-https://github.com/monitoring-mixins/docs.
+For more advanced uses of mixins, see [docs](https://github.com/monitoring-mixins/docs)

--- a/cilium-enterprise-mixin/alerts/ciliumAlerts.libsonnet
+++ b/cilium-enterprise-mixin/alerts/ciliumAlerts.libsonnet
@@ -272,6 +272,23 @@
           },
         ],
       },
+      {
+        name: 'Cilium Agent Scheduler Latency',
+        rules: [
+          {
+            alert: 'CiliumAgentSchedulerLatency',
+            expr: 'sum by (pod) (increase(go_sched_latencies_seconds_sum[5m]) / increase(go_sched_latencies_seconds_count[5m])) * 1000 >= 0.1',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              summary: 'Cilium Agent GO runtime scheduler is reporting high goroutine latencies.',
+              description: 'Cilium Agent {{$labels.pod}} is reporting high goroutines latencies.',
+            },
+            'for': '5m',
+          },
+        ],
+      },
     ],
   },
 }

--- a/cilium-enterprise-mixin/dashboards/cilium-agent-overview.json
+++ b/cilium-enterprise-mixin/dashboards/cilium-agent-overview.json
@@ -1514,6 +1514,125 @@
       ],
       "title": "Top Total BPF Maps Memory Usage",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Tracks GO runtime scheduler latency. This metric represent the time go routines spent waiting to run.  ",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 34
+      },
+      "id": 248,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "histogram_quantile(0.95, max by(le) (increase(go_sched_latencies_seconds_bucket{k8s_app=\"cilium\", namespace=\"$namespace\", pod=\"$pod\"}[$__rate_interval])))",
+          "hide": true,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "go_sched_latencies_seconds_sum",
+          "hide": true,
+          "legendFormat": "{{pod}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "quantile(.95, rate(go_sched_latencies_seconds_sum[$__rate_interval]) / rate(go_sched_latencies_seconds_count[$__rate_interval])) by (pod)",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "P95 Agent Scheduler Latency",
+      "type": "timeseries"
     }
   ],
   "refresh": "30s",

--- a/cilium-enterprise-mixin/jsonnetfile.json
+++ b/cilium-enterprise-mixin/jsonnetfile.json
@@ -1,0 +1,15 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": "ksonnet-util"
+        }
+      },
+      "version": "master"
+    }
+  ],
+  "legacyImports": true
+}


### PR DESCRIPTION
- Add panel (currently under agent overview) to display sched latency metrics
- Add shed latency alert
- Fix build
- Update docs

> NOTE: It's been a while since I've done this kind of work ;( Please double
check my promQL Qs and alert settings as they may need additional TLC...

> NOTE: This feels a lot like new frontiers work. Linter reports ~180
issues mostly related to missing chart descriptions and units.
Also found several refs to Cilium v1.12 which seem a bit out of place... 
Lastly not sure about the intent/necessity of some of the dashboard panels as there might be 
overlaps with k8s std dashboards??

Signed-off-by: Fernand <fernand.galiana@isovalent.com>