### PR TITLE
Create app-o11y version of jaeger-agent-mixin

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,7 @@
 # https://help.github.com/articles/about-codeowners/
 # https://git-scm.com/docs/gitignore#_pattern_format
 
+/app-o11y-jaeger-agent-mixin/ @grafana/app-o11y
 /consul*/ @grafana/mimir-maintainers @grafana/loki-team
 /etcd-operator/ @grafana/mimir-maintainers
 /memcached*/ @grafana/mimir-maintainers @grafana/loki-team

--- a/app-o11y-jaeger-agent-mixin/README.md
+++ b/app-o11y-jaeger-agent-mixin/README.md
@@ -1,0 +1,10 @@
+# App-O11y jaeger-agent-mixin
+
+
+The `app-o11y-jaeger-agent-mixin` is a copy of the [jaeger-agent-mixin][1] customised to add recommended [OpenTelemetry Resource][2] attributes to Grafana's existing OpenTracing-based Jaeger spans.
+
+The intent is to allow Grafana services to easily transition to OpenTelemetry conventions by changing usages of [jaeger-agent-mixin][1] to use this mixin instead.  
+
+[1]: ../jaeger-agent-mixin
+[2]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/README.md#service-experimental
+

--- a/app-o11y-jaeger-agent-mixin/jaeger.libsonnet
+++ b/app-o11y-jaeger-agent-mixin/jaeger.libsonnet
@@ -1,0 +1,21 @@
+local k = import 'ksonnet-util/kausal.libsonnet';
+
+{
+  _config+:: {
+    cluster: error 'Must define a cluster',
+    namespace: error 'Must define a namespace',
+    jaeger_agent_host: null,
+  },
+
+  local container = k.core.v1.container,
+
+  jaeger_mixin::
+    if $._config.jaeger_agent_host == null
+    then {}
+    else
+      container.withEnvMixin([
+        container.envType.new('JAEGER_AGENT_HOST', $._config.jaeger_agent_host),
+        container.envType.new('JAEGER_TAGS', 'namespace=%s,service.namespace=%s,cluster=%s' % [$._config.namespace, $._config.namespace, $._config.cluster]),
+        container.envType.new('JAEGER_SAMPLER_MANAGER_HOST_PORT', 'http://%s:5778/sampling' % $._config.jaeger_agent_host),
+      ]),
+}

--- a/app-o11y-jaeger-agent-mixin/jsonnetfile.json
+++ b/app-o11y-jaeger-agent-mixin/jsonnetfile.json
@@ -1,0 +1,15 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": "ksonnet-util"
+        }
+      },
+      "version": "master"
+    }
+  ],
+  "legacyImports": true
+}


### PR DESCRIPTION
This mixin is intended to allow teams to opt-in to including OpenTelemetry resource attributes such as service.namespace in spans emitted to the Grafana Agent