### PR TITLE
Fix(Apache Tomcat): Add job and instance to apache-tomcat logs filter

### DIFF
--- a/apache-tomcat-mixin/dashboards/apache-tomcat-overview.libsonnet
+++ b/apache-tomcat-mixin/dashboards/apache-tomcat-overview.libsonnet
@@ -646,7 +646,7 @@ local logsPanel = {
     {
       datasource: lokiDatasource,
       editorMode: 'code',
-      expr: '{filename=~"/var/log/tomcat.*/catalina.out|/opt/tomcat/logs/catalina.out|/Program Files/Apache Software Foundation/Tomcat .*..*/logs/catalina.out",job=~"$job"} |= ``',
+      expr: '{filename=~"/var/log/tomcat.*/catalina.out|/opt/tomcat/logs/catalina.out|/Program Files/Apache Software Foundation/Tomcat .*..*/logs/catalina.out",job=~"$job", instance=~"$instance"} |= ``',
       queryType: 'range',
       refId: 'A',
     },

--- a/apache-tomcat-mixin/dashboards/apache-tomcat-overview.libsonnet
+++ b/apache-tomcat-mixin/dashboards/apache-tomcat-overview.libsonnet
@@ -646,7 +646,7 @@ local logsPanel = {
     {
       datasource: lokiDatasource,
       editorMode: 'code',
-      expr: '{filename=~"/var/log/tomcat.*/catalina.out|/opt/tomcat/logs/catalina.out|/Program Files/Apache Software Foundation/Tomcat .*..*/logs/catalina.out"} |= ``',
+      expr: '{filename=~"/var/log/tomcat.*/catalina.out|/opt/tomcat/logs/catalina.out|/Program Files/Apache Software Foundation/Tomcat .*..*/logs/catalina.out",job=~"$job"} |= ``',
       queryType: 'range',
       refId: 'A',
     },


### PR DESCRIPTION
If multiple tomcat logs are ingested outside of the context of the job, we will most likely want to not include them. 