### PR TITLE
Show cancelled requests in yellow on QPS dashboards.

### DIFF
--- a/grafana-builder/grafana.libsonnet
+++ b/grafana-builder/grafana.libsonnet
@@ -434,6 +434,7 @@
       '5xx': '#E24D42',
       success: '#7EB26D',
       'error': '#E24D42',
+      cancel: '#ECCD47',
     },
     targets: [
       {


### PR DESCRIPTION
Without this override, cancelled requests are sometimes shown in the same green as successful requests, for example:

<img width="505" alt="Screenshot 2023-05-17 at 1 44 41 pm" src="https://github.com/grafana/jsonnet-libs/assets/4017646/29043d62-654f-46b3-8721-33b6816bc4f9">
