### PR TITLE
Add Squid Mixin

### DIFF
--- a/squid-mixin/.lint
+++ b/squid-mixin/.lint
@@ -1,0 +1,14 @@
+exclusions:
+  template-job-rule:
+    reason: "Prometheus datasource variable is being named as prometheus_datasource now while linter expects 'datasource'"
+  panel-datasource-rule:
+    reason: "Loki datasource variable is being named as loki_datasource now while linter expects 'datasource'"
+  template-datasource-rule:
+    reason: "Based on new convention we are using variable names prometheus_datasource and loki_datasource where as linter expects 'datasource'"
+  template-instance-rule:
+    reason: "Based on new convention we are using variable names prometheus_datasource and loki_datasource where as linter expects 'datasource'"
+  panel-units-rule:
+    reason: "Custom units are used for better user experience in these panels"
+    entries:
+    - panel: "Client request errors"
+    - panel: "Server request errors"

--- a/squid-mixin/Makefile
+++ b/squid-mixin/Makefile
@@ -1,0 +1,34 @@
+JSONNET_FMT := jsonnetfmt -n 2 --max-blank-lines 1 --string-style s --comment-style s
+
+.PHONY: all
+all: build dashboards_out prometheus_alerts.yaml
+
+vendor: jsonnetfile.json
+	jb install
+
+.PHONY: build
+build: vendor
+
+.PHONY: fmt
+fmt:
+	find . -name 'vendor' -prune -o -name '*.libsonnet' -print -o -name '*.jsonnet' -print | \
+		xargs -n 1 -- $(JSONNET_FMT) -i
+
+.PHONY: lint
+lint: build
+	find . -name 'vendor' -prune -o -name '*.libsonnet' -print -o -name '*.jsonnet' -print | \
+		while read f; do \
+			$(JSONNET_FMT) "$$f" | diff -u "$$f" -; \
+		done
+	mixtool lint mixin.libsonnet
+
+dashboards_out: mixin.libsonnet config.libsonnet $(wildcard dashboards/*)
+	@mkdir -p dashboards_out
+	mixtool generate dashboards mixin.libsonnet -d dashboards_out
+
+prometheus_alerts.yaml: mixin.libsonnet alerts/*.libsonnet
+	mixtool generate alerts mixin.libsonnet -a prometheus_alerts.yaml
+
+.PHONY: clean
+clean:
+	rm -rf dashboards_out prometheus_alerts.yaml

--- a/squid-mixin/README.md
+++ b/squid-mixin/README.md
@@ -20,6 +20,8 @@ The Squid overview dashboard provides details on both server and client HTTP, FT
 
 ![TODO Dashboard screenshots]()
 
+Squid logs are enabled by default in the `config.libsonnet` and can be removed by setting `enableLokiLogs` to `false`. Then run `make` again to regenerate the dashboard:
+
 ```
 {
   _config+:: {

--- a/squid-mixin/README.md
+++ b/squid-mixin/README.md
@@ -1,6 +1,6 @@
 # Squid Mixin
 
-Squid mixin is a set of configurable Grafana dashboards and alerts.
+The Squid mixin is a set of configurable Grafana dashboards and alerts.
 
 The Squid mixin contains the following dashboards:
 
@@ -28,7 +28,7 @@ The Squid overview dashboard provides details on both server and client HTTP, FT
 }
 ```
 
-In order for the selectors to properly work for access and cache logs ingested into your logs datasource, please also include the matching `job` label onto the [scrape_configs](https://grafana.com/docs/loki/latest/clients/promtail/configuration/#scrape_configs) as to match the labels for ingested metrics.
+In order for the selectors to properly work for access and cache logs ingested into your logs datasource, please also include the matching `job` and `instance` labels onto the [scrape_configs](https://grafana.com/docs/loki/latest/clients/promtail/configuration/#scrape_configs) as to match the labels for ingested metrics.
 
 ```yaml
 scrape_configs:
@@ -55,7 +55,7 @@ scrape_configs:
 | SquidHighPercentageOfFTPServerRequestErrors                | There are a high number of FTP server request errors.                         |
 | SquidHighPercentageOfOtherServerRequestErrors | There are a high number of other server request errors. |
 | SquidHighPercentageOfClientRequestErrors   | There are a high number of HTTP client request errors.                         |
-| SquidLowCacheHitRatio     | The cache hit ratio has fallen below 85%.                         |
+| SquidLowCacheHitRatio     | The cache hit ratio has fallen below the configured threshold (%).                         |
 
 
 Default thresholds can be configured in `config.libsonnet`

--- a/squid-mixin/README.md
+++ b/squid-mixin/README.md
@@ -1,0 +1,101 @@
+# Squid Mixin
+
+Squid mixin is a set of configurable Grafana dashboards and alerts.
+
+The Squid mixin contains the following dashboards:
+
+- Squid overview
+
+and the following alerts:
+
+- SquidHighPercentageOfHTTPServerRequestErrors
+- SquidHighPercentageOfFTPServerRequestErrors
+- SquidHighPercentageOfOtherServerRequestErrors
+- SquidHighPercentageOfClientRequestErrors
+- SquidLowCacheHitRatio
+
+## Squid Overview
+
+The Squid overview dashboard provides details on both server and client HTTP, FTP, and other requests, caching hits and misses, and both cache and access logs.
+
+![TODO Dashboard screenshots]()
+
+```
+{
+  _config+:: {
+    enableLokiLogs: false,
+  },
+}
+```
+
+In order for the selectors to properly work for access and cache logs ingested into your logs datasource, please also include the matching `job` label onto the [scrape_configs](https://grafana.com/docs/loki/latest/clients/promtail/configuration/#scrape_configs) as to match the labels for ingested metrics.
+
+```yaml
+scrape_configs:
+  - job_name: integrations/squid
+    static_configs:
+      - targets: [localhost]
+        labels:
+          job: integrations/squid
+          instance: '<your-instance-name>'
+          __path__: /var/log/squid/access.log
+      - targets: [localhost]
+        labels:
+          job: integrations/squid
+          instance: '<your-instance-name>'
+          __path__: /var/log/squid/cache.log
+```
+
+## Alerts Overview
+
+
+| Alert                               | Summary                                                                         |
+|-------------------------------------|---------------------------------------------------------------------------------|
+| SquidHighPercentageOfHTTPServerRequestErrors             | There are a high number of HTTP server errors.                      |
+| SquidHighPercentageOfFTPServerRequestErrors                | There are a high number of FTP server request errors.                         |
+| SquidHighPercentageOfOtherServerRequestErrors | There are a high number of other server request errors. |
+| SquidHighPercentageOfClientRequestErrors   | There are a high number of HTTP client request errors.                         |
+| SquidLowCacheHitRatio     | The cache hit ratio has fallen below 85%.                         |
+
+
+Default thresholds can be configured in `config.libsonnet`
+
+```js
+{
+  _config+:: {
+    alertsCriticalHighPercentageRequestErrors: 5,
+    alertsWarningLowCacheHitRatio: 85,
+  },
+}
+```
+
+## Install Tools
+
+```bash
+go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@latest
+go install github.com/monitoring-mixins/mixtool/cmd/mixtool@latest
+# or in brew: brew install go-jsonnet
+```
+
+For linting and formatting, you would also need `mixtool` and `jsonnetfmt` installed. If you
+have a working Go development environment, it's easiest to run the following:
+
+```bash
+go install github.com/google/go-jsonnet/cmd/jsonnetfmt@latest
+```
+
+The files in `dashboards_out` need to be imported
+into your Grafana server. The exact details will be depending on your environment.
+
+`prometheus_alerts.yaml` needs to be imported into Prometheus.
+
+## Generate Dashboards And Alerts
+
+Edit `config.libsonnet` if required and then build JSON dashboard files for Grafana:
+
+```bash
+make
+```
+
+For more advanced uses of mixins, see
+https://github.com/monitoring-mixins/docs.

--- a/squid-mixin/alerts/alerts.libsonnet
+++ b/squid-mixin/alerts/alerts.libsonnet
@@ -23,7 +23,7 @@
           {
             alert: 'SquidHighPercentageOfFTPServerRequestErrors',
             expr: |||
-             rate(squid_server_ftp_errors_total[5m]) / clamp_min(rate(squid_server_ftp_requests_total[5m]),1) * 100 > %(alertsCriticalHighPercentageRequestErrors)s
+              rate(squid_server_ftp_errors_total[5m]) / clamp_min(rate(squid_server_ftp_requests_total[5m]),1) * 100 > %(alertsCriticalHighPercentageRequestErrors)s
             ||| % $._config,
             'for': '5m',
             labels: {
@@ -39,7 +39,7 @@
           {
             alert: 'SquidHighPercentageOfOtherServerRequestErrors',
             expr: |||
-             rate(squid_server_other_errors_total[5m]) / clamp_min(rate(squid_server_other_requests_total[5m]),1) * 100 > %(alertsCriticalHighPercentageRequestErrors)s
+              rate(squid_server_other_errors_total[5m]) / clamp_min(rate(squid_server_other_requests_total[5m]),1) * 100 > %(alertsCriticalHighPercentageRequestErrors)s
             ||| % $._config,
             'for': '5m',
             labels: {
@@ -55,7 +55,7 @@
           {
             alert: 'SquidHighPercentageOfClientRequestErrors',
             expr: |||
-             rate(squid_client_http_errors_total[5m]) / clamp_min(rate(squid_client_http_requests_total[5m]),1) * 100 > %(alertsCriticalHighPercentageRequestErrors)s
+              rate(squid_client_http_errors_total[5m]) / clamp_min(rate(squid_client_http_requests_total[5m]),1) * 100 > %(alertsCriticalHighPercentageRequestErrors)s
             ||| % $._config,
             'for': '5m',
             labels: {
@@ -71,14 +71,14 @@
           {
             alert: 'SquidLowCacheHitRatio',
             expr: |||
-             rate(squid_client_http_hits_total[10m]) / clamp_min(rate(Squid_client_http_requests_total[10m]),1) * 100 < %(alertsWarningLowCacheHitRatio)s
+              rate(squid_client_http_hits_total[10m]) / clamp_min(rate(Squid_client_http_requests_total[10m]),1) * 100 < %(alertsWarningLowCacheHitRatio)s
             ||| % $._config,
             'for': '10m',
             labels: {
               severity: 'warning',
             },
             annotations: {
-              summary: 'The cache hit ratio has fallen below 85%.',
+              summary: 'The cache hit ratio has fallen below the configured threshold (%).',
               description: |||
                 The cache hit ratio is {{ printf "%%.0f" $value }} over the last 10m on {{ $labels.instance }} which is below the threshold of %(alertsWarningLowCacheHitRatio)s.
               ||| % $._config,

--- a/squid-mixin/alerts/alerts.libsonnet
+++ b/squid-mixin/alerts/alerts.libsonnet
@@ -1,0 +1,91 @@
+{
+  prometheusAlerts+:: {
+    groups+: [
+      {
+        name: 'squid',
+        rules: [
+          {
+            alert: 'SquidHighPercentageOfHTTPServerRequestErrors',
+            expr: |||
+              rate(squid_server_http_errors_total[5m]) / clamp_min(rate(squid_server_http_requests_total[5m]),1) * 100 > %(alertsCriticalHighPercentageRequestErrors)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              summary: 'There are a high number of HTTP server errors.',
+              description: |||
+                The percentage of HTTP server request errors is {{ printf "%%.0f" $value }} over the last 5m on {{ $labels.instance }} which is above the threshold of %(alertsCriticalHighPercentageRequestErrors)s.
+              ||| % $._config,
+            },
+          },
+          {
+            alert: 'SquidHighPercentageOfFTPServerRequestErrors',
+            expr: |||
+             rate(squid_server_ftp_errors_total[5m]) / clamp_min(rate(squid_server_ftp_requests_total[5m]),1) * 100 > %(alertsCriticalHighPercentageRequestErrors)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              summary: 'There are a high number of FTP server request errors.',
+              description: |||
+                The percentage of FTP server request errors is {{ printf "%%.0f" $value }} over the last 5m on {{ $labels.instance }} which is above the threshold of %(alertsCriticalHighPercentageRequestErrors)s.
+              ||| % $._config,
+            },
+          },
+          {
+            alert: 'SquidHighPercentageOfOtherServerRequestErrors',
+            expr: |||
+             rate(squid_server_other_errors_total[5m]) / clamp_min(rate(squid_server_other_requests_total[5m]),1) * 100 > %(alertsCriticalHighPercentageRequestErrors)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              summary: 'There are a high number of other server request errors.',
+              description: |||
+                The percentage of other server request errors is {{ printf "%%.0f" $value }} over the last 5m on {{ $labels.instance }} which is above the threshold of %(alertsCriticalHighPercentageRequestErrors)s.
+              ||| % $._config,
+            },
+          },
+          {
+            alert: 'SquidHighPercentageOfClientRequestErrors',
+            expr: |||
+             rate(squid_client_http_errors_total[5m]) / clamp_min(rate(squid_client_http_requests_total[5m]),1) * 100 > %(alertsCriticalHighPercentageRequestErrors)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              summary: 'There are a high number of HTTP client request errors.',
+              description: |||
+                The percentage of HTTP client request errors is {{ printf "%%.0f" $value }} over the last 5m on {{ $labels.instance }} which is above the threshold of %(alertsCriticalHighPercentageRequestErrors)s.
+              ||| % $._config,
+            },
+          },
+          {
+            alert: 'SquidLowCacheHitRatio',
+            expr: |||
+             rate(squid_client_http_hits_total[10m]) / clamp_min(rate(Squid_client_http_requests_total[10m]),1) * 100 < %(alertsWarningLowCacheHitRatio)s
+            ||| % $._config,
+            'for': '10m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              summary: 'The cache hit ratio has fallen below 85%.',
+              description: |||
+                The cache hit ratio is {{ printf "%%.0f" $value }} over the last 10m on {{ $labels.instance }} which is below the threshold of %(alertsWarningLowCacheHitRatio)s.
+              ||| % $._config,
+            },
+          },
+        ],
+      },
+    ],
+  },
+}

--- a/squid-mixin/config.libsonnet
+++ b/squid-mixin/config.libsonnet
@@ -1,0 +1,13 @@
+{
+  _config+:: {
+    dashboardTags: ['squid'],
+    dashboardPeriod: 'now-1h',
+    dashboardTimezone: 'default',
+    dashboardRefresh: '1m',
+
+    // alerts thresholds
+    alertsCriticalHighPercentageRequestErrors: 5,
+    alertsWarningLowCacheHitRatio: 85,
+    enableLokiLogs: true,
+  },
+}

--- a/squid-mixin/dashboards/dashboards.libsonnet
+++ b/squid-mixin/dashboards/dashboards.libsonnet
@@ -1,0 +1,1 @@
+(import 'squid-overview.libsonnet')

--- a/squid-mixin/dashboards/squid-overview.libsonnet
+++ b/squid-mixin/dashboards/squid-overview.libsonnet
@@ -1,0 +1,1454 @@
+local g = (import 'grafana-builder/grafana.libsonnet');
+local grafana = (import 'grafonnet/grafana.libsonnet');
+local dashboard = grafana.dashboard;
+local template = grafana.template;
+local prometheus = grafana.prometheus;
+
+local dashboardUid = 'squid-overview';
+
+local promDatasourceName = 'prometheus_datasource';
+local lokiDatasourceName = 'loki_datasource';
+
+local promDatasource = {
+  uid: '${%s}' % promDatasourceName,
+};
+
+
+local lokiDatasource = {
+  uid: '${%s}' % lokiDatasourceName,
+};
+
+local clientRow = {
+  datasource: promDatasource,
+  targets: [],
+  type: 'row',
+  title: 'Client',
+  collapsed: false,
+};
+
+local clientRequestsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'rate(squid_client_http_requests_total{job=~"$job", instance=~"$instance"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Client requests',
+  description: 'The request rate of client.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'reqps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local clientRequestErrorsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'rate(squid_client_http_errors_total{job=~"$job", instance=~"$instance"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Client request errors',
+  description: 'The number of client HTTP errors.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'errors/s',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local clientCacheHitRatioPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      '(rate(squid_client_http_hits_total{job=~"$job", instance=~"$instance"}[$__rate_interval]) / clamp_min(rate(squid_client_http_requests_total{job=~"$job", instance=~"$instance"}[$__rate_interval]),1)) * 100',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Client cache hit ratio',
+  description: 'The client cache hit ratio.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'percent',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local clientRequestSentThroughputPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'rate(squid_client_http_kbytes_out_kbytes_total{job=~"$job", instance=~"$instance"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Client request sent throughput',
+  description: 'The throughput of client HTTP data sent.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'KBs',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local clientHTTPReceivedThroughputPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'rate(squid_client_http_kbytes_in_kbytes_total{job=~"$job", instance=~"$instance"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Client HTTP received throughput',
+  description: 'The throughput of client HTTP data received.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'KBs',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local clientCacheHitThroughputPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'rate(squid_client_http_hit_kbytes_out_bytes_total{job=~"$job", instance=~"$instance"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Client cache hit throughput',
+  description: 'The throughput of client cache hit.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'KBs',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local httpRequestServiceTimePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'squid_HTTP_Requests_All_50{job=~"$job", instance=~"$instance"} ',
+      datasource=promDatasource,
+      legendFormat='50%',
+    ),
+    prometheus.target(
+      'squid_HTTP_Requests_All_75{job=~"$job", instance=~"$instance"}',
+      datasource=promDatasource,
+      legendFormat='75%',
+    ),
+    prometheus.target(
+      'squid_HTTP_Requests_All_95{job=~"$job", instance=~"$instance"}',
+      datasource=promDatasource,
+      legendFormat='95%',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'HTTP request service time',
+  description: 'HTTP request service time percentiles.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 's',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local cacheHitServiceTimePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'squid_Cache_Hits_50{job=~"$job", instance=~"$instance"}',
+      datasource=promDatasource,
+      legendFormat='50%',
+    ),
+    prometheus.target(
+      'squid_Cache_Hits_75{job=~"$job", instance=~"$instance"}',
+      datasource=promDatasource,
+      legendFormat='75%',
+    ),
+    prometheus.target(
+      'squid_Cache_Hits_95{job=~"$job", instance=~"$instance"}',
+      datasource=promDatasource,
+      legendFormat='95%',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Cache hit service time',
+  description: 'Cache hits service time percentiles.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 's',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local cacheMissesServiceTimePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'squid_Cache_Misses_50{job=~"$job", instance=~"$instance"}',
+      datasource=promDatasource,
+      legendFormat='50%',
+    ),
+    prometheus.target(
+      'squid_Cache_Misses_75{job=~"$job", instance=~"$instance"}',
+      datasource=promDatasource,
+      legendFormat='75%',
+    ),
+    prometheus.target(
+      'squid_Cache_Misses_95{job=~"$job", instance=~"$instance"}',
+      datasource=promDatasource,
+      legendFormat='95%',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Cache misses service time',
+  description: 'Cache misses service time percentiles.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 's',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local serverRow = {
+  datasource: promDatasource,
+  targets: [],
+  type: 'row',
+  title: 'Server',
+  collapsed: false,
+};
+
+local serverRequestsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'rate(squid_server_ftp_requests_total{job=~"$job", instance=~"$instance"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='FTP',
+    ),
+    prometheus.target(
+      'rate(squid_server_http_requests_total{job=~"$job", instance=~"$instance"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='HTTP',
+    ),
+    prometheus.target(
+      'rate(squid_server_other_requests_total{job=~"$job", instance=~"$instance"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='other',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Server requests',
+  description: 'The number of HTTP, FTP, and other server requests.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'reqps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local serverRequestErrorsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'rate(squid_server_ftp_errors_total{job=~"$job", instance=~"$instance"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='FTP',
+    ),
+    prometheus.target(
+      'rate(squid_server_http_errors_total{job=~"$job", instance=~"$instance"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='HTTP',
+    ),
+    prometheus.target(
+      'rate(squid_server_other_errors_total{job=~"$job", instance=~"$instance"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='other',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Server request errors',
+  description: 'The number of HTTP, FTP, and other server request errors.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'errors/s',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local serverRequestSentThroughputPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'rate(squid_server_ftp_kbytes_out_kbytes_total{job=~"$job", instance=~"$instance"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='FTP',
+    ),
+    prometheus.target(
+      'rate(squid_server_http_kbytes_out_kbytes_total{job=~"$job", instance=~"$instance"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='HTTP',
+    ),
+    prometheus.target(
+      'rate(squid_server_other_kbytes_out_kbytes_total{job=~"$job", instance=~"$instance"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='other',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Server request sent throughput',
+  description: 'The number of HTTP, FTP, and other server sent throughput.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'KBs',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local serverObjectSwapPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'rate(squid_swap_ins_total{job=~"$job", instance=~"$instance"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - read',
+    ),
+    prometheus.target(
+      'rate(squid_swap_outs_total{job=~"$job", instance=~"$instance"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - saved',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Server object swap',
+  description: 'The number of objects read from disk and the number of objects saved to disk.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'cps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local dnsLookupServiceTimePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'squid_DNS_Lookups_50{job=~"$job", instance=~"$instance"}',
+      datasource=promDatasource,
+      legendFormat='50%',
+    ),
+    prometheus.target(
+      'squid_DNS_Lookups_75{job=~"$job", instance=~"$instance"}',
+      datasource=promDatasource,
+      legendFormat='75%',
+    ),
+    prometheus.target(
+      'squid_DNS_Lookups_95{job=~"$job", instance=~"$instance"}',
+      datasource=promDatasource,
+      legendFormat='95%',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'DNS lookup service time',
+  description: 'DNS lookup service time percentiles',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 's',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local serverReceivedThroughputPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'rate(squid_server_ftp_kbytes_in_kbytes_total{job=~"$job", instance=~"$instance"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='FTP',
+    ),
+    prometheus.target(
+      'rate(squid_server_http_kbytes_in_kbytes_total{job=~"$job", instance=~"$instance"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='HTTP',
+    ),
+    prometheus.target(
+      'rate(squid_server_other_kbytes_in_kbytes_total{job=~"$job", instance=~"$instance"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='other',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Server received throughput',
+  description: 'The number of HTTP, FTP, and other server throughput.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'KBs',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local cacheLogsPanel = {
+  datasource: lokiDatasource,
+  targets: [
+    {
+      datasource: lokiDatasource,
+      editorMode: 'code',
+      expr: '{filename="/var/log/squid/cache.log", job=~"$job"} |= ``',
+      queryType: 'range',
+      refId: 'A',
+    },
+  ],
+  type: 'logs',
+  title: 'Cache logs',
+  description: 'The cache.log file that contains the debug and error messages that Squid generates.',
+  options: {
+    dedupStrategy: 'none',
+    enableLogDetails: true,
+    prettifyLogMessage: false,
+    showCommonLabels: false,
+    showLabels: false,
+    showTime: false,
+    sortOrder: 'Descending',
+    wrapLogMessage: false,
+  },
+};
+
+local accessLogsPanel = {
+  datasource: lokiDatasource,
+  targets: [
+    {
+      datasource: lokiDatasource,
+      editorMode: 'code',
+      expr: '{filename="/var/log/squid/access.log", job=~"$job"} |= ``',
+      queryType: 'range',
+      refId: 'A',
+    },
+  ],
+  type: 'logs',
+  title: 'Access logs',
+  description: 'The access.log file contains a record of all HTTP requests and responses processed by the Squid proxy server.',
+  options: {
+    dedupStrategy: 'none',
+    enableLogDetails: true,
+    prettifyLogMessage: false,
+    showCommonLabels: false,
+    showLabels: false,
+    showTime: false,
+    sortOrder: 'Descending',
+    wrapLogMessage: false,
+  },
+};
+
+
+{
+  grafanaDashboards+:: {
+    'squid-overview.json':
+      dashboard.new(
+        'Squid overview',
+        time_from='%s' % $._config.dashboardPeriod,
+        tags=($._config.dashboardTags),
+        timezone='%s' % $._config.dashboardTimezone,
+        refresh='%s' % $._config.dashboardRefresh,
+        description='',
+        uid=dashboardUid,
+      )
+
+      .addTemplates(
+        std.flattenArrays([
+          [
+            template.datasource(
+              promDatasourceName,
+              'prometheus',
+              null,
+              label='Data Source',
+              refresh='load'
+            ),
+          ],
+          if $._config.enableLokiLogs then [
+            template.datasource(
+              lokiDatasourceName,
+              'loki',
+              null,
+              label='Loki Datasource',
+              refresh='load'
+            ),
+          ] else [],
+          [
+            template.new(
+              'job',
+              promDatasource,
+              'label_values(squid_server_http_requests_total{}, job)',
+              label='Job',
+              refresh=2,
+              includeAll=true,
+              multi=true,
+              allValues='.+',
+              sort=0
+            ),
+            template.new(
+              'instance',
+              promDatasource,
+              'label_values(squid_server_http_requests_total{job=~"$job"},instance)',
+              label='Instance',
+              refresh=2,
+              includeAll=true,
+              multi=false,
+              allValues='',
+              sort=0
+            ),
+          ],
+        ])
+      )
+      .addPanels(
+        std.flattenArrays([
+          [
+            clientRow { gridPos: { h: 1, w: 24, x: 0, y: 0 } },
+            clientRequestsPanel { gridPos: { h: 8, w: 8, x: 0, y: 1 } },
+            clientRequestErrorsPanel { gridPos: { h: 8, w: 8, x: 8, y: 1 } },
+            clientCacheHitRatioPanel { gridPos: { h: 8, w: 8, x: 16, y: 1 } },
+            clientRequestSentThroughputPanel { gridPos: { h: 7, w: 8, x: 0, y: 9 } },
+            clientHTTPReceivedThroughputPanel { gridPos: { h: 7, w: 8, x: 8, y: 9 } },
+            clientCacheHitThroughputPanel { gridPos: { h: 7, w: 8, x: 16, y: 9 } },
+            httpRequestServiceTimePanel { gridPos: { h: 7, w: 8, x: 0, y: 16 } },
+            cacheHitServiceTimePanel { gridPos: { h: 7, w: 8, x: 8, y: 16 } },
+            cacheMissesServiceTimePanel { gridPos: { h: 7, w: 8, x: 16, y: 16 } },
+            serverRow { gridPos: { h: 1, w: 24, x: 0, y: 23 } },
+            serverRequestsPanel { gridPos: { h: 8, w: 8, x: 0, y: 24 } },
+            serverRequestErrorsPanel { gridPos: { h: 8, w: 8, x: 8, y: 24 } },
+            serverRequestSentThroughputPanel { gridPos: { h: 8, w: 8, x: 16, y: 24 } },
+            serverObjectSwapPanel { gridPos: { h: 8, w: 8, x: 0, y: 32 } },
+            dnsLookupServiceTimePanel { gridPos: { h: 8, w: 8, x: 8, y: 32 } },
+            serverReceivedThroughputPanel { gridPos: { h: 8, w: 8, x: 16, y: 32 } },
+          ],
+          if $._config.enableLokiLogs then [
+            cacheLogsPanel { gridPos: { h: 6, w: 24, x: 0, y: 40 } },
+          ] else [],
+          [
+          ],
+          if $._config.enableLokiLogs then [
+            accessLogsPanel { gridPos: { h: 6, w: 24, x: 0, y: 46 } },
+          ] else [],
+          [
+          ],
+        ])
+      ),
+
+  },
+}

--- a/squid-mixin/dashboards/squid-overview.libsonnet
+++ b/squid-mixin/dashboards/squid-overview.libsonnet
@@ -13,7 +13,6 @@ local promDatasource = {
   uid: '${%s}' % promDatasourceName,
 };
 
-
 local lokiDatasource = {
   uid: '${%s}' % lokiDatasourceName,
 };
@@ -1310,14 +1309,14 @@ local cacheLogsPanel = {
     {
       datasource: lokiDatasource,
       editorMode: 'code',
-      expr: '{filename="/var/log/squid/cache.log", job=~"$job"} |= ``',
+      expr: '{filename="/var/log/squid/cache.log", job=~"$job", instance=~"$instance"} |= ``',
       queryType: 'range',
       refId: 'A',
     },
   ],
   type: 'logs',
   title: 'Cache logs',
-  description: 'The cache.log file that contains the debug and error messages that Squid generates.',
+  description: 'The log file that contains the debug and error messages that Squid generates.',
   options: {
     dedupStrategy: 'none',
     enableLogDetails: true,
@@ -1336,14 +1335,14 @@ local accessLogsPanel = {
     {
       datasource: lokiDatasource,
       editorMode: 'code',
-      expr: '{filename="/var/log/squid/access.log", job=~"$job"} |= ``',
+      expr: '{filename="/var/log/squid/access.log", job=~"$job", instance=~"$instance"} |= ``',
       queryType: 'range',
       refId: 'A',
     },
   ],
   type: 'logs',
   title: 'Access logs',
-  description: 'The access.log file contains a record of all HTTP requests and responses processed by the Squid proxy server.',
+  description: 'The log file that contains a record of all HTTP requests and responses processed by the Squid proxy server.',
   options: {
     dedupStrategy: 'none',
     enableLogDetails: true,
@@ -1355,7 +1354,6 @@ local accessLogsPanel = {
     wrapLogMessage: false,
   },
 };
-
 
 {
   grafanaDashboards+:: {

--- a/squid-mixin/jsonnetfile.json
+++ b/squid-mixin/jsonnetfile.json
@@ -1,0 +1,15 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/grafonnet-lib.git",
+          "subdir": "grafonnet"
+        }
+      },
+      "version": "master"
+    }
+  ],
+  "legacyImports": true
+}

--- a/squid-mixin/mixin.libsonnet
+++ b/squid-mixin/mixin.libsonnet
@@ -1,0 +1,3 @@
+(import 'dashboards/dashboards.libsonnet') +
+(import 'alerts/alerts.libsonnet') +
+(import 'config.libsonnet')


### PR DESCRIPTION
Adds a new dashboards and several new alerts for [Squid](http://www.squid-cache.org).

Dashboards:

Squid overview

Alerts:

- SquidHighPercentageOfHTTPServerRequestErrors
- SquidHighPercentageOfFTPServerRequestErrors
- SquidHighPercentageOfOtherServerRequestErrors
- SquidHighPercentageOfClientRequestErrors
- SquidLowCacheHitRatio

<img width="1912" alt="image" src="https://github.com/grafana/jsonnet-libs/assets/48131175/f772a20a-2b73-4149-b8ee-521856662e43">
<img width="1917" alt="image" src="https://github.com/grafana/jsonnet-libs/assets/48131175/044c91a9-2e63-4319-b883-e43ff450717d">
<img width="1916" alt="image" src="https://github.com/grafana/jsonnet-libs/assets/48131175/0a254d10-6bc7-4e88-bc37-67d4f8b26a62">
