### PR TITLE
Add with_otel_resource_attrs option to jaeger-agent-mixin

### DIFF
--- a/jaeger-agent-mixin/jaeger.libsonnet
+++ b/jaeger-agent-mixin/jaeger.libsonnet
@@ -5,6 +5,7 @@ local k = import 'ksonnet-util/kausal.libsonnet';
     cluster: error 'Must define a cluster',
     namespace: error 'Must define a namespace',
     jaeger_agent_host: null,
+    with_otel_resource_attrs: false,
   },
 
   local container = k.core.v1.container,
@@ -13,9 +14,13 @@ local k = import 'ksonnet-util/kausal.libsonnet';
     if $._config.jaeger_agent_host == null
     then {}
     else
+      local jaegerTags = if $._config.with_otel_resource_attrs then
+        'namespace=%s,service.namespace=%s,cluster=%s' % [$._config.namespace, $._config.namespace, $._config.cluster]
+      else
+        'namespace=%s,cluster=%s' % [$._config.namespace, $._config.cluster];
       container.withEnvMixin([
         container.envType.new('JAEGER_AGENT_HOST', $._config.jaeger_agent_host),
-        container.envType.new('JAEGER_TAGS', 'namespace=%s,cluster=%s' % [$._config.namespace, $._config.cluster]),
+        container.envType.new('JAEGER_TAGS', jaegerTags),
         container.envType.new('JAEGER_SAMPLER_MANAGER_HOST_PORT', 'http://%s:5778/sampling' % $._config.jaeger_agent_host),
       ]),
 }


### PR DESCRIPTION
Flag causes service.namespace to be included in span attributes so Tempo can generate job labels