### PR TITLE
Add Apache Couchbase Mixin

### DIFF
--- a/apache-couchbase-mixin/.lint
+++ b/apache-couchbase-mixin/.lint
@@ -15,3 +15,5 @@ exclusions:
     reason: "Custom units are used for better user experience in these panels"
     entries:
       - panel: "XDCR docs received"
+      - panel: "Current connections"
+      - panel: "Top buckets by current items"

--- a/apache-couchbase-mixin/.lint
+++ b/apache-couchbase-mixin/.lint
@@ -1,0 +1,17 @@
+exclusions:
+  template-job-rule:
+    reason: "Prometheus datasource variable is being named as prometheus_datasource now while linter expects 'datasource'"
+  panel-datasource-rule:
+    reason: "Loki datasource variable is being named as loki_datasource now while linter expects 'datasource'"
+  template-datasource-rule:
+    reason: "Based on new convention we are using variable names prometheus_datasource and loki_datasource where as linter expects 'datasource'"
+  template-instance-rule:
+    reason: "Based on new convention we are using variable names prometheus_datasource and loki_datasource where as linter expects 'datasource'"
+  target-instance-rule:
+    reason: "The dashboard is a 'cluster' dashboard where the instance refers to nodes, this dashboard focuses only on the cluster view."
+    entries:
+      - dashboard: "Apache Couchbase cluster overview"
+  panel-units-rule:
+    reason: "Custom units are used for better user experience in these panels"
+    entries:
+      - panel: "XDCR docs received"

--- a/apache-couchbase-mixin/Makefile
+++ b/apache-couchbase-mixin/Makefile
@@ -1,0 +1,34 @@
+JSONNET_FMT := jsonnetfmt -n 2 --max-blank-lines 1 --string-style s --comment-style s
+
+.PHONY: all
+all: build dashboards_out prometheus_alerts.yaml
+
+vendor: jsonnetfile.json
+	jb install
+
+.PHONY: build
+build: vendor
+
+.PHONY: fmt
+fmt:
+	find . -name 'vendor' -prune -o -name '*.libsonnet' -print -o -name '*.jsonnet' -print | \
+		xargs -n 1 -- $(JSONNET_FMT) -i
+
+.PHONY: lint
+lint: build
+	find . -name 'vendor' -prune -o -name '*.libsonnet' -print -o -name '*.jsonnet' -print | \
+		while read f; do \
+			$(JSONNET_FMT) "$$f" | diff -u "$$f" -; \
+		done
+	mixtool lint mixin.libsonnet
+
+dashboards_out: mixin.libsonnet config.libsonnet $(wildcard dashboards/*)
+	@mkdir -p dashboards_out
+	mixtool generate dashboards mixin.libsonnet -d dashboards_out
+
+prometheus_alerts.yaml: mixin.libsonnet alerts/*.libsonnet
+	mixtool generate alerts mixin.libsonnet -a prometheus_alerts.yaml
+
+.PHONY: clean
+clean:
+	rm -rf dashboards_out prometheus_alerts.yaml

--- a/apache-couchbase-mixin/README.md
+++ b/apache-couchbase-mixin/README.md
@@ -23,7 +23,7 @@ The Apache Couchbase cluster overview dashboard provides details on the top node
 
 ## Apache Couchbase Node Overview
 
-The Apache Couchbase node overview dashboard provides details on memory usage, open OS files, open databases, database reads and writes, view info, request info (rate, latency, status code info), log type breakdown, and logs for a specific node in the cluster. To get Couchbase system logs, [Promtail and Loki needs to be installed](https://grafana.com/docs/loki/latest/installation/) and provisioned for logs with your Grafana instance. The default Couchbase system log path is `/var/log/Couchbase/Couchbase.log` on Linux.
+The Apache Couchbase node overview dashboard provides details on memory usage, cpu usage, network request info (request methods and response codes), query service request info (volume, type, and processing time), index service performance (request volume, cache hit ratio, and scan latency), and both error and couchdb logs. The default Couchbase system log path is `/opt/couchbase/var/lib/couchbase/logs` on Linux, or `C:\Program\Files\Couchbase\Server\var\lib\couchbase\logs` on Windows.
 
 ![First screenshot of the Apache Couchbase node overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-Couchbase/screenshots/Couchbase_nodes_1.png)
 
@@ -53,7 +53,7 @@ scrape_configs:
 
 ## Apache Couchbase Bucket Overview
 
-The Apache Bucket overview dashboard provides details on...
+The Apache Bucket overview dashboard provides details on the top buckets based on key resource usage, items, operations, operations failed, high priority requests, cache hit ratio, number of replica vBuckets, and vBucket queue memory usage.
 
 ![First screenshot of the Apache Couchbase bucket overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-Couchbase/screenshots/Couchbase_overview_1.png)
 

--- a/apache-couchbase-mixin/README.md
+++ b/apache-couchbase-mixin/README.md
@@ -64,6 +64,19 @@ The Apache Bucket overview dashboard provides details on the top buckets based o
 - ApacheCouchbaseMemoryEvictionRate: There is a spike in evictions in a bucket, which indicates high memory pressure.
 - ApacheCouchbaseInvalidRequestVolume: There is a high volume of incoming invalid requests, which may indicate a DOS or injection attack.
 
+Default thresholds can be configured in `config.libsonnet`.
+
+```js
+{
+  _config+:: {
+    alertsCriticalCPUUsage: 85, // percent 0-100
+    alertsCriticalMemoryUsage: 85, // percent 0-100
+    alertsWarningMemoryEvictionRate: 10, // count
+    alertsWarningInvalidRequestVolume: 1000, // count
+  },
+}
+```
+
 ## Install tools
 
 ```bash

--- a/apache-couchbase-mixin/README.md
+++ b/apache-couchbase-mixin/README.md
@@ -1,0 +1,95 @@
+# Apache Couchbase Mixin
+
+The Apache Couchbase mixin is a set of configurable Grafana dashboards and alerts.
+
+The Apache Couchbase mixin contains the following dashboards:
+
+- Apache Couchbase cluster overview
+- Apache Couchbase node overview
+- Apache Couchbase bucket overview
+
+and the following alerts:
+
+- ApacheCouchbaseHighCPUUsage
+- ApacheCouchbaseHighMemoryUsage
+- ApacheCouchbaseMemoryEvictionRate
+- ApacheCouchbaseInvalidRequestVolume
+
+## Apache Couchbase Cluster Overview
+
+The Apache Couchbase cluster overview dashboard provides details on the top nodes and buckets for a cluster, including memory and disk usage, network requests, key service metrics, rate of operations, along with replication metrics at all levels of a Couchbase cluster.
+
+![First screenshot of the Apache Couchbase cluster overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-Couchbase/screenshots/Couchbase_overview_1.png)
+
+## Apache Couchbase Node Overview
+
+The Apache Couchbase node overview dashboard provides details on memory usage, open OS files, open databases, database reads and writes, view info, request info (rate, latency, status code info), log type breakdown, and logs for a specific node in the cluster. To get Couchbase system logs, [Promtail and Loki needs to be installed](https://grafana.com/docs/loki/latest/installation/) and provisioned for logs with your Grafana instance. The default Couchbase system log path is `/var/log/Couchbase/Couchbase.log` on Linux.
+
+![First screenshot of the Apache Couchbase node overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-Couchbase/screenshots/Couchbase_nodes_1.png)
+
+Couchbase system logs are enabled by default in the `config.libsonnet` and can be removed by setting `enableLokiLogs` to `false`. Then run `make` again to regenerate the dashboard:
+
+```
+{
+  _config+:: {
+    enableLokiLogs: false,
+  },
+}
+```
+
+In order for the selectors to properly work for system logs ingested into your logs datasource, please also include the matching `instance`, `job`, and `cluster` labels onto the [scrape_configs](https://grafana.com/docs/loki/latest/clients/promtail/configuration/#scrape_configs) as to match the labels for ingested metrics.
+
+```yaml
+scrape_configs:
+  - job_name: integrations/couchbase
+    static_configs:
+      - targets: [localhost]
+        labels:
+          job: integrations/couchbase
+          instance: "<your-instance-name>"
+          cluster: "<your-cluster-name>"
+          __path__: /opt/couchbase/var/lib/couchbase/logs/*.log
+```
+
+## Apache Couchbase Bucket Overview
+
+The Apache Bucket overview dashboard provides details on...
+
+![First screenshot of the Apache Couchbase bucket overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-Couchbase/screenshots/Couchbase_overview_1.png)
+
+## Alerts Overview
+
+- ApacheCouchbaseHighCPUUsage: There is high cpu usage for a node.
+- ApacheCouchbaseHighMemoryUsage: There is a limited amount of memory available for a node.
+- ApacheCouchbaseMemoryEvictionRate: There is a spike in evictions in a bucket, which indicates high memory pressure.
+- ApacheCouchbaseInvalidRequestVolume: There is a high volume of incoming invalid requests, which may indicate a DOS or injection attack.
+
+## Install tools
+
+```bash
+go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@latest
+go install github.com/monitoring-mixins/mixtool/cmd/mixtool@latest
+```
+
+For linting and formatting, you would also need `jsonnetfmt` installed. If you
+have a working Go development environment, it's easiest to run the following:
+
+```bash
+go install github.com/google/go-jsonnet/cmd/jsonnetfmt@latest
+```
+
+The files in `dashboards_out` need to be imported
+into your Grafana server. The exact details will be depending on your environment.
+
+`prometheus_alerts.yaml` needs to be imported into Prometheus.
+
+## Generate dashboards and alerts
+
+Edit `config.libsonnet` if required and then build JSON dashboard files for Grafana:
+
+```bash
+make
+```
+
+For more advanced uses of mixins, see
+https://github.com/monitoring-mixins/docs.

--- a/apache-couchbase-mixin/README.md
+++ b/apache-couchbase-mixin/README.md
@@ -21,6 +21,7 @@ The Apache Couchbase cluster overview dashboard provides details on the top node
 
 ![First screenshot of the Apache Couchbase cluster overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-couchbase/screenshots/cluster-overview-1.png)
 ![Second screenshot of the Apache Couchbase cluster overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-couchbase/screenshots/cluster-overview-2.png)
+![Third screenshot of the Apache Couchbase cluster overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-couchbase/screenshots/cluster-overview-3.png)
 
 ## Apache Couchbase Node Overview
 
@@ -52,6 +53,9 @@ scrape_configs:
           instance: "<your-instance-name>"
           cluster: "<your-cluster-name>"
           __path__: /opt/couchbase/var/lib/couchbase/logs/*.log
+    pipeline_stages:
+      - multiline:
+          firstline: '\[(ns_server|couchdb):(error|info),.*\]'
 ```
 
 ## Apache Couchbase Bucket Overview

--- a/apache-couchbase-mixin/README.md
+++ b/apache-couchbase-mixin/README.md
@@ -19,13 +19,16 @@ and the following alerts:
 
 The Apache Couchbase cluster overview dashboard provides details on the top nodes and buckets for a cluster, including memory and disk usage, network requests, key service metrics, rate of operations, along with replication metrics at all levels of a Couchbase cluster.
 
-![First screenshot of the Apache Couchbase cluster overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-Couchbase/screenshots/Couchbase_overview_1.png)
+![First screenshot of the Apache Couchbase cluster overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-couchbase/screenshots/cluster-overview-1.png)
+![Second screenshot of the Apache Couchbase cluster overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-couchbase/screenshots/cluster-overview-2.png)
 
 ## Apache Couchbase Node Overview
 
 The Apache Couchbase node overview dashboard provides details on memory usage, cpu usage, network request info (request methods and response codes), query service request info (volume, type, and processing time), index service performance (request volume, cache hit ratio, and scan latency), and both error and couchdb logs. The default Couchbase system log path is `/opt/couchbase/var/lib/couchbase/logs` on Linux, or `C:\Program\Files\Couchbase\Server\var\lib\couchbase\logs` on Windows.
 
-![First screenshot of the Apache Couchbase node overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-Couchbase/screenshots/Couchbase_nodes_1.png)
+![First screenshot of the Apache Couchbase node overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-couchbase/screenshots/node-overview-1.png)
+![Second screenshot of the Apache Couchbase node overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-couchbase/screenshots/node-overview-2.png)
+![Third screenshot of the Apache Couchbase node overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-couchbase/screenshots/node-overview-3.png)
 
 Couchbase system logs are enabled by default in the `config.libsonnet` and can be removed by setting `enableLokiLogs` to `false`. Then run `make` again to regenerate the dashboard:
 
@@ -55,7 +58,8 @@ scrape_configs:
 
 The Apache Bucket overview dashboard provides details on the top buckets based on key resource usage, items, operations, operations failed, high priority requests, cache hit ratio, number of replica vBuckets, and vBucket queue memory usage.
 
-![First screenshot of the Apache Couchbase bucket overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-Couchbase/screenshots/Couchbase_overview_1.png)
+![First screenshot of the Apache Couchbase bucket overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-couchbase/screenshots/bucket-overview-1.png)
+![Second screenshot of the Apache Couchbase bucket overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-couchbase/screenshots/bucket-overview-2.png)
 
 ## Alerts Overview
 

--- a/apache-couchbase-mixin/alerts/alerts.libsonnet
+++ b/apache-couchbase-mixin/alerts/alerts.libsonnet
@@ -1,0 +1,102 @@
+{
+  prometheusAlerts+:: {
+    groups+: [
+      {
+        name: 'apache-couchbase',
+        rules: [
+          {
+            alert: 'ApacheCouchbaseHighCPUUsage',
+            expr: |||
+              max without(category) (sys_cpu_utilization_rate) > %(alertsCriticalCPUUsage)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              summary: 'There is high cpu usage for a node.',
+              description:
+                (
+                  '{{ printf "%%.0f" $value }} percent CPU usage on {{$labels.instance}}, ' +
+                  'which is above the threshold of %(alertsCriticalCPUUsage)s.'
+                ) % $._config,
+            },
+          },
+          {
+            alert: 'ApacheCouchbaseHighMemoryUsage',
+            expr: |||
+              100 * max without(category) (sys_mem_actual_used / (sys_mem_actual_used + sys_mem_actual_free)) > %(alertsCriticalMemoryUsage)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              summary: 'There is a limited amount of memory available for a node.',
+              description:
+                (
+                  '{{ printf "%%.0f" $value }} percent memory usage on node {{$labels.instance}}, ' +
+                  'which is above the threshold of %(alertsCriticalMemoryUsage)s.'
+                ) % $._config,
+            },
+          },
+          {
+            alert: 'ApacheCouchbaseMemoryEvictionRate',
+            expr: |||
+              max without() (kv_ep_num_value_ejects) > %(alertsWarningMemoryEvictionRate)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              summary: 'There is a spike in evictions in a bucket, which indicates high memory pressure.',
+              description:
+                (
+                  '{{ printf "%%.0f" $value }} evictions in bucket {{$labels.bucket}} on node {{$labels.instance}}, ' +
+                  'which is above the threshold of %(alertsWarningMemoryEvictionRate)s.'
+                ) % $._config,
+            },
+          },
+          {
+            alert: 'ApacheCouchbaseInvalidRequestVolume',
+            expr: |||
+              max without(instance) (rate(n1ql_invalid_requests[$__rate_interval])) > %(alertsWarningInvalidRequestVolume)s
+            ||| % $._config,
+            'for': '2m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              summary: 'There is a high volume of incoming invalid requests, which may indicate a DOS or injection attack.',
+              description:
+                (
+                  '{{ printf "%%.0f" $value }} invalid requests to {{$labels.couchbase_cluster}}, ' +
+                  'which is above the threshold of %(alertsWarningInvalidRequestVolume)s.'
+                ) % $._config,
+            },
+          },
+        ],
+      },
+    ],
+  },
+}
+ 14 changes: 14 additions & 0 deletions14
+integrations/couchbase/alerts/config.libsonnet
+Marking files as viewed can help keep track of your progress, but will not affect your submitted reviewViewed
+Comment on this file
+@@ -0,0 +1,14 @@
+{
+  _config+:: {
+    dashboardTags: ['couchbase-mixin'],
+    dashboardPeriod: 'now-3h',
+    dashboardTimezone: 'default',
+    dashboardRefresh: '1m',
+
+    // alerts thresholds
+    alertsCriticalCPUUsage: 85, // %
+    alertsCriticalMemoryUsage: 85,  // %
+    alertsWarningMemoryEvictionRate: 10,  // count
+    alertsWarningInvalidRequestVolume: 1000,  // count
+  },
+}

--- a/apache-couchbase-mixin/config.libsonnet
+++ b/apache-couchbase-mixin/config.libsonnet
@@ -1,7 +1,7 @@
 {
   _config+:: {
     dashboardTags: ['couchbase-mixin'],
-    dashboardPeriod: 'now-3h',
+    dashboardPeriod: 'now-1h',
     dashboardTimezone: 'default',
     dashboardRefresh: '1m',
 

--- a/apache-couchbase-mixin/config.libsonnet
+++ b/apache-couchbase-mixin/config.libsonnet
@@ -6,7 +6,7 @@
     dashboardRefresh: '1m',
 
     // alerts thresholds
-    alertsCriticalCPUUsage: 85, // %
+    alertsCriticalCPUUsage: 85,  // %
     alertsCriticalMemoryUsage: 85,  // %
     alertsWarningMemoryEvictionRate: 10,  // count
     alertsWarningInvalidRequestVolume: 1000,  // count

--- a/apache-couchbase-mixin/config.libsonnet
+++ b/apache-couchbase-mixin/config.libsonnet
@@ -1,0 +1,14 @@
+{
+  _config+:: {
+    dashboardTags: ['couchbase-mixin'],
+    dashboardPeriod: 'now-3h',
+    dashboardTimezone: 'default',
+    dashboardRefresh: '1m',
+
+    // alerts thresholds
+    alertsCriticalCPUUsage: 85, // %
+    alertsCriticalMemoryUsage: 85,  // %
+    alertsWarningMemoryEvictionRate: 10,  // count
+    alertsWarningInvalidRequestVolume: 1000,  // count
+  },
+}

--- a/apache-couchbase-mixin/config.libsonnet
+++ b/apache-couchbase-mixin/config.libsonnet
@@ -10,5 +10,7 @@
     alertsCriticalMemoryUsage: 85,  // %
     alertsWarningMemoryEvictionRate: 10,  // count
     alertsWarningInvalidRequestVolume: 1000,  // count
+
+    enableLokiLogs: true,
   },
 }

--- a/apache-couchbase-mixin/dashboards/couchbase-bucket-overview.libsonnet
+++ b/apache-couchbase-mixin/dashboards/couchbase-bucket-overview.libsonnet
@@ -1,0 +1,769 @@
+local g = (import 'grafana-builder/grafana.libsonnet');
+local grafana = (import 'grafonnet/grafana.libsonnet');
+local dashboard = grafana.dashboard;
+local template = grafana.template;
+local prometheus = grafana.prometheus;
+
+local dashboardUid = 'apache-couchbase-bucket-overview';
+
+local promDatasourceName = 'prometheus_datasource';
+
+local promDatasource = {
+  uid: '${%s}' % promDatasourceName,
+};
+
+
+local topBucketsByMemoryUsedPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'topk(5, kv_mem_used_bytes{job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance=~"$instance", bucket=~"$bucket"})',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - {{bucket}}',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Top buckets by memory used',
+  description: 'Memory used for the largest buckets',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'Bps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local topBucketsByDiskUsedPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'topk(5, couch_docs_actual_disk_size{job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance=~"$instance", bucket=~"$bucket"})',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - {{bucket}}',
+    ),
+  ],
+  type: 'bargauge',
+  title: 'Top buckets by disk used',
+  description: 'Total space on disk used for the largest buckets',
+  fieldConfig: {
+    defaults: {
+      color: {
+        fixedColor: 'green',
+        mode: 'fixed',
+      },
+      mappings: [],
+      min: 1,
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'decbytes',
+    },
+    overrides: [],
+  },
+  options: {
+    displayMode: 'basic',
+    minVizHeight: 10,
+    minVizWidth: 0,
+    orientation: 'horizontal',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    showUnfilled: true,
+    valueMode: 'color',
+  },
+  pluginVersion: '10.0.2-cloud.1.94a6f396',
+};
+
+local topBucketsByCurrentItemsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'topk(5, kv_curr_items{job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance=~"$instance", bucket=~"$bucket"})',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - {{bucket}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Top buckets by current items',
+  description: 'Number of active items for the largest buckets',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local topBucketsByOperationsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'topk(5, sum by(bucket, couchbase_cluster, instance, job, op) (rate(kv_ops{job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance=~"$instance", bucket=~"$bucket"}[$__rate_interval])))',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - {{bucket}} - {{op}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Top buckets by operations',
+  description: 'Rate of operations for the busiest buckets',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'ops',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local topBucketsByOperationsFailedPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'topk(5, sum by(bucket, couchbase_cluster, instance, job) (rate(kv_ops_failed{job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance=~"$instance", bucket=~"$bucket"}[$__rate_interval])))',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - {{bucket}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Top buckets by operations failed',
+  description: 'Rate of failed operations for the most problematic buckets',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'ops',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local topBucketsByHighPriorityRequestsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'topk(5, sum by(bucket, couchbase_cluster, instance, job) (kv_num_high_pri_requests{job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance=~"$instance", bucket=~"$bucket"}))',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - {{bucket}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Top buckets by high priority requests',
+  description: 'Rate of high priority requests processed by the KV engine for the top buckets',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'reqps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local bottomBucketsByCacheHitRatioPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'bottomk(5, sum by(couchbase_cluster, job, instance, bucket) (index_cache_hits{job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance="$instance", bucket=~"$bucket"})) / (clamp_min(sum by(couchbase_cluster, job, instance, bucket) (index_cache_hits{job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance=~"$instance", bucket=~"$bucket"}), 1) + sum by(couchbase_cluster, job, instance, bucket) (index_cache_misses{job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance=~"$instance", bucket=~"$bucket"}))',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - {{bucket}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Bottom buckets by cache hit ratio',
+  description: 'Worst buckets by cache hit ratio',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'percentunit',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local topBucketsByNumVBucketsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'topk(5, sum by(bucket, couchbase_cluster, instance, job) (kv_num_vbuckets{job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance=~"$instance", bucket=~"$bucket"}))',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - {{bucket}}',
+    ),
+  ],
+  type: 'bargauge',
+  title: 'Top buckets by num vBuckets',
+  description: 'Number of virtual buckets across the cluster for the top buckets',
+  fieldConfig: {
+    defaults: {
+      color: {
+        fixedColor: 'green',
+        mode: 'fixed',
+      },
+      mappings: [],
+      min: 1,
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    displayMode: 'basic',
+    minVizHeight: 10,
+    minVizWidth: 0,
+    orientation: 'horizontal',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    showUnfilled: true,
+    valueMode: 'color',
+  },
+  pluginVersion: '10.0.2-cloud.1.94a6f396',
+};
+
+local topBucketsByVBucketQueueMemoryPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'topk(5, sum by(bucket, couchbase_cluster, instance, job) (kv_vb_queue_memory_bytes{job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance=~"$instance", bucket=~"$bucket"}))',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - {{bucket}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Top buckets by vBucket queue memory',
+  description: 'Memory occupied by the queue for a virtual bucket for the top buckets',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'decbytes',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+
+{
+  grafanaDashboards+:: {
+    'apache-couchbase-bucket-overview.json':
+      dashboard.new(
+        'Apache Couchbase bucket overview',
+        time_from='%s' % $._config.dashboardPeriod,
+        tags=($._config.dashboardTags),
+        timezone='%s' % $._config.dashboardTimezone,
+        refresh='%s' % $._config.dashboardRefresh,
+        description='',
+        uid=dashboardUid,
+      )
+      .addLink(grafana.link.dashboards(
+        asDropdown=false,
+        title='Other Couchbase Dashboards',
+        includeVars=true,
+        keepTime=true,
+        tags=($._config.dashboardTags)
+      ))
+      .addTemplates(
+        [
+          template.datasource(
+            promDatasourceName,
+            'prometheus',
+            null,
+            label='Data Source',
+            refresh='load'
+          ),
+          template.new(
+            'job',
+            promDatasource,
+            'label_values(kv_mem_used_bytes,job)',
+            label='Job',
+            refresh=2,
+            includeAll=false,
+            multi=false,
+            allValues='',
+            sort=0
+          ),
+          template.new(
+            'couchbase_cluster',
+            promDatasource,
+            'label_values(kv_mem_used_bytes,couchbase_cluster)',
+            label='Couchbase Cluster',
+            refresh=2,
+            includeAll=true,
+            multi=true,
+            allValues='',
+            sort=0
+          ),
+          template.new(
+            'instance',
+            promDatasource,
+            'label_values(kv_mem_used_bytes,instance)',
+            label='Instance',
+            refresh=2,
+            includeAll=true,
+            multi=true,
+            allValues='',
+            sort=0
+          ),
+          template.new(
+            'bucket',
+            promDatasource,
+            'label_values(kv_mem_used_bytes,bucket)',
+            label='Bucket',
+            refresh=2,
+            includeAll=true,
+            multi=true,
+            allValues='',
+            sort=0
+          ),
+        ]
+      )
+      .addPanels(
+        [
+          topBucketsByMemoryUsedPanel { gridPos: { h: 8, w: 12, x: 0, y: 0 } },
+          topBucketsByDiskUsedPanel { gridPos: { h: 8, w: 12, x: 12, y: 0 } },
+          topBucketsByCurrentItemsPanel { gridPos: { h: 8, w: 8, x: 0, y: 8 } },
+          topBucketsByOperationsPanel { gridPos: { h: 8, w: 8, x: 8, y: 8 } },
+          topBucketsByOperationsFailedPanel { gridPos: { h: 8, w: 8, x: 16, y: 8 } },
+          topBucketsByHighPriorityRequestsPanel { gridPos: { h: 8, w: 12, x: 0, y: 16 } },
+          bottomBucketsByCacheHitRatioPanel { gridPos: { h: 8, w: 12, x: 12, y: 16 } },
+          topBucketsByNumVBucketsPanel { gridPos: { h: 8, w: 12, x: 0, y: 24 } },
+          topBucketsByVBucketQueueMemoryPanel { gridPos: { h: 8, w: 12, x: 12, y: 24 } },
+        ]
+      ),
+  },
+}

--- a/apache-couchbase-mixin/dashboards/couchbase-bucket-overview.libsonnet
+++ b/apache-couchbase-mixin/dashboards/couchbase-bucket-overview.libsonnet
@@ -702,7 +702,7 @@ local topBucketsByVBucketQueueMemoryPanel = {
             promDatasourceName,
             'prometheus',
             null,
-            label='Data Source',
+            label='Data source',
             refresh='load'
           ),
           template.new(
@@ -720,7 +720,7 @@ local topBucketsByVBucketQueueMemoryPanel = {
             'couchbase_cluster',
             promDatasource,
             'label_values(kv_mem_used_bytes,couchbase_cluster)',
-            label='Couchbase Cluster',
+            label='Couchbase cluster',
             refresh=2,
             includeAll=true,
             multi=true,

--- a/apache-couchbase-mixin/dashboards/couchbase-cluster-overview.libsonnet
+++ b/apache-couchbase-mixin/dashboards/couchbase-cluster-overview.libsonnet
@@ -919,7 +919,7 @@ local topBucketsByVBucketsCountPanel = {
             promDatasourceName,
             'prometheus',
             null,
-            label='Data Source',
+            label='Data source',
             refresh='load'
           ),
           template.new(
@@ -937,7 +937,7 @@ local topBucketsByVBucketsCountPanel = {
             'couchbase_cluster',
             promDatasource,
             'label_values(kv_num_vbuckets,couchbase_cluster)',
-            label='Couchbase Cluster',
+            label='Couchbase cluster',
             refresh=2,
             includeAll=true,
             multi=true,

--- a/apache-couchbase-mixin/dashboards/couchbase-node-overview.libsonnet
+++ b/apache-couchbase-mixin/dashboards/couchbase-node-overview.libsonnet
@@ -622,6 +622,7 @@ local queryServiceRequestsPanel = {
         steps: [
           {
             color: 'green',
+            value: null,
           },
           {
             color: 'red',
@@ -720,6 +721,7 @@ local queryServiceRequestProcessingTimePanel = {
         steps: [
           {
             color: 'green',
+            value: null,
           },
           {
             color: 'red',
@@ -798,6 +800,7 @@ local indexServiceRequestsPanel = {
         steps: [
           {
             color: 'green',
+            value: null,
           },
           {
             color: 'red',
@@ -877,6 +880,7 @@ local indexCacheHitRatioPanel = {
         steps: [
           {
             color: 'green',
+            value: null,
           },
           {
             color: 'red',
@@ -955,6 +959,7 @@ local averageScanLatencyPanel = {
         steps: [
           {
             color: 'green',
+            value: null,
           },
           {
             color: 'red',
@@ -986,7 +991,7 @@ local errorLogsPanel = {
     {
       datasource: lokiDatasource,
       editorMode: 'code',
-      expr: '{filename=~"/opt/couchbase/var/lib/couchbase/logs/error.log", job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance=~"$instance"} |= ``',
+      expr: '{filename=~"/opt/couchbase/var/lib/couchbase/logs/error\\.log", job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance=~"$instance"}',
       queryType: 'range',
       refId: 'A',
     },
@@ -1012,7 +1017,7 @@ local couchbaseLogsPanel = {
     {
       datasource: lokiDatasource,
       editorMode: 'code',
-      expr: '{job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance=~"$instance", filename=~"/opt/couchbase/var/lib/couchbase/logs/couchdb.log"} |= ``',
+      expr: '{job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance=~"$instance", filename=~"/opt/couchbase/var/lib/couchbase/logs/couchdb\\.log"} != `---`',
       queryType: 'range',
       refId: 'A',
     },
@@ -1045,13 +1050,7 @@ local couchbaseLogsPanel = {
         description='',
         uid=dashboardUid,
       )
-      .addLink(grafana.link.dashboards(
-        asDropdown=false,
-        title='Other Apache Couchbase dashboards',
-        includeVars=true,
-        keepTime=true,
-        tags=($._config.dashboardTags),
-      ))
+
       .addTemplates(
         std.flattenArrays([
           [
@@ -1088,7 +1087,7 @@ local couchbaseLogsPanel = {
               'couchbase_cluster',
               promDatasource,
               'label_values(sys_mem_actual_used,couchbase_cluster)',
-              label='Couchbase Cluster',
+              label='Couchbase cluster',
               refresh=2,
               includeAll=true,
               multi=true,

--- a/apache-couchbase-mixin/dashboards/couchbase-node-overview.libsonnet
+++ b/apache-couchbase-mixin/dashboards/couchbase-node-overview.libsonnet
@@ -986,7 +986,7 @@ local errorLogsPanel = {
     {
       datasource: lokiDatasource,
       editorMode: 'code',
-      expr: '{filename=~"/opt/couchbase/var/lib/couchbase/logs/error\\.log", job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance=~"$instance"} |= ``',
+      expr: '{filename=~"/opt/couchbase/var/lib/couchbase/logs/error\.log", job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance=~"$instance"} |= ``',
       queryType: 'range',
       refId: 'A',
     },
@@ -1012,7 +1012,7 @@ local couchbaseLogsPanel = {
     {
       datasource: lokiDatasource,
       editorMode: 'code',
-      expr: '{job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance=~"$instance", filename=~"/opt/couchbase/var/lib/couchbase/logs/couchdb\\.log"} |= ``',
+      expr: '{job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance=~"$instance", filename=~"/opt/couchbase/var/lib/couchbase/logs/couchdb\.log"} |= ``',
       queryType: 'range',
       refId: 'A',
     },

--- a/apache-couchbase-mixin/dashboards/couchbase-node-overview.libsonnet
+++ b/apache-couchbase-mixin/dashboards/couchbase-node-overview.libsonnet
@@ -986,7 +986,7 @@ local errorLogsPanel = {
     {
       datasource: lokiDatasource,
       editorMode: 'code',
-      expr: '{filename=~"/opt/couchbase/var/lib/couchbase/logs/error\.log", job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance=~"$instance"} |= ``',
+      expr: '{filename=~"/opt/couchbase/var/lib/couchbase/logs/error.log", job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance=~"$instance"} |= ``',
       queryType: 'range',
       refId: 'A',
     },
@@ -1012,7 +1012,7 @@ local couchbaseLogsPanel = {
     {
       datasource: lokiDatasource,
       editorMode: 'code',
-      expr: '{job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance=~"$instance", filename=~"/opt/couchbase/var/lib/couchbase/logs/couchdb\.log"} |= ``',
+      expr: '{job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance=~"$instance", filename=~"/opt/couchbase/var/lib/couchbase/logs/couchdb.log"} |= ``',
       queryType: 'range',
       refId: 'A',
     },

--- a/apache-couchbase-mixin/dashboards/couchbase-node-overview.libsonnet
+++ b/apache-couchbase-mixin/dashboards/couchbase-node-overview.libsonnet
@@ -1,0 +1,1141 @@
+local g = (import 'grafana-builder/grafana.libsonnet');
+local grafana = (import 'grafonnet/grafana.libsonnet');
+local dashboard = grafana.dashboard;
+local template = grafana.template;
+local prometheus = grafana.prometheus;
+
+local dashboardUid = 'apache-couchbase-node-overview';
+
+local promDatasourceName = 'prometheus_datasource';
+local lokiDatasourceName = 'loki_datasource';
+
+local promDatasource = {
+  uid: '${%s}' % promDatasourceName,
+};
+
+
+local lokiDatasource = {
+  uid: '${%s}' % lokiDatasourceName,
+};
+
+local memoryUtilizationPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sys_mem_actual_used{job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance=~"$instance"} / (clamp_min(sys_mem_actual_free{job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance=~"$instance"} + sys_mem_actual_used{job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance=~"$instance"}, 1))',
+      datasource=promDatasource,
+      legendFormat='{{couchbase_cluster}} - {{instance}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Memory utilization',
+  description: 'Percentage of memory allocated to Couchbase on this node actually in use.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'percentunit',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local cpuUtilizationPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by(couchbase_cluster, job, instance) (sys_cpu_utilization_rate{job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance=~"$instance"})',
+      datasource=promDatasource,
+      legendFormat='{{couchbase_cluster}} - {{instance}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'CPU utilization',
+  description: 'CPU utilization percentage across all available cores on this Couchbase node.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'percent',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local totalMemoryUsedByServicePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'index_memory_used_total{job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance=~"$instance"}',
+      datasource=promDatasource,
+      legendFormat='{{couchbase_cluster}} - {{instance}} - index',
+    ),
+    prometheus.target(
+      'cbas_direct_memory_used_bytes{job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance=~"$instance"}',
+      datasource=promDatasource,
+      legendFormat='{{couchbase_cluster}} - {{instance}} - analytics',
+    ),
+    prometheus.target(
+      'sum by(couchbase_cluster, instance, job) (kv_mem_used_bytes{job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance=~"$instance"})',
+      datasource=promDatasource,
+      legendFormat='{{couchbase_cluster}} - {{instance}} - data',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Total memory used by service',
+  description: 'Memory used by the index, analytics, and data services for a node.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'decbytes',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local backupSizePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by(couchbase_cluster, instance, job) (backup_data_size{job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance=~"$instance"})',
+      datasource=promDatasource,
+      legendFormat='{{couchbase_cluster}} - {{instance}}',
+    ),
+  ],
+  type: 'bargauge',
+  title: 'Backup size',
+  description: 'Size of locally replicated cluster data for a Couchbase node.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        fixedColor: 'green',
+        mode: 'fixed',
+      },
+      mappings: [],
+      min: 1,
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'decbytes',
+    },
+    overrides: [],
+  },
+  options: {
+    displayMode: 'basic',
+    minVizHeight: 10,
+    minVizWidth: 0,
+    orientation: 'vertical',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    showUnfilled: true,
+    valueMode: 'color',
+  },
+  pluginVersion: '10.0.2-cloud.1.94a6f396',
+};
+
+local currentConnectionsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'kv_curr_connections{job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance=~"$instance"}',
+      datasource=promDatasource,
+      legendFormat='{{couchbase_cluster}} - {{instance}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Current connections',
+  description: 'Number of active connections to a node.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'stepBefore',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      decimals: 0,
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local httpResponseCodesPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by(job, instance, couchbase_cluster, code) (rate(cm_http_requests_total{job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance=~"$instance"}[$__rate_interval]))',
+      datasource=promDatasource,
+      legendFormat='{{couchbase_cluster}} - {{instance}} - {{code}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'HTTP response codes',
+  description: 'Rate of HTTP response codes handled by the cluster manager.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      min: 0.001,
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'reqps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local httpRequestMethodsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by(job, instance, couchbase_cluster, method) (rate(cm_http_requests_total{job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance=~"$instance"}[$__rate_interval]))',
+      datasource=promDatasource,
+      legendFormat='{{couchbase_cluster}} - {{instance}} - {{method}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'HTTP request methods',
+  description: 'Rate of HTTP request methods handled by the cluster manager.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'reqps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local queryServiceRequestsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'rate(n1ql_requests{job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance=~"$instance"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='{{couchbase_cluster}} - {{instance}} - total',
+    ),
+    prometheus.target(
+      'rate(n1ql_errors{job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance=~"$instance"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='{{couchbase_cluster}} - {{instance}} - error',
+    ),
+    prometheus.target(
+      'rate(n1ql_invalid_requests{job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance=~"$instance"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='{{couchbase_cluster}} - {{instance}} - invalid',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Query service requests',
+  description: 'Rate of N1QL requests processed by the query service for a node.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'reqps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local queryServiceRequestProcessingTimePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'rate(n1ql_requests{job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance=~"$instance"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='{{couchbase_cluster}} - {{instance}} - >0ms',
+    ),
+    prometheus.target(
+      'rate(n1ql_requests_250ms{job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance=~"$instance"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='{{couchbase_cluster}} - {{instance}} - >250ms',
+    ),
+    prometheus.target(
+      'rate(n1ql_requests_500ms{job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance=~"$instance"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='{{couchbase_cluster}} - {{instance}} - >500ms',
+    ),
+    prometheus.target(
+      'rate(n1ql_requests_1000ms{job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance=~"$instance"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='{{couchbase_cluster}} - {{instance}} - >1000ms',
+    ),
+    prometheus.target(
+      'rate(n1ql_requests_5000ms{job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance=~"$instance"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='{{couchbase_cluster}} - {{instance}} - >5000ms',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Query service request processing time',
+  description: 'Rate of queries grouped by processing time.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'reqps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local indexServiceRequestsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by(couchbase_cluster, instance, job) (rate(index_num_requests{couchbase_cluster=~"$couchbase_cluster", job=~"$job", instance=~"$instance"}[$__rate_interval]))',
+      datasource=promDatasource,
+      legendFormat='{{couchbase_cluster}} - {{instance}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Index service requests',
+  description: 'Rate of index service requests served.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'reqps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local indexCacheHitRatioPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by(couchbase_cluster, job, instance) (index_cache_hits{job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance=~"$instance"}) / (clamp_min(sum by(couchbase_cluster, job, instance) (index_cache_hits{job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance=~"$instance"}), 1) + sum by(couchbase_cluster, job, instance) (index_cache_misses{job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance=~"$instance"}))',
+      datasource=promDatasource,
+      legendFormat='{{couchbase_cluster}} - {{instance}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Index cache hit ratio',
+  description: 'Ratio at which cache scans result in a hit rather than a miss.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      max: 1,
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'percentunit',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local averageScanLatencyPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by(couchbase_cluster, index, instance, job) (index_avg_scan_latency{job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance=~"$instance"})',
+      datasource=promDatasource,
+      legendFormat='{{couchbase_cluster}} - {{instance}} - {{index}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Average scan latency',
+  description: 'Average time to serve a scan request per index.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'ns',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local errorLogsPanel = {
+  datasource: lokiDatasource,
+  targets: [
+    {
+      datasource: lokiDatasource,
+      editorMode: 'code',
+      expr: '{filename=~"/opt/couchbase/var/lib/couchbase/logs/error\\.log", job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance=~"$instance"} |= ``',
+      queryType: 'range',
+      refId: 'A',
+    },
+  ],
+  type: 'logs',
+  title: 'Error logs',
+  description: 'Recent error logs from a node.',
+  options: {
+    dedupStrategy: 'none',
+    enableLogDetails: true,
+    prettifyLogMessage: true,
+    showCommonLabels: false,
+    showLabels: false,
+    showTime: false,
+    sortOrder: 'Descending',
+    wrapLogMessage: false,
+  },
+};
+
+local couchbaseLogsPanel = {
+  datasource: lokiDatasource,
+  targets: [
+    {
+      datasource: lokiDatasource,
+      editorMode: 'code',
+      expr: '{job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance=~"$instance", filename=~"/opt/couchbase/var/lib/couchbase/logs/couchdb\\.log"} |= ``',
+      queryType: 'range',
+      refId: 'A',
+    },
+  ],
+  type: 'logs',
+  title: 'Couchbase logs',
+  description: 'Recent couchbase logs from a node.',
+  options: {
+    dedupStrategy: 'none',
+    enableLogDetails: true,
+    prettifyLogMessage: false,
+    showCommonLabels: false,
+    showLabels: false,
+    showTime: false,
+    sortOrder: 'Descending',
+    wrapLogMessage: false,
+  },
+};
+
+
+{
+  grafanaDashboards+:: {
+    'apache-couchbase-node-overview.json':
+      dashboard.new(
+        'Apache Couchbase node overview',
+        time_from='%s' % $._config.dashboardPeriod,
+        tags=($._config.dashboardTags),
+        timezone='%s' % $._config.dashboardTimezone,
+        refresh='%s' % $._config.dashboardRefresh,
+        description='',
+        uid=dashboardUid,
+      )
+      .addLink(grafana.link.dashboards(
+        asDropdown=false,
+        title='Other Apache Couchbase dashboards',
+        includeVars=true,
+        keepTime=true,
+        tags=($._config.dashboardTags),
+      ))
+      .addTemplates(
+        std.flattenArrays([
+          [
+            template.datasource(
+              promDatasourceName,
+              'prometheus',
+              null,
+              label='Data Source',
+              refresh='load'
+            ),
+          ],
+          if $._config.enableLokiLogs then [
+            template.datasource(
+              lokiDatasourceName,
+              'loki',
+              null,
+              label='Loki Datasource',
+              refresh='load'
+            ),
+          ] else [],
+          [
+            template.new(
+              'job',
+              promDatasource,
+              'label_values(sys_mem_actual_used,job)',
+              label='Job',
+              refresh=2,
+              includeAll=false,
+              multi=false,
+              allValues='',
+              sort=0
+            ),
+            template.new(
+              'couchbase_cluster',
+              promDatasource,
+              'label_values(sys_mem_actual_used,couchbase_cluster)',
+              label='Couchbase Cluster',
+              refresh=2,
+              includeAll=true,
+              multi=true,
+              allValues='',
+              sort=0
+            ),
+            template.new(
+              'instance',
+              promDatasource,
+              'label_values(sys_mem_actual_used,instance)',
+              label='Instance',
+              refresh=2,
+              includeAll=true,
+              multi=true,
+              allValues='',
+              sort=0
+            ),
+          ],
+        ])
+      )
+      .addPanels(
+        std.flattenArrays([
+          [
+            memoryUtilizationPanel { gridPos: { h: 8, w: 12, x: 0, y: 0 } },
+            cpuUtilizationPanel { gridPos: { h: 8, w: 12, x: 12, y: 0 } },
+            totalMemoryUsedByServicePanel { gridPos: { h: 8, w: 8, x: 0, y: 8 } },
+            backupSizePanel { gridPos: { h: 8, w: 8, x: 8, y: 8 } },
+            currentConnectionsPanel { gridPos: { h: 8, w: 8, x: 16, y: 8 } },
+            httpResponseCodesPanel { gridPos: { h: 8, w: 12, x: 0, y: 16 } },
+            httpRequestMethodsPanel { gridPos: { h: 8, w: 12, x: 12, y: 16 } },
+            queryServiceRequestsPanel { gridPos: { h: 8, w: 12, x: 0, y: 24 } },
+            queryServiceRequestProcessingTimePanel { gridPos: { h: 8, w: 12, x: 12, y: 24 } },
+            indexServiceRequestsPanel { gridPos: { h: 8, w: 8, x: 0, y: 32 } },
+            indexCacheHitRatioPanel { gridPos: { h: 8, w: 8, x: 8, y: 32 } },
+            averageScanLatencyPanel { gridPos: { h: 8, w: 8, x: 16, y: 32 } },
+          ],
+          if $._config.enableLokiLogs then [
+            errorLogsPanel { gridPos: { h: 7, w: 24, x: 0, y: 40 } },
+          ] else [],
+          [
+          ],
+          if $._config.enableLokiLogs then [
+            couchbaseLogsPanel { gridPos: { h: 8, w: 24, x: 0, y: 47 } },
+          ] else [],
+          [
+          ],
+        ])
+      ),
+  },
+}

--- a/apache-couchbase-mixin/dashboards/couchbase-node-overview.libsonnet
+++ b/apache-couchbase-mixin/dashboards/couchbase-node-overview.libsonnet
@@ -991,7 +991,7 @@ local errorLogsPanel = {
     {
       datasource: lokiDatasource,
       editorMode: 'code',
-      expr: '{filename=~"/opt/couchbase/var/lib/couchbase/logs/error\\.log", job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance=~"$instance"}',
+      expr: '{filename=~"/opt/couchbase/var/lib/couchbase/logs/error.log", job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance=~"$instance"}',
       queryType: 'range',
       refId: 'A',
     },
@@ -1017,7 +1017,7 @@ local couchbaseLogsPanel = {
     {
       datasource: lokiDatasource,
       editorMode: 'code',
-      expr: '{job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance=~"$instance", filename=~"/opt/couchbase/var/lib/couchbase/logs/couchdb\\.log"} != `---`',
+      expr: '{job=~"$job", couchbase_cluster=~"$couchbase_cluster", instance=~"$instance", filename=~"/opt/couchbase/var/lib/couchbase/logs/couchdb.log"} != `---`',
       queryType: 'range',
       refId: 'A',
     },

--- a/apache-couchbase-mixin/dashboards/dashboards.libsonnet
+++ b/apache-couchbase-mixin/dashboards/dashboards.libsonnet
@@ -1,0 +1,1 @@
+(import 'couchbase-bucket-overview.libsonnet')

--- a/apache-couchbase-mixin/dashboards/dashboards.libsonnet
+++ b/apache-couchbase-mixin/dashboards/dashboards.libsonnet
@@ -1,1 +1,3 @@
-(import 'couchbase-bucket-overview.libsonnet')
+(import 'couchbase-bucket-overview.libsonnet') +
+(import 'couchbase-cluster-overview.libsonnet') +
+(import 'couchbase-node-overview.libsonnet')

--- a/apache-couchbase-mixin/jsonnetfile.json
+++ b/apache-couchbase-mixin/jsonnetfile.json
@@ -1,0 +1,15 @@
+{
+    "version": 1,
+    "dependencies": [
+        {
+            "source": {
+                "git": {
+                    "remote": "https://github.com/grafana/grafonnet-lib.git",
+                    "subdir": "grafonnet"
+                }
+            },
+            "version": "master"
+        }
+    ],
+    "legacyImports": true
+}

--- a/apache-couchbase-mixin/mixin.libsonnet
+++ b/apache-couchbase-mixin/mixin.libsonnet
@@ -1,0 +1,3 @@
+(import 'dashboards/dashboards.libsonnet') +
+(import 'alerts/alerts.libsonnet') +
+(import 'config.libsonnet')

--- a/apache-couchdb-mixin/README.md
+++ b/apache-couchdb-mixin/README.md
@@ -53,23 +53,17 @@ scrape_configs:
       - targets: [localhost]
         labels:
           job: integrations/apache-couchdb
-          instance: '<your-instance-name>'
-          cluster: '<your-cluster-name>'
+          instance: "<your-instance-name>"
+          cluster: "<your-cluster-name>"
           __path__: /var/log/couchdb/couchdb.log
 ```
 
 ## Alerts Overview
 
-- CouchDBUnhealthyCluster: At least one of the nodes in a cluster is reporting the cluster as being unstable.
-- CouchDBHigh4xxResponseCodes: There are a high number of 4xx responses for incoming requests to a node.
-- CouchDBHigh5xxResponseCodes: There are a high number of 5xx responses for incoming requests to a node.
-- CouchDBModerateRequestLatency: There is a moderate level of request latency for a node.
-- CouchDBHighRequestLatency: There is a high level of request latency for a node.
-- CouchDBManyReplicatorJobsPending: There is a high number of replicator jobs pending for a node.
-- CouchDBReplicatorJobsCrashing: There are replicator jobs crashing for a node.
-- CouchDBReplicatorChangesQueuesDying: There are replicator changes queue process deaths for a node.
-- CouchDBReplicatorConnectionOwnersCrashing: There are replicator connection owner process crashes for a node.
-- CouchDBReplicatorConnectionWorkersCrashing: There are replicator connection worker process crashes for a node.
+- ApacheCouchbaseHighCPUUsage: There is high cpu usage for a node.
+- ApacheCouchbaseHighMemoryUsage: There is a limited amount of memory available for a node.
+- ApacheCouchbaseMemoryEvictionRate: There is a spike in evictions in a bucket, which indicates high memory pressure.
+- ApacheCouchbaseInvalidRequestVolume: There is a high volume of incoming invalid requests, which may indicate a DOS or injection attack.
 
 ## Install tools
 

--- a/apache-couchdb-mixin/README.md
+++ b/apache-couchdb-mixin/README.md
@@ -53,8 +53,8 @@ scrape_configs:
       - targets: [localhost]
         labels:
           job: integrations/apache-couchdb
-          instance: "<your-instance-name>"
-          cluster: "<your-cluster-name>"
+          instance: '<your-instance-name>'
+          cluster: '<your-cluster-name>'
           __path__: /var/log/couchdb/couchdb.log
 ```
 

--- a/apache-couchdb-mixin/README.md
+++ b/apache-couchdb-mixin/README.md
@@ -60,10 +60,16 @@ scrape_configs:
 
 ## Alerts Overview
 
-- ApacheCouchbaseHighCPUUsage: There is high cpu usage for a node.
-- ApacheCouchbaseHighMemoryUsage: There is a limited amount of memory available for a node.
-- ApacheCouchbaseMemoryEvictionRate: There is a spike in evictions in a bucket, which indicates high memory pressure.
-- ApacheCouchbaseInvalidRequestVolume: There is a high volume of incoming invalid requests, which may indicate a DOS or injection attack.
+- CouchDBUnhealthyCluster: At least one of the nodes in a cluster is reporting the cluster as being unstable.
+- CouchDBHigh4xxResponseCodes: There are a high number of 4xx responses for incoming requests to a node.
+- CouchDBHigh5xxResponseCodes: There are a high number of 5xx responses for incoming requests to a node.
+- CouchDBModerateRequestLatency: There is a moderate level of request latency for a node.
+- CouchDBHighRequestLatency: There is a high level of request latency for a node.
+- CouchDBManyReplicatorJobsPending: There is a high number of replicator jobs pending for a node.
+- CouchDBReplicatorJobsCrashing: There are replicator jobs crashing for a node.
+- CouchDBReplicatorChangesQueuesDying: There are replicator changes queue process deaths for a node.
+- CouchDBReplicatorConnectionOwnersCrashing: There are replicator connection owner process crashes for a node.
+- CouchDBReplicatorConnectionWorkersCrashing: There are replicator connection worker process crashes for a node.
 
 ## Install tools
 


### PR DESCRIPTION
Adds dashboards and alerts for Apache Couchbase.

## Note:
The vm instance sending metrics to Grafana Cloud is a single cluster, and thus does not report Cross Datacenter Replication (XDCR) metrics. The data for these metrics that appears on any screenshots is generated using the mock metric generator.


Dashboards:
- Apache Couchbase cluster overview
- Apache Couchbase node overview
- Apache Couchbase bucket overview

Alerts:
- ApacheCouchbaseHighCPUUsage
- ApacheCouchbaseHighMemoryUsage
- ApacheCouchbaseMemoryEvictionRate
- ApacheCouchbaseInvalidRequestVolume

Apache Couchbase cluster overview
<img width="1920" alt="cluster-overview-1" src="https://github.com/grafana/jsonnet-libs/assets/69878936/4d046377-3a9f-4524-ba74-02cc2fa50317">
<img width="1920" alt="cluster-overview-2" src="https://github.com/grafana/jsonnet-libs/assets/69878936/e56204ad-360a-4c7f-ac4b-9f60445ee2ff">
<img width="1920" alt="cluster-overview-3" src="https://github.com/grafana/jsonnet-libs/assets/69878936/b3772f5e-422f-4e7e-b04e-5cfd0350415f">

Apache Couchbase node overview
<img width="1920" alt="node-overview-1" src="https://github.com/grafana/jsonnet-libs/assets/69878936/818c32b9-69d9-44cf-a980-07282db2a8ac">
<img width="1920" alt="node-overview-2" src="https://github.com/grafana/jsonnet-libs/assets/69878936/9a647ee1-0003-4b94-842e-cb14858ec389">
<img width="1920" alt="node-overview-3" src="https://github.com/grafana/jsonnet-libs/assets/69878936/ce93aaa2-dd3d-429f-a27f-d19115783b05">


Apache Couchbase bucket overview 
<img width="1920" alt="bucket-overview-1" src="https://github.com/grafana/jsonnet-libs/assets/69878936/f34170e9-c18c-4f91-bbcb-8f73163b605c">
<img width="1920" alt="bucket-overview-2" src="https://github.com/grafana/jsonnet-libs/assets/69878936/b395e8a6-721f-44e6-b680-8c8cb1b662a6">


