### PR TITLE
Show cancelled requests in grey on QPS dashboards.

### DIFF
--- a/grafana-builder/grafana.libsonnet
+++ b/grafana-builder/grafana.libsonnet
@@ -434,7 +434,7 @@
       '5xx': '#E24D42',
       success: '#7EB26D',
       'error': '#E24D42',
-      cancel: '#ECCD47',
+      cancel: '#A9A9A9',
     },
     targets: [
       {


### PR DESCRIPTION
I made cancelled requests show as yellow in #986, but I think grey is more appropriate - yellow indicates something of concern, whereas grey is more neutral.