### PR TITLE
Add IBM MQ Mixin

### DIFF
--- a/ibm-mq-mixin/.lint
+++ b/ibm-mq-mixin/.lint
@@ -9,8 +9,6 @@ exclusions:
     reason: "Based on new convention we are using variable names prometheus_datasource and loki_datasource where as linter expects 'datasource'"
   target-instance-rule:
     reason: "The dashboards use a mix of 'cluster', 'queue manager', and 'queue' labels as selectors, rather than 'instance'"
-  template-label-promql-rule:
-    reason: "The dashboards use a variable that which excludes certain label values, this is inline with the regex needed to exclude such values."
   panel-units-rule:
     reason: "Custom units are used for better user experience in these panels"
     entries:

--- a/ibm-mq-mixin/.lint
+++ b/ibm-mq-mixin/.lint
@@ -1,0 +1,22 @@
+exclusions:
+  template-job-rule:
+    reason: "Prometheus datasource variable is being named as prometheus_datasource now while linter expects 'datasource'"
+  panel-datasource-rule:
+    reason: "Loki datasource variable is being named as loki_datasource now while linter expects 'datasource'"
+  template-datasource-rule:
+    reason: "Based on new convention we are using variable names prometheus_datasource and loki_datasource where as linter expects 'datasource'"
+  template-instance-rule:
+    reason: "Based on new convention we are using variable names prometheus_datasource and loki_datasource where as linter expects 'datasource'"
+  panel-units-rule:
+    reason: "Custom units are used for better user experience in these panels"
+    entries:
+    - panel: "Clusters"
+    - panel: "Queue managers"
+    - panel: "Topics"
+    - panel: "Queues"
+    - panel: "Cluster status"
+    - panel: "Queue manager status"
+    - panel: "Topic messages received"
+    - panel: "Topic subscribers"
+    - panel: "Topic publishers"
+    - panel: "Subscription messages received"

--- a/ibm-mq-mixin/.lint
+++ b/ibm-mq-mixin/.lint
@@ -7,6 +7,10 @@ exclusions:
     reason: "Based on new convention we are using variable names prometheus_datasource and loki_datasource where as linter expects 'datasource'"
   template-instance-rule:
     reason: "Based on new convention we are using variable names prometheus_datasource and loki_datasource where as linter expects 'datasource'"
+  target-instance-rule:
+    reason: "The dashboards use a mix of 'cluster', 'queue manager', and 'queue' labels as selectors, rather than 'instance'"
+  template-label-promql-rule:
+    reason: "The dashboards use a variable that which excludes certain label values, this is inline with the regex needed to exclude such values."
   panel-units-rule:
     reason: "Custom units are used for better user experience in these panels"
     entries:
@@ -20,3 +24,11 @@ exclusions:
     - panel: "Topic subscribers"
     - panel: "Topic publishers"
     - panel: "Subscription messages received"
+    - panel: "Active listeners"
+    - panel: "Active connections"
+    - panel: "Published messages"
+    - panel: "Commits"
+    - panel: "Expired messages"
+    - panel: "Queue operations"
+    - panel: "Operations"
+    - panel: "Depth"

--- a/ibm-mq-mixin/Makefile
+++ b/ibm-mq-mixin/Makefile
@@ -1,0 +1,34 @@
+JSONNET_FMT := jsonnetfmt -n 2 --max-blank-lines 1 --string-style s --comment-style s
+
+.PHONY: all
+all: build dashboards_out prometheus_alerts.yaml
+
+vendor: jsonnetfile.json
+	jb install
+
+.PHONY: build
+build: vendor
+
+.PHONY: fmt
+fmt:
+	find . -name 'vendor' -prune -o -name '*.libsonnet' -print -o -name '*.jsonnet' -print | \
+		xargs -n 1 -- $(JSONNET_FMT) -i
+
+.PHONY: lint
+lint: build
+	find . -name 'vendor' -prune -o -name '*.libsonnet' -print -o -name '*.jsonnet' -print | \
+		while read f; do \
+			$(JSONNET_FMT) "$$f" | diff -u "$$f" -; \
+		done
+	mixtool lint mixin.libsonnet
+
+dashboards_out: mixin.libsonnet config.libsonnet $(wildcard dashboards/*)
+	@mkdir -p dashboards_out
+	mixtool generate dashboards mixin.libsonnet -d dashboards_out
+
+prometheus_alerts.yaml: mixin.libsonnet alerts/*.libsonnet
+	mixtool generate alerts mixin.libsonnet -a prometheus_alerts.yaml
+
+.PHONY: clean
+clean:
+	rm -rf dashboards_out prometheus_alerts.yaml

--- a/ibm-mq-mixin/README.md
+++ b/ibm-mq-mixin/README.md
@@ -20,7 +20,7 @@ and the following alerts:
 
 The IBM MQ cluster overview dashboard provides details on the number and status of clusters, queue managers, queues, and topics within and IBM MQ cluster. This also includes information about the amount of time it takes for a messsage to get through a transmission queue.
 
-# screenshots
+# Screenshots
 ![]()
 
 ## IBM MQ queue manager overview
@@ -60,13 +60,13 @@ In order for the selectors to properly work for error logs ingested into your lo
       - multiline:
           firstline: '^\s*\d{2}\/\d{2}\/\d{2}\s+\d{2}:\d{2}:\d{2}\s*-'
 ```
-# screenshots
+# Screenshots
 ![]()
 ## IBM MQ queue overview
 
 The IBM MQ queue overview dashboard provides details on queue depth, average queue time, expired queue messages, operations, and operations throughput. 
 
-# screenshots
+# Screenshots
 ![]()
 ## IBM MQ topics overview
 

--- a/ibm-mq-mixin/README.md
+++ b/ibm-mq-mixin/README.md
@@ -1,0 +1,95 @@
+# Microsoft IIS Mixin
+
+Microsoft IIS mixin is a set of configurable Grafana dashboards and alerts.
+
+The Microsoft IIS mixin contains the following dashboards:
+
+- Microsoft IIS overview
+- Microsoft IIS applications
+
+and the following alerts:
+
+- MicrosoftIISHighNumberOfRejectedAsyncIORequests
+- MicrosoftIISHighNumberOf5xxRequestErrors
+- MicrosoftIISLowSuccessRateForWebsocketConnections
+- MicrosoftIISThreadpoolUtilizationNearingMax
+- MicrosoftIISHighNumberOfWorkerProcessFailures
+
+Default thresholds can be configured in `config,libsonnet`
+
+```js
+{
+  _config+:: {
+    alertsWarningHighRejectedAsyncIORequests: 20        // requests
+    alertsCriticalHigh5xxRequests: 5,                   // # of 500 level requests
+    alertsCriticalLowWebsocketConnectionSuccessRate: 80,// %
+    alertsCriticalHighThreadPoolUtilization: 90,        // %
+    alertsWarningHighWorkerProcessFailures: 10,         // failures
+  },
+}
+```
+
+## Microsoft IIS overview
+
+The Microsoft IIS overview dashboard provides details on traffic, connections, files sent/received, and access logs. [Promtail and Loki needs to be installed](https://grafana.com/docs/loki/latest/installation/) and provisioned for logs with your Grafana instance. Microsoft IIS access logs can be found via this glob `C:\inetpub\logs\LogFiles\W3SVC*\u_ex*.txt`. There will typically be a folder `W3SVC[siteID]` for each site. Under that folder there will be a number of log files corresponding to each date (Example: u_ex230313.txt).
+
+Microsoft IIS logs are enabled by default in the `config.libsonnet` and can be removed by setting `enableLokiLogs` to `false`. Then run `make` again to regenerate the dashboard:
+
+```
+{
+  _config+:: {
+    enableLokiLogs: false,
+  },
+}
+```
+# screenshots
+![Screenshot1 of the overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/iis/screenshots/overview-1.png)
+![Screenshot2 of the overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/iis/screenshots/overview-2.png)
+![Screenshot3 of the overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/iis/screenshots/overview-3.png)
+
+## Microsoft IIS applications
+
+The Microsoft IIS applications dashboard provides details on worker requests, websocket connections, thread utilization, and worker process failures. 
+
+# screenshots
+![Screenshot1 of the applications dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/iis/screenshots/application-1.png)
+![Screenshot2 of the applications dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/iis/screenshots/application-2.png)
+![Screenshot3 of the applications dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/iis/screenshots/application-3.png)
+## Alerts overview
+
+MicrosoftIISHighNumberOfRejectedAsyncIORequests: There are a high number of rejected async I/O requests for a site.
+MicrosoftIISHighNumberOf5xxRequestErrors: There are a high number of 5xx request errors for an application.
+MicrosoftIISLowSuccessRateForWebsocketConnections: There is a low success rate for websocket connections for an application.
+MicrosoftIISThreadpoolUtilizationNearingMax: The thread pool utilization is nearing max capacity.
+MicrosoftIISHighNumberOfWorkerProcessFailures: There are a high number of worker process failures for an application.
+
+## Install Tools
+
+```bash
+go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@latest
+go install github.com/monitoring-mixins/mixtool/cmd/mixtool@latest
+# or in brew: brew install go-jsonnet
+```
+
+For linting and formatting, you would also need `mixtool` and `jsonnetfmt` installed. If you
+have a working Go development environment, it's easiest to run the following:
+
+```bash
+go install github.com/google/go-jsonnet/cmd/jsonnetfmt@latest
+```
+
+The files in `dashboards_out` need to be imported
+into your Grafana server. The exact details will be depending on your environment.
+
+`prometheus_alerts.yaml` needs to be imported into Prometheus.
+
+## Generate dashboards and alerts
+
+Edit `config.libsonnet` if required and then build JSON dashboard files for Grafana:
+
+```bash
+make
+```
+
+For more advanced uses of mixins, see
+https://github.com/monitoring-mixins/docs.

--- a/ibm-mq-mixin/README.md
+++ b/ibm-mq-mixin/README.md
@@ -16,7 +16,7 @@ and the following alerts:
 - IBMMQLowDiskSpace
 - IBMMQHighQueueManagerCpuUsage
 
-## IBM MQ cluster overview
+## IBM MQ cluster overview 
 
 The IBM MQ cluster overview dashboard provides details on the number and status of clusters, queue managers, queues, and topics within and IBM MQ cluster. This also includes information about the amount of time it takes for a messsage to get through a transmission queue.
 

--- a/ibm-mq-mixin/alerts/alerts.libsonnet
+++ b/ibm-mq-mixin/alerts/alerts.libsonnet
@@ -1,0 +1,79 @@
+{
+  prometheusAlerts+:: {
+    groups+: [
+      {
+        name: 'ibm-mq-alerts',
+        rules: [
+          {
+            alert: 'IBMMQExpiredMessages',
+            expr: |||
+              sum without (description,hostname,instance,job,platform) (ibmmq_qmgr_expired_message_count) > %(alertsExpiredMessages)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              summary: 'There are expired messages, which imply that application resilience is failing.',
+              description:
+                (
+                  'The number of expired messages in the {{$labels.qmgr}} is {{$labels.value}} which is above the threshold of %(alertsExpiredMessages)s.'
+                ) % $._config,
+            },
+          },
+          {
+            alert: 'IBMMQStaleMessages',
+            expr: |||
+              sum without (description,instance,job,platform) (ibmmq_queue_oldest_message_age) >= %(alertsStaleMessagesSeconds)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              summary: 'Stale messages have been detected.',
+              description:
+                (
+                  'A stale message with an age of {{$labels.value}} has been sitting in the {{$labels.queue}} which is above the threshold of %(alertsStaleMessagesSeconds)ss.'
+                ) % $._config,
+            },
+          },
+          {
+            alert: 'IBMMQLowDiskSpace',
+            expr: |||
+              sum without (description,hostname,instance,job,platform) (ibmmq_qmgr_queue_manager_file_system_free_space_percentage) <= %(alertsLowDiskSpace)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              summary: 'There is limited disk available for a queue manager.',
+              description:
+                (
+                  'The amount of disk space available for {{$labels.qmgr}} is at {{$labels.value}}%% which is below the threshold of %(alertsLowDiskSpace)s%%.'
+                ) % $._config,
+            },
+          },
+          {
+            alert: 'IBMMQHighQueueManagerCpuUsage',
+            expr: |||
+              sum without (description,hostname,instance,job,platform) (ibmmq_qmgr_user_cpu_time_estimate_for_queue_manager_percentage) >= %(alertsHighQueueManagerCpuUsage)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              summary: 'There is a high CPU usage estimate for a queue manager.',
+              description:
+                (
+                  'The amount of CPU usage for the queue manager {{$labels.qmgr}} is at {{$labels.value}}%% which is above the threshold of %(alertsHighQueueManagerCpuUsage)s%%.'
+                ) % $._config,
+            },
+          },
+        ],
+      },
+    ],
+  },
+}

--- a/ibm-mq-mixin/config.libsonnet
+++ b/ibm-mq-mixin/config.libsonnet
@@ -10,6 +10,7 @@
     alertsStaleMessagesSeconds: 300,  //seconds
     alertsLowDiskSpace: 5,  //percentage: 0-100
     alertsHighQueueManagerCpuUsage: 85,  //percentage: 0-100
+
     enableLokiLogs: true,
   },
 }

--- a/ibm-mq-mixin/config.libsonnet
+++ b/ibm-mq-mixin/config.libsonnet
@@ -1,0 +1,15 @@
+{
+  _config+:: {
+    dashboardTags: ['ibm-mq-mixin'],
+    dashboardPeriod: 'now-1h',
+    dashboardTimezone: 'default',
+    dashboardRefresh: '1m',
+
+    //alerts thresholds
+    alertsExpiredMessages: 2,  //count
+    alertsStaleMessagesSeconds: 300,  //seconds
+    alertsLowDiskSpace: 5,  //percentage: 0-100
+    alertsHighQueueManagerCpuUsage: 85,  //percentage: 0-100
+    enableLokiLogs: true,
+  },
+}

--- a/ibm-mq-mixin/dashboards/cluster-overview.libsonnet
+++ b/ibm-mq-mixin/dashboards/cluster-overview.libsonnet
@@ -1,3 +1,4 @@
+local g = (import 'grafana-builder/grafana.libsonnet');
 local grafana = (import 'grafonnet/grafana.libsonnet');
 local dashboard = grafana.dashboard;
 local template = grafana.template;
@@ -11,6 +12,7 @@ local promDatasource = {
   uid: '${%s}' % promDatasourceName,
 };
 
+
 local clustersPanel = {
   datasource: promDatasource,
   targets: [
@@ -18,6 +20,7 @@ local clustersPanel = {
       'count(count(ibmmq_qmgr_commit_count{job=~"$job"}) by (mq_cluster))',
       datasource=promDatasource,
       legendFormat='{{job}} - {{mq_cluster}}',
+      format='time_series',
     ),
   ],
   type: 'stat',
@@ -59,7 +62,6 @@ local clustersPanel = {
     },
     textMode: 'auto',
   },
-  pluginVersion: '10.0.2-cloud.1.94a6f396',
 };
 
 local queueManagersPanel = {
@@ -68,6 +70,8 @@ local queueManagersPanel = {
     prometheus.target(
       'count(count(ibmmq_qmgr_commit_count{job=~"$job"}) by (qmgr, mq_cluster))',
       datasource=promDatasource,
+      legendFormat='',
+      format='time_series',
     ),
   ],
   type: 'stat',
@@ -109,7 +113,108 @@ local queueManagersPanel = {
     },
     textMode: 'auto',
   },
-  pluginVersion: '10.0.2-cloud.1.94a6f396',
+};
+
+local topicsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'count(count(ibmmq_topic_messages_received{job=~"$job"}) by (topic, mq_cluster))',
+      datasource=promDatasource,
+      legendFormat='{{job}} - {{mq_cluster}}',
+      format='time_series',
+    ),
+  ],
+  type: 'stat',
+  title: 'Topics',
+  description: 'The unique number of topics in the cluster.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+    },
+    overrides: [],
+  },
+  options: {
+    colorMode: 'value',
+    graphMode: 'none',
+    justifyMode: 'auto',
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    textMode: 'auto',
+  },
+};
+
+local queuesPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'count(count(ibmmq_queue_depth{job=~"$job"}) by (queue, mq_cluster))',
+      datasource=promDatasource,
+      legendFormat='',
+      format='time_series',
+    ),
+  ],
+  type: 'stat',
+  title: 'Queues',
+  description: 'The unique number of queues in the cluster.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+    },
+    overrides: [],
+  },
+  options: {
+    colorMode: 'value',
+    graphMode: 'none',
+    justifyMode: 'auto',
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    textMode: 'auto',
+  },
 };
 
 local queueOperationsPanel = {
@@ -119,31 +224,37 @@ local queueOperationsPanel = {
       'sum by (mq_cluster) (ibmmq_queue_mqset_count{mq_cluster=~"$mq_cluster", job=~"$job"})',
       datasource=promDatasource,
       legendFormat='MQSET',
+      format='time_series',
     ),
     prometheus.target(
       'sum by (mq_cluster) (ibmmq_queue_mqinq_count{mq_cluster=~"$mq_cluster", job=~"$job"})',
       datasource=promDatasource,
       legendFormat='MQINQ',
+      format='time_series',
     ),
     prometheus.target(
       'sum by (mq_cluster) (ibmmq_queue_mqget_count{mq_cluster=~"$mq_cluster", job=~"$job"})',
       datasource=promDatasource,
       legendFormat='MQGET',
+      format='time_series',
     ),
     prometheus.target(
       'sum by (mq_cluster) (ibmmq_queue_mqopen_count{mq_cluster=~"$mq_cluster", job=~"$job"})',
       datasource=promDatasource,
       legendFormat='MQOPEN',
+      format='time_series',
     ),
     prometheus.target(
       'sum by (mq_cluster) (ibmmq_queue_mqclose_count{mq_cluster=~"$mq_cluster", job=~"$job"})',
       datasource=promDatasource,
       legendFormat='MQCLOSE',
+      format='time_series',
     ),
     prometheus.target(
       'sum by (mq_cluster) (ibmmq_queue_mqput_mqput1_count{mq_cluster=~"$mq_cluster", job=~"$job"})',
       datasource=promDatasource,
       legendFormat='MQPUT/MQPUT1',
+      format='time_series',
     ),
   ],
   type: 'piechart',
@@ -215,108 +326,6 @@ local queueOperationsPanel = {
   },
 };
 
-local topicsPanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'count(count(ibmmq_topic_messages_received{job=~"$job"}) by (topic, mq_cluster))',
-      datasource=promDatasource,
-      legendFormat='{{job}} - {{mq_cluster}}',
-    ),
-  ],
-  type: 'stat',
-  title: 'Topics',
-  description: 'The unique number of topics in the cluster.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-          {
-            color: 'red',
-            value: 80,
-          },
-        ],
-      },
-    },
-    overrides: [],
-  },
-  options: {
-    colorMode: 'value',
-    graphMode: 'none',
-    justifyMode: 'auto',
-    orientation: 'auto',
-    reduceOptions: {
-      calcs: [
-        'lastNotNull',
-      ],
-      fields: '',
-      values: false,
-    },
-    textMode: 'auto',
-  },
-  pluginVersion: '10.0.2-cloud.1.94a6f396',
-};
-
-local queuesPanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'count(count(ibmmq_queue_depth{job=~"$job"}) by (queue, mq_cluster))',
-      datasource=promDatasource,
-      legendFormat='',
-    ),
-  ],
-  type: 'stat',
-  title: 'Queues',
-  description: 'The unique number of queues in the cluster.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-          {
-            color: 'red',
-            value: 80,
-          },
-        ],
-      },
-    },
-    overrides: [],
-  },
-  options: {
-    colorMode: 'value',
-    graphMode: 'none',
-    justifyMode: 'auto',
-    orientation: 'auto',
-    reduceOptions: {
-      calcs: [
-        'lastNotNull',
-      ],
-      fields: '',
-      values: false,
-    },
-    textMode: 'auto',
-  },
-  pluginVersion: '10.0.2-cloud.1.94a6f396',
-};
-
 local clusterStatusPanel = {
   datasource: promDatasource,
   targets: [
@@ -324,6 +333,7 @@ local clusterStatusPanel = {
       'ibmmq_cluster_suspend{mq_cluster=~"$mq_cluster", job=~"$job"}',
       datasource=promDatasource,
       legendFormat='{{job}} - {{mq_cluster}}',
+      format='time_series',
     ),
   ],
   type: 'table',
@@ -384,7 +394,6 @@ local clusterStatusPanel = {
     },
     showHeader: true,
   },
-  pluginVersion: '10.0.2-cloud.1.94a6f396',
   transformations: [
     {
       id: 'joinByLabels',
@@ -430,6 +439,7 @@ local queueManagerStatusPanel = {
       'ibmmq_qmgr_status{mq_cluster=~"$mq_cluster", job=~"$job"}',
       datasource=promDatasource,
       legendFormat='',
+      format='time_series',
     ),
   ],
   type: 'table',
@@ -516,7 +526,6 @@ local queueManagerStatusPanel = {
       },
     ],
   },
-  pluginVersion: '10.0.2-cloud.1.94a6f396',
   transformations: [
     {
       id: 'joinByLabels',
@@ -562,11 +571,13 @@ local transmissionQueueTimePanel = {
       'ibmmq_channel_xmitq_time_short{type="SENDER",job=~"$job", mq_cluster=~"$mq_cluster"}',
       datasource=promDatasource,
       legendFormat='{{channel}} - short',
+      format='time_series',
     ),
     prometheus.target(
       'ibmmq_channel_xmitq_time_long{type=~"SENDER", job=~"$job", mq_cluster=~"$mq_cluster"}',
       datasource=promDatasource,
       legendFormat='{{channel}} - long',
+      format='time_series',
     ),
   ],
   type: 'timeseries',
@@ -584,7 +595,7 @@ local transmissionQueueTimePanel = {
         axisPlacement: 'auto',
         barAlignment: 0,
         drawStyle: 'line',
-        fillOpacity: 0,
+        fillOpacity: 10,
         gradientMode: 'none',
         hideFrom: {
           legend: false,
@@ -597,7 +608,7 @@ local transmissionQueueTimePanel = {
         scaleDistribution: {
           type: 'linear',
         },
-        showPoints: 'auto',
+        showPoints: 'never',
         spanNulls: false,
         stacking: {
           group: 'A',
@@ -637,8 +648,8 @@ local transmissionQueueTimePanel = {
       sort: 'desc',
     },
   },
-  pluginVersion: '10.0.2-cloud.1.94a6f396',
 };
+
 
 {
   grafanaDashboards+:: {
@@ -695,14 +706,14 @@ local transmissionQueueTimePanel = {
       ))
       .addPanels(
         [
-          clustersPanel { gridPos: { h: 8, w: 6, x: 0, y: 0 } },
-          queueManagersPanel { gridPos: { h: 8, w: 6, x: 6, y: 0 } },
-          queueOperationsPanel { gridPos: { h: 16, w: 12, x: 12, y: 0 } },
-          topicsPanel { gridPos: { h: 8, w: 6, x: 0, y: 8 } },
-          queuesPanel { gridPos: { h: 8, w: 6, x: 6, y: 8 } },
-          clusterStatusPanel { gridPos: { h: 5, w: 24, x: 0, y: 16 } },
-          queueManagerStatusPanel { gridPos: { h: 4, w: 24, x: 0, y: 21 } },
-          transmissionQueueTimePanel { gridPos: { h: 8, w: 24, x: 0, y: 25 } },
+          clustersPanel { gridPos: { h: 7, w: 4, x: 0, y: 0 } },
+          queueManagersPanel { gridPos: { h: 7, w: 4, x: 4, y: 0 } },
+          topicsPanel { gridPos: { h: 7, w: 4, x: 8, y: 0 } },
+          queuesPanel { gridPos: { h: 7, w: 4, x: 12, y: 0 } },
+          queueOperationsPanel { gridPos: { h: 15, w: 8, x: 16, y: 0 } },
+          clusterStatusPanel { gridPos: { h: 4, w: 16, x: 0, y: 7 } },
+          queueManagerStatusPanel { gridPos: { h: 4, w: 16, x: 0, y: 11 } },
+          transmissionQueueTimePanel { gridPos: { h: 8, w: 24, x: 0, y: 15 } },
         ]
       ),
 

--- a/ibm-mq-mixin/dashboards/cluster-overview.libsonnet
+++ b/ibm-mq-mixin/dashboards/cluster-overview.libsonnet
@@ -62,7 +62,6 @@ local clustersPanel = {
     },
     textMode: 'auto',
   },
-  pluginVersion: '10.0.3-cloud.2.14737d80',
 };
 
 local queueManagersPanel = {
@@ -114,7 +113,6 @@ local queueManagersPanel = {
     },
     textMode: 'auto',
   },
-  pluginVersion: '10.0.3-cloud.2.14737d80',
 };
 
 local topicsPanel = {
@@ -166,7 +164,6 @@ local topicsPanel = {
     },
     textMode: 'auto',
   },
-  pluginVersion: '10.0.3-cloud.2.14737d80',
 };
 
 local queuesPanel = {
@@ -218,7 +215,6 @@ local queuesPanel = {
     },
     textMode: 'auto',
   },
-  pluginVersion: '10.0.3-cloud.2.14737d80',
 };
 
 local queueOperationsPanel = {
@@ -401,7 +397,6 @@ local clusterStatusPanel = {
     },
     showHeader: true,
   },
-  pluginVersion: '10.0.3-cloud.2.14737d80',
   transformations: [
     {
       id: 'joinByLabels',
@@ -539,7 +534,6 @@ local queueManagerStatusPanel = {
       },
     ],
   },
-  pluginVersion: '10.0.3-cloud.2.14737d80',
   transformations: [
     {
       id: 'joinByLabels',

--- a/ibm-mq-mixin/dashboards/cluster-overview.libsonnet
+++ b/ibm-mq-mixin/dashboards/cluster-overview.libsonnet
@@ -12,6 +12,7 @@ local promDatasource = {
   uid: '${%s}' % promDatasourceName,
 };
 
+
 local clustersPanel = {
   datasource: promDatasource,
   targets: [
@@ -40,7 +41,7 @@ local clustersPanel = {
           },
           {
             color: 'red',
-            value: 80,
+            value: 0,
           },
         ],
       },
@@ -61,6 +62,7 @@ local clustersPanel = {
     },
     textMode: 'auto',
   },
+  pluginVersion: '10.0.3-cloud.2.14737d80',
 };
 
 local queueManagersPanel = {
@@ -91,7 +93,7 @@ local queueManagersPanel = {
           },
           {
             color: 'red',
-            value: 80,
+            value: 0,
           },
         ],
       },
@@ -112,6 +114,7 @@ local queueManagersPanel = {
     },
     textMode: 'auto',
   },
+  pluginVersion: '10.0.3-cloud.2.14737d80',
 };
 
 local topicsPanel = {
@@ -142,7 +145,7 @@ local topicsPanel = {
           },
           {
             color: 'red',
-            value: 80,
+            value: 0,
           },
         ],
       },
@@ -163,6 +166,7 @@ local topicsPanel = {
     },
     textMode: 'auto',
   },
+  pluginVersion: '10.0.3-cloud.2.14737d80',
 };
 
 local queuesPanel = {
@@ -193,7 +197,7 @@ local queuesPanel = {
           },
           {
             color: 'red',
-            value: 80,
+            value: 0,
           },
         ],
       },
@@ -214,6 +218,7 @@ local queuesPanel = {
     },
     textMode: 'auto',
   },
+  pluginVersion: '10.0.3-cloud.2.14737d80',
 };
 
 local queueOperationsPanel = {
@@ -341,12 +346,12 @@ local clusterStatusPanel = {
   fieldConfig: {
     defaults: {
       color: {
-        mode: 'thresholds',
+        mode: 'fixed',
       },
       custom: {
         align: 'center',
         cellOptions: {
-          type: 'auto',
+          type: 'color-text',
         },
         inspect: false,
       },
@@ -354,10 +359,12 @@ local clusterStatusPanel = {
         {
           options: {
             '0': {
+              color: 'green',
               index: 0,
               text: 'Not suspended',
             },
             '1': {
+              color: 'red',
               index: 1,
               text: 'Suspended',
             },
@@ -385,6 +392,7 @@ local clusterStatusPanel = {
     cellHeight: 'sm',
     footer: {
       countRows: false,
+      enablePagination: false,
       fields: '',
       reducer: [
         'sum',
@@ -393,6 +401,7 @@ local clusterStatusPanel = {
     },
     showHeader: true,
   },
+  pluginVersion: '10.0.3-cloud.2.14737d80',
   transformations: [
     {
       id: 'joinByLabels',
@@ -447,12 +456,12 @@ local queueManagerStatusPanel = {
   fieldConfig: {
     defaults: {
       color: {
-        mode: 'thresholds',
+        mode: 'fixed',
       },
       custom: {
         align: 'center',
         cellOptions: {
-          type: 'auto',
+          type: 'color-text',
         },
         inspect: false,
       },
@@ -460,18 +469,22 @@ local queueManagerStatusPanel = {
         {
           options: {
             '-1': {
+              color: 'dark-red',
               index: 0,
               text: 'N/A',
             },
             '0': {
+              color: 'red',
               index: 1,
               text: 'Stopped',
             },
             '1': {
+              color: 'light-green',
               index: 2,
               text: 'Starting',
             },
             '2': {
+              color: 'green',
               index: 3,
               text: 'Running',
             },
@@ -480,6 +493,7 @@ local queueManagerStatusPanel = {
               text: 'Quiescing',
             },
             '4': {
+              color: 'light-red',
               index: 5,
               text: 'Stopping',
             },
@@ -525,6 +539,7 @@ local queueManagerStatusPanel = {
       },
     ],
   },
+  pluginVersion: '10.0.3-cloud.2.14737d80',
   transformations: [
     {
       id: 'joinByLabels',
@@ -648,6 +663,7 @@ local transmissionQueueTimePanel = {
     },
   },
 };
+
 
 {
   grafanaDashboards+:: {

--- a/ibm-mq-mixin/dashboards/cluster-overview.libsonnet
+++ b/ibm-mq-mixin/dashboards/cluster-overview.libsonnet
@@ -1,0 +1,703 @@
+local g = (import 'grafana-builder/grafana.libsonnet');
+local grafana = (import 'grafonnet/grafana.libsonnet');
+local dashboard = grafana.dashboard;
+local template = grafana.template;
+local prometheus = grafana.prometheus;
+
+local dashboardUid = 'ibm-mq-cluster-overview';
+
+local promDatasourceName = 'prometheus_datasource';
+
+local promDatasource = {
+  uid: '${%s}' % promDatasourceName,
+};
+
+local clustersPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'count(count(ibmmq_qmgr_commit_count) by (mq_cluster))',
+      datasource=promDatasource,
+      legendFormat='{{job}} - {{mq_cluster}}',
+    ),
+  ],
+  type: 'stat',
+  title: 'Clusters',
+  description: 'The unique number of clusters being reported.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+    },
+    overrides: [],
+  },
+  options: {
+    colorMode: 'value',
+    graphMode: 'none',
+    justifyMode: 'auto',
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    textMode: 'auto',
+  },
+  pluginVersion: '10.0.2-cloud.1.94a6f396',
+};
+
+local queueManagersPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'count(count(ibmmq_qmgr_commit_count) by (qmgr, mq_cluster))',
+      datasource=promDatasource,
+    ),
+  ],
+  type: 'stat',
+  title: 'Queue managers',
+  description: 'The unique number of queue managers in the cluster being reported.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+    },
+    overrides: [],
+  },
+  options: {
+    colorMode: 'value',
+    graphMode: 'none',
+    justifyMode: 'auto',
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    textMode: 'auto',
+  },
+  pluginVersion: '10.0.2-cloud.1.94a6f396',
+};
+
+local queueOperationsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by (mq_cluster) (ibmmq_queue_mqset_count{mq_cluster=~"$mq_cluster", job=~"$job"})',
+      datasource=promDatasource,
+      legendFormat='MQSET',
+    ),
+    prometheus.target(
+      'sum by (mq_cluster) (ibmmq_queue_mqinq_count{mq_cluster=~"$mq_cluster", job=~"$job"})',
+      datasource=promDatasource,
+      legendFormat='MQINQ',
+    ),
+    prometheus.target(
+      'sum by (mq_cluster) (ibmmq_queue_mqget_count{mq_cluster=~"$mq_cluster", job=~"$job"})',
+      datasource=promDatasource,
+      legendFormat='MQGET',
+    ),
+    prometheus.target(
+      'sum by (mq_cluster) (ibmmq_queue_mqopen_count{mq_cluster=~"$mq_cluster", job=~"$job"})',
+      datasource=promDatasource,
+      legendFormat='MQOPEN',
+    ),
+    prometheus.target(
+      'sum by (mq_cluster) (ibmmq_queue_mqclose_count{mq_cluster=~"$mq_cluster", job=~"$job"})',
+      datasource=promDatasource,
+      legendFormat='MQCLOSE',
+    ),
+    prometheus.target(
+      'sum by (mq_cluster) (ibmmq_queue_mqput_mqput1_count{mq_cluster=~"$mq_cluster", job=~"$job"})',
+      datasource=promDatasource,
+      legendFormat='MQPUT/MQPUT1',
+    ),
+  ],
+  type: 'piechart',
+  title: 'Queue operations',
+  description: 'The number of queue operations of the cluster. ',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+      },
+      mappings: [],
+    },
+    overrides: [
+      {
+        __systemRef: 'hideSeriesFrom',
+        matcher: {
+          id: 'byNames',
+          options: {
+            mode: 'exclude',
+            names: [
+              'MQINQ',
+              'MQGET',
+              'MQOPEN',
+              'MQPUT/MQPUT1',
+            ],
+            prefix: 'All except:',
+            readOnly: true,
+          },
+        },
+        properties: [
+          {
+            id: 'custom.hideFrom',
+            value: {
+              legend: false,
+              tooltip: false,
+              viz: true,
+            },
+          },
+        ],
+      },
+    ],
+  },
+  options: {
+    legend: {
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    pieType: 'pie',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'none',
+    },
+  },
+};
+
+local topicsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'count(count(ibmmq_topic_messages_received) by (topic, mq_cluster))',
+      datasource=promDatasource,
+      legendFormat='{{job}} - {{mq_cluster}}',
+    ),
+  ],
+  type: 'stat',
+  title: 'Topics',
+  description: 'The unique number of topics in the cluster.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+    },
+    overrides: [],
+  },
+  options: {
+    colorMode: 'value',
+    graphMode: 'none',
+    justifyMode: 'auto',
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    textMode: 'auto',
+  },
+  pluginVersion: '10.0.2-cloud.1.94a6f396',
+};
+
+local queuesPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'count(count(ibmmq_queue_depth) by (queue, mq_cluster))',
+      datasource=promDatasource,
+      legendFormat='',
+    ),
+  ],
+  type: 'stat',
+  title: 'Queues',
+  description: 'The unique number of queues in the cluster.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+    },
+    overrides: [],
+  },
+  options: {
+    colorMode: 'value',
+    graphMode: 'none',
+    justifyMode: 'auto',
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    textMode: 'auto',
+  },
+  pluginVersion: '10.0.2-cloud.1.94a6f396',
+};
+
+local clusterStatusPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'ibmmq_cluster_suspend{mq_cluster=~"$mq_cluster"}',
+      datasource=promDatasource,
+      legendFormat='{{job}} - {{mq_cluster}}',
+    ),
+  ],
+  type: 'table',
+  title: 'Cluster status',
+  description: 'The status of the cluster.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      custom: {
+        align: 'center',
+        cellOptions: {
+          type: 'auto',
+        },
+        inspect: false,
+      },
+      mappings: [
+        {
+          options: {
+            '0': {
+              index: 0,
+              text: 'Not suspended',
+            },
+            '1': {
+              index: 1,
+              text: 'Suspended',
+            },
+          },
+          type: 'value',
+        },
+      ],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+    },
+    overrides: [],
+  },
+  options: {
+    cellHeight: 'sm',
+    footer: {
+      countRows: false,
+      fields: '',
+      reducer: [
+        'sum',
+      ],
+      show: false,
+    },
+    showHeader: true,
+  },
+  pluginVersion: '10.0.2-cloud.1.94a6f396',
+  transformations: [
+    {
+      id: 'joinByLabels',
+      options: {
+        join: [
+          'cluster',
+          'mq_cluster',
+          'qmgr',
+        ],
+        value: '__name__',
+      },
+    },
+    {
+      id: 'organize',
+      options: {
+        excludeByName: {},
+        indexByName: {},
+        renameByName: {
+          cluster: 'Cluster',
+          ibmmq_cluster_suspend: 'Status',
+          mq_cluster: 'MQ cluster',
+          qmgr: 'Queue manager',
+        },
+      },
+    },
+    {
+      id: 'reduce',
+      options: {
+        includeTimeField: false,
+        mode: 'reduceFields',
+        reducers: [
+          'last',
+        ],
+      },
+    },
+  ],
+};
+
+local queueManagerStatusPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'ibmmq_qmgr_status{mq_cluster=~"$mq_cluster"}',
+      datasource=promDatasource,
+      legendFormat='',
+    ),
+  ],
+  type: 'table',
+  title: 'Queue manager status',
+  description: 'The queue managers of the cluster displayed in a table.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      custom: {
+        align: 'center',
+        cellOptions: {
+          type: 'auto',
+        },
+        inspect: false,
+      },
+      mappings: [
+        {
+          options: {
+            '-1': {
+              index: 0,
+              text: 'N/A',
+            },
+            '0': {
+              index: 1,
+              text: 'Stopped',
+            },
+            '1': {
+              index: 2,
+              text: 'Starting',
+            },
+            '2': {
+              index: 3,
+              text: 'Running',
+            },
+            '3': {
+              index: 4,
+              text: 'Quiescing',
+            },
+            '4': {
+              index: 5,
+              text: 'Stopping',
+            },
+            '5': {
+              index: 6,
+              text: 'Standby',
+            },
+          },
+          type: 'value',
+        },
+      ],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+    },
+    overrides: [],
+  },
+  options: {
+    cellHeight: 'sm',
+    footer: {
+      countRows: false,
+      fields: '',
+      reducer: [
+        'sum',
+      ],
+      show: false,
+    },
+    showHeader: true,
+    sortBy: [
+      {
+        desc: false,
+        displayName: 'ibmmq_qmgr_status{description="-", hostname="keith-ibm-mq-1804-2-test", instance="localhost:9157", job="integrations/ibm_mq", mq_cluster="<mq_cluster>", platform="UNIX", qmgr="QM1"}',
+      },
+    ],
+  },
+  pluginVersion: '10.0.2-cloud.1.94a6f396',
+  transformations: [
+    {
+      id: 'joinByLabels',
+      options: {
+        join: [
+          'mq_cluster',
+          'qmgr',
+          'instance',
+        ],
+        value: '__name__',
+      },
+    },
+    {
+      id: 'organize',
+      options: {
+        excludeByName: {},
+        indexByName: {},
+        renameByName: {
+          ibmmq_qmgr_status: 'Status',
+          instance: 'Instance',
+          mq_cluster: 'MQ cluster',
+          qmgr: 'Queue manager',
+        },
+      },
+    },
+    {
+      id: 'reduce',
+      options: {
+        includeTimeField: false,
+        mode: 'reduceFields',
+        reducers: [
+          'last',
+        ],
+      },
+    },
+  ],
+};
+
+local transmissionQueueTimePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'ibmmq_channel_xmitq_time_short{type="SENDER",job=~"$job", mq_cluster=~"$mq_cluster"}',
+      datasource=promDatasource,
+      legendFormat='{{channel}} - short',
+    ),
+    prometheus.target(
+      'ibmmq_channel_xmitq_time_long{type=~"SENDER", job=~"$job", mq_cluster=~"$mq_cluster"}',
+      datasource=promDatasource,
+      legendFormat='{{channel}} - long',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Transmission queue time',
+  description: 'The time it takes for the messages to get through the transmission queue.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'µs',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+  pluginVersion: '10.0.2-cloud.1.94a6f396',
+};
+
+{
+  grafanaDashboards+:: {
+    'ibm-mq-cluster-overview.json':
+      dashboard.new(
+        'IBM MQ cluster overview',
+        time_from='%s' % $._config.dashboardPeriod,
+        tags=($._config.dashboardTags),
+        timezone='%s' % $._config.dashboardTimezone,
+        refresh='%s' % $._config.dashboardRefresh,
+        description='',
+        uid=dashboardUid,
+      )
+
+      .addTemplates(
+        [
+          template.datasource(
+            promDatasourceName,
+            'prometheus',
+            null,
+            label='Data Source',
+            refresh='load'
+          ),
+          template.new(
+            'job',
+            promDatasource,
+            'label_values(ibmmq_qmgr_commit_count,job)',
+            label='Job',
+            refresh=1,
+            includeAll=true,
+            multi=true,
+            allValues='.+',
+            sort=0
+          ),
+          template.new(
+            'mq_cluster',
+            promDatasource,
+            'label_values(ibmmq_qmgr_commit_count,mq_cluster)',
+            label='MQ cluster',
+            refresh=2,
+            includeAll=false,
+            multi=false,
+            allValues='',
+            sort=0
+          ),
+        ]
+      )
+      .addPanels(
+        [
+          clustersPanel { gridPos: { h: 8, w: 6, x: 0, y: 0 } },
+          queueManagersPanel { gridPos: { h: 8, w: 6, x: 6, y: 0 } },
+          queueOperationsPanel { gridPos: { h: 16, w: 12, x: 12, y: 0 } },
+          topicsPanel { gridPos: { h: 8, w: 6, x: 0, y: 8 } },
+          queuesPanel { gridPos: { h: 8, w: 6, x: 6, y: 8 } },
+          clusterStatusPanel { gridPos: { h: 5, w: 24, x: 0, y: 16 } },
+          queueManagerStatusPanel { gridPos: { h: 4, w: 24, x: 0, y: 21 } },
+          transmissionQueueTimePanel { gridPos: { h: 8, w: 24, x: 0, y: 25 } },
+        ]
+      ),
+
+  },
+}

--- a/ibm-mq-mixin/dashboards/cluster-overview.libsonnet
+++ b/ibm-mq-mixin/dashboards/cluster-overview.libsonnet
@@ -16,7 +16,7 @@ local clustersPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'count(count(ibmmq_qmgr_commit_count) by (mq_cluster))',
+      'count(count(ibmmq_qmgr_commit_count{job=~"$job"}) by (mq_cluster))',
       datasource=promDatasource,
       legendFormat='{{job}} - {{mq_cluster}}',
     ),
@@ -67,7 +67,7 @@ local queueManagersPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'count(count(ibmmq_qmgr_commit_count) by (qmgr, mq_cluster))',
+      'count(count(ibmmq_qmgr_commit_count{job=~"$job"}) by (qmgr, mq_cluster))',
       datasource=promDatasource,
     ),
   ],
@@ -219,7 +219,7 @@ local topicsPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'count(count(ibmmq_topic_messages_received) by (topic, mq_cluster))',
+      'count(count(ibmmq_topic_messages_received{job=~"$job"}) by (topic, mq_cluster))',
       datasource=promDatasource,
       legendFormat='{{job}} - {{mq_cluster}}',
     ),
@@ -270,7 +270,7 @@ local queuesPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'count(count(ibmmq_queue_depth) by (queue, mq_cluster))',
+      'count(count(ibmmq_queue_depth{job=~"$job"}) by (queue, mq_cluster))',
       datasource=promDatasource,
       legendFormat='',
     ),
@@ -321,7 +321,7 @@ local clusterStatusPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'ibmmq_cluster_suspend{mq_cluster=~"$mq_cluster"}',
+      'ibmmq_cluster_suspend{mq_cluster=~"$mq_cluster", job=~"$job"}',
       datasource=promDatasource,
       legendFormat='{{job}} - {{mq_cluster}}',
     ),
@@ -427,7 +427,7 @@ local queueManagerStatusPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'ibmmq_qmgr_status{mq_cluster=~"$mq_cluster"}',
+      'ibmmq_qmgr_status{mq_cluster=~"$mq_cluster", job=~"$job"}',
       datasource=promDatasource,
       legendFormat='',
     ),

--- a/ibm-mq-mixin/dashboards/cluster-overview.libsonnet
+++ b/ibm-mq-mixin/dashboards/cluster-overview.libsonnet
@@ -596,7 +596,7 @@ local transmissionQueueTimePanel = {
   ],
   type: 'timeseries',
   title: 'Transmission queue time',
-  description: 'The time it takes for the messages to get through the transmission queue.',
+  description: 'The time it takes for the messages to get through the transmission queue. (Long) - total time taken for messages to be transmitted over the channel, (Short) - an average, minimum, or maximum time taken to transmit messages over the channel in recent intervals.  ',
   fieldConfig: {
     defaults: {
       color: {

--- a/ibm-mq-mixin/dashboards/cluster-overview.libsonnet
+++ b/ibm-mq-mixin/dashboards/cluster-overview.libsonnet
@@ -1,4 +1,3 @@
-local g = (import 'grafana-builder/grafana.libsonnet');
 local grafana = (import 'grafonnet/grafana.libsonnet');
 local dashboard = grafana.dashboard;
 local template = grafana.template;
@@ -163,6 +162,7 @@ local queueOperationsPanel = {
         },
       },
       mappings: [],
+      unit: 'operations',
     },
     overrides: [
       {
@@ -686,6 +686,13 @@ local transmissionQueueTimePanel = {
           ),
         ]
       )
+      .addLink(grafana.link.dashboards(
+        asDropdown=false,
+        title='Other IBM MQ dashboards',
+        includeVars=true,
+        keepTime=true,
+        tags=($._config.dashboardTags),
+      ))
       .addPanels(
         [
           clustersPanel { gridPos: { h: 8, w: 6, x: 0, y: 0 } },

--- a/ibm-mq-mixin/dashboards/cluster-overview.libsonnet
+++ b/ibm-mq-mixin/dashboards/cluster-overview.libsonnet
@@ -12,7 +12,6 @@ local promDatasource = {
   uid: '${%s}' % promDatasourceName,
 };
 
-
 local clustersPanel = {
   datasource: promDatasource,
   targets: [
@@ -649,7 +648,6 @@ local transmissionQueueTimePanel = {
     },
   },
 };
-
 
 {
   grafanaDashboards+:: {

--- a/ibm-mq-mixin/dashboards/dashboards.libsonnet
+++ b/ibm-mq-mixin/dashboards/dashboards.libsonnet
@@ -1,1 +1,4 @@
-(import 'queue-manager-overview.libsonnet')
+(import 'cluster-overview.libsonnet') +
+(import 'queue-manager-overview.libsonnet') +
+(import 'queue-overview.libsonnet') +
+(import 'topics-overview.libsonnet')

--- a/ibm-mq-mixin/dashboards/dashboards.libsonnet
+++ b/ibm-mq-mixin/dashboards/dashboards.libsonnet
@@ -1,0 +1,1 @@
+(import 'queue-manager-overview.libsonnet')

--- a/ibm-mq-mixin/dashboards/queue-manager-overview.libsonnet
+++ b/ibm-mq-mixin/dashboards/queue-manager-overview.libsonnet
@@ -66,6 +66,7 @@ local activeListenersPanel = {
     },
     textMode: 'auto',
   },
+  pluginVersion: '10.0.3-cloud.2.14737d80',
 };
 
 local activeConnectionsPanel = {
@@ -117,6 +118,7 @@ local activeConnectionsPanel = {
     },
     textMode: 'auto',
   },
+  pluginVersion: '10.0.3-cloud.2.14737d80',
 };
 
 local queuesPanel = {
@@ -168,6 +170,7 @@ local queuesPanel = {
     },
     textMode: 'auto',
   },
+  pluginVersion: '10.0.3-cloud.2.14737d80',
 };
 
 local estimatedMemoryUtilizationPanel = {
@@ -397,6 +400,7 @@ local queueManagerStatusPanel = {
     showHeader: true,
     sortBy: [],
   },
+  pluginVersion: '10.0.3-cloud.2.14737d80',
   transformations: [
     {
       id: 'joinByField',
@@ -580,7 +584,7 @@ local diskUsagePanel = {
         spanNulls: false,
         stacking: {
           group: 'A',
-          mode: 'none',
+          mode: 'normal',
         },
         thresholdsStyle: {
           mode: 'off',
@@ -1109,7 +1113,6 @@ local logLatencyPanel = {
         steps: [
           {
             color: 'green',
-            value: null,
           },
           {
             color: 'red',
@@ -1189,7 +1192,6 @@ local logUsagePanel = {
         steps: [
           {
             color: 'green',
-            value: null,
           },
           {
             color: 'red',

--- a/ibm-mq-mixin/dashboards/queue-manager-overview.libsonnet
+++ b/ibm-mq-mixin/dashboards/queue-manager-overview.libsonnet
@@ -66,7 +66,6 @@ local activeListenersPanel = {
     },
     textMode: 'auto',
   },
-  pluginVersion: '10.0.3-cloud.2.14737d80',
 };
 
 local activeConnectionsPanel = {
@@ -118,7 +117,6 @@ local activeConnectionsPanel = {
     },
     textMode: 'auto',
   },
-  pluginVersion: '10.0.3-cloud.2.14737d80',
 };
 
 local queuesPanel = {
@@ -170,7 +168,6 @@ local queuesPanel = {
     },
     textMode: 'auto',
   },
-  pluginVersion: '10.0.3-cloud.2.14737d80',
 };
 
 local estimatedMemoryUtilizationPanel = {
@@ -400,7 +397,6 @@ local queueManagerStatusPanel = {
     showHeader: true,
     sortBy: [],
   },
-  pluginVersion: '10.0.3-cloud.2.14737d80',
   transformations: [
     {
       id: 'joinByField',

--- a/ibm-mq-mixin/dashboards/queue-manager-overview.libsonnet
+++ b/ibm-mq-mixin/dashboards/queue-manager-overview.libsonnet
@@ -13,7 +13,6 @@ local promDatasource = {
   uid: '${%s}' % promDatasourceName,
 };
 
-
 local lokiDatasource = {
   uid: '${%s}' % lokiDatasourceName,
 };
@@ -1241,7 +1240,6 @@ local errorLogsPanel = {
     wrapLogMessage: false,
   },
 };
-
 
 {
   grafanaDashboards+:: {

--- a/ibm-mq-mixin/dashboards/queue-manager-overview.libsonnet
+++ b/ibm-mq-mixin/dashboards/queue-manager-overview.libsonnet
@@ -1,0 +1,1253 @@
+local g = (import 'grafana-builder/grafana.libsonnet');
+local grafana = (import 'grafonnet/grafana.libsonnet');
+local dashboard = grafana.dashboard;
+local template = grafana.template;
+local prometheus = grafana.prometheus;
+
+local dashboardUid = 'ibm-mq-queue-manager-overview';
+
+local promDatasourceName = 'prometheus_datasource';
+local lokiDatasourceName = 'loki_datasource';
+
+local promDatasource = {
+  uid: '${%s}' % promDatasourceName,
+};
+
+local lokiDatasource = {
+  uid: '${%s}' % lokiDatasourceName,
+};
+
+local activeListenersPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'ibmmq_qmgr_active_listeners{mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", job=~"$job"}',
+      datasource=promDatasource,
+    ),
+  ],
+  type: 'stat',
+  title: 'Active listeners',
+  description: 'The number of active listeners for the queue manager.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'red',
+            value: null,
+          },
+          {
+            color: 'green',
+            value: 1,
+          },
+        ],
+      },
+    },
+    overrides: [],
+  },
+  options: {
+    colorMode: 'value',
+    graphMode: 'area',
+    justifyMode: 'auto',
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    textMode: 'auto',
+  },
+  pluginVersion: '10.0.1-cloud.3.f250259e',
+};
+
+local activeConnectionsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'ibmmq_qmgr_connection_count{mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", job=~"$job"}',
+      datasource=promDatasource,
+    ),
+  ],
+  type: 'stat',
+  title: 'Active connections',
+  description: 'The number of active connections for the queue manager.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'red',
+            value: null,
+          },
+          {
+            color: 'green',
+            value: 1,
+          },
+        ],
+      },
+    },
+    overrides: [],
+  },
+  options: {
+    colorMode: 'value',
+    graphMode: 'area',
+    justifyMode: 'auto',
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    textMode: 'auto',
+  },
+  pluginVersion: '10.0.1-cloud.3.f250259e',
+};
+
+local queuesPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'count(count(ibmmq_queue_depth) by (queue, mq_cluster, qmgr))',
+      datasource=promDatasource,
+    ),
+  ],
+  type: 'stat',
+  title: 'Queues',
+  description: 'The unique number of queues being managed by the queue manager.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'red',
+            value: null,
+          },
+          {
+            color: 'green',
+            value: 1,
+          },
+        ],
+      },
+    },
+    overrides: [],
+  },
+  options: {
+    colorMode: 'value',
+    graphMode: 'area',
+    justifyMode: 'auto',
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    textMode: 'auto',
+  },
+  pluginVersion: '10.0.1-cloud.3.f250259e',
+};
+
+local cpuUsagePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'ibmmq_qmgr_user_cpu_time_percentage{mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", job=~"$job"}',
+      datasource=promDatasource,
+      legendFormat='{{mq_cluster}} - {{qmgr}} - user',
+    ),
+    prometheus.target(
+      'ibmmq_qmgr_system_cpu_time_percentage{mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", job=~"$job"}',
+      datasource=promDatasource,
+      legendFormat='{{mq_cluster}} - {{qmgr}} - system',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'CPU usage',
+  description: 'The system/user CPU usage of the queue manager.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'percent',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'none',
+    },
+  },
+};
+
+local estimatedMemoryUtilizationPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      '(ibmmq_qmgr_ram_total_estimate_for_queue_manager_bytes{mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", job=~"$job"}/ibmmq_qmgr_ram_total_bytes{mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", job=~"$job"}) * 100',
+      datasource=promDatasource,
+      legendFormat='{{mq_cluster}} - {{qmgr}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Estimated memory utilization',
+  description: 'The estimated memory usage of the queue managers.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'percent',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local queueManagerStatusPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'ibmmq_qmgr_uptime{mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", job=~"$job"}',
+      datasource=promDatasource,
+      legendFormat='Uptime',
+      format='table',
+    ),
+    prometheus.target(
+      'ibmmq_qmgr_status{mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", job=~"$job"}',
+      datasource=promDatasource,
+      legendFormat='Status',
+    ),
+  ],
+  type: 'table',
+  title: 'Queue manager status',
+  description: 'A table showing the status and uptime of the queue manager.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      custom: {
+        align: 'auto',
+        cellOptions: {
+          type: 'auto',
+        },
+        filterable: false,
+        inspect: false,
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+    },
+    overrides: [
+      {
+        matcher: {
+          id: 'byName',
+          options: 'Uptime',
+        },
+        properties: [
+          {
+            id: 'custom.width',
+            value: 280,
+          },
+          {
+            id: 'unit',
+            value: 's',
+          },
+        ],
+      },
+      {
+        matcher: {
+          id: 'byName',
+          options: '__name__',
+        },
+        properties: [
+          {
+            id: 'custom.width',
+            value: 318,
+          },
+        ],
+      },
+    ],
+  },
+  options: {
+    cellHeight: 'sm',
+    footer: {
+      countRows: false,
+      enablePagination: false,
+      fields: '',
+      reducer: [
+        'sum',
+      ],
+      show: false,
+    },
+    frameIndex: 1,
+    showHeader: true,
+    sortBy: [],
+  },
+  pluginVersion: '10.0.1-cloud.3.f250259e',
+  transformations: [
+    {
+      id: 'joinByField',
+      options: {
+        byField: 'Time',
+        mode: 'inner',
+      },
+    },
+    {
+      id: 'organize',
+      options: {
+        excludeByName: {
+          Time: true,
+          __name__: true,
+          description: true,
+          hostname: true,
+          instance: true,
+          job: true,
+          platform: true,
+        },
+        indexByName: {
+          Time: 0,
+          Value: 10,
+          __name__: 1,
+          description: 2,
+          hostname: 3,
+          'ibmmq_qmgr_status{job="$job", mq_cluster=~"$mq_cluster", qmgr="$qmgr"}': 9,
+          instance: 4,
+          job: 5,
+          mq_cluster: 6,
+          platform: 7,
+          qmgr: 8,
+        },
+        renameByName: {
+          Time: '',
+          Value: 'Uptime',
+          'ibmmq_qmgr_status{job="$job", mq_cluster=~"$mq_cluster", qmgr="$qmgr"}': 'Status',
+          mq_cluster: 'MQ cluster',
+          qmgr: 'Queue manager',
+        },
+      },
+    },
+    {
+      id: 'reduce',
+      options: {
+        includeTimeField: false,
+        mode: 'reduceFields',
+        reducers: [
+          'lastNotNull',
+        ],
+      },
+    },
+  ],
+};
+
+local diskUsagePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'ibmmq_qmgr_queue_manager_file_system_in_use_bytes{mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", job=~"$job"}',
+      datasource=promDatasource,
+      legendFormat='{{mq_cluster}} - {{qmgr}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Disk usage',
+  description: 'The disk allocated to the queue manager that is being used.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'decbytes',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local publishThroughputPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'ibmmq_qmgr_published_to_subscribers_bytes{mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", job=~"$job"}',
+      datasource=promDatasource,
+      legendFormat='{{mq_cluster}} - {{qmgr}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Publish throughput',
+  description: 'The amount of data being pushed from the queue manager to subscribers.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'decbytes',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local publishedMessagesPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'ibmmq_qmgr_published_to_subscribers_message_count{mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", job=~"$job"}',
+      datasource=promDatasource,
+      legendFormat='{{mq_cluster}} - {{qmgr}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Published messages',
+  description: 'The number of messages being published by the queue manager.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local commitsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'ibmmq_qmgr_commit_count{mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", job=~"$job"}',
+      datasource=promDatasource,
+      legendFormat='{{mq_cluster}} - {{qmgr}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Commits',
+  description: 'The commits of the queue manager.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local expiredMessagesPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'ibmmq_qmgr_expired_message_count{mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", job=~"$job"}',
+      datasource=promDatasource,
+      legendFormat='{{mq_cluster}} - {{qmgr}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Expired messages',
+  description: 'The expired messages of the queue manager.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local queueOperationsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by (mq_cluster, qmgr, job) (ibmmq_queue_mqset_count{mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", job=~"$job"})',
+      datasource=promDatasource,
+      legendFormat='{{mq_cluster}} - {{qmgr}} - MQSET',
+    ),
+    prometheus.target(
+      'sum by (mq_cluster, qmgr, job) (ibmmq_queue_mqinq_count{mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", job=~"$job"})',
+      datasource=promDatasource,
+      legendFormat='{{mq_cluster}} - {{qmgr}} - MQINQ',
+    ),
+    prometheus.target(
+      'sum by (mq_cluster, qmgr, job) (ibmmq_queue_mqget_count{mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", job=~"$job"})',
+      datasource=promDatasource,
+      legendFormat='{{mq_cluster}} - {{qmgr}} - MQGET',
+    ),
+    prometheus.target(
+      'sum by (mq_cluster, qmgr, job) (ibmmq_queue_mqopen_count{mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", job=~"$job"})',
+      datasource=promDatasource,
+      legendFormat='{{mq_cluster}} - {{qmgr}} - MQOPEN',
+    ),
+    prometheus.target(
+      'sum by (mq_cluster, qmgr, job) (ibmmq_queue_mqclose_count{mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", job=~"$job"})',
+      datasource=promDatasource,
+      legendFormat='{{mq_cluster}} - {{qmgr}} - MQCLOSE',
+    ),
+    prometheus.target(
+      'sum by (mq_cluster, qmgr, job) (ibmmq_queue_mqput_mqput1_count{mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", job=~"$job"})',
+      datasource=promDatasource,
+      legendFormat='{{mq_cluster}} - {{qmgr}} - MQPUT/MQPUT1',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Queue operations',
+  description: 'The number of queue operations of the queue manager. ',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'none',
+    },
+  },
+};
+
+local logsRow = {
+  datasource: promDatasource,
+  targets: [],
+  type: 'row',
+  title: 'Logs',
+  collapsed: false,
+};
+
+local logLatencyPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'ibmmq_qmgr_log_write_latency_seconds{mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", job=~"$job"}',
+      datasource=promDatasource,
+      legendFormat='{{mq_cluster}} - {{qmgr}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Log latency',
+  description: 'The recent latency of log writes.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 's',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local logUsagePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'ibmmq_qmgr_log_in_use_bytes{mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", job=~"$job"}',
+      datasource=promDatasource,
+      legendFormat='{{mq_cluster}} - {{qmgr}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Log usage',
+  description: 'The amount of data on the filesystem occupied by queue manager logs.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'decbytes',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
+local errorLogsPanel = {
+  datasource: lokiDatasource,
+  targets: [
+    {
+      datasource: lokiDatasource,
+      editorMode: 'code',
+      expr: '{job=~"$job", filename=~"/var/mqm/qmgrs/.*/errors/.*LOG", qmgr=~"$qmgr"} |= ``',
+      queryType: 'range',
+      refId: 'A',
+    },
+  ],
+  type: 'logs',
+  title: 'Error logs',
+  description: 'Recent error logs from the queue manager.',
+  options: {
+    dedupStrategy: 'none',
+    enableLogDetails: true,
+    prettifyLogMessage: false,
+    showCommonLabels: false,
+    showLabels: false,
+    showTime: false,
+    sortOrder: 'Descending',
+    wrapLogMessage: false,
+  },
+};
+
+{
+  grafanaDashboards+:: {
+    'ibm-mq-queue-manager-overview.json':
+      dashboard.new(
+        'IBM MQ queue manager overview',
+        time_from='%s' % $._config.dashboardPeriod,
+        tags=($._config.dashboardTags),
+        timezone='%s' % $._config.dashboardTimezone,
+        refresh='%s' % $._config.dashboardRefresh,
+        description='',
+        uid=dashboardUid,
+      )
+
+      .addTemplates(
+        std.flattenArrays([
+          [
+            template.datasource(
+              promDatasourceName,
+              'prometheus',
+              null,
+              label='Data Source',
+              refresh='load'
+            ),
+          ],
+          if $._config.enableLokiLogs then [
+            template.datasource(
+              lokiDatasourceName,
+              'loki',
+              null,
+              label='Loki Datasource',
+              refresh='load'
+            ),
+          ] else [],
+          [
+            template.new(
+              'job',
+              promDatasource,
+              'label_values(ibmmq_topic_messages_received,job)',
+              label='Job',
+              refresh=2,
+              includeAll=true,
+              multi=true,
+              allValues='.+',
+              sort=0
+            ),
+            template.new(
+              'mq_cluster',
+              promDatasource,
+              'label_values(ibmmq_topic_messages_received,mq_cluster)',
+              label='MQ cluster',
+              refresh=1,
+              includeAll=true,
+              multi=true,
+              allValues='.+',
+              sort=0
+            ),
+            template.new(
+              'qmgr',
+              promDatasource,
+              'label_values(ibmmq_topic_messages_received{mq_cluster=~"$mq_cluster"},qmgr)',
+              label='Queue manager',
+              refresh=1,
+              includeAll=true,
+              multi=true,
+              allValues='',
+              sort=0
+            ),
+          ],
+        ])
+      )
+      .addPanels(
+        std.flattenArrays([
+          [
+            activeListenersPanel { gridPos: { h: 7, w: 8, x: 0, y: 0 } },
+            activeConnectionsPanel { gridPos: { h: 7, w: 8, x: 8, y: 0 } },
+            queuesPanel { gridPos: { h: 7, w: 8, x: 16, y: 0 } },
+            cpuUsagePanel { gridPos: { h: 8, w: 12, x: 0, y: 7 } },
+            estimatedMemoryUtilizationPanel { gridPos: { h: 8, w: 12, x: 12, y: 7 } },
+            queueManagerStatusPanel { gridPos: { h: 9, w: 24, x: 0, y: 15 } },
+            diskUsagePanel { gridPos: { h: 8, w: 8, x: 0, y: 24 } },
+            publishThroughputPanel { gridPos: { h: 8, w: 8, x: 8, y: 24 } },
+            publishedMessagesPanel { gridPos: { h: 8, w: 8, x: 16, y: 24 } },
+            commitsPanel { gridPos: { h: 8, w: 8, x: 0, y: 32 } },
+            expiredMessagesPanel { gridPos: { h: 8, w: 8, x: 8, y: 32 } },
+            queueOperationsPanel { gridPos: { h: 8, w: 8, x: 16, y: 32 } },
+            logsRow { gridPos: { h: 1, w: 24, x: 0, y: 40 } },
+            logLatencyPanel { gridPos: { h: 8, w: 12, x: 0, y: 41 } },
+            logUsagePanel { gridPos: { h: 8, w: 12, x: 12, y: 41 } },
+          ],
+          if $._config.enableLokiLogs then [
+            errorLogsPanel { gridPos: { h: 8, w: 24, x: 0, y: 49 } },
+          ] else [],
+          [
+          ],
+        ])
+      ),
+
+  },
+}

--- a/ibm-mq-mixin/dashboards/queue-manager-overview.libsonnet
+++ b/ibm-mq-mixin/dashboards/queue-manager-overview.libsonnet
@@ -121,7 +121,7 @@ local queuesPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'count(count(ibmmq_queue_depth) by (queue, mq_cluster, qmgr))',
+      'count(count(ibmmq_queue_depth{job=~"$job"}) by (queue, mq_cluster, qmgr))',
       datasource=promDatasource,
     ),
   ],
@@ -361,7 +361,41 @@ local queueManagerStatusPanel = {
         filterable: false,
         inspect: false,
       },
-      mappings: [],
+      mappings: [
+        {
+          options: {
+            '-1': {
+              index: 0,
+              text: 'N/A',
+            },
+            '0': {
+              index: 1,
+              text: 'Stopped',
+            },
+            '1': {
+              index: 2,
+              text: 'Starting',
+            },
+            '2': {
+              index: 3,
+              text: 'Running',
+            },
+            '3': {
+              index: 4,
+              text: 'Quiescing',
+            },
+            '4': {
+              index: 5,
+              text: 'Stopping',
+            },
+            '5': {
+              index: 6,
+              text: 'Standby',
+            },
+          },
+          type: 'value',
+        },
+      ],
       thresholds: {
         mode: 'absolute',
         steps: [

--- a/ibm-mq-mixin/dashboards/queue-manager-overview.libsonnet
+++ b/ibm-mq-mixin/dashboards/queue-manager-overview.libsonnet
@@ -1,3 +1,4 @@
+local g = (import 'grafana-builder/grafana.libsonnet');
 local grafana = (import 'grafonnet/grafana.libsonnet');
 local dashboard = grafana.dashboard;
 local template = grafana.template;
@@ -12,6 +13,7 @@ local promDatasource = {
   uid: '${%s}' % promDatasourceName,
 };
 
+
 local lokiDatasource = {
   uid: '${%s}' % lokiDatasourceName,
 };
@@ -22,6 +24,8 @@ local activeListenersPanel = {
     prometheus.target(
       'ibmmq_qmgr_active_listeners{mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", job=~"$job"}',
       datasource=promDatasource,
+      legendFormat='',
+      format='time_series',
     ),
   ],
   type: 'stat',
@@ -51,7 +55,7 @@ local activeListenersPanel = {
   },
   options: {
     colorMode: 'value',
-    graphMode: 'area',
+    graphMode: 'none',
     justifyMode: 'auto',
     orientation: 'auto',
     reduceOptions: {
@@ -63,7 +67,6 @@ local activeListenersPanel = {
     },
     textMode: 'auto',
   },
-  pluginVersion: '10.0.1-cloud.3.f250259e',
 };
 
 local activeConnectionsPanel = {
@@ -72,6 +75,8 @@ local activeConnectionsPanel = {
     prometheus.target(
       'ibmmq_qmgr_connection_count{mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", job=~"$job"}',
       datasource=promDatasource,
+      legendFormat='',
+      format='time_series',
     ),
   ],
   type: 'stat',
@@ -101,7 +106,7 @@ local activeConnectionsPanel = {
   },
   options: {
     colorMode: 'value',
-    graphMode: 'area',
+    graphMode: 'none',
     justifyMode: 'auto',
     orientation: 'auto',
     reduceOptions: {
@@ -113,7 +118,6 @@ local activeConnectionsPanel = {
     },
     textMode: 'auto',
   },
-  pluginVersion: '10.0.1-cloud.3.f250259e',
 };
 
 local queuesPanel = {
@@ -122,6 +126,8 @@ local queuesPanel = {
     prometheus.target(
       'count(count(ibmmq_queue_depth{job=~"$job"}) by (queue, mq_cluster, qmgr))',
       datasource=promDatasource,
+      legendFormat='',
+      format='time_series',
     ),
   ],
   type: 'stat',
@@ -151,7 +157,7 @@ local queuesPanel = {
   },
   options: {
     colorMode: 'value',
-    graphMode: 'area',
+    graphMode: 'none',
     justifyMode: 'auto',
     orientation: 'auto',
     reduceOptions: {
@@ -163,100 +169,16 @@ local queuesPanel = {
     },
     textMode: 'auto',
   },
-  pluginVersion: '10.0.1-cloud.3.f250259e',
-};
-
-local cpuUsagePanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'ibmmq_qmgr_user_cpu_time_percentage{mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", job=~"$job"}',
-      datasource=promDatasource,
-      legendFormat='{{mq_cluster}} - {{qmgr}} - user',
-    ),
-    prometheus.target(
-      'ibmmq_qmgr_system_cpu_time_percentage{mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", job=~"$job"}',
-      datasource=promDatasource,
-      legendFormat='{{mq_cluster}} - {{qmgr}} - system',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'CPU usage',
-  description: 'The system/user CPU usage of the queue manager.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-          {
-            color: 'red',
-            value: 80,
-          },
-        ],
-      },
-      unit: 'percent',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'multi',
-      sort: 'none',
-    },
-  },
 };
 
 local estimatedMemoryUtilizationPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      '(ibmmq_qmgr_ram_total_estimate_for_queue_manager_bytes{mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", job=~"$job"}/ibmmq_qmgr_ram_total_bytes{mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", job=~"$job"}) * 100',
+      '(ibmmq_qmgr_ram_total_estimate_for_queue_manager_bytes{mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", job=~"$job"}/ibmmq_qmgr_ram_total_bytes{mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", job=~"$job"})',
       datasource=promDatasource,
       legendFormat='{{mq_cluster}} - {{qmgr}}',
+      format='time_series',
     ),
   ],
   type: 'timeseries',
@@ -274,7 +196,7 @@ local estimatedMemoryUtilizationPanel = {
         axisPlacement: 'auto',
         barAlignment: 0,
         drawStyle: 'line',
-        fillOpacity: 0,
+        fillOpacity: 10,
         gradientMode: 'none',
         hideFrom: {
           legend: false,
@@ -287,7 +209,7 @@ local estimatedMemoryUtilizationPanel = {
         scaleDistribution: {
           type: 'linear',
         },
-        showPoints: 'auto',
+        showPoints: 'never',
         spanNulls: false,
         stacking: {
           group: 'A',
@@ -311,7 +233,7 @@ local estimatedMemoryUtilizationPanel = {
           },
         ],
       },
-      unit: 'percent',
+      unit: 'percentunit',
     },
     overrides: [],
   },
@@ -342,6 +264,7 @@ local queueManagerStatusPanel = {
       'ibmmq_qmgr_status{mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", job=~"$job"}',
       datasource=promDatasource,
       legendFormat='Status',
+      format='time_series',
     ),
   ],
   type: 'table',
@@ -353,7 +276,7 @@ local queueManagerStatusPanel = {
         mode: 'thresholds',
       },
       custom: {
-        align: 'auto',
+        align: 'left',
         cellOptions: {
           type: 'auto',
         },
@@ -414,7 +337,7 @@ local queueManagerStatusPanel = {
         properties: [
           {
             id: 'custom.width',
-            value: 280,
+            value: 149,
           },
           {
             id: 'unit',
@@ -431,6 +354,30 @@ local queueManagerStatusPanel = {
           {
             id: 'custom.width',
             value: 318,
+          },
+        ],
+      },
+      {
+        matcher: {
+          id: 'byName',
+          options: 'Queue manager',
+        },
+        properties: [
+          {
+            id: 'custom.width',
+            value: 168,
+          },
+        ],
+      },
+      {
+        matcher: {
+          id: 'byName',
+          options: 'MQ cluster',
+        },
+        properties: [
+          {
+            id: 'custom.width',
+            value: 129,
           },
         ],
       },
@@ -451,7 +398,6 @@ local queueManagerStatusPanel = {
     showHeader: true,
     sortBy: [],
   },
-  pluginVersion: '10.0.1-cloud.3.f250259e',
   transformations: [
     {
       id: 'joinByField',
@@ -507,6 +453,92 @@ local queueManagerStatusPanel = {
   ],
 };
 
+local cpuUsagePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'ibmmq_qmgr_user_cpu_time_percentage{mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", job=~"$job"}',
+      datasource=promDatasource,
+      legendFormat='{{mq_cluster}} - {{qmgr}} - user',
+      format='time_series',
+    ),
+    prometheus.target(
+      'ibmmq_qmgr_system_cpu_time_percentage{mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", job=~"$job"}',
+      datasource=promDatasource,
+      legendFormat='{{mq_cluster}} - {{qmgr}} - system',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'CPU usage',
+  description: 'The system/user CPU usage of the queue manager.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 10,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'percent',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'none',
+    },
+  },
+};
+
 local diskUsagePanel = {
   datasource: promDatasource,
   targets: [
@@ -514,6 +546,7 @@ local diskUsagePanel = {
       'ibmmq_qmgr_queue_manager_file_system_in_use_bytes{mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", job=~"$job"}',
       datasource=promDatasource,
       legendFormat='{{mq_cluster}} - {{qmgr}}',
+      format='time_series',
     ),
   ],
   type: 'timeseries',
@@ -531,7 +564,7 @@ local diskUsagePanel = {
         axisPlacement: 'auto',
         barAlignment: 0,
         drawStyle: 'line',
-        fillOpacity: 0,
+        fillOpacity: 10,
         gradientMode: 'none',
         hideFrom: {
           legend: false,
@@ -544,7 +577,7 @@ local diskUsagePanel = {
         scaleDistribution: {
           type: 'linear',
         },
-        showPoints: 'auto',
+        showPoints: 'never',
         spanNulls: false,
         stacking: {
           group: 'A',
@@ -586,6 +619,85 @@ local diskUsagePanel = {
   },
 };
 
+local commitsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'ibmmq_qmgr_commit_count{mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", job=~"$job"}',
+      datasource=promDatasource,
+      legendFormat='{{mq_cluster}} - {{qmgr}}',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Commits',
+  description: 'The commits of the queue manager.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 10,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+};
+
 local publishThroughputPanel = {
   datasource: promDatasource,
   targets: [
@@ -593,6 +705,7 @@ local publishThroughputPanel = {
       'ibmmq_qmgr_published_to_subscribers_bytes{mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", job=~"$job"}',
       datasource=promDatasource,
       legendFormat='{{mq_cluster}} - {{qmgr}}',
+      format='time_series',
     ),
   ],
   type: 'timeseries',
@@ -610,7 +723,7 @@ local publishThroughputPanel = {
         axisPlacement: 'auto',
         barAlignment: 0,
         drawStyle: 'line',
-        fillOpacity: 0,
+        fillOpacity: 10,
         gradientMode: 'none',
         hideFrom: {
           legend: false,
@@ -623,7 +736,7 @@ local publishThroughputPanel = {
         scaleDistribution: {
           type: 'linear',
         },
-        showPoints: 'auto',
+        showPoints: 'never',
         spanNulls: false,
         stacking: {
           group: 'A',
@@ -672,6 +785,7 @@ local publishedMessagesPanel = {
       'ibmmq_qmgr_published_to_subscribers_message_count{mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", job=~"$job"}',
       datasource=promDatasource,
       legendFormat='{{mq_cluster}} - {{qmgr}}',
+      format='time_series',
     ),
   ],
   type: 'timeseries',
@@ -689,7 +803,7 @@ local publishedMessagesPanel = {
         axisPlacement: 'auto',
         barAlignment: 0,
         drawStyle: 'line',
-        fillOpacity: 0,
+        fillOpacity: 10,
         gradientMode: 'none',
         hideFrom: {
           legend: false,
@@ -702,7 +816,7 @@ local publishedMessagesPanel = {
         scaleDistribution: {
           type: 'linear',
         },
-        showPoints: 'auto',
+        showPoints: 'never',
         spanNulls: false,
         stacking: {
           group: 'A',
@@ -739,83 +853,6 @@ local publishedMessagesPanel = {
   },
 };
 
-local commitsPanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'ibmmq_qmgr_commit_count{mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", job=~"$job"}',
-      datasource=promDatasource,
-      legendFormat='{{mq_cluster}} - {{qmgr}}',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'Commits',
-  description: 'The commits of the queue manager.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-          },
-          {
-            color: 'red',
-            value: 80,
-          },
-        ],
-      },
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'single',
-      sort: 'none',
-    },
-  },
-};
-
 local expiredMessagesPanel = {
   datasource: promDatasource,
   targets: [
@@ -823,6 +860,7 @@ local expiredMessagesPanel = {
       'ibmmq_qmgr_expired_message_count{mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", job=~"$job"}',
       datasource=promDatasource,
       legendFormat='{{mq_cluster}} - {{qmgr}}',
+      format='time_series',
     ),
   ],
   type: 'timeseries',
@@ -840,7 +878,7 @@ local expiredMessagesPanel = {
         axisPlacement: 'auto',
         barAlignment: 0,
         drawStyle: 'line',
-        fillOpacity: 0,
+        fillOpacity: 10,
         gradientMode: 'none',
         hideFrom: {
           legend: false,
@@ -853,7 +891,7 @@ local expiredMessagesPanel = {
         scaleDistribution: {
           type: 'linear',
         },
-        showPoints: 'auto',
+        showPoints: 'never',
         spanNulls: false,
         stacking: {
           group: 'A',
@@ -869,6 +907,7 @@ local expiredMessagesPanel = {
         steps: [
           {
             color: 'green',
+            value: null,
           },
           {
             color: 'red',
@@ -900,31 +939,37 @@ local queueOperationsPanel = {
       'sum by (mq_cluster, qmgr, job) (ibmmq_queue_mqset_count{mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", job=~"$job"})',
       datasource=promDatasource,
       legendFormat='{{mq_cluster}} - {{qmgr}} - MQSET',
+      format='time_series',
     ),
     prometheus.target(
       'sum by (mq_cluster, qmgr, job) (ibmmq_queue_mqinq_count{mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", job=~"$job"})',
       datasource=promDatasource,
       legendFormat='{{mq_cluster}} - {{qmgr}} - MQINQ',
+      format='time_series',
     ),
     prometheus.target(
       'sum by (mq_cluster, qmgr, job) (ibmmq_queue_mqget_count{mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", job=~"$job"})',
       datasource=promDatasource,
       legendFormat='{{mq_cluster}} - {{qmgr}} - MQGET',
+      format='time_series',
     ),
     prometheus.target(
       'sum by (mq_cluster, qmgr, job) (ibmmq_queue_mqopen_count{mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", job=~"$job"})',
       datasource=promDatasource,
       legendFormat='{{mq_cluster}} - {{qmgr}} - MQOPEN',
+      format='time_series',
     ),
     prometheus.target(
       'sum by (mq_cluster, qmgr, job) (ibmmq_queue_mqclose_count{mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", job=~"$job"})',
       datasource=promDatasource,
       legendFormat='{{mq_cluster}} - {{qmgr}} - MQCLOSE',
+      format='time_series',
     ),
     prometheus.target(
       'sum by (mq_cluster, qmgr, job) (ibmmq_queue_mqput_mqput1_count{mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", job=~"$job"})',
       datasource=promDatasource,
       legendFormat='{{mq_cluster}} - {{qmgr}} - MQPUT/MQPUT1',
+      format='time_series',
     ),
   ],
   type: 'timeseries',
@@ -942,7 +987,7 @@ local queueOperationsPanel = {
         axisPlacement: 'auto',
         barAlignment: 0,
         drawStyle: 'line',
-        fillOpacity: 0,
+        fillOpacity: 10,
         gradientMode: 'none',
         hideFrom: {
           legend: false,
@@ -955,7 +1000,7 @@ local queueOperationsPanel = {
         scaleDistribution: {
           type: 'linear',
         },
-        showPoints: 'auto',
+        showPoints: 'never',
         spanNulls: false,
         stacking: {
           group: 'A',
@@ -971,6 +1016,7 @@ local queueOperationsPanel = {
         steps: [
           {
             color: 'green',
+            value: null,
           },
           {
             color: 'red',
@@ -985,8 +1031,8 @@ local queueOperationsPanel = {
   options: {
     legend: {
       calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
+      displayMode: 'table',
+      placement: 'right',
       showLegend: true,
     },
     tooltip: {
@@ -998,7 +1044,13 @@ local queueOperationsPanel = {
 
 local logsRow = {
   datasource: promDatasource,
-  targets: [],
+  targets: [
+    prometheus.target(
+      '',
+      datasource=promDatasource,
+      legendFormat='',
+    ),
+  ],
   type: 'row',
   title: 'Logs',
   collapsed: false,
@@ -1011,6 +1063,7 @@ local logLatencyPanel = {
       'ibmmq_qmgr_log_write_latency_seconds{mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", job=~"$job"}',
       datasource=promDatasource,
       legendFormat='{{mq_cluster}} - {{qmgr}}',
+      format='time_series',
     ),
   ],
   type: 'timeseries',
@@ -1028,7 +1081,7 @@ local logLatencyPanel = {
         axisPlacement: 'auto',
         barAlignment: 0,
         drawStyle: 'line',
-        fillOpacity: 0,
+        fillOpacity: 10,
         gradientMode: 'none',
         hideFrom: {
           legend: false,
@@ -1041,7 +1094,7 @@ local logLatencyPanel = {
         scaleDistribution: {
           type: 'linear',
         },
-        showPoints: 'auto',
+        showPoints: 'never',
         spanNulls: false,
         stacking: {
           group: 'A',
@@ -1057,6 +1110,7 @@ local logLatencyPanel = {
         steps: [
           {
             color: 'green',
+            value: null,
           },
           {
             color: 'red',
@@ -1089,6 +1143,7 @@ local logUsagePanel = {
       'ibmmq_qmgr_log_in_use_bytes{mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", job=~"$job"}',
       datasource=promDatasource,
       legendFormat='{{mq_cluster}} - {{qmgr}}',
+      format='time_series',
     ),
   ],
   type: 'timeseries',
@@ -1106,7 +1161,7 @@ local logUsagePanel = {
         axisPlacement: 'auto',
         barAlignment: 0,
         drawStyle: 'line',
-        fillOpacity: 0,
+        fillOpacity: 10,
         gradientMode: 'none',
         hideFrom: {
           legend: false,
@@ -1119,7 +1174,7 @@ local logUsagePanel = {
         scaleDistribution: {
           type: 'linear',
         },
-        showPoints: 'auto',
+        showPoints: 'never',
         spanNulls: false,
         stacking: {
           group: 'A',
@@ -1135,6 +1190,7 @@ local logUsagePanel = {
         steps: [
           {
             color: 'green',
+            value: null,
           },
           {
             color: 'red',
@@ -1185,6 +1241,7 @@ local errorLogsPanel = {
     wrapLogMessage: false,
   },
 };
+
 
 {
   grafanaDashboards+:: {
@@ -1266,24 +1323,24 @@ local errorLogsPanel = {
       .addPanels(
         std.flattenArrays([
           [
-            activeListenersPanel { gridPos: { h: 7, w: 8, x: 0, y: 0 } },
-            activeConnectionsPanel { gridPos: { h: 7, w: 8, x: 8, y: 0 } },
-            queuesPanel { gridPos: { h: 7, w: 8, x: 16, y: 0 } },
-            cpuUsagePanel { gridPos: { h: 8, w: 12, x: 0, y: 7 } },
-            estimatedMemoryUtilizationPanel { gridPos: { h: 8, w: 12, x: 12, y: 7 } },
-            queueManagerStatusPanel { gridPos: { h: 9, w: 24, x: 0, y: 15 } },
-            diskUsagePanel { gridPos: { h: 8, w: 8, x: 0, y: 24 } },
-            publishThroughputPanel { gridPos: { h: 8, w: 8, x: 8, y: 24 } },
-            publishedMessagesPanel { gridPos: { h: 8, w: 8, x: 16, y: 24 } },
-            commitsPanel { gridPos: { h: 8, w: 8, x: 0, y: 32 } },
-            expiredMessagesPanel { gridPos: { h: 8, w: 8, x: 8, y: 32 } },
-            queueOperationsPanel { gridPos: { h: 8, w: 8, x: 16, y: 32 } },
-            logsRow { gridPos: { h: 1, w: 24, x: 0, y: 40 } },
-            logLatencyPanel { gridPos: { h: 8, w: 12, x: 0, y: 41 } },
-            logUsagePanel { gridPos: { h: 8, w: 12, x: 12, y: 41 } },
+            activeListenersPanel { gridPos: { h: 7, w: 4, x: 0, y: 0 } },
+            activeConnectionsPanel { gridPos: { h: 7, w: 4, x: 4, y: 0 } },
+            queuesPanel { gridPos: { h: 7, w: 4, x: 8, y: 0 } },
+            estimatedMemoryUtilizationPanel { gridPos: { h: 7, w: 12, x: 12, y: 0 } },
+            queueManagerStatusPanel { gridPos: { h: 7, w: 8, x: 0, y: 7 } },
+            cpuUsagePanel { gridPos: { h: 7, w: 8, x: 8, y: 7 } },
+            diskUsagePanel { gridPos: { h: 7, w: 8, x: 16, y: 7 } },
+            commitsPanel { gridPos: { h: 7, w: 8, x: 0, y: 14 } },
+            publishThroughputPanel { gridPos: { h: 7, w: 8, x: 8, y: 14 } },
+            publishedMessagesPanel { gridPos: { h: 7, w: 8, x: 16, y: 14 } },
+            expiredMessagesPanel { gridPos: { h: 7, w: 8, x: 0, y: 21 } },
+            queueOperationsPanel { gridPos: { h: 7, w: 16, x: 8, y: 21 } },
+            logsRow { gridPos: { h: 1, w: 24, x: 0, y: 28 } },
+            logLatencyPanel { gridPos: { h: 7, w: 12, x: 0, y: 29 } },
+            logUsagePanel { gridPos: { h: 7, w: 12, x: 12, y: 29 } },
           ],
           if $._config.enableLokiLogs then [
-            errorLogsPanel { gridPos: { h: 8, w: 24, x: 0, y: 49 } },
+            errorLogsPanel { gridPos: { h: 8, w: 24, x: 0, y: 36 } },
           ] else [],
           [
           ],

--- a/ibm-mq-mixin/dashboards/queue-manager-overview.libsonnet
+++ b/ibm-mq-mixin/dashboards/queue-manager-overview.libsonnet
@@ -1,4 +1,3 @@
-local g = (import 'grafana-builder/grafana.libsonnet');
 local grafana = (import 'grafonnet/grafana.libsonnet');
 local dashboard = grafana.dashboard;
 local template = grafana.template;
@@ -979,6 +978,7 @@ local queueOperationsPanel = {
           },
         ],
       },
+      unit: 'operations',
     },
     overrides: [],
   },
@@ -1256,6 +1256,13 @@ local errorLogsPanel = {
           ],
         ])
       )
+      .addLink(grafana.link.dashboards(
+        asDropdown=false,
+        title='Other IBM MQ dashboards',
+        includeVars=true,
+        keepTime=true,
+        tags=($._config.dashboardTags),
+      ))
       .addPanels(
         std.flattenArrays([
           [

--- a/ibm-mq-mixin/dashboards/queue-overview.libsonnet
+++ b/ibm-mq-mixin/dashboards/queue-overview.libsonnet
@@ -1,3 +1,4 @@
+local g = (import 'grafana-builder/grafana.libsonnet');
 local grafana = (import 'grafonnet/grafana.libsonnet');
 local dashboard = grafana.dashboard;
 local template = grafana.template;
@@ -18,6 +19,7 @@ local averageQueueTimePanel = {
       'ibmmq_queue_average_queue_time_seconds{job=~"$job", mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", queue=~"$queue"}',
       datasource=promDatasource,
       legendFormat='{{mq_cluster}} - {{qmgr}} - {{queue}}',
+      format='time_series',
     ),
   ],
   type: 'timeseries',
@@ -35,7 +37,7 @@ local averageQueueTimePanel = {
         axisPlacement: 'auto',
         barAlignment: 0,
         drawStyle: 'line',
-        fillOpacity: 0,
+        fillOpacity: 10,
         gradientMode: 'none',
         hideFrom: {
           legend: false,
@@ -48,7 +50,7 @@ local averageQueueTimePanel = {
         scaleDistribution: {
           type: 'linear',
         },
-        showPoints: 'auto',
+        showPoints: 'never',
         spanNulls: false,
         stacking: {
           group: 'A',
@@ -93,6 +95,7 @@ local expiredMessagesPanel = {
       'ibmmq_queue_expired_messages{job=~"$job", mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", queue=~"$queue"}',
       datasource=promDatasource,
       legendFormat='{{mq_cluster}} - {{qmgr}} - {{queue}}',
+      format='time_series',
     ),
   ],
   type: 'timeseries',
@@ -110,7 +113,7 @@ local expiredMessagesPanel = {
         axisPlacement: 'auto',
         barAlignment: 0,
         drawStyle: 'line',
-        fillOpacity: 0,
+        fillOpacity: 10,
         gradientMode: 'none',
         hideFrom: {
           legend: false,
@@ -123,7 +126,7 @@ local expiredMessagesPanel = {
         scaleDistribution: {
           type: 'linear',
         },
-        showPoints: 'auto',
+        showPoints: 'never',
         spanNulls: false,
         stacking: {
           group: 'A',
@@ -154,7 +157,7 @@ local expiredMessagesPanel = {
     legend: {
       calcs: [],
       displayMode: 'list',
-      placement: 'bottom',
+      placement: 'right',
       showLegend: true,
     },
     tooltip: {
@@ -171,6 +174,7 @@ local depthPanel = {
       'ibmmq_queue_depth{job=~"$job", mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", queue=~"$queue"}',
       datasource=promDatasource,
       legendFormat='{{mq_cluster}} - {{qmgr}} - {{queue}}',
+      format='time_series',
     ),
   ],
   type: 'timeseries',
@@ -188,7 +192,7 @@ local depthPanel = {
         axisPlacement: 'auto',
         barAlignment: 0,
         drawStyle: 'line',
-        fillOpacity: 0,
+        fillOpacity: 10,
         gradientMode: 'none',
         hideFrom: {
           legend: false,
@@ -201,7 +205,7 @@ local depthPanel = {
         scaleDistribution: {
           type: 'linear',
         },
-        showPoints: 'auto',
+        showPoints: 'never',
         spanNulls: false,
         stacking: {
           group: 'A',
@@ -225,110 +229,6 @@ local depthPanel = {
           },
         ],
       },
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'multi',
-      sort: 'desc',
-    },
-  },
-};
-
-local operationsPanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'ibmmq_queue_mqset_count{job=~"$job", mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", queue=~"$queue"}',
-      datasource=promDatasource,
-      legendFormat='{{qmgr}} - {{queue}} - MQSET',
-    ),
-    prometheus.target(
-      'ibmmq_queue_mqinq_count{job=~"$job", mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", queue=~"$queue"}',
-      datasource=promDatasource,
-      legendFormat='{{qmgr}} - {{queue}} - MQINQ',
-    ),
-    prometheus.target(
-      'ibmmq_queue_mqget_count{job=~"$job", mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", queue=~"$queue"}',
-      datasource=promDatasource,
-      legendFormat='{{qmgr}} - {{queue}} - MQGET',
-    ),
-    prometheus.target(
-      'ibmmq_queue_mqopen_count{job=~"$job", mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", queue=~"$queue"}',
-      datasource=promDatasource,
-      legendFormat='{{qmgr}} - {{queue}} - MQOPEN',
-    ),
-    prometheus.target(
-      'ibmmq_queue_mqclose_count{job=~"$job", mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", queue=~"$queue"}',
-      datasource=promDatasource,
-      legendFormat='{{qmgr}} - {{queue}} - MQCLOSE',
-    ),
-    prometheus.target(
-      'ibmmq_queue_mqput_mqput1_count{job=~"$job", mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", queue=~"$queue"}',
-      datasource=promDatasource,
-      legendFormat='{{qmgr}} - {{queue}} - MQPUT/MQPUT1',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'Operations',
-  description: 'The number of queue operations of the queue manager.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-          {
-            color: 'red',
-            value: 80,
-          },
-        ],
-      },
-      unit: 'operations',
     },
     overrides: [],
   },
@@ -353,11 +253,13 @@ local operationThroughputPanel = {
       'ibmmq_queue_mqget_bytes{job=~"$job", mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", queue=~"$queue"}',
       datasource=promDatasource,
       legendFormat='{{qmgr}} - {{queue}} - MQGET',
+      format='time_series',
     ),
     prometheus.target(
       'ibmmq_queue_mqput_bytes{job=~"$job", mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", queue=~"$queue"}',
       datasource=promDatasource,
       legendFormat='{{qmgr}} - {{queue}} - MQPUT',
+      format='time_series',
     ),
   ],
   type: 'timeseries',
@@ -375,7 +277,7 @@ local operationThroughputPanel = {
         axisPlacement: 'auto',
         barAlignment: 0,
         drawStyle: 'line',
-        fillOpacity: 0,
+        fillOpacity: 10,
         gradientMode: 'none',
         hideFrom: {
           legend: false,
@@ -388,7 +290,7 @@ local operationThroughputPanel = {
         scaleDistribution: {
           type: 'linear',
         },
-        showPoints: 'auto',
+        showPoints: 'never',
         spanNulls: false,
         stacking: {
           group: 'A',
@@ -420,7 +322,117 @@ local operationThroughputPanel = {
     legend: {
       calcs: [],
       displayMode: 'list',
-      placement: 'bottom',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local operationsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'ibmmq_queue_mqset_count{job=~"$job", mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", queue=~"$queue"}',
+      datasource=promDatasource,
+      legendFormat='{{qmgr}} - {{queue}} - MQSET',
+      format='time_series',
+    ),
+    prometheus.target(
+      'ibmmq_queue_mqinq_count{job=~"$job", mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", queue=~"$queue"}',
+      datasource=promDatasource,
+      legendFormat='{{qmgr}} - {{queue}} - MQINQ',
+      format='time_series',
+    ),
+    prometheus.target(
+      'ibmmq_queue_mqget_count{job=~"$job", mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", queue=~"$queue"}',
+      datasource=promDatasource,
+      legendFormat='{{qmgr}} - {{queue}} - MQGET',
+      format='time_series',
+    ),
+    prometheus.target(
+      'ibmmq_queue_mqopen_count{job=~"$job", mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", queue=~"$queue"}',
+      datasource=promDatasource,
+      legendFormat='{{qmgr}} - {{queue}} - MQOPEN',
+      format='time_series',
+    ),
+    prometheus.target(
+      'ibmmq_queue_mqclose_count{job=~"$job", mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", queue=~"$queue"}',
+      datasource=promDatasource,
+      legendFormat='{{qmgr}} - {{queue}} - MQCLOSE',
+      format='time_series',
+    ),
+    prometheus.target(
+      'ibmmq_queue_mqput_mqput1_count{job=~"$job", mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", queue=~"$queue"}',
+      datasource=promDatasource,
+      legendFormat='{{qmgr}} - {{queue}} - MQPUT/MQPUT1',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Operations',
+  description: 'The number of queue operations of the queue manager.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 10,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'operations',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'right',
       showLegend: true,
     },
     tooltip: {
@@ -468,7 +480,7 @@ local operationThroughputPanel = {
             promDatasource,
             'label_values(ibmmq_queue_average_queue_time_seconds{job=~"$job"},mq_cluster)',
             label='MQ cluster',
-            refresh=1,
+            refresh=2,
             includeAll=true,
             multi=true,
             allValues='',
@@ -498,22 +510,14 @@ local operationThroughputPanel = {
           ),
         ]
       )
-      .addLink(grafana.link.dashboards(
-        asDropdown=false,
-        title='Other IBM MQ dashboards',
-        includeVars=true,
-        keepTime=true,
-        tags=($._config.dashboardTags),
-      ))
       .addPanels(
         [
           averageQueueTimePanel { gridPos: { h: 8, w: 12, x: 0, y: 0 } },
           expiredMessagesPanel { gridPos: { h: 8, w: 12, x: 12, y: 0 } },
           depthPanel { gridPos: { h: 8, w: 24, x: 0, y: 8 } },
-          operationsPanel { gridPos: { h: 8, w: 12, x: 0, y: 16 } },
-          operationThroughputPanel { gridPos: { h: 8, w: 12, x: 12, y: 16 } },
+          operationThroughputPanel { gridPos: { h: 8, w: 9, x: 0, y: 16 } },
+          operationsPanel { gridPos: { h: 8, w: 15, x: 9, y: 16 } },
         ]
       ),
-
   },
 }

--- a/ibm-mq-mixin/dashboards/queue-overview.libsonnet
+++ b/ibm-mq-mixin/dashboards/queue-overview.libsonnet
@@ -1,0 +1,512 @@
+local g = (import 'grafana-builder/grafana.libsonnet');
+local grafana = (import 'grafonnet/grafana.libsonnet');
+local dashboard = grafana.dashboard;
+local template = grafana.template;
+local prometheus = grafana.prometheus;
+
+local dashboardUid = 'ibm-mq-queue-overview';
+
+local promDatasourceName = 'prometheus_datasource';
+
+local promDatasource = {
+  uid: '${%s}' % promDatasourceName,
+};
+
+local averageQueueTimePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'ibmmq_queue_average_queue_time_seconds{job=~"$job", mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", queue=~"$queue"}',
+      datasource=promDatasource,
+      legendFormat='{{mq_cluster}} - {{qmgr}} - {{queue}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Average queue time',
+  description: 'The average amount of time a message spends in the queue.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 's',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local expiredMessagesPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'ibmmq_queue_expired_messages{job=~"$job", mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", queue=~"$queue"}',
+      datasource=promDatasource,
+      legendFormat='{{mq_cluster}} - {{qmgr}} - {{queue}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Expired messages',
+  description: 'The amount of expired messages in the queue.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local depthPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'ibmmq_queue_depth{job=~"$job", mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", queue=~"$queue"}',
+      datasource=promDatasource,
+      legendFormat='{{mq_cluster}} - {{qmgr}} - {{queue}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Depth',
+  description: 'The number of active messages in the queue.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local operationsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'ibmmq_queue_mqset_count{job=~"$job", mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", queue=~"$queue"}',
+      datasource=promDatasource,
+      legendFormat='{{qmgr}} - {{queue}} - MQSET',
+    ),
+    prometheus.target(
+      'ibmmq_queue_mqinq_count{job=~"$job", mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", queue=~"$queue"}',
+      datasource=promDatasource,
+      legendFormat='{{qmgr}} - {{queue}} - MQINQ',
+    ),
+    prometheus.target(
+      'ibmmq_queue_mqget_count{job=~"$job", mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", queue=~"$queue"}',
+      datasource=promDatasource,
+      legendFormat='{{qmgr}} - {{queue}} - MQGET',
+    ),
+    prometheus.target(
+      'ibmmq_queue_mqopen_count{job=~"$job", mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", queue=~"$queue"}',
+      datasource=promDatasource,
+      legendFormat='{{qmgr}} - {{queue}} - MQOPEN',
+    ),
+    prometheus.target(
+      'ibmmq_queue_mqclose_count{job=~"$job", mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", queue=~"$queue"}',
+      datasource=promDatasource,
+      legendFormat='{{qmgr}} - {{queue}} - MQCLOSE',
+    ),
+    prometheus.target(
+      'ibmmq_queue_mqput_mqput1_count{job=~"$job", mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", queue=~"$queue"}',
+      datasource=promDatasource,
+      legendFormat='{{qmgr}} - {{queue}} - MQPUT/MQPUT1',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Operations',
+  description: 'The number of queue operations of the queue manager.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local operationThroughputPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'ibmmq_queue_mqget_bytes{job=~"$job", mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", queue=~"$queue"}',
+      datasource=promDatasource,
+      legendFormat='{{qmgr}} - {{queue}} - MQGET',
+    ),
+    prometheus.target(
+      'ibmmq_queue_mqput_bytes{job=~"$job", mq_cluster=~"$mq_cluster", qmgr=~"$qmgr", queue=~"$queue"}',
+      datasource=promDatasource,
+      legendFormat='{{qmgr}} - {{queue}} - MQPUT',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Operation throughput',
+  description: 'The amount of throughput going through the queue via MQGETs and MQPUTs.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'decbytes',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+{
+  grafanaDashboards+:: {
+    'ibm-mq-queue-overview.json':
+      dashboard.new(
+        'IBM MQ queue overview',
+        time_from='%s' % $._config.dashboardPeriod,
+        tags=($._config.dashboardTags),
+        timezone='%s' % $._config.dashboardTimezone,
+        refresh='%s' % $._config.dashboardRefresh,
+        description='',
+        uid=dashboardUid,
+      )
+
+      .addTemplates(
+        [
+          template.datasource(
+            promDatasourceName,
+            'prometheus',
+            null,
+            label='Data Source',
+            refresh='load'
+          ),
+          template.new(
+            'job',
+            promDatasource,
+            'label_values(ibmmq_queue_average_queue_time_seconds,job)',
+            label='Job',
+            refresh=2,
+            includeAll=true,
+            multi=true,
+            allValues='.+',
+            sort=0
+          ),
+          template.new(
+            'mq_cluster',
+            promDatasource,
+            'label_values(ibmmq_queue_average_queue_time_seconds{job=~"$job"},mq_cluster)',
+            label='MQ cluster',
+            refresh=1,
+            includeAll=true,
+            multi=true,
+            allValues='',
+            sort=0
+          ),
+          template.new(
+            'qmgr',
+            promDatasource,
+            'label_values(ibmmq_queue_average_queue_time_seconds{mq_cluster=~"$mq_cluster"},qmgr)',
+            label='Queue manager',
+            refresh=2,
+            includeAll=true,
+            multi=true,
+            allValues='',
+            sort=0
+          ),
+          template.new(
+            'queue',
+            promDatasource,
+            'label_values(ibmmq_queue_average_queue_time_seconds{qmgr=~"$qmgr"},queue)',
+            label='Queue',
+            refresh=2,
+            includeAll=true,
+            multi=true,
+            allValues='',
+            sort=0
+          ),
+        ]
+      )
+      .addPanels(
+        [
+          averageQueueTimePanel { gridPos: { h: 8, w: 12, x: 0, y: 0 } },
+          expiredMessagesPanel { gridPos: { h: 8, w: 12, x: 12, y: 0 } },
+          depthPanel { gridPos: { h: 8, w: 24, x: 0, y: 8 } },
+          operationsPanel { gridPos: { h: 8, w: 12, x: 0, y: 16 } },
+          operationThroughputPanel { gridPos: { h: 8, w: 12, x: 12, y: 16 } },
+        ]
+      ),
+
+  },
+}

--- a/ibm-mq-mixin/dashboards/queue-overview.libsonnet
+++ b/ibm-mq-mixin/dashboards/queue-overview.libsonnet
@@ -130,7 +130,7 @@ local expiredMessagesPanel = {
         spanNulls: false,
         stacking: {
           group: 'A',
-          mode: 'none',
+          mode: 'normal',
         },
         thresholdsStyle: {
           mode: 'off',
@@ -294,7 +294,7 @@ local operationThroughputPanel = {
         spanNulls: false,
         stacking: {
           group: 'A',
-          mode: 'none',
+          mode: 'normal',
         },
         thresholdsStyle: {
           mode: 'off',
@@ -404,7 +404,7 @@ local operationsPanel = {
         spanNulls: false,
         stacking: {
           group: 'A',
-          mode: 'none',
+          mode: 'normal',
         },
         thresholdsStyle: {
           mode: 'off',

--- a/ibm-mq-mixin/dashboards/queue-overview.libsonnet
+++ b/ibm-mq-mixin/dashboards/queue-overview.libsonnet
@@ -12,6 +12,7 @@ local promDatasource = {
   uid: '${%s}' % promDatasourceName,
 };
 
+
 local averageQueueTimePanel = {
   datasource: promDatasource,
   targets: [
@@ -430,8 +431,12 @@ local operationsPanel = {
   },
   options: {
     legend: {
-      calcs: [],
-      displayMode: 'list',
+      calcs: [
+        'min',
+        'max',
+        'mean',
+      ],
+      displayMode: 'table',
       placement: 'right',
       showLegend: true,
     },
@@ -441,6 +446,7 @@ local operationsPanel = {
     },
   },
 };
+
 
 {
   grafanaDashboards+:: {

--- a/ibm-mq-mixin/dashboards/queue-overview.libsonnet
+++ b/ibm-mq-mixin/dashboards/queue-overview.libsonnet
@@ -1,4 +1,3 @@
-local g = (import 'grafana-builder/grafana.libsonnet');
 local grafana = (import 'grafonnet/grafana.libsonnet');
 local dashboard = grafana.dashboard;
 local template = grafana.template;
@@ -329,6 +328,7 @@ local operationsPanel = {
           },
         ],
       },
+      unit: 'operations',
     },
     overrides: [],
   },
@@ -498,6 +498,13 @@ local operationThroughputPanel = {
           ),
         ]
       )
+      .addLink(grafana.link.dashboards(
+        asDropdown=false,
+        title='Other IBM MQ dashboards',
+        includeVars=true,
+        keepTime=true,
+        tags=($._config.dashboardTags),
+      ))
       .addPanels(
         [
           averageQueueTimePanel { gridPos: { h: 8, w: 12, x: 0, y: 0 } },

--- a/ibm-mq-mixin/dashboards/topics-overview.libsonnet
+++ b/ibm-mq-mixin/dashboards/topics-overview.libsonnet
@@ -1,3 +1,4 @@
+local g = (import 'grafana-builder/grafana.libsonnet');
 local grafana = (import 'grafonnet/grafana.libsonnet');
 local dashboard = grafana.dashboard;
 local template = grafana.template;
@@ -13,7 +14,13 @@ local promDatasource = {
 
 local topicsRow = {
   datasource: promDatasource,
-  targets: [],
+  targets: [
+    prometheus.target(
+      '',
+      datasource=promDatasource,
+      legendFormat='',
+    ),
+  ],
   type: 'row',
   title: 'Topics',
 };
@@ -25,6 +32,7 @@ local topicMessagesReceivedPanel = {
       'ibmmq_topic_messages_received{job=~"$job",mq_cluster=~"$mq_cluster",qmgr=~"$qmgr",topic=~"$topic"}',
       datasource=promDatasource,
       legendFormat='{{mq_cluster}} - {{qmgr}} - {{topic}}',
+      format='time_series',
     ),
   ],
   type: 'timeseries',
@@ -42,7 +50,7 @@ local topicMessagesReceivedPanel = {
         axisPlacement: 'auto',
         barAlignment: 0,
         drawStyle: 'line',
-        fillOpacity: 0,
+        fillOpacity: 10,
         gradientMode: 'none',
         hideFrom: {
           legend: false,
@@ -55,7 +63,7 @@ local topicMessagesReceivedPanel = {
         scaleDistribution: {
           type: 'linear',
         },
-        showPoints: 'auto',
+        showPoints: 'never',
         spanNulls: false,
         stacking: {
           group: 'A',
@@ -84,7 +92,7 @@ local topicMessagesReceivedPanel = {
     legend: {
       calcs: [],
       displayMode: 'list',
-      placement: 'bottom',
+      placement: 'right',
       showLegend: true,
     },
     tooltip: {
@@ -141,7 +149,7 @@ local timeSinceLastMessagePanel = {
     showUnfilled: true,
     valueMode: 'color',
   },
-  pluginVersion: '10.0.2-cloud.1.94a6f396',
+  pluginVersion: '10.0.2',
 };
 
 local topicSubscribersPanel = {
@@ -151,6 +159,7 @@ local topicSubscribersPanel = {
       'ibmmq_topic_subscriber_count{job=~"$job",mq_cluster=~"$mq_cluster",qmgr=~"$qmgr",topic=~"$topic"}',
       datasource=promDatasource,
       legendFormat='{{mq_cluster}} - {{qmgr}} - {{topic}}',
+      format='time_series',
     ),
   ],
   type: 'timeseries',
@@ -168,7 +177,7 @@ local topicSubscribersPanel = {
         axisPlacement: 'auto',
         barAlignment: 0,
         drawStyle: 'line',
-        fillOpacity: 0,
+        fillOpacity: 10,
         gradientMode: 'none',
         hideFrom: {
           legend: false,
@@ -181,7 +190,7 @@ local topicSubscribersPanel = {
         scaleDistribution: {
           type: 'linear',
         },
-        showPoints: 'auto',
+        showPoints: 'never',
         spanNulls: false,
         stacking: {
           group: 'A',
@@ -227,6 +236,7 @@ local topicPublishersPanel = {
       'ibmmq_topic_publisher_count{job=~"$job",mq_cluster=~"$mq_cluster",qmgr=~"$qmgr",topic=~"$topic"}',
       datasource=promDatasource,
       legendFormat='{{mq_cluster}} - {{qmgr}} - {{topic}}',
+      format='time_series',
     ),
   ],
   type: 'timeseries',
@@ -244,7 +254,7 @@ local topicPublishersPanel = {
         axisPlacement: 'auto',
         barAlignment: 0,
         drawStyle: 'line',
-        fillOpacity: 0,
+        fillOpacity: 10,
         gradientMode: 'none',
         hideFrom: {
           legend: false,
@@ -257,7 +267,7 @@ local topicPublishersPanel = {
         scaleDistribution: {
           type: 'linear',
         },
-        showPoints: 'auto',
+        showPoints: 'never',
         spanNulls: false,
         stacking: {
           group: 'A',
@@ -298,7 +308,13 @@ local topicPublishersPanel = {
 
 local subscriptionsRow = {
   datasource: promDatasource,
-  targets: [],
+  targets: [
+    prometheus.target(
+      '',
+      datasource=promDatasource,
+      legendFormat='',
+    ),
+  ],
   type: 'row',
   title: 'Subscriptions',
   collapsed: false,
@@ -311,6 +327,7 @@ local subscriptionMessagesReceivedPanel = {
       'ibmmq_subscription_messsages_received{job=~"$job",mq_cluster=~"$mq_cluster",qmgr=~"$qmgr",subscription=~"$subscription"}',
       datasource=promDatasource,
       legendFormat='{{mq_cluster}} - {{qmgr}} - {{subscription}}',
+      format='time_series',
     ),
   ],
   type: 'timeseries',
@@ -328,7 +345,7 @@ local subscriptionMessagesReceivedPanel = {
         axisPlacement: 'auto',
         barAlignment: 0,
         drawStyle: 'line',
-        fillOpacity: 0,
+        fillOpacity: 10,
         gradientMode: 'none',
         hideFrom: {
           legend: false,
@@ -341,7 +358,7 @@ local subscriptionMessagesReceivedPanel = {
         scaleDistribution: {
           type: 'linear',
         },
-        showPoints: 'auto',
+        showPoints: 'never',
         spanNulls: false,
         stacking: {
           group: 'A',
@@ -370,7 +387,7 @@ local subscriptionMessagesReceivedPanel = {
     legend: {
       calcs: [],
       displayMode: 'list',
-      placement: 'bottom',
+      placement: 'right',
       showLegend: true,
     },
     tooltip: {
@@ -444,7 +461,7 @@ local subscriptionStatusPanel = {
       },
     ],
   },
-  pluginVersion: '10.0.2-cloud.1.94a6f396',
+  pluginVersion: '10.0.2',
   transformations: [
     {
       id: 'organize',
@@ -549,7 +566,7 @@ local subscriptionStatusPanel = {
             promDatasource,
             'label_values(ibmmq_topic_messages_received,job)',
             label='Job',
-            refresh=1,
+            refresh=2,
             includeAll=false,
             multi=false,
             allValues='',
@@ -560,7 +577,7 @@ local subscriptionStatusPanel = {
             promDatasource,
             'label_values(ibmmq_topic_messages_received{job=~"$job"},mq_cluster)',
             label='MQ cluster',
-            refresh=1,
+            refresh=2,
             includeAll=false,
             multi=false,
             allValues='',
@@ -571,7 +588,7 @@ local subscriptionStatusPanel = {
             promDatasource,
             'label_values(ibmmq_topic_messages_received{mq_cluster=~"$mq_cluster"},qmgr)',
             label='Queue manager',
-            refresh=1,
+            refresh=2,
             includeAll=false,
             multi=false,
             allValues='',
@@ -582,7 +599,7 @@ local subscriptionStatusPanel = {
             promDatasource,
             'label_values(ibmmq_topic_subscriber_count{qmgr=~"$qmgr",topic!~"SYSTEM.*|\\\\$SYS.*|"},topic)',
             label='Topic',
-            refresh=1,
+            refresh=2,
             includeAll=true,
             multi=true,
             allValues='',
@@ -593,7 +610,7 @@ local subscriptionStatusPanel = {
             promDatasource,
             'label_values(ibmmq_subscription_messsages_received{qmgr=~"$qmgr",subscription!~"SYSTEM.*|"},subscription)',
             label='Subscription',
-            refresh=1,
+            refresh=2,
             includeAll=true,
             multi=true,
             allValues='',
@@ -601,13 +618,6 @@ local subscriptionStatusPanel = {
           ),
         ]
       )
-      .addLink(grafana.link.dashboards(
-        asDropdown=false,
-        title='Other IBM MQ dashboards',
-        includeVars=true,
-        keepTime=true,
-        tags=($._config.dashboardTags),
-      ))
       .addPanels(
         [
           topicsRow { gridPos: { h: 1, w: 24, x: 0, y: 0 } },
@@ -620,6 +630,5 @@ local subscriptionStatusPanel = {
           subscriptionStatusPanel { gridPos: { h: 10, w: 24, x: 0, y: 20 } },
         ]
       ),
-
   },
 }

--- a/ibm-mq-mixin/dashboards/topics-overview.libsonnet
+++ b/ibm-mq-mixin/dashboards/topics-overview.libsonnet
@@ -1,4 +1,3 @@
-local g = (import 'grafana-builder/grafana.libsonnet');
 local grafana = (import 'grafonnet/grafana.libsonnet');
 local dashboard = grafana.dashboard;
 local template = grafana.template;
@@ -581,7 +580,7 @@ local subscriptionStatusPanel = {
           template.new(
             'topic',
             promDatasource,
-            'label_values(ibmmq_topic_subscriber_count{qmgr=~"$qmgr",topic!~"SYSTEM.*|\\$SYS.*|"},topic)',
+            'label_values(ibmmq_topic_subscriber_count{qmgr=~"$qmgr",topic!~"SYSTEM.*|\\\\$SYS.*|"},topic)',
             label='Topic',
             refresh=1,
             includeAll=true,
@@ -602,6 +601,13 @@ local subscriptionStatusPanel = {
           ),
         ]
       )
+      .addLink(grafana.link.dashboards(
+        asDropdown=false,
+        title='Other IBM MQ dashboards',
+        includeVars=true,
+        keepTime=true,
+        tags=($._config.dashboardTags),
+      ))
       .addPanels(
         [
           topicsRow { gridPos: { h: 1, w: 24, x: 0, y: 0 } },

--- a/ibm-mq-mixin/dashboards/topics-overview.libsonnet
+++ b/ibm-mq-mixin/dashboards/topics-overview.libsonnet
@@ -578,9 +578,9 @@ local subscriptionStatusPanel = {
             'label_values(ibmmq_topic_messages_received{job=~"$job"},mq_cluster)',
             label='MQ cluster',
             refresh=2,
-            includeAll=false,
-            multi=false,
-            allValues='',
+            includeAll=true,
+            multi=true,
+            allValues='.+',
             sort=0
           ),
           template.new(

--- a/ibm-mq-mixin/dashboards/topics-overview.libsonnet
+++ b/ibm-mq-mixin/dashboards/topics-overview.libsonnet
@@ -1,0 +1,619 @@
+local g = (import 'grafana-builder/grafana.libsonnet');
+local grafana = (import 'grafonnet/grafana.libsonnet');
+local dashboard = grafana.dashboard;
+local template = grafana.template;
+local prometheus = grafana.prometheus;
+
+local dashboardUid = 'ibm-mq-topics-overview';
+
+local promDatasourceName = 'prometheus_datasource';
+
+local promDatasource = {
+  uid: '${%s}' % promDatasourceName,
+};
+
+local topicsRow = {
+  datasource: promDatasource,
+  targets: [],
+  type: 'row',
+  title: 'Topics',
+};
+
+local topicMessagesReceivedPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'ibmmq_topic_messages_received{job=~"$job",mq_cluster=~"$mq_cluster",qmgr=~"$qmgr",topic=~"$topic"}',
+      datasource=promDatasource,
+      legendFormat='{{mq_cluster}} - {{qmgr}} - {{topic}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Topic messages received',
+  description: 'Received messages per topic.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      decimals: 0,
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local timeSinceLastMessagePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'ibmmq_topic_time_since_msg_received{job=~"$job",mq_cluster=~"$mq_cluster",qmgr=~"$qmgr",topic=~"$topic"}',
+      datasource=promDatasource,
+      legendFormat='{{mq_cluster}} - {{qmgr}} - {{topic}}',
+      format='time_series',
+    ),
+  ],
+  type: 'bargauge',
+  title: 'Time since last message',
+  description: 'The time since the topic last received a message.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 's',
+    },
+    overrides: [],
+  },
+  options: {
+    displayMode: 'basic',
+    minVizHeight: 10,
+    minVizWidth: 0,
+    orientation: 'horizontal',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    showUnfilled: true,
+    valueMode: 'color',
+  },
+  pluginVersion: '10.0.2-cloud.1.94a6f396',
+};
+
+local topicSubscribersPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'ibmmq_topic_subscriber_count{job=~"$job",mq_cluster=~"$mq_cluster",qmgr=~"$qmgr",topic=~"$topic"}',
+      datasource=promDatasource,
+      legendFormat='{{mq_cluster}} - {{qmgr}} - {{topic}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Topic subscribers',
+  description: 'The number of subscribers per topic.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      decimals: 0,
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local topicPublishersPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'ibmmq_topic_publisher_count{job=~"$job",mq_cluster=~"$mq_cluster",qmgr=~"$qmgr",topic=~"$topic"}',
+      datasource=promDatasource,
+      legendFormat='{{mq_cluster}} - {{qmgr}} - {{topic}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Topic publishers',
+  description: 'The number of publishers per topic.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      decimals: 0,
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local subscriptionsRow = {
+  datasource: promDatasource,
+  targets: [],
+  type: 'row',
+  title: 'Subscriptions',
+  collapsed: false,
+};
+
+local subscriptionMessagesReceivedPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'ibmmq_subscription_messsages_received{job=~"$job",mq_cluster=~"$mq_cluster",qmgr=~"$qmgr",subscription=~"$subscription"}',
+      datasource=promDatasource,
+      legendFormat='{{mq_cluster}} - {{qmgr}} - {{subscription}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Subscription messages received',
+  description: 'The number of messages a subscription receives.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      decimals: 0,
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+  transformations: [],
+};
+
+local subscriptionStatusPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'ibmmq_subscription_time_since_message_published{job=~"$job",mq_cluster=~"$mq_cluster",qmgr=~"$qmgr",subscription=~"$subscription"}',
+      datasource=promDatasource,
+      legendFormat='{{label_name}}',
+      format='table',
+    ),
+  ],
+  type: 'table',
+  title: 'Subscription status',
+  description: 'A table for at a glance information about a subscription.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      custom: {
+        align: 'center',
+        cellOptions: {
+          type: 'auto',
+        },
+        filterable: false,
+        inspect: false,
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 's',
+    },
+    overrides: [],
+  },
+  options: {
+    cellHeight: 'sm',
+    footer: {
+      countRows: false,
+      enablePagination: false,
+      fields: '',
+      reducer: [
+        'sum',
+      ],
+      show: false,
+    },
+    showHeader: true,
+    sortBy: [
+      {
+        desc: false,
+        displayName: 'subid',
+      },
+    ],
+  },
+  pluginVersion: '10.0.2-cloud.1.94a6f396',
+  transformations: [
+    {
+      id: 'organize',
+      options: {
+        excludeByName: {
+          Time: true,
+          __name__: true,
+          instance: true,
+          job: true,
+          platform: true,
+          subid: true,
+          type: false,
+        },
+        indexByName: {
+          Time: 6,
+          Value: 5,
+          __name__: 7,
+          instance: 8,
+          job: 9,
+          mq_cluster: 1,
+          platform: 10,
+          qmgr: 0,
+          subid: 11,
+          subscription: 2,
+          topic: 4,
+          type: 3,
+        },
+        renameByName: {},
+      },
+    },
+    {
+      id: 'groupBy',
+      options: {
+        fields: {
+          Value: {
+            aggregations: [
+              'last',
+            ],
+            operation: 'aggregate',
+          },
+          mq_cluster: {
+            aggregations: [],
+            operation: 'groupby',
+          },
+          qmgr: {
+            aggregations: [],
+            operation: 'groupby',
+          },
+          subscription: {
+            aggregations: [],
+            operation: 'groupby',
+          },
+          topic: {
+            aggregations: [],
+            operation: 'groupby',
+          },
+          type: {
+            aggregations: [],
+            operation: 'groupby',
+          },
+        },
+      },
+    },
+    {
+      id: 'organize',
+      options: {
+        excludeByName: {},
+        indexByName: {},
+        renameByName: {
+          'Value (last)': 'Time since last subscription message',
+          'Value (lastNotNull)': 'Time since last subscription message',
+        },
+      },
+    },
+  ],
+};
+
+{
+  grafanaDashboards+:: {
+    'ibm-mq-topics-overview.json':
+      dashboard.new(
+        'IBM MQ topics overview',
+        time_from='%s' % $._config.dashboardPeriod,
+        tags=($._config.dashboardTags),
+        timezone='%s' % $._config.dashboardTimezone,
+        refresh='%s' % $._config.dashboardRefresh,
+        description='',
+        uid=dashboardUid,
+      )
+
+      .addTemplates(
+        [
+          template.datasource(
+            promDatasourceName,
+            'prometheus',
+            null,
+            label='Data Source',
+            refresh='load'
+          ),
+          template.new(
+            'job',
+            promDatasource,
+            'label_values(ibmmq_topic_messages_received,job)',
+            label='Job',
+            refresh=1,
+            includeAll=false,
+            multi=false,
+            allValues='',
+            sort=0
+          ),
+          template.new(
+            'mq_cluster',
+            promDatasource,
+            'label_values(ibmmq_topic_messages_received{job=~"$job"},mq_cluster)',
+            label='MQ cluster',
+            refresh=1,
+            includeAll=false,
+            multi=false,
+            allValues='',
+            sort=0
+          ),
+          template.new(
+            'qmgr',
+            promDatasource,
+            'label_values(ibmmq_topic_messages_received{mq_cluster=~"$mq_cluster"},qmgr)',
+            label='Queue manager',
+            refresh=1,
+            includeAll=false,
+            multi=false,
+            allValues='',
+            sort=0
+          ),
+          template.new(
+            'topic',
+            promDatasource,
+            'label_values(ibmmq_topic_subscriber_count{qmgr=~"$qmgr",topic!~"SYSTEM.*|\\$SYS.*|"},topic)',
+            label='Topic',
+            refresh=1,
+            includeAll=true,
+            multi=true,
+            allValues='',
+            sort=0
+          ),
+          template.new(
+            'subscription',
+            promDatasource,
+            'label_values(ibmmq_subscription_messsages_received{qmgr=~"$qmgr",subscription!~"SYSTEM.*|"},subscription)',
+            label='Subscription',
+            refresh=1,
+            includeAll=true,
+            multi=true,
+            allValues='',
+            sort=0
+          ),
+        ]
+      )
+      .addPanels(
+        [
+          topicsRow { gridPos: { h: 1, w: 24, x: 0, y: 0 } },
+          topicMessagesReceivedPanel { gridPos: { h: 6, w: 16, x: 0, y: 1 } },
+          timeSinceLastMessagePanel { gridPos: { h: 6, w: 8, x: 16, y: 1 } },
+          topicSubscribersPanel { gridPos: { h: 6, w: 12, x: 0, y: 7 } },
+          topicPublishersPanel { gridPos: { h: 6, w: 12, x: 12, y: 7 } },
+          subscriptionsRow { gridPos: { h: 1, w: 24, x: 0, y: 13 } },
+          subscriptionMessagesReceivedPanel { gridPos: { h: 6, w: 24, x: 0, y: 14 } },
+          subscriptionStatusPanel { gridPos: { h: 10, w: 24, x: 0, y: 20 } },
+        ]
+      ),
+
+  },
+}

--- a/ibm-mq-mixin/dashboards/topics-overview.libsonnet
+++ b/ibm-mq-mixin/dashboards/topics-overview.libsonnet
@@ -67,7 +67,7 @@ local topicMessagesReceivedPanel = {
         spanNulls: false,
         stacking: {
           group: 'A',
-          mode: 'none',
+          mode: 'normal',
         },
         thresholdsStyle: {
           mode: 'off',
@@ -362,7 +362,7 @@ local subscriptionMessagesReceivedPanel = {
         spanNulls: false,
         stacking: {
           group: 'A',
-          mode: 'none',
+          mode: 'normal',
         },
         thresholdsStyle: {
           mode: 'off',

--- a/ibm-mq-mixin/dashboards/topics-overview.libsonnet
+++ b/ibm-mq-mixin/dashboards/topics-overview.libsonnet
@@ -149,7 +149,6 @@ local timeSinceLastMessagePanel = {
     showUnfilled: true,
     valueMode: 'color',
   },
-  pluginVersion: '10.0.2',
 };
 
 local topicSubscribersPanel = {
@@ -461,7 +460,6 @@ local subscriptionStatusPanel = {
       },
     ],
   },
-  pluginVersion: '10.0.2',
   transformations: [
     {
       id: 'organize',

--- a/ibm-mq-mixin/jsonnetfile.json
+++ b/ibm-mq-mixin/jsonnetfile.json
@@ -1,0 +1,15 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/grafonnet-lib.git",
+          "subdir": "grafonnet"
+        }
+      },
+      "version": "master"
+    }
+  ],
+  "legacyImports": true
+}

--- a/ibm-mq-mixin/mixin.libsonnet
+++ b/ibm-mq-mixin/mixin.libsonnet
@@ -1,0 +1,3 @@
+(import 'dashboards/dashboards.libsonnet') +
+(import 'alerts/alerts.libsonnet') +
+(import 'config.libsonnet')


### PR DESCRIPTION
Adds dashboards and alerts for IBM MQ.

Dashboards:

 IBM MQ cluster overview
 IBM MQ queue overview
 IBM MQ queue manager overview
 IBM MQ topics overview

Alerts:

IBMMQStaleMessages
IBMMQStaleMessages
IBMMQLowDiskSpace
IBMMQHighQueueManagerCpuUsage

## Screenshots

## IBM MQ queue manager overview

<img width="1916" alt="image" src="https://github.com/grafana/jsonnet-libs/assets/48131175/d23761c0-c108-4060-bb3f-4ecb30660c31">
<img width="1915" alt="image" src="https://github.com/grafana/jsonnet-libs/assets/48131175/1d4cc67d-3fc2-4a0d-93ab-bd499615cf1a">

## IBM MQ queue overview

![image](https://github.com/grafana/jsonnet-libs/assets/48131175/183772a1-dfe9-41aa-a8ab-bb25696d529d)


## IBM MQ cluster overview

<img width="1917" alt="image" src="https://github.com/grafana/jsonnet-libs/assets/48131175/fa88eb5d-3037-4c0f-b0e7-c6a38415b0e2">

## IBM MQ topics overview

![image](https://github.com/grafana/jsonnet-libs/assets/48131175/686eccd5-0536-4ff7-bc76-3e704df98e21)

