### PR TITLE
Logs lib update

### DIFF
--- a/logs-lib/README.md
+++ b/logs-lib/README.md
@@ -27,12 +27,23 @@ local kubeLabels = ['cluster', 'namespace', 'app', 'pod', 'container'];
 // set null or do not provide at all if parsing is not required.
 local formatParser = 'logfmt';
 
+//group by 'app' label instead of 'level':
+local logsVolumeGroupBy = 'app';
 
-(logsDashboard.new('Kubernetes apps logs',
-               datasourceRegex='',
-               filterSelector=kubeFilterSelector,
-               labels=kubeLabels,
-               formatParser=formatParser)
+//extra filters to do advanced line_format:
+local extraFilters = |||
+  | label_format timestamp="{{__timestamp__}}"
+  | line_format `{{ if eq "[[pod]]" ".*" }}{{.pod | trunc 20}}:{{else}}{{.container}}:{{end}} {{__line__}}`
+|||;
+
+(
+  logsDashboard.new('Kubernetes apps logs',
+                    datasourceRegex='',
+                    filterSelector=kubeFilterSelector,
+                    labels=kubeLabels,
+                    formatParser=formatParser,
+                    logsVolumeGroupBy=logsVolumeGroupBy,
+                    extraFilters=extraFilters)
 ).dashboards.logs
 ```
 

--- a/logs-lib/logs/main.libsonnet
+++ b/logs-lib/logs/main.libsonnet
@@ -13,6 +13,8 @@ local g = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonn
     datasourceName='datasource',
     formatParser=null,
     showLogsVolume=true,
+    logsVolumeGroupBy='level',
+    extraFilters='',
   ): {
 
     local this = self,
@@ -26,11 +28,13 @@ local g = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonn
     targets: targets(
       this.variables,
       formatParser,
+      logsVolumeGroupBy,
+      extraFilters,
     ),
 
     panels: panels(
       this.targets.logsVolumeTarget,
-      this.targets.logsTarget
+      this.targets.logsTarget,
     ),
 
     dashboards: dashboards(

--- a/logs-lib/logs/panels.libsonnet
+++ b/logs-lib/logs/panels.libsonnet
@@ -22,12 +22,13 @@ function(
       + custom.withFillOpacity(50)
       + timeSeries.withInterval('30s')  // must be set , otherwise interval is around 1ms
       + options.tooltip.withMode('multi')
+      + options.tooltip.withSort('desc')
       + timeSeries.withTransformationsMixin(
         {
           id: 'renameByRegex',
           options: {
             regex: 'Value',
-            renamePattern: 'unknown',
+            renamePattern: 'logs',
           },
         }
       )
@@ -57,7 +58,7 @@ function(
               { regex: '(N|n)(otice|ote)|(I|i)(nf.*|NF.*)', color: 'green' },
               { regex: 'dbg.*|DBG.*|(D|d)(EBUG|ebug)', color: 'blue' },
               { regex: '(T|t)(race|RACE)', color: 'light-blue' },
-              { regex: 'unknown', color: 'text' },
+              { regex: 'logs', color: 'text' },
             ]
         ]
       ),


### PR DESCRIPTION
- Sort values in tooltip by default
- Set default unknown value to 'logs' on legend, not 'unknown'
- [Add extraFilters and optional logsVolumeGroupBy](https://github.com/grafana/jsonnet-libs/commit/a722dce36d375584fd7c8dd312700fdf84f38793)

For example, next kubernetes snippet now can add:
- group by `app` not `level` label (which is missing in kubernetes by default)
- hide timestamp in line to preserve space(and make it a field just in case)
- append line with podname if pod is multiselected. If pod is singleselected, then append line with container name

```
// add logs
local g = import 'github.com/grafana/grafonnet/gen/grafonnet-v10.0.0/main.libsonnet';
local logsDashboard = import 'github.com/grafana/jsonnet-libs/logs-lib/logs/main.libsonnet';

{
  local filterSelector = 'namespace!=""',
  local labels = ['cluster', 'namespace', 'app', 'pod', 'container'],

  local formatParser = null,
  local logsDash =
    logsDashboard.new(
      '%s Pod Logs' % $._config.grafanaK8s.dashboardNamePrefix,
      datasourceRegex='',
      filterSelector=filterSelector,
      labels=labels,
      formatParser=formatParser,
      showLogsVolume=$._config.showLogsVolume,
      logsVolumeGroupBy=$._config.logsVolumeGroupBy,
      extraFilters=|||
        | label_format timestamp="{{__timestamp__}}"
        | line_format `{{ if eq "[[pod]]" ".*" }}{{.pod | trunc 20}}:{{else}}{{.container}}:{{end}} {{__line__}}`
      |||
    )

    {
      // overwrite dashboard 'log'
      dashboards+:
        {
          logs+: g.dashboard.withLinksMixin($.grafanaDashboards['k8s-resources-cluster.json'].links)
                 + g.dashboard.withUid($._config.grafanaDashboardIDs['pods-logs.json'])
                 + g.dashboard.withTags($._config.grafanaK8s.dashboardTags)
                 + g.dashboard.withRefresh($._config.grafanaK8s.refresh),
        },
      // overwrite panel 'log'
      panels+:
        {
          logs+: g.panel.logs.options.withEnableLogDetails(true)
                 + g.panel.logs.options.withShowTime(false),
        },
    },

  grafanaDashboards+:: if $._config.enableLokiLogs then {
    'pods-logs':
      logsDash.dashboards.logs,
  } else {},
}

```
Before:
![image](https://github.com/grafana/jsonnet-libs/assets/14870891/22b69aad-1a92-4611-bbcf-bbeecfa9847e)


Now:
![image](https://github.com/grafana/jsonnet-libs/assets/14870891/7f8abc30-1c1b-48cd-af50-6a72b758e7ff)
