### PR TITLE
Add interval into threads panel

### DIFF
--- a/varnish-mixin/dashboards/varnish-overview.libsonnet
+++ b/varnish-mixin/dashboards/varnish-overview.libsonnet
@@ -1030,16 +1030,22 @@ local threadsPanel = {
       'increase(varnish_main_threads_failed{job=~"$job",instance=~"$instance"}[$__interval:])',
       datasource=promDatasource,
       legendFormat='{{instance}} - Failed',
+      format='time_series',
+      interval='1m',
     ),
     prometheus.target(
       'increase(varnish_main_threads_created{job=~"$job",instance=~"$instance"}[$__interval:])',
       datasource=promDatasource,
       legendFormat='{{instance}} - Created',
+      format='time_series',
+      interval='1m',
     ),
     prometheus.target(
       'increase(varnish_main_threads_limited{job=~"$job",instance=~"$instance"}[$__interval:])',
       datasource=promDatasource,
       legendFormat='{{instance}} - Limited',
+      format='time_series',
+      interval='1m',
     ),
     prometheus.target(
       'varnish_main_threads{job=~"$job",instance=~"$instance"}',


### PR DESCRIPTION
Dashboard converter that converts json => libsonnet was throwing away interval on threads panel. This PR adds the ones that got thrown away back in.