### PR TITLE
Grafana: Remove wrong/unused `step` parameter from targets

### DIFF
--- a/grafana-builder/grafana.libsonnet
+++ b/grafana-builder/grafana.libsonnet
@@ -291,7 +291,6 @@
         format: 'time_series',
         intervalFactor: 2,
         legendFormat: ql.l,
-        step: 10,
       }
       for ql in qsandls
     ],
@@ -371,7 +370,6 @@
         instant: true,
         intervalFactor: 2,
         legendFormat: '',
-        step: 10,
         refId: std.char(65 + i),
       }
       for i in std.range(0, std.length(qs) - 1)
@@ -449,7 +447,6 @@
         intervalFactor: 2,
         legendFormat: '{{status}}',
         refId: 'A',
-        step: 10,
       },
     ],
   } + $.stack,
@@ -463,7 +460,6 @@
         intervalFactor: 2,
         legendFormat: '99th Percentile',
         refId: 'A',
-        step: 10,
       },
       {
         expr: 'histogram_quantile(0.50, sum(rate(%s_bucket%s[$__rate_interval])) by (le)) * %s' % [metricName, selector, multiplier],
@@ -471,7 +467,6 @@
         intervalFactor: 2,
         legendFormat: '50th Percentile',
         refId: 'B',
-        step: 10,
       },
       {
         expr: 'sum(rate(%s_sum%s[$__rate_interval])) * %s / sum(rate(%s_count%s[$__rate_interval]))' % [metricName, selector, multiplier, metricName, selector],
@@ -479,7 +474,6 @@
         intervalFactor: 2,
         legendFormat: 'Average',
         refId: 'C',
-        step: 10,
       },
     ],
     yaxes: $.yaxes('ms'),


### PR DESCRIPTION
Using the grafana-builder/grafana.libsonnet to create queries lead to every target object containing a `step` parameter. I did not find any relevant places in at least the current Grafana version, thus I am removing this from the default settings.

Currently we added a `step` parameter to the `LokiQuery` type, which however expects the `step` value to be a string. This caused provisioned dashboards that use grafana-builder/grafana.libsonnet to build Loki queries to fail.

**Please note:** I don't know if this change introduces any backwards compatible issues or anything else. Would be glad if someone can either confirm that the change makes sense, or if we should change the recent Loki implementation.

PR that added the `step` parameter to `LokiQuery`: https://github.com/grafana/grafana/pull/69558