### PR TITLE
Redis Enterprise: Fix filename filter to accept multiple databases

### DIFF
--- a/redis-enterprise-mixin/dashboards/redis-enterprise-nodes.libsonnet
+++ b/redis-enterprise-mixin/dashboards/redis-enterprise-nodes.libsonnet
@@ -932,7 +932,7 @@ local redisLogsPanel = {
     {
       datasource: lokiDatasource,
       editorMode: 'code',
-      expr: '{filename="/var/opt/redislabs/log/redis.log", job=~"$job", redis_cluster=~"$redis_cluster"} |= ``',
+      expr: '{filename=~"/var/opt/redislabs/log/redis-.*.log", job=~"$job", redis_cluster=~"$redis_cluster"} |= ``',
       queryType: 'range',
       refId: 'A',
     },


### PR DESCRIPTION
On a node there is multiple redis logs that have numerics differentiating the different databases i.e `/var/opt/redislabs/log/redis-1.log`

<img width="733" alt="image" src="https://user-images.githubusercontent.com/32067685/233448387-fdb59ab7-37b7-4e4a-9aca-7df5fd29736d.png">

