### PR TITLE
Apache Hadoop: fix typo

### DIFF
--- a/apache-hadoop-mixin/README.md
+++ b/apache-hadoop-mixin/README.md
@@ -24,28 +24,28 @@ and the following alerts:
 
 The Apache Hadoop NameNode overview dashboard provides details on all DataNode state, capacity utilization, total, missing and under-replicated blocks, volume failures, total file and total load.
 
-![First screenshot of the Apache Hadoop NameNode overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-hadoop/screenshots/hadoop_namenode_overview_1.png)
-![Second screenshot of the Apache Hadoop NameNode overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-hadoop/screenshots/hadoop_namenode_overview_2.png)
+![First screenshot of the Apache Hadoop NameNode overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-hadoop/screenshots/hadoop-overview-1.png)
+![Second screenshot of the Apache Hadoop NameNode overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-hadoop/screenshots/hadoop-overview-2.png)
 
 ## Apache Hadoop DataNode overview
 
 The Apache Hadoop DataNode overview dashboard provides details on the number of unread blocks evicted, blocks removed and volume failures.
 
-![First screenshot of the Apache Hadoop DataNode overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-hadoop/screenshots/hadoop_datanode_overview_1.png)
+![First screenshot of the Apache Hadoop DataNode overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-hadoop/screenshots/hadoop-overview-3.png)
 
 ## Apache Hadoop NodeManager overview
 
 The Apache Hadoop NodeManager overview dashboard provides details on number of applications running, allocated containers, containers localization duration, launch duration and state, JVM resource metrics, Node resource metrics and container resource metrics.
 
-![First screenshot of the Apache Hadoop NodeManager overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-hadoop/screenshots/hadoop_nodemanager_overview_1.png)
-![Second screenshot of the Apache Hadoop NodeManager overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-hadoop/screenshots/hadoop_nodemanager_overview_2.png)
+![First screenshot of the Apache Hadoop NodeManager overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-hadoop/screenshots/hadoop-overview-4.png)
+![Second screenshot of the Apache Hadoop NodeManager overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-hadoop/screenshots/hadoop-overview-5.png)
 
 ## Apache ResourceManager overview
 
 The Apache Hadoop ResourceManager overview dashboard provides details on Node Managers state, application state and resource metrics and JVM resource metrics.
 
-![First screenshot of the Apache Hadoop ResourceManager overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-hadoop/screenshots/hadoop_resourcemanager_overview_1.png)
-![Second screenshot of the Apache Hadoop ResourceManager overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-hadoop/screenshots/hadoop_resourcemanager_overview_2.png)
+![First screenshot of the Apache Hadoop ResourceManager overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-hadoop/screenshots/hadoop-overview-6.png)
+![Second screenshot of the Apache Hadoop ResourceManager overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-hadoop/screenshots/hadoop-overview-7.png)
 
 ## Logging
 

--- a/apache-hadoop-mixin/README.md
+++ b/apache-hadoop-mixin/README.md
@@ -49,7 +49,7 @@ The Apache Hadoop ResourceManager overview dashboard provides details on Node Ma
 
 ## Logging
 
-To get Apache Hadoop NameNode, DataNode, NodeManager or ResourceManager logs on the related dashboard, [Promtail and Loki needs to be installed](https://grafana.com/docs/loki/latest/installation/) and provisioned for logs with your Grafana instance. The default Apache Hadoop log path is indicated in the `HADDOP_LOG_DIR` for your system located in `/etc/hadoop/conf`. An example log path may look like `/hadoop/logs/*.log` on Linux.
+To get Apache Hadoop NameNode, DataNode, NodeManager or ResourceManager logs on the related dashboard, [Promtail and Loki needs to be installed](https://grafana.com/docs/loki/latest/installation/) and provisioned for logs with your Grafana instance. The default Apache Hadoop log path is indicated in the `HADOOP_LOG_DIR` for your system located in `/etc/hadoop/conf`. An example log path may look like `/hadoop/logs/*.log` on Linux.
 
 Hadoop NameNode, DataNode, NodeManager and ResourceManager logs are enabled by default in the `config.libsonnet` and can be removed by setting `enableLokiLogs` to `false`. Then run `make` again to regenerate the dashboard:
 

--- a/apache-hadoop-mixin/dashboards/hadoop-namenode-overview.libsonnet
+++ b/apache-hadoop-mixin/dashboards/hadoop-namenode-overview.libsonnet
@@ -140,32 +140,7 @@ local capacityUtilizationPanel = {
       },
       unit: 'percent',
     },
-    overrides: [
-      {
-        __systemRef: 'hideSeriesFrom',
-        matcher: {
-          id: 'byNames',
-          options: {
-            mode: 'exclude',
-            names: [
-              'hadoop-cluster-0 - instance-0',
-            ],
-            prefix: 'All except:',
-            readOnly: true,
-          },
-        },
-        properties: [
-          {
-            id: 'custom.hideFrom',
-            value: {
-              legend: false,
-              tooltip: false,
-              viz: true,
-            },
-          },
-        ],
-      },
-    ],
+    overrides: [],
   },
   options: {
     legend: {


### PR DESCRIPTION
- fix variable name type
- removes override that is hiding a metric on view
- updates image name paths