### PR TITLE
Add Apache Hadoop mixin

### DIFF
--- a/apache-hadoop-mixin/.lint
+++ b/apache-hadoop-mixin/.lint
@@ -1,0 +1,30 @@
+exclusions:
+  template-job-rule:
+    reason: "Prometheus datasource variable is being named as prometheus_datasource now while linter expects 'datasource'"
+  panel-datasource-rule:
+    reason: "Loki datasource variable is being named as loki_datasource now while linter expects 'datasource'"
+  template-datasource-rule:
+    reason: "Based on new convention we are using variable names prometheus_datasource and loki_datasource where as linter expects 'datasource'"
+  template-instance-rule:
+    reason: "Based on new convention we are using variable names prometheus_datasource and loki_datasource where as linter expects 'datasource'"
+  panel-units-rule:
+    reason: "Custom units are used for better user experience in these panels"
+    entries:
+    - panel: "Unread blocks evicted"
+    - panel: "Blocks removed"
+    - panel: "Volume failures"
+    - panel: "Total blocks"
+    - panel: "Missing blocks"
+    - panel: "Under-replicated blocks"
+    - panel: "Transactions since last checkpoint"
+    - panel: "Volume failures"
+    - panel: "Total files"
+    - panel: "Total load"
+    - panel: "Applications running"
+    - panel: "Allocated containers"
+    - panel: "Garbage collection count"
+    - panel: "Containers state"
+    - panel: "Containers available virtual cores"
+    - panel: "Applications state"
+    - panel: "Available virtual cores"
+    - panel: "Garbage collection count"

--- a/apache-hadoop-mixin/Makefile
+++ b/apache-hadoop-mixin/Makefile
@@ -1,0 +1,34 @@
+JSONNET_FMT := jsonnetfmt -n 2 --max-blank-lines 1 --string-style s --comment-style s
+
+.PHONY: all
+all: build dashboards_out prometheus_alerts.yaml
+
+vendor: jsonnetfile.json
+	jb install
+
+.PHONY: build
+build: vendor
+
+.PHONY: fmt
+fmt:
+	find . -name 'vendor' -prune -o -name '*.libsonnet' -print -o -name '*.jsonnet' -print | \
+		xargs -n 1 -- $(JSONNET_FMT) -i
+
+.PHONY: lint
+lint: build
+	find . -name 'vendor' -prune -o -name '*.libsonnet' -print -o -name '*.jsonnet' -print | \
+		while read f; do \
+			$(JSONNET_FMT) "$$f" | diff -u "$$f" -; \
+		done
+	mixtool lint mixin.libsonnet
+
+dashboards_out: mixin.libsonnet config.libsonnet $(wildcard dashboards/*)
+	@mkdir -p dashboards_out
+	mixtool generate dashboards mixin.libsonnet -d dashboards_out
+
+prometheus_alerts.yaml: mixin.libsonnet alerts/*.libsonnet
+	mixtool generate alerts mixin.libsonnet -a prometheus_alerts.yaml
+
+.PHONY: clean
+clean:
+	rm -rf dashboards_out prometheus_alerts.yaml

--- a/apache-hadoop-mixin/README.md
+++ b/apache-hadoop-mixin/README.md
@@ -49,7 +49,7 @@ The Apache Hadoop ResourceManager overview dashboard provides details on Node Ma
 
 ## Logging
 
-To get Apache Hadoop NameNode, DataNode, NodeManager or ResourceManager logs on the related dashboard, [Promtail and Loki needs to be installed](https://grafana.com/docs/loki/latest/installation/) and provisioned for logs with your Grafana instance. The default Apache Hadoop log path is indicated in the `HADDOP_LOG_DIR` for your system located in `/etc/hadoop/conf`. An example log path may look like `/var/log/hadoop/hdfs/*.log` on Linux.
+To get Apache Hadoop NameNode, DataNode, NodeManager or ResourceManager logs on the related dashboard, [Promtail and Loki needs to be installed](https://grafana.com/docs/loki/latest/installation/) and provisioned for logs with your Grafana instance. The default Apache Hadoop log path is indicated in the `HADDOP_LOG_DIR` for your system located in `/etc/hadoop/conf`. An example log path may look like `/hadoop/logs/*.log` on Linux.
 
 Hadoop NameNode, DataNode, NodeManager and ResourceManager logs are enabled by default in the `config.libsonnet` and can be removed by setting `enableLokiLogs` to `false`. Then run `make` again to regenerate the dashboard:
 

--- a/apache-hadoop-mixin/README.md
+++ b/apache-hadoop-mixin/README.md
@@ -1,4 +1,4 @@
-# Apache Hadoop Mixin
+# Apache Hadoop mixin
 
 The Apache Hadoop mixin is a set of configurable Grafana dashboards and alerts.
 
@@ -20,27 +20,27 @@ and the following alerts:
 - ApacheHadoopHighResourceManagerVirtualCoreCPUUsage
 - ApacheHadoopHighResourceManagerMemoryUsage
 
-## Apache Hadoop NameNode Overview
+## Apache Hadoop NameNode overview
 
 The Apache Hadoop NameNode overview dashboard provides details on all DataNode state, capacity utilization, total, missing and under-replicated blocks, volume failures, total file and total load.
 
 ![First screenshot of the Apache Hadoop NameNode overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-hadoop/screenshots/hadoop_namenode_overview_1.png)
 ![Second screenshot of the Apache Hadoop NameNode overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-hadoop/screenshots/hadoop_namenode_overview_2.png)
 
-## Apache Hadoop DataNode Overview
+## Apache Hadoop DataNode overview
 
 The Apache Hadoop DataNode overview dashboard provides details on the number of unread blocks evicted, blocks removed and volume failures.
 
 ![First screenshot of the Apache Hadoop DataNode overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-hadoop/screenshots/hadoop_datanode_overview_1.png)
 
-## Apache Hadoop NodeManager Overview
+## Apache Hadoop NodeManager overview
 
 The Apache Hadoop NodeManager overview dashboard provides details on number of applications running, allocated containers, containers localization duration, launch duration and state, JVM resource metrics, Node resource metrics and container resource metrics.
 
 ![First screenshot of the Apache Hadoop NodeManager overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-hadoop/screenshots/hadoop_nodemanager_overview_1.png)
 ![Second screenshot of the Apache Hadoop NodeManager overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-hadoop/screenshots/hadoop_nodemanager_overview_2.png)
 
-## Apache ResourceManager Overview
+## Apache ResourceManager overview
 
 The Apache Hadoop ResourceManager overview dashboard provides details on Node Managers state, application state and resource metrics and JVM resource metrics.
 
@@ -75,7 +75,7 @@ scrape_configs:
           __path__: '<your-log-path>'
 ```
 
-## Alerts Overview
+## Alerts overview
 
 ApacheHadoopLowHDFSCapacity - Remaining HDFS cluster capacity is low which may result in DataNode failures or prevent DataNodes from writing data.
 ApacheHadoopHDFSMissingBlocks - There are missing blocks in the HDFS cluster which may indicate potential data loss.

--- a/apache-hadoop-mixin/README.md
+++ b/apache-hadoop-mixin/README.md
@@ -49,7 +49,7 @@ The Apache Hadoop ResourceManager overview dashboard provides details on Node Ma
 
 ## Logging
 
-To get Apache Hadoop NameNode, DataNode, NodeManager or ResourceManager logs on the related dashboard, [Promtail and Loki needs to be installed](https://grafana.com/docs/loki/latest/installation/) and provisioned for logs with your Grafana instance. The default Apache Hadoop log path is is indicated in the `HADDOP_LOG_DIR` for your system located in `/etc/hadoop/conf`. An example log path may look like `/var/log/hadoop/hdfs/*.log` on Linux.
+To get Apache Hadoop NameNode, DataNode, NodeManager or ResourceManager logs on the related dashboard, [Promtail and Loki needs to be installed](https://grafana.com/docs/loki/latest/installation/) and provisioned for logs with your Grafana instance. The default Apache Hadoop log path is indicated in the `HADDOP_LOG_DIR` for your system located in `/etc/hadoop/conf`. An example log path may look like `/var/log/hadoop/hdfs/*.log` on Linux.
 
 Hadoop NameNode, DataNode, NodeManager and ResourceManager logs are enabled by default in the `config.libsonnet` and can be removed by setting `enableLokiLogs` to `false`. Then run `make` again to regenerate the dashboard:
 

--- a/apache-hadoop-mixin/README.md
+++ b/apache-hadoop-mixin/README.md
@@ -86,17 +86,14 @@ ApacheHadoopHighNodeManagerMemoryUsage - A NodeManager has a higher memory utili
 ApacheHadoopHighResourceManagerVirtualCoreCPUUsage - A ResourceManager has a virtual core CPU usage higher than the configured threshold.
 ApacheHadoopHighResourceManagerMemoryUsage - A ResourceManager has a higher memory utilization than the configured threshold.
 
-## Install tools
+## Install Tools
+
+For linting and formatting, you would also need `mixtool` and `jsonnetfmt` installed. If you
+have a working Go development environment, it's easiest to run the following:
 
 ```bash
 go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@latest
 go install github.com/monitoring-mixins/mixtool/cmd/mixtool@latest
-```
-
-For linting and formatting, you would also need `jsonnetfmt` installed. If you
-have a working Go development environment, it's easiest to run the following:
-
-```bash
 go install github.com/google/go-jsonnet/cmd/jsonnetfmt@latest
 ```
 
@@ -105,7 +102,7 @@ into your Grafana server. The exact details will be depending on your environmen
 
 `prometheus_alerts.yaml` needs to be imported into Prometheus.
 
-## Generate dashboards and alerts
+# Generate Dashboards And Alerts
 
 Edit `config.libsonnet` if required and then build JSON dashboard files for Grafana:
 

--- a/apache-hadoop-mixin/README.md
+++ b/apache-hadoop-mixin/README.md
@@ -1,0 +1,117 @@
+# Apache Hadoop Mixin
+
+The Apache Hadoop mixin is a set of configurable Grafana dashboards and alerts.
+
+The Apache Hadoop mixin contains the following dashboards:
+
+- Apache Hadoop NameNode overview
+- Apache Hadoop DataNode overview
+- Apache Hadoop NodeManager overview
+- Apache Hadoop ResourceManager overview
+
+and the following alerts:
+
+- ApacheHadoopLowHDFSCapacity
+- ApacheHadoopHDFSMissingBlocks
+- ApacheHadoopHDFSHighVolumeFailures
+- ApacheHadoopHighDeadDataNodes
+- ApacheHadoopHighNodeManagerCPUUsage
+- ApacheHadoopHighNodeManagerMemoryUsage
+- ApacheHadoopHighResourceManagerVirtualCoreCPUUsage
+- ApacheHadoopHighResourceManagerMemoryUsage
+
+## Apache Hadoop NameNode Overview
+
+The Apache Hadoop NameNode overview dashboard provides details on all DataNode state, capacity utilization, total, missing and under-replicated blocks, volume failures, total file and total load.
+
+![First screenshot of the Apache Hadoop NameNode overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-hadoop/screenshots/hadoop_namenode_overview_1.png)
+![Second screenshot of the Apache Hadoop NameNode overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-hadoop/screenshots/hadoop_namenode_overview_2.png)
+
+## Apache Hadoop DataNode Overview
+
+The Apache Hadoop DataNode overview dashboard provides details on the number of unread blocks evicted, blocks removed and volume failures.
+
+![First screenshot of the Apache Hadoop DataNode overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-hadoop/screenshots/hadoop_datanode_overview_1.png)
+
+## Apache Hadoop NodeManager Overview
+
+The Apache Hadoop NodeManager overview dashboard provides details on number of applications running, allocated containers, containers localization duration, launch duration and state, JVM resource metrics, Node resource metrics and container resource metrics.
+
+![First screenshot of the Apache Hadoop NodeManager overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-hadoop/screenshots/hadoop_nodemanager_overview_1.png)
+![Second screenshot of the Apache Hadoop NodeManager overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-hadoop/screenshots/hadoop_nodemanager_overview_2.png)
+
+## Apache ResourceManager Overview
+
+The Apache Hadoop ResourceManager overview dashboard provides details on Node Managers state, application state and resource metrics and JVM resource metrics.
+
+![First screenshot of the Apache Hadoop ResourceManager overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-hadoop/screenshots/hadoop_resourcemanager_overview_1.png)
+![Second screenshot of the Apache Hadoop ResourceManager overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-hadoop/screenshots/hadoop_resourcemanager_overview_2.png)
+
+## Logging
+
+To get Apache Hadoop NameNode, DataNode, NodeManager or ResourceManager logs on the related dashboard, [Promtail and Loki needs to be installed](https://grafana.com/docs/loki/latest/installation/) and provisioned for logs with your Grafana instance. The default Apache Hadoop log path is is indicated in the `HADDOP_LOG_DIR` for your system located in `/etc/hadoop/conf`. An example log path may look like `/var/log/hadoop/hdfs/*.log` on Linux.
+
+Hadoop NameNode, DataNode, NodeManager and ResourceManager logs are enabled by default in the `config.libsonnet` and can be removed by setting `enableLokiLogs` to `false`. Then run `make` again to regenerate the dashboard:
+
+```
+{
+  _config+:: {
+    enableLokiLogs: false,
+  },
+}
+```
+
+In order for the selectors to properly work for system logs ingested into your logs datasource, please also include the matching `instance`, `job`, and `hadoop_cluster` labels onto the [scrape_configs](https://grafana.com/docs/loki/latest/clients/promtail/configuration/#scrape_configs) as to match the labels for ingested metrics.
+
+```yaml
+scrape_configs:
+  - job_name: integrations/apache-hadoop
+    static_configs:
+      - targets: [localhost]
+        labels:
+          job: integrations/apache-hadoop
+          instance: '<your-instance-name>'
+          hadoop_cluster: '<your-cluster-name>'
+          __path__: '<your-log-path>'
+```
+
+## Alerts Overview
+
+ApacheHadoopLowHDFSCapacity - Remaining HDFS cluster capacity is low which may result in DataNode failures or prevent DataNodes from writing data.
+ApacheHadoopHDFSMissingBlocks - There are missing blocks in the HDFS cluster which may indicate potential data loss.
+ApacheHadoopHDFSHighVolumeFailures - A volume failure in HDFS cluster may indicate hardware failures.
+ApacheHadoopHighDeadDataNodes - Number of dead DataNodes has increased, which could result in data loss and increased network activity.
+ApacheHadoopHighNodeManagerCPUUsage - A NodeManager has a CPU usage higher than the configured threshold.
+ApacheHadoopHighNodeManagerMemoryUsage - A NodeManager has a higher memory utilization than the configured threshold.
+ApacheHadoopHighResourceManagerVirtualCoreCPUUsage - A ResourceManager has a virtual core CPU usage higher than the configured threshold.
+ApacheHadoopHighResourceManagerMemoryUsage - A ResourceManager has a higher memory utilization than the configured threshold.
+
+## Install tools
+
+```bash
+go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@latest
+go install github.com/monitoring-mixins/mixtool/cmd/mixtool@latest
+```
+
+For linting and formatting, you would also need `jsonnetfmt` installed. If you
+have a working Go development environment, it's easiest to run the following:
+
+```bash
+go install github.com/google/go-jsonnet/cmd/jsonnetfmt@latest
+```
+
+The files in `dashboards_out` need to be imported
+into your Grafana server. The exact details will be depending on your environment.
+
+`prometheus_alerts.yaml` needs to be imported into Prometheus.
+
+## Generate dashboards and alerts
+
+Edit `config.libsonnet` if required and then build JSON dashboard files for Grafana:
+
+```bash
+make
+```
+
+For more advanced uses of mixins, see
+https://github.com/monitoring-mixins/docs.

--- a/apache-hadoop-mixin/alerts/alerts.libsonnet
+++ b/apache-hadoop-mixin/alerts/alerts.libsonnet
@@ -27,7 +27,7 @@
             expr: |||
               max without(job, name) (hadoop_namenode_missingblocks) > %(alertsCriticalHDFSMissingBlocks)s
             ||| % $._config,
-            'for': '1m',
+            'for': '5m',
             labels: {
               severity: 'critical',
             },
@@ -45,7 +45,7 @@
             expr: |||
               max without(job, name) (hadoop_namenode_volumefailurestotal) > %(alertsCriticalHDFSVolumeFailures)s
             ||| % $._config,
-            'for': '1m',
+            'for': '5m',
             labels: {
               severity: 'critical',
             },
@@ -63,7 +63,7 @@
             expr: |||
               max without(job, name) (hadoop_namenode_numdeaddatanodes) > %(alertsCriticalDeadDataNodes)s
             ||| % $._config,
-            'for': '1m',
+            'for': '5m',
             labels: {
               severity: 'critical',
             },

--- a/apache-hadoop-mixin/alerts/alerts.libsonnet
+++ b/apache-hadoop-mixin/alerts/alerts.libsonnet
@@ -1,0 +1,155 @@
+{
+  prometheusAlerts+:: {
+    groups+: [
+      {
+        name: 'apache-hadoop',
+        rules: [
+          {
+            alert: 'ApacheHadoopLowHDFSCapacity',
+            expr: |||
+              min without(job, name) (100 * hadoop_namenode_capacityremaining / clamp_min(hadoop_namenode_capacitytotal, 1)) < %(alertsWarningHDFSCapacity)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              summary: 'Remaining HDFS cluster capacity is low which may result in DataNode failures or prevent DataNodes from writing data.',
+              description:
+                (
+                  '{{ printf "%%.0f" $value }} percent remaining HDFS usage on {{$labels.hadoop_cluster}} - {{$labels.instance}}, ' +
+                  'which is below the threshold of %(alertsWarningHDFSCapacity)s.'
+                ) % $._config,
+            },
+          },
+          {
+            alert: 'ApacheHadoopHDFSMissingBlocks',
+            expr: |||
+              max without(job, name) (hadoop_namenode_missingblocks) > %(alertsCriticalHDFSMissingBlocks)s
+            ||| % $._config,
+            'for': '1m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              summary: 'There are missing blocks in the HDFS cluster which may indicate potential data loss.',
+              description:
+                (
+                  '{{ printf "%%.0f" $value }} HDFS missing blocks on {{$labels.hadoop_cluster}} - {{$labels.instance}}, ' +
+                  'which is above the threshold of %(alertsCriticalHDFSMissingBlocks)s.'
+                ) % $._config,
+            },
+          },
+          {
+            alert: 'ApacheHadoopHDFSHighVolumeFailures',
+            expr: |||
+              max without(job, name) (hadoop_namenode_volumefailurestotal) > %(alertsCriticalHDFSVolumeFailures)s
+            ||| % $._config,
+            'for': '1m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              summary: 'A volume failure in HDFS cluster may indicate hardware failures.',
+              description:
+                (
+                  '{{ printf "%%.0f" $value }} HDFS volume failures on {{$labels.hadoop_cluster}} - {{$labels.instance}}, ' +
+                  'which is above the threshold of %(alertsCriticalHDFSVolumeFailures)s.'
+                ) % $._config,
+            },
+          },
+          {
+            alert: 'ApacheHadoopHighDeadDataNodes',
+            expr: |||
+              max without(job, name) (hadoop_namenode_numdeaddatanodes) > %(alertsCriticalDeadDataNodes)s
+            ||| % $._config,
+            'for': '1m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              summary: 'Number of dead DataNodes has increased, which could result in data loss and increased network activity.',
+              description:
+                (
+                  '{{ printf "%%.0f" $value }} dead HDFS volume failures on {{$labels.hadoop_cluster}} - {{$labels.instance}}, ' +
+                  'which is above the threshold of %(alertsCriticalDeadDataNodes)s.'
+                ) % $._config,
+            },
+          },
+          {
+            alert: 'ApacheHadoopHighNodeManagerCPUUsage',
+            expr: |||
+              max without(job, name) (100 * hadoop_nodemanager_nodecpuutilization) > %(alertsCriticalNodeManagerCPUUsage)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              summary: 'A NodeManager has a CPU usage higher than the configured threshold.',
+              description:
+                (
+                  '{{ printf "%%.0f" $value }} CPU usage on {{$labels.hadoop_cluster}} - {{$labels.instance}}, ' +
+                  'which is above the threshold of %(alertsCriticalNodeManagerCPUUsage)s.'
+                ) % $._config,
+            },
+          },
+          {
+            alert: 'ApacheHadoopHighNodeManagerMemoryUsage',
+            expr: |||
+              max without(job, name) (100 * hadoop_nodemanager_allocatedgb / clamp_min(hadoop_nodemanager_availablegb + hadoop_nodemanager_allocatedgb,1)) > %(alertsCriticalNodeManagerMemoryUsage)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              summary: 'A NodeManager has a higher memory utilization than the configured threshold.',
+              description:
+                (
+                  '{{ printf "%%.0f" $value}} percent NodeManager memory usage on {{$labels.hadoop_cluster}} - {{$labels.instance}}, ' +
+                  'which is above the threshold of %(alertsCriticalNodeManagerMemoryUsage)s.'
+                ) % $._config,
+            },
+          },
+          {
+            alert: 'ApacheHadoopHighResourceManagerVirtualCoreCPUUsage',
+            expr: |||
+              max without(job, name) (100 * hadoop_resourcemanager_allocatedvcores / clamp_min(hadoop_resourcemanager_availablevcores + hadoop_resourcemanager_allocatedvcores,1)) > %(alertsCriticalResourceManagerVCoreCPUUsage)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              summary: 'A ResourceManager has a virtual core CPU usage higher than the configured threshold.',
+              description:
+                (
+                  '{{ printf "%%.0f" $value }} virtual core CPU usage on {{$labels.hadoop_cluster}} - {{$labels.instance}}, ' +
+                  'which is above the threshold of %(alertsCriticalResourceManagerVCoreCPUUsage)s.'
+                ) % $._config,
+            },
+          },
+          {
+            alert: 'ApacheHadoopHighResourceManagerMemoryUsage',
+            expr: |||
+              max without(job, name) (100 * hadoop_resourcemanager_allocatedmb / clamp_min(hadoop_resourcemanager_availablemb + hadoop_resourcemanager_allocatedmb,1)) > %(alertsCriticalResourceManagerMemoryUsage)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              summary: 'A ResourceManager has a higher memory utilization than the configured threshold.',
+              description:
+                (
+                  '{{ printf "%%.0f" $value}} percent ResourceManager memory usage on {{$labels.hadoop_cluster}} - {{$labels.instance}}, ' +
+                  'which is above the threshold of %(alertsCriticalResourceManagerMemoryUsage)s.'
+                ) % $._config,
+            },
+          },
+        ],
+      },
+    ],
+  },
+}

--- a/apache-hadoop-mixin/config.libsonnet
+++ b/apache-hadoop-mixin/config.libsonnet
@@ -1,0 +1,20 @@
+{
+  _config+:: {
+    dashboardTags: ['apache-hadoop-mixin'],
+    dashboardPeriod: 'now-1h',
+    dashboardTimezone: 'default',
+    dashboardRefresh: '1m',
+
+    // alerts thresholds
+    alertsWarningHDFSCapacity: 20,  // %
+    alertsCriticalHDFSMissingBlocks: 0,  // count
+    alertsCriticalHDFSVolumeFailures: 0,  // count
+    alertsCriticalDeadDataNodes: 0,  // count
+    alertsCriticalNodeManagerCPUUsage: 80,  // %
+    alertsCriticalNodeManagerMemoryUsage: 80,  // %
+    alertsCriticalResourceManagerVCoreCPUUsage: 80,  // %
+    alertsCriticalResourceManagerMemoryUsage: 80,  // %
+
+    enableLokiLogs: true,
+  },
+}

--- a/apache-hadoop-mixin/dashboards/dashboards.libsonnet
+++ b/apache-hadoop-mixin/dashboards/dashboards.libsonnet
@@ -1,0 +1,4 @@
+(import 'hadoop-namenode-overview.libsonnet') +
+(import 'hadoop-datanode-overview.libsonnet') +
+(import 'hadoop-nodemanager-overview.libsonnet') +
+(import 'hadoop-resourcemanager-overview.libsonnet')

--- a/apache-hadoop-mixin/dashboards/hadoop-datanode-overview.libsonnet
+++ b/apache-hadoop-mixin/dashboards/hadoop-datanode-overview.libsonnet
@@ -299,7 +299,13 @@ local datanodeLogsPanel = {
         description='',
         uid=dashboardUid,
       )
-
+      .addLink(grafana.link.dashboards(
+        asDropdown=false,
+        title='Other Apache Hadoop dashboards',
+        includeVars=true,
+        keepTime=true,
+        tags=($._config.dashboardTags),
+      ))
       .addTemplates(
         std.flattenArrays([
           [

--- a/apache-hadoop-mixin/dashboards/hadoop-datanode-overview.libsonnet
+++ b/apache-hadoop-mixin/dashboards/hadoop-datanode-overview.libsonnet
@@ -1,4 +1,3 @@
-local g = (import 'grafana-builder/grafana.libsonnet');
 local grafana = (import 'grafonnet/grafana.libsonnet');
 local dashboard = grafana.dashboard;
 local template = grafana.template;

--- a/apache-hadoop-mixin/dashboards/hadoop-datanode-overview.libsonnet
+++ b/apache-hadoop-mixin/dashboards/hadoop-datanode-overview.libsonnet
@@ -1,0 +1,377 @@
+local g = (import 'grafana-builder/grafana.libsonnet');
+local grafana = (import 'grafonnet/grafana.libsonnet');
+local dashboard = grafana.dashboard;
+local template = grafana.template;
+local prometheus = grafana.prometheus;
+
+local dashboardUid = 'apache-hadoop-datanode-overview';
+
+local promDatasourceName = 'prometheus_datasource';
+local lokiDatasourceName = 'loki_datasource';
+
+local promDatasource = {
+  uid: '${%s}' % promDatasourceName,
+};
+
+local lokiDatasource = {
+  uid: '${%s}' % lokiDatasourceName,
+};
+
+local datanodesRow = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      '',
+      datasource=promDatasource,
+      legendFormat='',
+    ),
+  ],
+  type: 'row',
+  title: 'DataNodes',
+  collapsed: false,
+};
+
+local unreadBlocksEvictedPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'increase(hadoop_datanode_ramdiskblocksevictedwithoutread{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster"}[$__interval:])',
+      datasource=promDatasource,
+      legendFormat='{{hadoop_cluster}} - {{instance}}',
+      format='time_series',
+      interval='1m',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Unread blocks evicted',
+  description: 'Total number of blocks evicted without being read by the Hadoop DataNode.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: '',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local blocksRemovedPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'increase(hadoop_datanode_blocksremoved{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster"}[$__interval:])',
+      datasource=promDatasource,
+      legendFormat='{{hadoop_cluster}} - {{instance}}',
+      format='time_series',
+      interval='1m',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Blocks removed',
+  description: 'Total number of blocks removed by the Hadoop DataNode.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: '',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local volumeFailuresPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'increase(hadoop_datanode_volumefailures{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster"}[$__interval:])',
+      datasource=promDatasource,
+      legendFormat='{{hadoop_cluster}} - {{instance}}',
+      format='time_series',
+      interval='1m',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Volume failures',
+  description: 'Displays the total number of volume failures encountered by the Hadoop DataNode.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: '',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local datanodeLogsPanel = {
+  datasource: lokiDatasource,
+  targets: [
+    {
+      datasource: lokiDatasource,
+      editorMode: 'code',
+      expr: '{job=~"$job", hadoop_cluster=~"$hadoop_cluster", instance=~"$instance", filename=~".*/hadoop/logs/.*-datanode.*\\.log"} |= ``',
+      queryType: 'range',
+      refId: 'A',
+    },
+  ],
+  type: 'logs',
+  title: 'DataNode logs',
+  description: 'The DataNode logs.',
+  options: {
+    dedupStrategy: 'none',
+    enableLogDetails: true,
+    prettifyLogMessage: false,
+    showCommonLabels: false,
+    showLabels: false,
+    showTime: false,
+    sortOrder: 'Descending',
+    wrapLogMessage: false,
+  },
+};
+
+{
+  grafanaDashboards+:: {
+    'apache-hadoop-datanode-overview.json':
+      dashboard.new(
+        'Apache Hadoop DataNode overview',
+        time_from='%s' % $._config.dashboardPeriod,
+        tags=($._config.dashboardTags),
+        timezone='%s' % $._config.dashboardTimezone,
+        refresh='%s' % $._config.dashboardRefresh,
+        description='',
+        uid=dashboardUid,
+      )
+
+      .addTemplates(
+        std.flattenArrays([
+          [
+            template.datasource(
+              promDatasourceName,
+              'prometheus',
+              null,
+              label='Data Source',
+              refresh='load'
+            ),
+          ],
+          if $._config.enableLokiLogs then [
+            template.datasource(
+              lokiDatasourceName,
+              'loki',
+              null,
+              label='Loki Datasource',
+              refresh='load'
+            ),
+          ] else [],
+          [
+            template.new(
+              'job',
+              promDatasource,
+              'label_values(hadoop_datanode_ramdiskblocksevictedwithoutread,job)',
+              label='Job',
+              refresh=2,
+              includeAll=true,
+              multi=true,
+              allValues='.+',
+              sort=1
+            ),
+            template.new(
+              'instance',
+              promDatasource,
+              'label_values(hadoop_datanode_ramdiskblocksevictedwithoutread{job=~"$job"}, instance)',
+              label='Instance',
+              refresh=2,
+              includeAll=true,
+              multi=true,
+              allValues='.+',
+              sort=1
+            ),
+            template.new(
+              'hadoop_cluster',
+              promDatasource,
+              'label_values(hadoop_datanode_ramdiskblocksevictedwithoutread{job=~"$job"}, hadoop_cluster)',
+              label='Hadoop cluster',
+              refresh=2,
+              includeAll=true,
+              multi=true,
+              allValues='.+',
+              sort=1
+            ),
+          ],
+        ])
+      )
+      .addPanels(
+        std.flattenArrays([
+          [
+            datanodesRow { gridPos: { h: 1, w: 24, x: 0, y: 0 } },
+            unreadBlocksEvictedPanel { gridPos: { h: 6, w: 8, x: 0, y: 1 } },
+            blocksRemovedPanel { gridPos: { h: 6, w: 8, x: 8, y: 1 } },
+            volumeFailuresPanel { gridPos: { h: 6, w: 8, x: 16, y: 1 } },
+          ],
+          if $._config.enableLokiLogs then [
+            datanodeLogsPanel { gridPos: { h: 8, w: 24, x: 0, y: 7 } },
+          ] else [],
+          [
+          ],
+        ])
+      ),
+  },
+}

--- a/apache-hadoop-mixin/dashboards/hadoop-datanode-overview.libsonnet
+++ b/apache-hadoop-mixin/dashboards/hadoop-datanode-overview.libsonnet
@@ -267,7 +267,7 @@ local datanodeLogsPanel = {
     {
       datasource: lokiDatasource,
       editorMode: 'code',
-      expr: '{job=~"$job", hadoop_cluster=~"$hadoop_cluster", instance=~"$instance", filename=~".*/hadoop/logs/.*-datanode.*\\.log"} |= ``',
+      expr: '{job=~"$job", hadoop_cluster=~"$hadoop_cluster", instance=~"$instance", filename=~".*/hadoop/logs/.*-datanode.*.log"} |= ``',
       queryType: 'range',
       refId: 'A',
     },

--- a/apache-hadoop-mixin/dashboards/hadoop-namenode-overview.libsonnet
+++ b/apache-hadoop-mixin/dashboards/hadoop-namenode-overview.libsonnet
@@ -720,7 +720,7 @@ local namenodeLogsPanel = {
     {
       datasource: lokiDatasource,
       editorMode: 'code',
-      expr: '{job=~"$job", hadoop_cluster=~"$hadoop_cluster", instance=~"$instance", filename=~".*/hadoop/logs/.*-namenode.*\\.log"} |= ``',
+      expr: "{job=~\"$job\", hadoop_cluster=~\"$hadoop_cluster\", instance=~\"$instance\", filename=~\".*/hadoop/logs/.*-namenode.*.log\"} |= ``",
       queryType: 'range',
       refId: 'A',
     },

--- a/apache-hadoop-mixin/dashboards/hadoop-namenode-overview.libsonnet
+++ b/apache-hadoop-mixin/dashboards/hadoop-namenode-overview.libsonnet
@@ -1,0 +1,835 @@
+local g = (import 'grafana-builder/grafana.libsonnet');
+local grafana = (import 'grafonnet/grafana.libsonnet');
+local dashboard = grafana.dashboard;
+local template = grafana.template;
+local prometheus = grafana.prometheus;
+
+local dashboardUid = 'apache-hadoop-namenode-overview';
+
+local promDatasourceName = 'prometheus_datasource';
+local lokiDatasourceName = 'loki_datasource';
+
+local promDatasource = {
+  uid: '${%s}' % promDatasourceName,
+};
+
+local lokiDatasource = {
+  uid: '${%s}' % lokiDatasourceName,
+};
+
+local datanodeStatePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'hadoop_namenode_numlivedatanodes{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster", name="FSNamesystem"}',
+      datasource=promDatasource,
+      legendFormat='{{hadoop_cluster}} - {{instance}} - live DataNodes',
+    ),
+    prometheus.target(
+      'hadoop_namenode_numdeaddatanodes{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster", name="FSNamesystem"}',
+      datasource=promDatasource,
+      legendFormat='{{hadoop_cluster}} - {{instance}} - dead DataNodes',
+    ),
+    prometheus.target(
+      'hadoop_namenode_numstaledatanodes{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster"}',
+      datasource=promDatasource,
+      legendFormat='{{hadoop_cluster}} - {{instance}} - stale DataNodes',
+    ),
+    prometheus.target(
+      'hadoop_namenode_numdecommissioningdatanodes{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster", name="FSNamesystem"}',
+      datasource=promDatasource,
+      legendFormat='{{hadoop_cluster}} - {{instance}} - decommissioning DataNodes',
+    ),
+  ],
+  type: 'piechart',
+  title: 'DataNode state',
+  description: 'The DataNodes current state.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+      },
+      mappings: [],
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      displayMode: 'table',
+      placement: 'right',
+      showLegend: true,
+    },
+    pieType: 'pie',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local capacityUtilizationPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      '100 * hadoop_namenode_capacityused{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster", name="FSNamesystem"} / clamp_min(hadoop_namenode_capacitytotal{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster", name="FSNamesystem"}, 1)',
+      datasource=promDatasource,
+      legendFormat='{{hadoop_cluster}} - {{instance}}',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Capacity utilization',
+  description: 'The storage utilization of the NameNode.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'percent',
+    },
+    overrides: [
+      {
+        __systemRef: 'hideSeriesFrom',
+        matcher: {
+          id: 'byNames',
+          options: {
+            mode: 'exclude',
+            names: [
+              'hadoop-cluster-0 - instance-0',
+            ],
+            prefix: 'All except:',
+            readOnly: true,
+          },
+        },
+        properties: [
+          {
+            id: 'custom.hideFrom',
+            value: {
+              legend: false,
+              tooltip: false,
+              viz: true,
+            },
+          },
+        ],
+      },
+    ],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local totalBlocksPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'hadoop_namenode_blockstotal{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster", name="FSNamesystem"}',
+      datasource=promDatasource,
+      legendFormat='{{hadoop_cluster}} - {{instance}}',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Total blocks',
+  description: 'Total number of blocks managed by the NameNode.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: '',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local missingBlocksPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'hadoop_namenode_missingblocks{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster", name="FSNamesystem"}',
+      datasource=promDatasource,
+      legendFormat='{{hadoop_cluster}} - {{instance}}',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Missing blocks',
+  description: 'Number of blocks reported by DataNodes as missing.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: '',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local underreplicatedBlocksPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'hadoop_namenode_underreplicatedblocks{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster", name="FSNamesystem"}',
+      datasource=promDatasource,
+      legendFormat='{{hadoop_cluster}} - {{instance}}',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Under-replicated blocks',
+  description: 'Number of blocks that are under-replicated.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: '',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local transactionsSinceLastCheckpointPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'hadoop_namenode_transactionssincelastcheckpoint{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster", name="FSNamesystem"}',
+      datasource=promDatasource,
+      legendFormat='{{hadoop_cluster}} - {{instance}}',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Transactions since last checkpoint',
+  description: 'Number of transactions processed by the NameNode since the last checkpoint.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: '',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local volumeFailuresPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'increase(hadoop_namenode_volumefailurestotal{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster", name="FSNamesystem"}[$__interval:])',
+      datasource=promDatasource,
+      legendFormat='{{hadoop_cluster}} - {{instance}}',
+      format='time_series',
+      interval='1m',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Volume failures',
+  description: 'The recent increase in number of volume failures on all DataNodes.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: '',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local totalFilesPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'hadoop_namenode_filestotal{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster", name="FSNamesystem"}',
+      datasource=promDatasource,
+      legendFormat='{{hadoop_cluster}} - {{instance}}',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Total files',
+  description: 'Total number of files managed by the NameNode.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: '',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local totalLoadPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'hadoop_namenode_totalload{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster", name="FSNamesystem"}',
+      datasource=promDatasource,
+      legendFormat='{{hadoop_cluster}} - {{instance}}',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Total load',
+  description: 'Total load on the NameNode.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: '',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local namenodeLogsPanel = {
+  datasource: lokiDatasource,
+  targets: [
+    {
+      datasource: lokiDatasource,
+      editorMode: 'code',
+      expr: '{job=~"$job", hadoop_cluster=~"$hadoop_cluster", instance=~"$instance", filename=~".*/hadoop/logs/.*-namenode.*\\.log"} |= ``',
+      queryType: 'range',
+      refId: 'A',
+    },
+  ],
+  type: 'logs',
+  title: 'NameNode logs',
+  description: 'The NameNode logs.',
+  options: {
+    dedupStrategy: 'none',
+    enableLogDetails: true,
+    prettifyLogMessage: false,
+    showCommonLabels: false,
+    showLabels: false,
+    showTime: false,
+    sortOrder: 'Descending',
+    wrapLogMessage: false,
+  },
+};
+
+{
+  grafanaDashboards+:: {
+    'apache-hadoop-namenode-overview.json':
+      dashboard.new(
+        'Apache Hadoop NameNode overview',
+        time_from='%s' % $._config.dashboardPeriod,
+        tags=($._config.dashboardTags),
+        timezone='%s' % $._config.dashboardTimezone,
+        refresh='%s' % $._config.dashboardRefresh,
+        description='',
+        uid=dashboardUid,
+      )
+
+      .addTemplates(
+        std.flattenArrays([
+          [
+            template.datasource(
+              promDatasourceName,
+              'prometheus',
+              null,
+              label='Data Source',
+              refresh='load'
+            ),
+          ],
+          if $._config.enableLokiLogs then [
+            template.datasource(
+              lokiDatasourceName,
+              'loki',
+              null,
+              label='Loki Datasource',
+              refresh='load'
+            ),
+          ] else [],
+          [
+            template.new(
+              'job',
+              promDatasource,
+              'label_values(hadoop_namenode_blockstotal,job)',
+              label='Job',
+              refresh=2,
+              includeAll=true,
+              multi=true,
+              allValues='.+',
+              sort=1
+            ),
+            template.new(
+              'instance',
+              promDatasource,
+              'label_values(hadoop_namenode_blockstotal{job=~"$job"}, instance)',
+              label='Instance',
+              refresh=2,
+              includeAll=true,
+              multi=true,
+              allValues='.+',
+              sort=1
+            ),
+            template.new(
+              'hadoop_cluster',
+              promDatasource,
+              'label_values(hadoop_namenode_blockstotal{job=~"$job"}, hadoop_cluster)',
+              label='Hadoop cluster',
+              refresh=2,
+              includeAll=true,
+              multi=true,
+              allValues='.+',
+              sort=1
+            ),
+          ],
+        ])
+      )
+      .addPanels(
+        std.flattenArrays([
+          [
+            datanodeStatePanel { gridPos: { h: 9, w: 12, x: 0, y: 0 } },
+            capacityUtilizationPanel { gridPos: { h: 9, w: 12, x: 12, y: 0 } },
+            totalBlocksPanel { gridPos: { h: 6, w: 8, x: 0, y: 9 } },
+            missingBlocksPanel { gridPos: { h: 6, w: 8, x: 8, y: 9 } },
+            underreplicatedBlocksPanel { gridPos: { h: 6, w: 8, x: 16, y: 9 } },
+            transactionsSinceLastCheckpointPanel { gridPos: { h: 6, w: 12, x: 0, y: 15 } },
+            volumeFailuresPanel { gridPos: { h: 6, w: 12, x: 12, y: 15 } },
+            totalFilesPanel { gridPos: { h: 6, w: 12, x: 0, y: 21 } },
+            totalLoadPanel { gridPos: { h: 6, w: 12, x: 12, y: 21 } },
+          ],
+          if $._config.enableLokiLogs then [
+            namenodeLogsPanel { gridPos: { h: 8, w: 24, x: 0, y: 27 } },
+          ] else [],
+          [
+          ],
+        ])
+      ),
+  },
+}

--- a/apache-hadoop-mixin/dashboards/hadoop-namenode-overview.libsonnet
+++ b/apache-hadoop-mixin/dashboards/hadoop-namenode-overview.libsonnet
@@ -1,4 +1,3 @@
-local g = (import 'grafana-builder/grafana.libsonnet');
 local grafana = (import 'grafonnet/grafana.libsonnet');
 local dashboard = grafana.dashboard;
 local template = grafana.template;

--- a/apache-hadoop-mixin/dashboards/hadoop-namenode-overview.libsonnet
+++ b/apache-hadoop-mixin/dashboards/hadoop-namenode-overview.libsonnet
@@ -752,7 +752,13 @@ local namenodeLogsPanel = {
         description='',
         uid=dashboardUid,
       )
-
+      .addLink(grafana.link.dashboards(
+        asDropdown=false,
+        title='Other Apache Hadoop dashboards',
+        includeVars=true,
+        keepTime=true,
+        tags=($._config.dashboardTags),
+      ))
       .addTemplates(
         std.flattenArrays([
           [

--- a/apache-hadoop-mixin/dashboards/hadoop-nodemanager-overview.libsonnet
+++ b/apache-hadoop-mixin/dashboards/hadoop-nodemanager-overview.libsonnet
@@ -1303,7 +1303,7 @@ local nodemanagerLogsPanel = {
     {
       datasource: lokiDatasource,
       editorMode: 'code',
-      expr: '{job=~"$job", hadoop_cluster=~"$hadoop_cluster", instance=~"$instance", filename=~".*/hadoop/logs/.*-nodemanager.*\\.log"} |= ``',
+      expr: '{job=~"$job", hadoop_cluster=~"$hadoop_cluster", instance=~"$instance", filename=~".*/hadoop/logs/.*-nodemanager.*.log"} |= ``',
       queryType: 'range',
       refId: 'A',
     },

--- a/apache-hadoop-mixin/dashboards/hadoop-nodemanager-overview.libsonnet
+++ b/apache-hadoop-mixin/dashboards/hadoop-nodemanager-overview.libsonnet
@@ -1,0 +1,1429 @@
+local g = (import 'grafana-builder/grafana.libsonnet');
+local grafana = (import 'grafonnet/grafana.libsonnet');
+local dashboard = grafana.dashboard;
+local template = grafana.template;
+local prometheus = grafana.prometheus;
+
+local dashboardUid = 'apache-hadoop-nodemanager-overview';
+
+local promDatasourceName = 'prometheus_datasource';
+local lokiDatasourceName = 'loki_datasource';
+
+local promDatasource = {
+  uid: '${%s}' % promDatasourceName,
+};
+
+local lokiDatasource = {
+  uid: '${%s}' % lokiDatasourceName,
+};
+
+local applicationsRunningPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'hadoop_nodemanager_applicationsrunning{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster"}',
+      datasource=promDatasource,
+      legendFormat='{{hadoop_cluster}} - {{instance}}',
+      format='time_series',
+    ),
+  ],
+  type: 'stat',
+  title: 'Applications running',
+  description: 'Number of applications currently running for the NodeManager.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+        ],
+      },
+      unit: '',
+    },
+    overrides: [],
+  },
+  options: {
+    colorMode: 'value',
+    graphMode: 'none',
+    justifyMode: 'auto',
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    textMode: 'auto',
+  },
+  pluginVersion: '10.0.2-cloud.1.94a6f396',
+};
+
+local allocatedContainersPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'hadoop_nodemanager_allocatedcontainers{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster"}',
+      datasource=promDatasource,
+      legendFormat='{{hadoop_cluster}} - {{instance}}',
+      format='time_series',
+    ),
+  ],
+  type: 'stat',
+  title: 'Allocated containers',
+  description: 'Number of containers currently allocated for the NodeManager.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+        ],
+      },
+      unit: '',
+    },
+    overrides: [],
+  },
+  options: {
+    colorMode: 'value',
+    graphMode: 'none',
+    justifyMode: 'auto',
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    textMode: 'auto',
+  },
+  pluginVersion: '10.0.2-cloud.1.94a6f396',
+};
+
+local containersLocalizationDurationPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'hadoop_nodemanager_localizationdurationmillisavgtime{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster"}',
+      datasource=promDatasource,
+      legendFormat='{{hadoop_cluster}} - {{instance}}',
+      format='time_series',
+    ),
+  ],
+  type: 'stat',
+  title: 'Containers localization duration',
+  description: 'Average time taken for the NodeManager to localize necessary resources for a container.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+        ],
+      },
+      unit: 'ms',
+    },
+    overrides: [],
+  },
+  options: {
+    colorMode: 'value',
+    graphMode: 'none',
+    justifyMode: 'auto',
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    textMode: 'auto',
+  },
+  pluginVersion: '10.0.2-cloud.1.94a6f396',
+};
+
+local containersLaunchDurationPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'hadoop_nodemanager_containerlaunchdurationavgtime{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster"}',
+      datasource=promDatasource,
+      legendFormat='{{hadoop_cluster}} - {{instance}}',
+      format='time_series',
+    ),
+  ],
+  type: 'stat',
+  title: 'Containers launch duration',
+  description: 'Average time taken to launch a container on the NodeManager after the necessary resources have been localized.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+        ],
+      },
+      unit: 'ms',
+    },
+    overrides: [],
+  },
+  options: {
+    colorMode: 'value',
+    graphMode: 'none',
+    justifyMode: 'auto',
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    textMode: 'auto',
+  },
+  pluginVersion: '10.0.2-cloud.1.94a6f396',
+};
+
+local jvmRow = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      '',
+      datasource=promDatasource,
+      legendFormat='',
+    ),
+  ],
+  type: 'row',
+  title: 'JVM',
+  collapsed: false,
+};
+
+local memoryUsedPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'hadoop_nodemanager_memheapusedm{name="JvmMetrics", job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster"}',
+      datasource=promDatasource,
+      legendFormat='{{hadoop_cluster}} - {{instance}} - heap',
+      format='time_series',
+    ),
+    prometheus.target(
+      'hadoop_nodemanager_memnonheapusedm{name="JvmMetrics", job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster"}',
+      datasource=promDatasource,
+      legendFormat='{{hadoop_cluster}} - {{instance}} - nonheap',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Memory used',
+  description: 'The Heap and non-heap memory used for the NodeManager.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+        ],
+      },
+      unit: 'decmbytes',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local memoryCommittedPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'hadoop_nodemanager_memheapcommittedm{name="JvmMetrics", job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster"}',
+      datasource=promDatasource,
+      legendFormat='{{hadoop_cluster}} - {{instance}} - heap',
+      format='time_series',
+    ),
+    prometheus.target(
+      'hadoop_nodemanager_memnonheapcommittedm{name="JvmMetrics", job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster"}',
+      datasource=promDatasource,
+      legendFormat='{{hadoop_cluster}} - {{instance}} - nonheap',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Memory committed',
+  description: 'The Heap and non-heap memory committed for the NodeManager.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+        ],
+      },
+      unit: 'decmbytes',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local garbageCollectionCountPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'increase(hadoop_nodemanager_gccount{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster"}[$__interval:])',
+      datasource=promDatasource,
+      legendFormat='{{hadoop_cluster}} - {{instance}}',
+      format='time_series',
+      interval='1m',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Garbage collection count',
+  description: 'The recent increase in the number of garbage collection events for the NodeManager JVM.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+        ],
+      },
+      unit: '',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local averageGarbageCollectionTimePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'increase(hadoop_nodemanager_gctimemillis{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster"}[$__interval:]) / clamp_min(increase(hadoop_nodemanager_gccount{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster"}[$__interval:]), 1)',
+      datasource=promDatasource,
+      legendFormat='{{hadoop_cluster}} - {{instance}}',
+      format='time_series',
+      interval='1m',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Average garbage collection time',
+  description: 'The average duration for each garbage collection operation in the NodeManager JVM.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+        ],
+      },
+      unit: 'ms',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local nodeRow = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      '',
+      datasource=promDatasource,
+      legendFormat='',
+    ),
+  ],
+  type: 'row',
+  title: 'Node',
+  collapsed: false,
+};
+
+local nodeMemoryUsedPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'hadoop_nodemanager_memheapusedm{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster"}',
+      datasource=promDatasource,
+      legendFormat='{{hadoop_cluster}} - {{instance}} - heap',
+      format='time_series',
+    ),
+    prometheus.target(
+      'hadoop_nodemanager_memnonheapusedm{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster"}',
+      datasource=promDatasource,
+      legendFormat='{{hadoop_cluster}} - {{instance}} - nonheap',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Node memory used',
+  description: 'The Heap and non-heap memory used for the NodeManager.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+        ],
+      },
+      unit: 'decmbytes',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local nodeMemoryCommittedPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'hadoop_nodemanager_memheapcommittedm{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster"}',
+      datasource=promDatasource,
+      legendFormat='{{hadoop_cluster}} - {{instance}} - heap',
+      format='time_series',
+    ),
+    prometheus.target(
+      'hadoop_nodemanager_memnonheapcommittedm{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster"}',
+      datasource=promDatasource,
+      legendFormat='{{hadoop_cluster}} - {{instance}} - nonheap',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Node memory committed',
+  description: 'The Heap and non-heap memory committed for the NodeManager.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+        ],
+      },
+      unit: 'decmbytes',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local nodeCPUUtilizationPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      '100 * hadoop_nodemanager_nodecpuutilization{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster"}',
+      datasource=promDatasource,
+      legendFormat='{{hadoop_cluster}} - {{instance}}',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Node CPU utilization',
+  description: 'CPU utilization of the Node.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+        ],
+      },
+      unit: 'percent',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local nodeGPUUtilizationPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      '100 * hadoop_nodemanager_nodegpuutilization{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster"}',
+      datasource=promDatasource,
+      legendFormat='{{hadoop_cluster}} - {{instance}}',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Node GPU utilization',
+  description: 'GPU utilization of the Node.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+        ],
+      },
+      unit: 'percent',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local containersRow = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      '',
+      datasource=promDatasource,
+      legendFormat='',
+    ),
+  ],
+  type: 'row',
+  title: 'Containers',
+  collapsed: false,
+};
+
+local containersStatePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'hadoop_nodemanager_containerspaused{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster"} > 0',
+      datasource=promDatasource,
+      legendFormat='{{hadoop_cluster}} - {{instance}} - paused',
+      format='time_series',
+    ),
+    prometheus.target(
+      'hadoop_nodemanager_containerslaunched{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster"} > 0',
+      datasource=promDatasource,
+      legendFormat='{{hadoop_cluster}} - {{instance}} - launched',
+      format='time_series',
+    ),
+    prometheus.target(
+      'hadoop_nodemanager_containerscompleted{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster"} > 0',
+      datasource=promDatasource,
+      legendFormat='{{hadoop_cluster}} - {{instance}} - completed',
+      format='time_series',
+    ),
+    prometheus.target(
+      'hadoop_nodemanager_containersfailed{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster"} > 0',
+      datasource=promDatasource,
+      legendFormat='{{hadoop_cluster}} - {{instance}} - failed',
+      format='time_series',
+    ),
+    prometheus.target(
+      'hadoop_nodemanager_containerskilled{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster"} > 0',
+      datasource=promDatasource,
+      legendFormat='{{hadoop_cluster}} - {{instance}} - killed',
+      format='time_series',
+    ),
+    prometheus.target(
+      'hadoop_nodemanager_containersiniting{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster"} > 0',
+      datasource=promDatasource,
+      legendFormat='{{hadoop_cluster}} - {{instance}} - initing',
+      format='time_series',
+    ),
+    prometheus.target(
+      'hadoop_nodemanager_containersreiniting{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster"} > 0',
+      datasource=promDatasource,
+      legendFormat='{{hadoop_cluster}} - {{instance}} - reiniting',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Containers state',
+  description: 'Number of containers with a given state for the NodeManager.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+        ],
+      },
+      unit: '',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local containersUsedMemoryPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'hadoop_nodemanager_containerusedmemgb{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster"}',
+      datasource=promDatasource,
+      legendFormat='{{hadoop_cluster}} - {{instance}}',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Containers used memory',
+  description: 'Total memory used by containers for the NodeManager.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+        ],
+      },
+      unit: 'decmbytes',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local containersUsedVirtualMemoryPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'hadoop_nodemanager_containerusedvmemgb{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster"}',
+      datasource=promDatasource,
+      legendFormat='{{hadoop_cluster}} - {{instance}}',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Containers used virtual memory',
+  description: 'Total virtual memory used by containers for the NodeManager.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+        ],
+      },
+      unit: 'decmbytes',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local containersAvailableMemoryPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'hadoop_nodemanager_availablegb{name="NodeManagerMetrics", job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster"}',
+      datasource=promDatasource,
+      legendFormat='{{hadoop_cluster}} - {{instance}} - available',
+      format='time_series',
+    ),
+    prometheus.target(
+      'hadoop_nodemanager_allocatedgb{name="NodeManagerMetrics", job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster"}',
+      datasource=promDatasource,
+      legendFormat='{{hadoop_cluster}} - {{instance}} - allocated',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Containers available memory',
+  description: 'The memory available and currently allocated for containers by the NodeManager.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+        ],
+      },
+      unit: 'decgbytes',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local containersAvailableVirtualCoresPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'hadoop_nodemanager_availablevcores{name="NodeManagerMetrics", job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster"}',
+      datasource=promDatasource,
+      legendFormat='{{hadoop_cluster}} - {{instance}} - available',
+      format='time_series',
+    ),
+    prometheus.target(
+      'hadoop_nodemanager_allocatedvcores{name="NodeManagerMetrics", job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster"}',
+      datasource=promDatasource,
+      legendFormat='{{hadoop_cluster}} - {{instance}} - allocated',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Containers available virtual cores',
+  description: 'The virtual available and currently allocated for containers by the NodeManager.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+        ],
+      },
+      unit: '',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local nodemanagerLogsPanel = {
+  datasource: lokiDatasource,
+  targets: [
+    {
+      datasource: lokiDatasource,
+      editorMode: 'code',
+      expr: '{job=~"$job", hadoop_cluster=~"$hadoop_cluster", instance=~"$instance", filename=~".*/hadoop/logs/.*-nodemanager.*\\.log"} |= ``',
+      queryType: 'range',
+      refId: 'A',
+    },
+  ],
+  type: 'logs',
+  title: 'NodeManager logs',
+  description: 'The Nodemanager logs.',
+  options: {
+    dedupStrategy: 'none',
+    enableLogDetails: true,
+    prettifyLogMessage: false,
+    showCommonLabels: false,
+    showLabels: false,
+    showTime: false,
+    sortOrder: 'Descending',
+    wrapLogMessage: false,
+  },
+};
+
+{
+  grafanaDashboards+:: {
+    'apache-hadoop-nodemanager-overview.json':
+      dashboard.new(
+        'Apache Hadoop NodeManager overview',
+        time_from='%s' % $._config.dashboardPeriod,
+        tags=($._config.dashboardTags),
+        timezone='%s' % $._config.dashboardTimezone,
+        refresh='%s' % $._config.dashboardRefresh,
+        description='',
+        uid=dashboardUid,
+      )
+
+      .addTemplates(
+        std.flattenArrays([
+          [
+            template.datasource(
+              promDatasourceName,
+              'prometheus',
+              null,
+              label='Data Source',
+              refresh='load'
+            ),
+          ],
+          if $._config.enableLokiLogs then [
+            template.datasource(
+              lokiDatasourceName,
+              'loki',
+              null,
+              label='Loki Datasource',
+              refresh='load'
+            ),
+          ] else [],
+          [
+            template.new(
+              'job',
+              promDatasource,
+              'label_values(hadoop_nodemanager_availablegb,job)',
+              label='Job',
+              refresh=2,
+              includeAll=true,
+              multi=true,
+              allValues='.+',
+              sort=1
+            ),
+            template.new(
+              'instance',
+              promDatasource,
+              'label_values(hadoop_nodemanager_availablegb{job=~"$job"}, instance)',
+              label='Instance',
+              refresh=2,
+              includeAll=true,
+              multi=true,
+              allValues='.+',
+              sort=1
+            ),
+            template.new(
+              'hadoop_cluster',
+              promDatasource,
+              'label_values(hadoop_nodemanager_availablegb{job=~"$job"}, hadoop_cluster)',
+              label='Hadoop cluster',
+              refresh=2,
+              includeAll=true,
+              multi=true,
+              allValues='.+',
+              sort=1
+            ),
+          ],
+        ])
+      )
+      .addPanels(
+        std.flattenArrays([
+          [
+            applicationsRunningPanel { gridPos: { h: 6, w: 6, x: 0, y: 0 } },
+            allocatedContainersPanel { gridPos: { h: 6, w: 6, x: 6, y: 0 } },
+            containersLocalizationDurationPanel { gridPos: { h: 6, w: 6, x: 12, y: 0 } },
+            containersLaunchDurationPanel { gridPos: { h: 6, w: 6, x: 18, y: 0 } },
+            jvmRow { gridPos: { h: 1, w: 24, x: 0, y: 6 } },
+            memoryUsedPanel { gridPos: { h: 6, w: 12, x: 0, y: 7 } },
+            memoryCommittedPanel { gridPos: { h: 6, w: 12, x: 12, y: 7 } },
+            garbageCollectionCountPanel { gridPos: { h: 6, w: 12, x: 0, y: 13 } },
+            averageGarbageCollectionTimePanel { gridPos: { h: 6, w: 12, x: 12, y: 13 } },
+            nodeRow { gridPos: { h: 1, w: 24, x: 0, y: 19 } },
+            nodeMemoryUsedPanel { gridPos: { h: 6, w: 12, x: 0, y: 20 } },
+            nodeMemoryCommittedPanel { gridPos: { h: 6, w: 12, x: 12, y: 20 } },
+            nodeCPUUtilizationPanel { gridPos: { h: 6, w: 12, x: 0, y: 26 } },
+            nodeGPUUtilizationPanel { gridPos: { h: 6, w: 12, x: 12, y: 26 } },
+            containersRow { gridPos: { h: 1, w: 24, x: 0, y: 32 } },
+            containersStatePanel { gridPos: { h: 6, w: 8, x: 0, y: 33 } },
+            containersUsedMemoryPanel { gridPos: { h: 6, w: 8, x: 8, y: 33 } },
+            containersUsedVirtualMemoryPanel { gridPos: { h: 6, w: 8, x: 16, y: 33 } },
+            containersAvailableMemoryPanel { gridPos: { h: 6, w: 12, x: 0, y: 39 } },
+            containersAvailableVirtualCoresPanel { gridPos: { h: 6, w: 12, x: 12, y: 39 } },
+          ],
+          if $._config.enableLokiLogs then [
+            nodemanagerLogsPanel { gridPos: { h: 8, w: 24, x: 0, y: 45 } },
+          ] else [],
+          [
+          ],
+        ])
+      ),
+  },
+}

--- a/apache-hadoop-mixin/dashboards/hadoop-nodemanager-overview.libsonnet
+++ b/apache-hadoop-mixin/dashboards/hadoop-nodemanager-overview.libsonnet
@@ -1335,7 +1335,13 @@ local nodemanagerLogsPanel = {
         description='',
         uid=dashboardUid,
       )
-
+      .addLink(grafana.link.dashboards(
+        asDropdown=false,
+        title='Other Apache Hadoop dashboards',
+        includeVars=true,
+        keepTime=true,
+        tags=($._config.dashboardTags),
+      ))
       .addTemplates(
         std.flattenArrays([
           [

--- a/apache-hadoop-mixin/dashboards/hadoop-nodemanager-overview.libsonnet
+++ b/apache-hadoop-mixin/dashboards/hadoop-nodemanager-overview.libsonnet
@@ -1,4 +1,3 @@
-local g = (import 'grafana-builder/grafana.libsonnet');
 local grafana = (import 'grafonnet/grafana.libsonnet');
 local dashboard = grafana.dashboard;
 local template = grafana.template;

--- a/apache-hadoop-mixin/dashboards/hadoop-resourcemanager-overview.libsonnet
+++ b/apache-hadoop-mixin/dashboards/hadoop-resourcemanager-overview.libsonnet
@@ -709,7 +709,7 @@ local resourcemanagerLogsPanel = {
     {
       datasource: lokiDatasource,
       editorMode: 'code',
-      expr: '{job=~"$job", hadoop_cluster=~"$hadoop_cluster", instance=~"$instance", filename=~".*/hadoop/logs/.*-resourcemanager.*\\.log"} |= ``',
+      expr: '{job=~"$job", hadoop_cluster=~"$hadoop_cluster", instance=~"$instance", filename=~".*/hadoop/logs/.*-resourcemanager.*.log"} |= ``',
       queryType: 'range',
       refId: 'A',
     },

--- a/apache-hadoop-mixin/dashboards/hadoop-resourcemanager-overview.libsonnet
+++ b/apache-hadoop-mixin/dashboards/hadoop-resourcemanager-overview.libsonnet
@@ -1,0 +1,825 @@
+local g = (import 'grafana-builder/grafana.libsonnet');
+local grafana = (import 'grafonnet/grafana.libsonnet');
+local dashboard = grafana.dashboard;
+local template = grafana.template;
+local prometheus = grafana.prometheus;
+
+local dashboardUid = 'apache-hadoop-resourcemanager-overview';
+
+local promDatasourceName = 'prometheus_datasource';
+local lokiDatasourceName = 'loki_datasource';
+
+local promDatasource = {
+  uid: '${%s}' % promDatasourceName,
+};
+
+local lokiDatasource = {
+  uid: '${%s}' % lokiDatasourceName,
+};
+
+local nodeManagersStatePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'hadoop_resourcemanager_numactivenms{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster", name="ClusterMetrics",}',
+      datasource=promDatasource,
+      legendFormat='active',
+    ),
+    prometheus.target(
+      'hadoop_resourcemanager_numdecommissionednms{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster", name="ClusterMetrics",}',
+      datasource=promDatasource,
+      legendFormat='decommissioned',
+    ),
+    prometheus.target(
+      'hadoop_resourcemanager_numlostnms{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster", name="ClusterMetrics"}',
+      datasource=promDatasource,
+      legendFormat='lost',
+    ),
+    prometheus.target(
+      'hadoop_resourcemanager_numunhealthynms{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster", name="ClusterMetrics"}',
+      datasource=promDatasource,
+      legendFormat='healthy',
+    ),
+    prometheus.target(
+      'hadoop_resourcemanager_numrebootednms{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster", name="ClusterMetrics"}',
+      datasource=promDatasource,
+      legendFormat='rebooted',
+    ),
+    prometheus.target(
+      'hadoop_resourcemanager_numshutdownnms{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster", name="ClusterMetrics"}',
+      datasource=promDatasource,
+      legendFormat='shutdown',
+    ),
+  ],
+  type: 'bargauge',
+  title: 'Node Managers state',
+  description: 'The number of Node Managers by state in the Hadoop ResourceManager.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+    },
+    overrides: [],
+  },
+  options: {
+    displayMode: 'gradient',
+    minVizHeight: 10,
+    minVizWidth: 0,
+    orientation: 'horizontal',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    showUnfilled: true,
+    valueMode: 'color',
+  },
+  pluginVersion: '10.0.2-cloud.1.94a6f396',
+};
+
+local applicationsRow = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      '',
+      datasource=promDatasource,
+      legendFormat='',
+    ),
+  ],
+  type: 'row',
+  title: 'Applications',
+  collapsed: false,
+};
+
+local applicationsStatePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'hadoop_resourcemanager_appsrunning{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster", name="QueueMetrics",q0="root", q1="default"}',
+      datasource=promDatasource,
+      legendFormat='running',
+    ),
+    prometheus.target(
+      'hadoop_resourcemanager_appspending{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster", name="QueueMetrics",q0="root", q1="default"}',
+      datasource=promDatasource,
+      legendFormat='pending',
+    ),
+    prometheus.target(
+      'hadoop_resourcemanager_appskilled{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster", name="QueueMetrics",q0="root", q1="default"}',
+      datasource=promDatasource,
+      legendFormat='killed',
+    ),
+    prometheus.target(
+      'hadoop_resourcemanager_appssubmitted{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster", name="QueueMetrics",q0="root", q1="default"}',
+      datasource=promDatasource,
+      legendFormat='submitted',
+    ),
+    prometheus.target(
+      'hadoop_resourcemanager_appscompleted{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster", name="QueueMetrics",q0="root", q1="default"}',
+      datasource=promDatasource,
+      legendFormat='completed',
+    ),
+    prometheus.target(
+      'hadoop_resourcemanager_appsfailed{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster", name="QueueMetrics",q0="root", q1="default"}',
+      datasource=promDatasource,
+      legendFormat='failed',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Applications state',
+  description: 'Number of applications by state for the Hadoop ResourceManager.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local availableMemoryPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'hadoop_resourcemanager_allocatedmb{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster", name="QueueMetrics",q0="root", q1="default"}',
+      datasource=promDatasource,
+      legendFormat='allocated',
+      format='time_series',
+    ),
+    prometheus.target(
+      'hadoop_resourcemanager_availablemb{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster", name="QueueMetrics",q0="root", q1="default"}',
+      datasource=promDatasource,
+      legendFormat='available',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Available memory',
+  description: 'The available memory in the Hadoop ResourceManager.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'decmbytes',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local availableVirtualCoresPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'hadoop_resourcemanager_availablevcores{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster", name="QueueMetrics",q0="root", q1="default"}',
+      datasource=promDatasource,
+      legendFormat='available',
+      format='time_series',
+    ),
+    prometheus.target(
+      'hadoop_resourcemanager_allocatedvcores{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster", name="QueueMetrics",q0="root", q1="default"}',
+      datasource=promDatasource,
+      legendFormat='allocated',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Available virtual cores',
+  description: 'The available virtual cores in the Hadoop ResourceManager.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: '',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local jvmRow = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      '',
+      datasource=promDatasource,
+      legendFormat='',
+    ),
+  ],
+  type: 'row',
+  title: 'JVM',
+  collapsed: false,
+};
+
+local memoryUsedPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'hadoop_resourcemanager_memheapusedm{name="JvmMetrics", job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster"}',
+      datasource=promDatasource,
+      legendFormat='heap',
+      format='time_series',
+    ),
+    prometheus.target(
+      'hadoop_resourcemanager_memnonheapusedm{name="JvmMetrics", job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster"}',
+      datasource=promDatasource,
+      legendFormat='nonheap',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Memory used',
+  description: 'The Heap and non-heap memory used for the ResourceManager.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'decmbytes',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+  pluginVersion: '10.0.2-cloud.1.94a6f396',
+};
+
+local memoryCommittedPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'hadoop_resourcemanager_memheapcommittedm{name="JvmMetrics", job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster"}',
+      datasource=promDatasource,
+      legendFormat='heap',
+      format='time_series',
+    ),
+    prometheus.target(
+      'hadoop_resourcemanager_memnonheapcommittedm{name="JvmMetrics", job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster"}',
+      datasource=promDatasource,
+      legendFormat='nonheap',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Memory committed',
+  description: 'The Heap and non-heap memory committed for the ResourceManager.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'decmbytes',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local garbageCollectionCountPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'increase(hadoop_resourcemanager_gccount{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster"}[$__interval:])',
+      datasource=promDatasource,
+      legendFormat='{{hadoop_cluster}} - {{instance}}',
+      format='time_series',
+      interval='1m',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Garbage collection count',
+  description: 'The recent increase in the number of garbage collection events for the ResourceManager JVM.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: '',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local averageGarbageCollectionTimePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'increase(hadoop_resourcemanager_gctimemillis{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster"}[$__interval:]) / clamp_min(increase(hadoop_resourcemanager_gccount{job=~"$job", instance=~"$instance", hadoop_cluster=~"$hadoop_cluster"}[$__interval:]), 1)',
+      datasource=promDatasource,
+      legendFormat='{{hadoop_cluster}} - {{instance}}',
+      format='time_series',
+      interval='1m',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Average garbage collection time',
+  description: 'The average duration for each garbage collection operation in the ResourceManager JVM.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'ms',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local resourcemanagerLogsPanel = {
+  datasource: lokiDatasource,
+  targets: [
+    {
+      datasource: lokiDatasource,
+      editorMode: 'code',
+      expr: '{job=~"$job", hadoop_cluster=~"$hadoop_cluster", instance=~"$instance", filename=~".*/hadoop/logs/.*-resourcemanager.*\\.log"} |= ``',
+      queryType: 'range',
+      refId: 'A',
+    },
+  ],
+  type: 'logs',
+  title: 'ResourceManager logs',
+  description: 'The ResourceManager logs.',
+  options: {
+    dedupStrategy: 'none',
+    enableLogDetails: true,
+    prettifyLogMessage: false,
+    showCommonLabels: false,
+    showLabels: false,
+    showTime: false,
+    sortOrder: 'Descending',
+    wrapLogMessage: false,
+  },
+};
+
+{
+  grafanaDashboards+:: {
+    'apache-hadoop-resourcemanager-overview.json':
+      dashboard.new(
+        'Apache Hadoop ResourceManager overview',
+        time_from='%s' % $._config.dashboardPeriod,
+        tags=($._config.dashboardTags),
+        timezone='%s' % $._config.dashboardTimezone,
+        refresh='%s' % $._config.dashboardRefresh,
+        description='',
+        uid=dashboardUid,
+      )
+
+      .addTemplates(
+        std.flattenArrays([
+          [
+            template.datasource(
+              promDatasourceName,
+              'prometheus',
+              null,
+              label='Data Source',
+              refresh='load'
+            ),
+          ],
+          if $._config.enableLokiLogs then [
+            template.datasource(
+              lokiDatasourceName,
+              'loki',
+              null,
+              label='Loki Datasource',
+              refresh='load'
+            ),
+          ] else [],
+          [
+            template.new(
+              'job',
+              promDatasource,
+              'label_values(hadoop_resourcemanager_activeapplications,job)',
+              label='Job',
+              refresh=2,
+              includeAll=true,
+              multi=true,
+              allValues='.+',
+              sort=1
+            ),
+            template.new(
+              'instance',
+              promDatasource,
+              'label_values(hadoop_resourcemanager_activeapplications{job=~"$job"}, instance)',
+              label='Instance',
+              refresh=2,
+              includeAll=true,
+              multi=true,
+              allValues='.+',
+              sort=1
+            ),
+            template.new(
+              'hadoop_cluster',
+              promDatasource,
+              'label_values(hadoop_resourcemanager_activeapplications{job=~"$job"}, hadoop_cluster)',
+              label='Hadoop cluster',
+              refresh=2,
+              includeAll=true,
+              multi=true,
+              allValues='.+',
+              sort=1
+            ),
+          ],
+        ])
+      )
+      .addPanels(
+        std.flattenArrays([
+          [
+            nodeManagersStatePanel { gridPos: { h: 9, w: 24, x: 0, y: 0 } },
+            applicationsRow { gridPos: { h: 1, w: 24, x: 0, y: 9 } },
+            applicationsStatePanel { gridPos: { h: 8, w: 24, x: 0, y: 10 } },
+            availableMemoryPanel { gridPos: { h: 6, w: 12, x: 0, y: 18 } },
+            availableVirtualCoresPanel { gridPos: { h: 6, w: 12, x: 12, y: 18 } },
+            jvmRow { gridPos: { h: 1, w: 24, x: 0, y: 24 } },
+            memoryUsedPanel { gridPos: { h: 6, w: 12, x: 0, y: 25 } },
+            memoryCommittedPanel { gridPos: { h: 6, w: 12, x: 12, y: 25 } },
+            garbageCollectionCountPanel { gridPos: { h: 6, w: 12, x: 0, y: 31 } },
+            averageGarbageCollectionTimePanel { gridPos: { h: 6, w: 12, x: 12, y: 31 } },
+          ],
+          if $._config.enableLokiLogs then [
+            resourcemanagerLogsPanel { gridPos: { h: 8, w: 24, x: 0, y: 37 } },
+          ] else [],
+          [
+          ],
+        ])
+      ),
+  },
+}

--- a/apache-hadoop-mixin/dashboards/hadoop-resourcemanager-overview.libsonnet
+++ b/apache-hadoop-mixin/dashboards/hadoop-resourcemanager-overview.libsonnet
@@ -1,4 +1,3 @@
-local g = (import 'grafana-builder/grafana.libsonnet');
 local grafana = (import 'grafonnet/grafana.libsonnet');
 local dashboard = grafana.dashboard;
 local template = grafana.template;

--- a/apache-hadoop-mixin/dashboards/hadoop-resourcemanager-overview.libsonnet
+++ b/apache-hadoop-mixin/dashboards/hadoop-resourcemanager-overview.libsonnet
@@ -741,7 +741,13 @@ local resourcemanagerLogsPanel = {
         description='',
         uid=dashboardUid,
       )
-
+      .addLink(grafana.link.dashboards(
+        asDropdown=false,
+        title='Other Apache Hadoop dashboards',
+        includeVars=true,
+        keepTime=true,
+        tags=($._config.dashboardTags),
+      ))
       .addTemplates(
         std.flattenArrays([
           [

--- a/apache-hadoop-mixin/jsonnetfile.json
+++ b/apache-hadoop-mixin/jsonnetfile.json
@@ -1,0 +1,15 @@
+{
+    "version": 1,
+    "dependencies": [
+        {
+            "source": {
+                "git": {
+                    "remote": "https://github.com/grafana/grafonnet-lib.git",
+                    "subdir": "grafonnet"
+                }
+            },
+            "version": "master"
+        }
+    ],
+    "legacyImports": true
+}

--- a/apache-hadoop-mixin/mixin.libsonnet
+++ b/apache-hadoop-mixin/mixin.libsonnet
@@ -1,0 +1,3 @@
+(import 'dashboards/dashboards.libsonnet') +
+(import 'alerts/alerts.libsonnet') +
+(import 'config.libsonnet')


### PR DESCRIPTION
Adds dashboards and alerts for Apache Hadoop.

Let me know if the dashboards look good, they are 1920 by 1080. 

Dashboards:
Apache Hadoop NameNode overview
Apache Hadoop DataNode overview
Apache Hadoop NodeManager overview
Apache Hadoop ResourceManager overview

Alerts:
ApacheHadoopLowHDFSCapacity
ApacheHadoopHDFSMissingBlocks
ApacheHadoopHDFSHighVolumeFailures
ApacheHadoopHighDeadDataNodes
ApacheHadoopHighNodeManagerCPUUsage
ApacheHadoopHighNodeManagerMemoryUsage
ApacheHadoopHighResourceManagerVirtualCoreCPUUsage
ApacheHadoopHighResourceManagerMemoryUsage

## NameNode overview
![Screenshot 2023-07-13 at 2 39 39 PM](https://github.com/grafana/jsonnet-libs/assets/13648435/8590a653-d045-4d14-a6da-7e2cbe2a18a9)
![Screenshot 2023-07-13 at 2 39 55 PM](https://github.com/grafana/jsonnet-libs/assets/13648435/410be054-846a-46d9-8b1d-32a034caa110)


## DataNode overview
![Screenshot 2023-07-13 at 2 39 18 PM](https://github.com/grafana/jsonnet-libs/assets/13648435/4e8ef637-d779-4ec0-adb8-512d5ee7e06c)

## NodeManager overview

![Screenshot 2023-07-13 at 2 38 54 PM](https://github.com/grafana/jsonnet-libs/assets/13648435/48894836-343f-41e2-b197-506c9294f33c)
![Screenshot 2023-07-13 at 2 39 02 PM](https://github.com/grafana/jsonnet-libs/assets/13648435/aef86378-4b3c-4617-bfe1-26e1bd33fbea)

## ResourceManager overview
![Screenshot 2023-07-13 at 2 40 30 PM](https://github.com/grafana/jsonnet-libs/assets/13648435/78768de2-e432-48cb-b978-41ed8f0c474f)
![Screenshot 2023-07-13 at 2 40 37 PM](https://github.com/grafana/jsonnet-libs/assets/13648435/6195a00e-2c38-4c12-bb89-72cce062766c)
