### PR TITLE
etcd-operator :: Add RBAC policy to allow managing PodDisruptionBudget

### DIFF
--- a/etcd-operator/operator.libsonnet
+++ b/etcd-operator/operator.libsonnet
@@ -28,6 +28,11 @@
       policyRule.withApiGroups(['apps']) +
       policyRule.withResources(['deployments']) +
       policyRule.withVerbs(['*']),
+
+      policyRule.new() +
+      policyRule.withApiGroups(['policy']) +
+      policyRule.withResources(['poddisruptionbudgets']) +
+      policyRule.withVerbs(['*']),
     ]),
 
   local container = k.core.v1.container,


### PR DESCRIPTION
The upstream etc-operator has been archived but forked versions allow managing PDBs, add the necessary policy rule so the operator can apply these.