### PR TITLE
Removed an alert for Varnish Cache Mixin

### DIFF
--- a/varnish-mixin/README.md
+++ b/varnish-mixin/README.md
@@ -13,7 +13,6 @@ and the following alerts:
 - VarnishCacheHighCacheEvictionRate
 - VarnishCacheHighSaturation
 - VarnishCacheSessionsDropping
-- VarnishCacheBackendFailure
 - VarnishCacheBackendUnhealthy
 
 ## Varnish Cache overview
@@ -51,7 +50,7 @@ scrape_configs:
           - localhost
         labels:
           job: integrations/varnish-cache
-          instance: <varnish_host>:9131
+          instance: <exporter_host>:<exporter_port>
           __path__: /var/log/varnish/varnishncsa*.log*
 ```
 
@@ -64,7 +63,6 @@ scrape_configs:
 | VarnishCacheHighCacheEvictionRate | The cache is evicting too many objects.                                             |
 | VarnishCacheHighSaturation        | There are too many threads in queue, Varnish is saturated and responses are slowed. |
 | VarnishCacheSessionsDropping      | Incoming requests are being dropped due to a lack of free worker threads.           |
-| VarnishCacheBackendFailure        | There was a failure to connect to the backend.                                      |
 | VarnishCacheBackendUnhealthy      | Backend has been marked as unhealthy due to slow 200 responses.                     |
 
 Default thresholds can be configured in `config.libsonnet`.
@@ -77,7 +75,6 @@ Default thresholds can be configured in `config.libsonnet`.
     alertsCriticalCacheEviction: 0,
     alertsWarningHighSaturation: 0,
     alertsCriticalSessionsDropped: 0,
-    alertsCriticalBackendFailure: 0,
     alertsCriticalBackendUnhealthy: 0,
     enableLokiLogs: true,
   },

--- a/varnish-mixin/alerts/alerts.libsonnet
+++ b/varnish-mixin/alerts/alerts.libsonnet
@@ -95,24 +95,6 @@
             },
           },
           {
-            alert: 'VarnishCacheBackendFailure',
-            expr: |||
-              increase(varnish_main_backend_fail[5m]) > %(alertsCriticalBackendFailure)s
-            ||| % $._config,
-            'for': '5m',
-            labels: {
-              severity: 'critical',
-            },
-            annotations: {
-              summary: 'There was a failure to connect to the backend.',
-              description:
-                (
-                  'The number of backend failures is {{ printf "%%.0f" $value }} over the last 5 minutes on {{$labels.instance}}, ' +
-                  'which is above the threshold of %(alertsCriticalBackendFailure)s.'
-                ) % $._config,
-            },
-          },
-          {
             alert: 'VarnishCacheBackendUnhealthy',
             expr: |||
               increase(varnish_main_backend_unhealthy[5m]) > %(alertsCriticalBackendUnhealthy)s

--- a/varnish-mixin/config.libsonnet
+++ b/varnish-mixin/config.libsonnet
@@ -11,7 +11,6 @@
     alertsCriticalCacheEviction: 0,
     alertsWarningHighSaturation: 0,
     alertsCriticalSessionsDropped: 0,
-    alertsCriticalBackendFailure: 0,
     alertsCriticalBackendUnhealthy: 0,
     enableLokiLogs: true,
   },


### PR DESCRIPTION
Removed an alert (VarnishCacheBackendFailure)  that was based off a broken exporter metric.