### PR TITLE
Update apache mesos cluster filter

### DIFF
--- a/apache-mesos-mixin/README.md
+++ b/apache-mesos-mixin/README.md
@@ -18,15 +18,15 @@ The Apache Mesos mixin contains the following alerts:
 
 The Apache Mesos overview dashboard provides details on resource utilization, queue usage, registrar state, allocator usage and master and agent logs. [Promtail and Loki needs to be installed](https://grafana.com/docs/loki/latest/installation/) and provisioned for logs with your Grafana instance.
 
-When running the Mesos master and agent process, specify the logs director using `--log_dir=/var/log/mesos/master/` and `--log_dir=/var/log/mesos/agent/` so logs can be found in the path `/var/log/mesos/master/*.log*` and `/var/log/mesos/agent/*.log*` when ingesting logs through the Promtail config..
+When running the Mesos master and agent process, specify the log directory using `--log_dir=/var/log/mesos/master/` and `--log_dir=/var/log/mesos/agent/` so logs can be found in the path `/var/log/mesos/master/*.log*` and `/var/log/mesos/agent/*.log*` when ingesting logs through the Promtail config..
 
 Logs from Apache Mesos are not enabled by default which will result in empty log panels if the following step is not performed. When running the Mesos master and agent process, specify the logs director using `--log_dir=` for both the master and agent. This path will differ depending on if you are running Linux or Windows but is required so that Promtail can ingest the logs.
 
-When running the mesos master add the following flag:
+When running the Mesos master add the following flag:
 `--log_dir=/var/log/mesos/master/` on Linux masters
 `–-log_dir=C:\Program Files\mesos\master\` on Windows masters
 
-When running the mesos agent add the following flag:
+When running the Mesos agent add the following flag:
 `--log_dir=/var/log/mesos/agent/` on Linux agents
 `–-log_dir=C:\Program Files\mesos\agent\` on Windows agents
 

--- a/apache-mesos-mixin/dashboards/apache-mesos-overview.libsonnet
+++ b/apache-mesos-mixin/dashboards/apache-mesos-overview.libsonnet
@@ -18,7 +18,7 @@ local masterUptimePanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'max by(mesos_cluster) (mesos_master_uptime_seconds{job=~"$job", instance=~"$instance"})',
+      'max by(mesos_cluster) (mesos_master_uptime_seconds{job=~"$job", instance=~"$instance", mesos_cluster=~"$mesos_cluster"})',
       datasource=promDatasource,
       legendFormat='{{mesos_cluster}}',
       format='time_series',
@@ -67,7 +67,7 @@ local cpusAvailablePanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'max by(mesos_cluster) (mesos_master_cpus{job=~"$job", instance=~"$instance", type="total"})',
+      'max by(mesos_cluster) (mesos_master_cpus{job=~"$job", instance=~"$instance", mesos_cluster=~"$mesos_cluster", type="total"})',
       datasource=promDatasource,
       legendFormat='{{mesos_cluster}}',
       format='time_series',
@@ -116,7 +116,7 @@ local memoryAvailablePanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'max by(mesos_cluster) (mesos_master_mem{job=~"$job", instance=~"$instance", type="total"})',
+      'max by(mesos_cluster) (mesos_master_mem{job=~"$job", instance=~"$instance", mesos_cluster=~"$mesos_cluster", type="total"})',
       datasource=promDatasource,
       legendFormat='{{mesos_cluster}}',
       format='time_series',
@@ -165,7 +165,7 @@ local gpusAvailablePanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'max by(mesos_cluster) (mesos_master_gpus{job=~"$job", instance=~"$instance", type="total"})',
+      'max by(mesos_cluster) (mesos_master_gpus{job=~"$job", instance=~"$instance", mesos_cluster=~"$mesos_cluster", type="total"})',
       datasource=promDatasource,
       legendFormat='{{mesos_cluster}}',
       format='time_series',
@@ -214,7 +214,7 @@ local diskAvailablePanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'max by(mesos_cluster) (mesos_master_disk{job=~"$job", instance=~"$instance", type="total"})',
+      'max by(mesos_cluster) (mesos_master_disk{job=~"$job", instance=~"$instance", mesos_cluster=~"$mesos_cluster", type="total"})',
       datasource=promDatasource,
       legendFormat='{{mesos_cluster}}',
       format='time_series',
@@ -263,7 +263,7 @@ local memoryUtilizationPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'max by(mesos_cluster) (mesos_master_mem{job=~"$job", instance=~"$instance", type="percent"})',
+      'max by(mesos_cluster) (mesos_master_mem{job=~"$job", instance=~"$instance", mesos_cluster=~"$mesos_cluster", type="percent"})',
       datasource=promDatasource,
       legendFormat='{{mesos_cluster}}',
       format='time_series',
@@ -339,7 +339,7 @@ local diskUtilizationPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'max by(mesos_cluster) (mesos_master_disk{job=~"$job", instance=~"$instance", type="percent"})',
+      'max by(mesos_cluster) (mesos_master_disk{job=~"$job", instance=~"$instance", mesos_cluster=~"$mesos_cluster", type="percent"})',
       datasource=promDatasource,
       legendFormat='{{mesos_cluster}}',
       format='time_series',
@@ -415,7 +415,7 @@ local eventsInQueuePanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'max by(mesos_cluster, type) (mesos_master_event_queue_length{job=~"$job", instance=~"$instance"})',
+      'max by(mesos_cluster, type) (mesos_master_event_queue_length{job=~"$job", instance=~"$instance", mesos_cluster=~"$mesos_cluster"})',
       datasource=promDatasource,
       legendFormat='{{mesos_cluster}} - {{type}}',
       format='time_series',
@@ -491,7 +491,7 @@ local messagesPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'max by(mesos_cluster, type) (increase(mesos_master_messages{job=~"$job", instance=~"$instance"}[$__interval:])) > 0',
+      'max by(mesos_cluster, type) (increase(mesos_master_messages{job=~"$job", instance=~"$instance", mesos_cluster=~"$mesos_cluster"}[$__interval:])) > 0',
       datasource=promDatasource,
       legendFormat='{{mesos_cluster}} - {{type}}',
       format='time_series',
@@ -568,13 +568,13 @@ local registrarStatePanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'max by(mesos_cluster) (mesos_registrar_state_store_ms{job=~"$job", instance=~"$instance", type="mean"})',
+      'max by(mesos_cluster) (mesos_registrar_state_store_ms{job=~"$job", instance=~"$instance", mesos_cluster=~"$mesos_cluster", type="mean"})',
       datasource=promDatasource,
       legendFormat='{{mesos_cluster}} - store',
       format='time_series',
     ),
     prometheus.target(
-      'max by(mesos_cluster) (mesos_registrar_state_fetch_ms{job=~"$job", instance=~"$instance"})',
+      'max by(mesos_cluster) (mesos_registrar_state_fetch_ms{job=~"$job", instance=~"$instance", mesos_cluster=~"$mesos_cluster"})',
       datasource=promDatasource,
       legendFormat='{{mesos_cluster}} - fetch',
       format='time_series',
@@ -650,7 +650,7 @@ local registrarLogRecoveredPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'max by(mesos_cluster) (mesos_registrar_log_recovered{job=~"$job", instance=~"$instance"})',
+      'max by(mesos_cluster) (mesos_registrar_log_recovered{job=~"$job", instance=~"$instance", mesos_cluster=~"$mesos_cluster"})',
       datasource=promDatasource,
       legendFormat='{{mesos_cluster}}',
       format='time_series',
@@ -741,7 +741,7 @@ local allocationRunsPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'max by(mesos_cluster) (rate(mesos_master_allocation_run_ms_count{job=~"$job", instance=~"$instance"}[$__rate_interval]))',
+      'max by(mesos_cluster) (rate(mesos_master_allocation_run_ms_count{job=~"$job", instance=~"$instance", mesos_cluster=~"$mesos_cluster"}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='{{mesos_cluster}}',
       format='time_series',
@@ -817,7 +817,7 @@ local allocationDurationPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'max by(mesos_cluster) (mesos_master_allocation_run_ms{job=~"$job", instance=~"$instance"})',
+      'max by(mesos_cluster) (mesos_master_allocation_run_ms{job=~"$job", instance=~"$instance", mesos_cluster=~"$mesos_cluster"})',
       datasource=promDatasource,
       legendFormat='{{mesos_cluster}}',
       format='time_series',
@@ -893,7 +893,7 @@ local allocationLatencyPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'max by(mesos_cluster) (mesos_master_allocation_run_latency_ms{job=~"$job", instance=~"$instance"})',
+      'max by(mesos_cluster) (mesos_master_allocation_run_latency_ms{job=~"$job", instance=~"$instance", mesos_cluster=~"$mesos_cluster"})',
       datasource=promDatasource,
       legendFormat='{{mesos_cluster}}',
       format='time_series',
@@ -969,7 +969,7 @@ local eventQueueDispatchesPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'max by(mesos_cluster) (mesos_master_event_queue_dispatches{job=~"$job", instance=~"$instance"})',
+      'max by(mesos_cluster) (mesos_master_event_queue_dispatches{job=~"$job", instance=~"$instance", mesos_cluster=~"$mesos_cluster"})',
       datasource=promDatasource,
       legendFormat='{{mesos_cluster}}',
       format='time_series',
@@ -1059,7 +1059,7 @@ local agentMemoryUtilizationPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'max by(mesos_cluster) (100 * mesos_slave_mem_used_bytes{job=~"$job", instance=~"$instance"} / clamp_min(mesos_slave_mem_bytes{job=~"$job", instance=~"$instance"},1))',
+      'max by(mesos_cluster) (100 * mesos_slave_mem_used_bytes{job=~"$job", instance=~"$instance", mesos_cluster=~"$mesos_cluster"} / clamp_min(mesos_slave_mem_bytes{job=~"$job", instance=~"$instance", mesos_cluster=~"$mesos_cluster"},1))',
       datasource=promDatasource,
       legendFormat='{{mesos_cluster}}',
       format='time_series',
@@ -1135,7 +1135,7 @@ local agentDiskUtilizationPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'max by(mesos_cluster) (100 * mesos_slave_disk_used_bytes{job=~"$job", instance=~"$instance"} / clamp_min(mesos_slave_disk_bytes{job=~"$job", instance=~"$instance"},1))',
+      'max by(mesos_cluster) (100 * mesos_slave_disk_used_bytes{job=~"$job", instance=~"$instance", mesos_cluster=~"$mesos_cluster"} / clamp_min(mesos_slave_disk_bytes{job=~"$job", instance=~"$instance", mesos_cluster=~"$mesos_cluster"},1))',
       datasource=promDatasource,
       legendFormat='{{mesos_cluster}}',
       format='time_series',


### PR DESCRIPTION
This PR
- Adds a cluster filter so the template selector can filter the dashboard by mesos_cluster type
- Fixes typos

Before selecting a cluster would do nothing because the mesos_cluster was missing from the PromQL queries as shown below:
<img width="1103" alt="Screenshot 2023-06-08 at 10 45 53 AM" src="https://github.com/grafana/jsonnet-libs/assets/13648435/4e64d8bf-d69d-4a01-9b33-3605054d3ed0">

With this fix the cluster filters applies to the dashboard.
<img width="1103" alt="Screenshot 2023-06-08 at 10 38 39 AM" src="https://github.com/grafana/jsonnet-libs/assets/13648435/4337d836-487a-4a25-b72e-e6048ca40905">
