### PR TITLE
chore: add a `/ping` endpoint for checking healthiness

### DIFF
--- a/nginx-directory/files/nginx.conf
+++ b/nginx-directory/files/nginx.conf
@@ -19,6 +19,10 @@ http {
   server {
     listen 80;
     %(locations)s
+    location = /ping {
+      access_log off;
+      return 200 'OK';
+    }
     location ~ /(index.html)? {
       root /var/www/html;
     }


### PR DESCRIPTION
Adds a static `/ping` endpoint which returns HTTP/200 `OK`. Can be
used as a readiness probe under Kubernetes for checking health of
NGINX.
