### PR TITLE
Adds better expression to Airflow logs panels

### DIFF
--- a/apache-airflow-mixin/README.md
+++ b/apache-airflow-mixin/README.md
@@ -30,7 +30,7 @@ Apache Airflow system logs are enabled by default in the `config.libsonnet` and 
 }
 ```
 
-In order for the selectors to properly work for system logs ingested into your logs datasource, please also include the matching `instance` and `job` labels onto the [scrape_configs](https://grafana.com/docs/loki/latest/clients/promtail/configuration/#scrape_configs) as to match the labels for ingested metrics. It is also important to add matching `dag_id` and `task_id` labels for the task logs to match the labels for ingested metrics as well as add labels for `dag_file` for the scheduler logs to allow for filtering in the dashboard.
+In order for the selectors to properly work for system logs ingested into your logs datasource, please also include the matching `instance` and `job` labels onto the [scrape_configs](https://grafana.com/docs/loki/latest/clients/promtail/configuration/#scrape_configs) as to match the labels for ingested metrics. Please use the correct `$AIRFLOW_HOME` directory in the `__path__` labels as well. It is also necessary to add matching `dag_id` and `task_id` labels for the task logs to match the labels for ingested metrics as well as add labels for `dag_file` for the scheduler logs to allow for filtering in the dashboard. The correct `$AIRFLOW_HOME` will also need to be used in the `expression` regexes.
 
 ```yaml
 scrape_configs:
@@ -41,20 +41,20 @@ scrape_configs:
     labels:
       job: integrations/apache-airflow
       instance: <instance>
-      __path__: /var/log/airflow/logs/dag_id=*/**/*.log
+      __path__: <airflow_home>/logs/dag_id=*/**/*.log
   - targets:
     - localhost
     labels:
       job: integrations/apache-airflow
       instance: localhost:8125
-      __path__: /var/log/airflow/logs/scheduler/latest/*.py.log
+      __path__: <airflow_home>/logs/scheduler/latest/*.py.log
   pipeline_stages:
   - match:
       selector: '{job="integrations/apache-airflow",instance="<instance>"}'
       stages:
       - regex:
           source: filename
-          expression: "/var/log/airflow/logs/dag_id=(?P<dag_id>\\S+?)/.*/task_id=(?P<task_id>\\S+?)/.*log"
+          expression: "<airflow_home>/logs/dag_id=(?P<dag_id>\\S+?)/.*/task_id=(?P<task_id>\\S+?)/.*log"
       - labels:
           dag_id:
           task_id:
@@ -63,7 +63,7 @@ scrape_configs:
       stages:
       - regex:
           source: filename
-          expression: "/var/log/airflow/logs/scheduler/latest/(?P<dag_file>\\S+?)\\.log"
+          expression: "<airflow_home>/logs/scheduler/latest/(?P<dag_file>\\S+?)\\.log"
       - labels:
           dag_file:   
   - multiline:

--- a/apache-airflow-mixin/dashboards/airflow-overview.libsonnet
+++ b/apache-airflow-mixin/dashboards/airflow-overview.libsonnet
@@ -611,7 +611,7 @@ local taskLogsPanel = {
     {
       datasource: lokiDatasource,
       editorMode: 'code',
-      expr: '{job=~"$job", instance=~"$instance", dag_id=~"$dag_id", task_id=~"$task_id"} |= ``',
+      expr: '{job=~"$job", instance=~"$instance", dag_id=~"$dag_id", task_id=~"$task_id", filename=~".*/airflow/logs/dag_id.*"} |= ``',
       queryType: 'range',
       refId: 'A',
     },
@@ -999,7 +999,7 @@ local schedulerLogsPanel = {
     {
       datasource: lokiDatasource,
       editorMode: 'code',
-      expr: '{job=~"$job", instance=~"$instance", dag_file=~"$dag_file"} |= ``',
+      expr: '{job=~"$job", instance=~"$instance", dag_file=~"$dag_file", filename=~".*/airflow/logs/scheduler/latest/.*"} |= ``',
       queryType: 'range',
       refId: 'A',
     },


### PR DESCRIPTION
This update ensures that the task and scheduler logs will be limited to the proper log types. 

Before this change, I noticed that the scheduler logs panel was showing k3d logs for Airflow because job and instance were matching the selectors but the dag_file variable was not filled in because these logs were not configured to be sent to loki yet. This caused unexpected logs to show in the panel.

This also updates the README to better reflect the default installation path of Airflow logs (the home directory of the user).