### PR TITLE
Include all option for job in mongodb mixin

### DIFF
--- a/mongodb-mixin/dashboards/MongoDB_Cluster.json
+++ b/mongodb-mixin/dashboards/MongoDB_Cluster.json
@@ -2571,7 +2571,7 @@
         "description": null,
         "error": null,
         "hide": 2,
-        "includeAll": false,
+        "includeAll": true,
         "label": "job",
         "multi": true,
         "name": "job",

--- a/mongodb-mixin/dashboards/MongoDB_Instance.json
+++ b/mongodb-mixin/dashboards/MongoDB_Instance.json
@@ -1517,7 +1517,7 @@
         "description": null,
         "error": null,
         "hide": 2,
-        "includeAll": false,
+        "includeAll": true,
         "label": "job",
         "multi": true,
         "name": "job",

--- a/mongodb-mixin/dashboards/MongoDB_ReplicaSet.json
+++ b/mongodb-mixin/dashboards/MongoDB_ReplicaSet.json
@@ -1597,7 +1597,7 @@
         "description": null,
         "error": null,
         "hide": 2,
-        "includeAll": false,
+        "includeAll": true,
         "label": "job",
         "multi": true,
         "name": "job",


### PR DESCRIPTION
Should include all, otherwise hidden 'job' label can 'stuck' to first job value found in the list.