### PR TITLE
Refactor opensearch to use as submixin (modular observ lib)

### DIFF
--- a/opensearch-mixin/.lint
+++ b/opensearch-mixin/.lint
@@ -3,6 +3,7 @@ exclusions:
     reason: Uses --mixed-- (generated from grafonnet)
     entries:
       - panel: 'OpenSearch cluster overview'
+      - panel: 'Roles'
   panel-units-rule:
     reason: "Custom units are used for better user experience in these panels"
     entries:
@@ -32,6 +33,7 @@ exclusions:
       - panel: "Shard count"
       - panel: "Node open connections"
       - panel: 'OpenSearch cluster overview'
+      - panel: 'Roles'
   template-instance-rule:
     reason: "Based on new convention we are using variable names prometheus_datasource and loki_datasource where as linter expects 'datasource'"
   target-instance-rule:

--- a/opensearch-mixin/.lint
+++ b/opensearch-mixin/.lint
@@ -1,4 +1,8 @@
 exclusions:
+  panel-datasource-rule:
+    reason: Uses --mixed-- (generated from grafonnet)
+    entries:
+      - panel: 'OpenSearch cluster overview'
   panel-units-rule:
     reason: "Custom units are used for better user experience in these panels"
     entries:
@@ -27,6 +31,7 @@ exclusions:
       - panel: "Merge count"
       - panel: "Shard count"
       - panel: "Node open connections"
+      - panel: 'OpenSearch cluster overview'
   template-instance-rule:
     reason: "Based on new convention we are using variable names prometheus_datasource and loki_datasource where as linter expects 'datasource'"
   target-instance-rule:

--- a/opensearch-mixin/alerts/alerts.libsonnet
+++ b/opensearch-mixin/alerts/alerts.libsonnet
@@ -2,7 +2,7 @@
   prometheusAlerts+:: {
     groups+: [
       {
-        name: $._config.uid+'-alerts',
+        name: $._config.uid + '-alerts',
         rules: [
           {
             alert: 'OpenSearchYellowCluster',

--- a/opensearch-mixin/alerts/alerts.libsonnet
+++ b/opensearch-mixin/alerts/alerts.libsonnet
@@ -7,7 +7,7 @@
           {
             alert: 'OpenSearchYellowCluster',
             expr: |||
-              opensearch_cluster_status == 1
+              opensearch_cluster_status{%(filteringSelector)s} == 1
             ||| % $._config,
             'for': '5m',
             labels: {
@@ -24,7 +24,7 @@
           {
             alert: 'OpenSearchRedCluster',
             expr: |||
-              opensearch_cluster_status == 2
+              opensearch_cluster_status%(filteringSelector)s == 2
             ||| % $._config,
             'for': '5m',
             labels: {
@@ -41,7 +41,7 @@
           {
             alert: 'OpenSearchUnstableShardReallocation',
             expr: |||
-              sum without(type) (opensearch_cluster_shards_number{type="relocating"}) > %(alertsWarningShardReallocations)s
+              sum without(type) (opensearch_cluster_shards_number{%(filteringSelector)s, type="relocating"}) > %(alertsWarningShardReallocations)s
             ||| % $._config,
             'for': '1m',
             labels: {
@@ -57,7 +57,7 @@
           {
             alert: 'OpenSearchUnstableShardUnassigned',
             expr: |||
-              sum without(type) (opensearch_cluster_shards_number{type="unassigned"}) > %(alertsWarningShardUnassigned)s
+              sum without(type) (opensearch_cluster_shards_number{%(filteringSelector)s, type="unassigned"}) > %(alertsWarningShardUnassigned)s
             ||| % $._config,
             'for': '5m',
             labels: {
@@ -73,7 +73,7 @@
           {
             alert: 'OpenSearchModerateNodeDiskUsage',
             expr: |||
-              100 * sum without(nodeid, path, mount, type) ((opensearch_fs_path_total_bytes - opensearch_fs_path_free_bytes) / opensearch_fs_path_total_bytes) > %(alertsWarningDiskUsage)s
+              100 * sum without(nodeid, path, mount, type) ((opensearch_fs_path_total_bytes{%(filteringSelector)s} - opensearch_fs_path_free_bytes{%(filteringSelector)s}) / opensearch_fs_path_total_bytes{%(filteringSelector)s}) > %(alertsWarningDiskUsage)s
             ||| % $._config,
             'for': '5m',
             labels: {
@@ -89,7 +89,7 @@
           {
             alert: 'OpenSearchHighNodeDiskUsage',
             expr: |||
-              100 * sum without(nodeid, path, mount, type) ((opensearch_fs_path_total_bytes - opensearch_fs_path_free_bytes) / opensearch_fs_path_total_bytes) > %(alertsCriticalDiskUsage)s
+              100 * sum without(nodeid, path, mount, type) ((opensearch_fs_path_total_bytes{%(filteringSelector)s} - opensearch_fs_path_free_bytes) / opensearch_fs_path_total_bytes{%(filteringSelector)s}) > %(alertsCriticalDiskUsage)s
             ||| % $._config,
             'for': '5m',
             labels: {
@@ -105,7 +105,7 @@
           {
             alert: 'OpenSearchModerateNodeCpuUsage',
             expr: |||
-              sum without(nodeid) (opensearch_os_cpu_percent) > %(alertsWarningCPUUsage)s
+              sum without(nodeid) (opensearch_os_cpu_percent{%(filteringSelector)s}) > %(alertsWarningCPUUsage)s
             ||| % $._config,
             'for': '5m',
             labels: {
@@ -121,7 +121,7 @@
           {
             alert: 'OpenSearchHighNodeCpuUsage',
             expr: |||
-              sum without(nodeid) (opensearch_os_cpu_percent) > %(alertsCriticalCPUUsage)s
+              sum without(nodeid) (opensearch_os_cpu_percent{%(filteringSelector)s}) > %(alertsCriticalCPUUsage)s
             ||| % $._config,
             'for': '5m',
             labels: {
@@ -137,7 +137,7 @@
           {
             alert: 'OpenSearchModerateNodeMemoryUsage',
             expr: |||
-              sum without(nodeid) (opensearch_os_mem_used_percent) > %(alertsWarningMemoryUsage)s
+              sum without(nodeid) (opensearch_os_mem_used_percent{%(filteringSelector)s}) > %(alertsWarningMemoryUsage)s
             ||| % $._config,
             'for': '5m',
             labels: {
@@ -153,7 +153,7 @@
           {
             alert: 'OpenSearchHighNodeMemoryUsage',
             expr: |||
-              sum without(nodeid) (opensearch_os_mem_used_percent) > %(alertsCriticalMemoryUsage)s
+              sum without(nodeid) (opensearch_os_mem_used_percent{%(filteringSelector)s}) > %(alertsCriticalMemoryUsage)s
             ||| % $._config,
             'for': '5m',
             labels: {
@@ -169,7 +169,7 @@
           {
             alert: 'OpenSearchModerateRequestLatency',
             expr: |||
-              sum without(context) ((increase(opensearch_index_search_fetch_time_seconds{context="total"}[5m])+increase(opensearch_index_search_query_time_seconds{context="total"}[5m])+increase(opensearch_index_search_scroll_time_seconds{context="total"}[5m])) / clamp_min(increase(opensearch_index_search_fetch_count{context="total"}[5m])+increase(opensearch_index_search_query_count{context="total"}[5m])+increase(opensearch_index_search_scroll_count{context="total"}[5m]), 1)) > %(alertsWarningRequestLatency)s
+              sum without(context) ((increase(opensearch_index_search_fetch_time_seconds{%(filteringSelector)s, context="total"}[5m])+increase(opensearch_index_search_query_time_seconds{context="total"}[5m])+increase(opensearch_index_search_scroll_time_seconds{context="total"}[5m])) / clamp_min(increase(opensearch_index_search_fetch_count{context="total"}[5m])+increase(opensearch_index_search_query_count{context="total"}[5m])+increase(opensearch_index_search_scroll_count{context="total"}[5m]), 1)) > %(alertsWarningRequestLatency)s
             ||| % $._config,
             'for': '5m',
             labels: {
@@ -185,7 +185,7 @@
           {
             alert: 'OpenSearchModerateIndexLatency',
             expr: |||
-              sum without(context) (increase(opensearch_index_indexing_index_time_seconds{context="total"}[5m]) / clamp_min(increase(opensearch_index_indexing_index_count{context="total"}[5m]), 1)) > %(alertsWarningIndexLatency)s
+              sum without(context) (increase(opensearch_index_indexing_index_time_seconds{%(filteringSelector)s, context="total"}[5m]) / clamp_min(increase(opensearch_index_indexing_index_count{context="total"}[5m]), 1)) > %(alertsWarningIndexLatency)s
             ||| % $._config,
             'for': '5m',
             labels: {

--- a/opensearch-mixin/alerts/alerts.libsonnet
+++ b/opensearch-mixin/alerts/alerts.libsonnet
@@ -2,7 +2,7 @@
   prometheusAlerts+:: {
     groups+: [
       {
-        name: 'opensearch',
+        name: $._config.uid+'-alerts',
         rules: [
           {
             alert: 'OpenSearchYellowCluster',
@@ -24,7 +24,7 @@
           {
             alert: 'OpenSearchRedCluster',
             expr: |||
-              opensearch_cluster_status%(filteringSelector)s == 2
+              opensearch_cluster_status{%(filteringSelector)s} == 2
             ||| % $._config,
             'for': '5m',
             labels: {

--- a/opensearch-mixin/config.libsonnet
+++ b/opensearch-mixin/config.libsonnet
@@ -2,7 +2,8 @@
   _config+:: {
     // extra static selector to apply to all templated variables and alerts
     filteringSelector: 'cluster!=""',
-
+    groupLabels: ['job','cluster'],
+    instanceLabels: ['node'],
     dashboardTags: ['opensearch-mixin'],
     dashboardPeriod: 'now-1h',
     dashboardTimezone: 'default',

--- a/opensearch-mixin/config.libsonnet
+++ b/opensearch-mixin/config.libsonnet
@@ -8,6 +8,7 @@
     dashboardPeriod: 'now-1h',
     dashboardTimezone: 'default',
     dashboardRefresh: '1m',
+    dashboardNamePrefix: '',
 
     // prefix dashboards uids
     uid: "opensearch",

--- a/opensearch-mixin/config.libsonnet
+++ b/opensearch-mixin/config.libsonnet
@@ -1,5 +1,8 @@
 {
   _config+:: {
+    // extra static selector to apply to all templated variables and alerts
+    filteringSelector: 'cluster!=""',
+
     dashboardTags: ['opensearch-mixin'],
     dashboardPeriod: 'now-1h',
     dashboardTimezone: 'default',

--- a/opensearch-mixin/config.libsonnet
+++ b/opensearch-mixin/config.libsonnet
@@ -2,7 +2,7 @@
   _config+:: {
     // extra static selector to apply to all templated variables and alerts
     filteringSelector: 'cluster!=""',
-    groupLabels: ['job','cluster'],
+    groupLabels: ['job', 'cluster'],
     instanceLabels: ['node'],
     dashboardTags: ['opensearch-mixin'],
     dashboardPeriod: 'now-1h',
@@ -11,7 +11,7 @@
     dashboardNamePrefix: '',
 
     // prefix dashboards uids
-    uid: "opensearch",
+    uid: 'opensearch',
 
     // alerts thresholds
     alertsWarningShardReallocations: 0,

--- a/opensearch-mixin/config.libsonnet
+++ b/opensearch-mixin/config.libsonnet
@@ -8,6 +8,9 @@
     dashboardTimezone: 'default',
     dashboardRefresh: '1m',
 
+    // prefix dashboards uids
+    uid: "opensearch",
+
     // alerts thresholds
     alertsWarningShardReallocations: 0,
     alertsWarningShardUnassigned: 0,

--- a/opensearch-mixin/dashboards/opensearch-cluster-overview.libsonnet
+++ b/opensearch-mixin/dashboards/opensearch-cluster-overview.libsonnet
@@ -4,7 +4,7 @@ local dashboard = grafana.dashboard;
 local template = grafana.template;
 local prometheus = grafana.prometheus;
 
-local dashboardUid = 'opensearch-cluster-overview';
+local dashboardUidSuffix = '-cluster-overview';
 
 local promDatasourceName = 'prometheus_datasource';
 
@@ -1541,7 +1541,7 @@ local topIndicesByIndexFailuresPanel = {
         timezone='%s' % $._config.dashboardTimezone,
         refresh='%s' % $._config.dashboardRefresh,
         description='',
-        uid=dashboardUid,
+        uid=$._config.uid+dashboardUidSuffix,
       )
       .addLink(grafana.link.dashboards(
         asDropdown=false,

--- a/opensearch-mixin/dashboards/opensearch-cluster-overview.libsonnet
+++ b/opensearch-mixin/dashboards/opensearch-cluster-overview.libsonnet
@@ -1,7 +1,5 @@
-local g = (import 'grafana-builder/grafana.libsonnet');
+local g = (import '../g.libsonnet');
 local grafana = (import 'grafonnet/grafana.libsonnet');
-local dashboard = grafana.dashboard;
-local template = grafana.template;
 local prometheus = grafana.prometheus;
 local commonlib = import 'common-lib/common/main.libsonnet';
 local utils = commonlib.utils;
@@ -1660,29 +1658,22 @@ local dashboardUidSuffix = '-cluster-overview';
     },
   },
 
-
   grafanaDashboards+:: {
     'opensearch-cluster-overview.json':
-      dashboard.new(
-        'OpenSearch cluster overview',
-        time_from='%s' % $._config.dashboardPeriod,
-        tags=($._config.dashboardTags),
-        timezone='%s' % $._config.dashboardTimezone,
-        refresh='%s' % $._config.dashboardRefresh,
-        description='',
-        uid=$._config.uid + dashboardUidSuffix,
+      g.dashboard.new('OpenSearch cluster overview')
+      + g.dashboard.withTags($._config.dashboardTags)
+      + g.dashboard.time.withFrom($._config.dashboardPeriod)
+      + g.dashboard.withTimezone($._config.dashboardTimezone)
+      + g.dashboard.withRefresh($._config.dashboardRefresh)
+      + g.dashboard.withUid($._config.uid + dashboardUidSuffix)
+      + g.dashboard.link.dashboards.new(
+        'Other Opensearch dashboards',
+        $._config.dashboardTags
       )
-      .addLink(grafana.link.dashboards(
-        asDropdown=false,
-        title='Other OpenSearch dashboards',
-        includeVars=true,
-        keepTime=true,
-        tags=($._config.dashboardTags),
-      ))
-      .addTemplates(
-        variables.singleInstance
-      )
-      .addPanels(
+      + g.dashboard.link.dashboards.options.withIncludeVars(true)
+      + g.dashboard.link.dashboards.options.withKeepTime(true)
+      + g.dashboard.link.dashboards.options.withAsDropdown(false)
+      + g.dashboard.withPanels(
         [
           clusterStatusPanel { gridPos: { h: 4, w: 4, x: 0, y: 0 } },
           nodeCountPanel { gridPos: { h: 4, w: 5, x: 4, y: 0 } },
@@ -1708,6 +1699,7 @@ local dashboardUidSuffix = '-cluster-overview';
           topIndicesByIndexLatencyPanel { gridPos: { h: 8, w: 8, x: 8, y: 40 } },
           topIndicesByIndexFailuresPanel { gridPos: { h: 8, w: 8, x: 16, y: 40 } },
         ]
-      ),
+      )
+      + g.dashboard.withVariables(variables.singleInstance),
   },
 }

--- a/opensearch-mixin/dashboards/opensearch-cluster-overview.libsonnet
+++ b/opensearch-mixin/dashboards/opensearch-cluster-overview.libsonnet
@@ -1,5 +1,5 @@
-local g = (import '../g.libsonnet');
-local grafana = (import 'grafonnet/grafana.libsonnet');
+local g = import '../g.libsonnet';
+local grafana = import 'grafonnet/grafana.libsonnet';
 local prometheus = grafana.prometheus;
 local commonlib = import 'common-lib/common/main.libsonnet';
 local utils = commonlib.utils;
@@ -14,6 +14,12 @@ local dashboardUidSuffix = '-cluster-overview';
     groupLabels=$._config.groupLabels,
     instanceLabels=[],
     varMetric='opensearch_cluster_status'
+  ),
+
+  local panels = (import '../panels.libsonnet').new(
+    $._config.groupLabels,
+    $._config.instanceLabels,
+    variables,
   ),
 
   local promDatasource = {
@@ -1660,7 +1666,7 @@ local dashboardUidSuffix = '-cluster-overview';
 
   grafanaDashboards+:: {
     'opensearch-cluster-overview.json':
-      g.dashboard.new($._config.dashboardNamePrefix +'OpenSearch cluster overview')
+      g.dashboard.new($._config.dashboardNamePrefix + 'OpenSearch cluster overview')
       + g.dashboard.withTags($._config.dashboardTags)
       + g.dashboard.time.withFrom($._config.dashboardPeriod)
       + g.dashboard.withTimezone($._config.dashboardTimezone)
@@ -1677,11 +1683,13 @@ local dashboardUidSuffix = '-cluster-overview';
       )
       + g.dashboard.withPanels(
         [
-          clusterStatusPanel { gridPos: { h: 4, w: 4, x: 0, y: 0 } },
-          nodeCountPanel { gridPos: { h: 4, w: 5, x: 4, y: 0 } },
-          dataNodeCountPanel { gridPos: { h: 4, w: 5, x: 9, y: 0 } },
-          shardCountPanel { gridPos: { h: 4, w: 5, x: 14, y: 0 } },
-          activeShardsPercentagePanel { gridPos: { h: 4, w: 5, x: 19, y: 0 } },
+          panels.osRoles { gridPos: { h: 6, w: 24, x: 0, y: 0 } },
+          clusterStatusPanel { gridPos: { h: 5, w: 3, x: 0, y: 2 } },
+          nodeCountPanel { gridPos: { h: 5, w: 3, x: 3, y: 2 } },
+          dataNodeCountPanel { gridPos: { h: 5, w: 3, x: 6, y: 2 } },
+          shardCountPanel { gridPos: { h: 5, w: 3, x: 9, y: 2 } },
+          activeShardsPercentagePanel { gridPos: { h: 5, w: 3, x: 12, y: 2 } },
+          panels.osRolesTimeline { gridPos: { h: 5, w: 9, x: 15, y: 2 } },
           topNodesByCPUUsagePanel { gridPos: { h: 9, w: 8, x: 0, y: 4 } },
           breakersTrippedPanel { gridPos: { h: 9, w: 8, x: 8, y: 4 } },
           shardStatusPanel { gridPos: { h: 9, w: 8, x: 16, y: 4 } },

--- a/opensearch-mixin/dashboards/opensearch-cluster-overview.libsonnet
+++ b/opensearch-mixin/dashboards/opensearch-cluster-overview.libsonnet
@@ -1660,19 +1660,21 @@ local dashboardUidSuffix = '-cluster-overview';
 
   grafanaDashboards+:: {
     'opensearch-cluster-overview.json':
-      g.dashboard.new('OpenSearch cluster overview')
+      g.dashboard.new($._config.dashboardNamePrefix +'OpenSearch cluster overview')
       + g.dashboard.withTags($._config.dashboardTags)
       + g.dashboard.time.withFrom($._config.dashboardPeriod)
       + g.dashboard.withTimezone($._config.dashboardTimezone)
       + g.dashboard.withRefresh($._config.dashboardRefresh)
       + g.dashboard.withUid($._config.uid + dashboardUidSuffix)
-      + g.dashboard.link.dashboards.new(
-        'Other Opensearch dashboards',
-        $._config.dashboardTags
+      + g.dashboard.withLinks(
+        g.dashboard.link.dashboards.new(
+          'Other Opensearch dashboards',
+          $._config.dashboardTags
+        )
+        + g.dashboard.link.dashboards.options.withIncludeVars(true)
+        + g.dashboard.link.dashboards.options.withKeepTime(true)
+        + g.dashboard.link.dashboards.options.withAsDropdown(false)
       )
-      + g.dashboard.link.dashboards.options.withIncludeVars(true)
-      + g.dashboard.link.dashboards.options.withKeepTime(true)
-      + g.dashboard.link.dashboards.options.withAsDropdown(false)
       + g.dashboard.withPanels(
         [
           clusterStatusPanel { gridPos: { h: 4, w: 4, x: 0, y: 0 } },

--- a/opensearch-mixin/dashboards/opensearch-cluster-overview.libsonnet
+++ b/opensearch-mixin/dashboards/opensearch-cluster-overview.libsonnet
@@ -3,1535 +3,1664 @@ local grafana = (import 'grafonnet/grafana.libsonnet');
 local dashboard = grafana.dashboard;
 local template = grafana.template;
 local prometheus = grafana.prometheus;
+local commonlib = import 'common-lib/common/main.libsonnet';
+local utils = commonlib.utils;
 
 local dashboardUidSuffix = '-cluster-overview';
 
-local promDatasourceName = 'prometheus_datasource';
-
-local promDatasource = {
-  uid: '${%s}' % promDatasourceName,
-};
-
-local clusterStatusPanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'min by(job, cluster) (opensearch_cluster_status{job=~"$job", cluster=~"$opensearch_cluster"})',
-      datasource=promDatasource,
-      legendFormat='{{cluster}}',
-    ),
-  ],
-  type: 'stat',
-  title: 'Cluster status',
-  description: 'The overall health and availability of the OpenSearch cluster.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'thresholds',
-      },
-      mappings: [
-        {
-          options: {
-            '0': {
-              index: 0,
-              text: 'Green',
-            },
-            '1': {
-              index: 1,
-              text: 'Yellow',
-            },
-            '2': {
-              index: 2,
-              text: 'Red',
-            },
-          },
-          type: 'value',
-        },
-      ],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-          {
-            color: 'green',
-            value: 0,
-          },
-          {
-            color: 'yellow',
-            value: 1,
-          },
-          {
-            color: 'red',
-            value: 2,
-          },
-        ],
-      },
-    },
-    overrides: [],
-  },
-  options: {
-    colorMode: 'value',
-    graphMode: 'none',
-    justifyMode: 'auto',
-    orientation: 'auto',
-    reduceOptions: {
-      calcs: [
-        'lastNotNull',
-      ],
-      fields: '',
-      values: false,
-    },
-    textMode: 'auto',
-  },
-  pluginVersion: '9.4.3',
-};
-
-local nodeCountPanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'sum by(job, cluster) (opensearch_cluster_nodes_number{job=~"$job", cluster=~"$opensearch_cluster"})',
-      datasource=promDatasource,
-      legendFormat='{{ cluster }}',
-    ),
-  ],
-  type: 'stat',
-  title: 'Node count',
-  description: 'The number of running nodes across the OpenSearch cluster.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'thresholds',
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-          {
-            color: 'red',
-            value: 0,
-          },
-          {
-            color: 'green',
-            value: 1,
-          },
-        ],
-      },
-    },
-    overrides: [],
-  },
-  options: {
-    colorMode: 'value',
-    graphMode: 'none',
-    justifyMode: 'auto',
-    orientation: 'auto',
-    reduceOptions: {
-      calcs: [
-        'lastNotNull',
-      ],
-      fields: '',
-      values: false,
-    },
-    textMode: 'auto',
-  },
-  pluginVersion: '9.4.3',
-};
-
-local dataNodeCountPanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'sum by(job, cluster) (opensearch_cluster_datanodes_number{job=~"$job", cluster=~"$opensearch_cluster"})',
-      datasource=promDatasource,
-      legendFormat='{{ cluster }}',
-    ),
-  ],
-  type: 'stat',
-  title: 'Data node count',
-  description: 'The number of data nodes in the OpenSearch cluster.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'thresholds',
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-          {
-            color: 'red',
-            value: 0,
-          },
-          {
-            color: 'green',
-            value: 1,
-          },
-        ],
-      },
-    },
-    overrides: [],
-  },
-  options: {
-    colorMode: 'value',
-    graphMode: 'none',
-    justifyMode: 'auto',
-    orientation: 'auto',
-    reduceOptions: {
-      calcs: [
-        'lastNotNull',
-      ],
-      fields: '',
-      values: false,
-    },
-    textMode: 'auto',
-  },
-  pluginVersion: '9.4.3',
-};
-
-local shardCountPanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'sum by(job, cluster) (opensearch_cluster_shards_number{job=~"$job", cluster=~"$opensearch_cluster"})',
-      datasource=promDatasource,
-      legendFormat='{{cluster}}',
-    ),
-  ],
-  type: 'stat',
-  title: 'Shard count',
-  description: 'The number of shards in the OpenSearch cluster across all indices.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'thresholds',
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-          {
-            color: 'red',
-            value: 0,
-          },
-          {
-            color: 'green',
-            value: 1,
-          },
-        ],
-      },
-    },
-    overrides: [],
-  },
-  options: {
-    colorMode: 'value',
-    graphMode: 'none',
-    justifyMode: 'auto',
-    orientation: 'auto',
-    reduceOptions: {
-      calcs: [
-        'lastNotNull',
-      ],
-      fields: '',
-      values: false,
-    },
-    textMode: 'auto',
-  },
-  pluginVersion: '9.4.3',
-};
-
-local activeShardsPercentagePanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'avg by(job, cluster) (opensearch_cluster_shards_active_percent{job=~"$job", cluster=~"$opensearch_cluster"})',
-      datasource=promDatasource,
-      legendFormat='{{cluster}}',
-    ),
-  ],
-  type: 'stat',
-  title: 'Active shards %',
-  description: 'Percent of active shards across the OpenSearch cluster.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'thresholds',
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-          {
-            color: 'red',
-            value: 0,
-          },
-          {
-            color: 'yellow',
-            value: 1,
-          },
-          {
-            color: 'green',
-            value: 100,
-          },
-        ],
-      },
-      unit: 'percent',
-    },
-    overrides: [],
-  },
-  options: {
-    colorMode: 'value',
-    graphMode: 'none',
-    justifyMode: 'auto',
-    orientation: 'auto',
-    reduceOptions: {
-      calcs: [
-        'lastNotNull',
-      ],
-      fields: '',
-      values: false,
-    },
-    textMode: 'auto',
-  },
-  pluginVersion: '9.4.3',
-};
-
-local topNodesByCPUUsagePanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'topk(10, sort_desc(sum by(node, cluster, job) (opensearch_os_cpu_percent{job=~"$job", cluster=~"$opensearch_cluster"})))',
-      datasource=promDatasource,
-      legendFormat='{{node}}',
-    ),
-  ],
-  type: 'bargauge',
-  title: 'Top nodes by CPU usage',
-  description: 'Top nodes by OS CPU usage across the OpenSearch cluster.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'thresholds',
-      },
-      mappings: [],
-      max: 100,
-      min: 0,
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-          {
-            color: 'red',
-            value: 80,
-          },
-        ],
-      },
-      unit: 'percent',
-    },
-    overrides: [],
-  },
-  options: {
-    displayMode: 'gradient',
-    minVizHeight: 10,
-    minVizWidth: 0,
-    orientation: 'horizontal',
-    reduceOptions: {
-      calcs: [
-        'lastNotNull',
-      ],
-      fields: '',
-      values: false,
-    },
-    showUnfilled: true,
-  },
-  pluginVersion: '9.4.3',
-};
-
-local breakersTrippedPanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'sum by(job, cluster, node) (increase(opensearch_circuitbreaker_tripped_count{job=~"$job", cluster=~"$opensearch_cluster"}[$__interval:]))',
-      datasource=promDatasource,
-      legendFormat='{{node}}',
-      interval='1m',
-    ),
-  ],
-  type: 'bargauge',
-  title: 'Breakers tripped',
-  description: 'The total count of circuit breakers tripped across the OpenSearch cluster.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'thresholds',
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-          {
-            color: 'red',
-            value: 80,
-          },
-        ],
-      },
-      unit: 'trips',
-    },
-    overrides: [],
-  },
-  options: {
-    displayMode: 'gradient',
-    minVizHeight: 10,
-    minVizWidth: 0,
-    orientation: 'horizontal',
-    reduceOptions: {
-      calcs: [
-        'lastNotNull',
-      ],
-      fields: '',
-      values: false,
-    },
-    showUnfilled: true,
-  },
-  pluginVersion: '9.4.3',
-};
-
-local shardStatusPanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'sum by(type, job, cluster) (opensearch_cluster_shards_number{job=~"$job", cluster=~"$opensearch_cluster"})',
-      datasource=promDatasource,
-      legendFormat='{{type}}',
-    ),
-  ],
-  type: 'bargauge',
-  title: 'Shard status',
-  description: 'Shard status counts across the Opensearch cluster.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'thresholds',
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-          {
-            color: 'red',
-            value: 80,
-          },
-        ],
-      },
-      unit: 'shards',
-    },
-    overrides: [],
-  },
-  options: {
-    displayMode: 'gradient',
-    minVizHeight: 10,
-    minVizWidth: 0,
-    orientation: 'horizontal',
-    reduceOptions: {
-      calcs: [
-        'lastNotNull',
-      ],
-      fields: '',
-      values: false,
-    },
-    showUnfilled: true,
-  },
-  pluginVersion: '9.4.3',
-};
-
-local topNodesByDiskUsagePanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'topk(10, sort_desc((100 * (sum by(node, job, cluster) (opensearch_fs_path_total_bytes{job=~"$job", cluster=~"$opensearch_cluster"}) - sum by(node, job, cluster) (opensearch_fs_path_free_bytes{job=~"$job", cluster=~"$opensearch_cluster"})) / sum by(node, job, cluster) (opensearch_fs_path_total_bytes{job=~"$job", cluster=~"$opensearch_cluster"}))))',
-      datasource=promDatasource,
-      legendFormat='{{node}}',
-    ),
-  ],
-  type: 'bargauge',
-  title: 'Top nodes by disk usage',
-  description: 'Top nodes by disk usage across the OpenSearch cluster.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'thresholds',
-      },
-      mappings: [],
-      max: 100,
-      min: 0,
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-          {
-            color: 'red',
-            value: 80,
-          },
-        ],
-      },
-      unit: 'percent',
-    },
-    overrides: [],
-  },
-  options: {
-    displayMode: 'gradient',
-    minVizHeight: 10,
-    minVizWidth: 0,
-    orientation: 'horizontal',
-    reduceOptions: {
-      calcs: [
-        'lastNotNull',
-      ],
-      fields: '',
-      values: false,
-    },
-    showUnfilled: true,
-  },
-  pluginVersion: '9.4.3',
-};
-
-local totalDocumentsPanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'sum by(job, cluster) (opensearch_indices_indexing_index_count{job=~"$job", cluster=~"$opensearch_cluster"})',
-      datasource=promDatasource,
-      legendFormat='{{cluster}}',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'Total documents',
-  description: 'The total count of documents indexed across the OpenSearch cluster.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-        ],
-      },
-      unit: 'documents',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'single',
-      sort: 'none',
-    },
-  },
-};
-
-local pendingTasksPanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'sum by(cluster, job) (opensearch_cluster_pending_tasks_number{job=~"$job", cluster=~"$opensearch_cluster"})',
-      datasource=promDatasource,
-      legendFormat='{{cluster}}',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'Pending tasks',
-  description: 'The number of tasks waiting to be executed across the OpenSearch cluster.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-        ],
-      },
-      unit: 'tasks',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'single',
-      sort: 'none',
-    },
-  },
-};
-
-local storeSizePanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'sum by(job, cluster) (opensearch_indices_store_size_bytes{job=~"$job", cluster=~"$opensearch_cluster"})',
-      datasource=promDatasource,
-      legendFormat='{{cluster}}',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'Store size',
-  description: 'The total size of the store across the OpenSearch cluster.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-        ],
-      },
-      unit: 'bytes',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'single',
-      sort: 'none',
-    },
-  },
-};
-
-local maxTaskWaitTimePanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'max by (cluster, job) (opensearch_cluster_task_max_waiting_time_seconds{job=~"$job", cluster=~"$opensearch_cluster"})',
-      datasource=promDatasource,
-      legendFormat='{{cluster}}',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'Max task wait time',
-  description: 'The max wait time for tasks to be executed across the OpenSearch cluster.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-        ],
-      },
-      unit: 's',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'single',
-      sort: 'none',
-    },
-  },
-};
-
-local clusterSearchAndIndexSummaryRow = {
-  datasource: promDatasource,
-  targets: [],
-  type: 'row',
-  title: 'Cluster search and index summary',
-  collapsed: false,
-};
-
-local topIndicesByRequestRatePanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'topk(10, sort_desc(sum by(index, job, cluster) (opensearch_index_search_fetch_current_number{job=~"$job", cluster=~"$opensearch_cluster", context="total"}+opensearch_index_search_query_current_number{job=~"$job", cluster=~"$opensearch_cluster", context="total"}+opensearch_index_search_scroll_current_number{job=~"$job", cluster=~"$opensearch_cluster", context="total"})))',
-      datasource=promDatasource,
-      legendFormat='{{index}}',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'Top indices by request rate',
-  description: 'Top indices by combined fetch, query, and scroll request rate across the OpenSearch cluster.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-          {
-            color: 'red',
-            value: 80,
-          },
-        ],
-      },
-      unit: 'reqps',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'single',
-      sort: 'none',
-    },
-  },
-};
-
-local topIndicesByRequestLatencyPanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'topk(10, sort_desc(sum by(index, job, cluster) ((increase(opensearch_index_search_fetch_time_seconds{job=~"$job", cluster=~"$opensearch_cluster", context="total"}[$__interval:])+increase(opensearch_index_search_query_time_seconds{job=~"$job", cluster=~"$opensearch_cluster", context="total"}[$__interval:])+increase(opensearch_index_search_scroll_time_seconds{job=~"$job", cluster=~"$opensearch_cluster", context="total"}[$__interval:])) / clamp_min(increase(opensearch_index_search_fetch_count{job=~"$job", cluster=~"$opensearch_cluster", context="total"}[$__interval:])+increase(opensearch_index_search_query_count{job=~"$job", cluster=~"$opensearch_cluster", context="total"}[$__interval:])+increase(opensearch_index_search_scroll_count{job=~"$job", cluster=~"$opensearch_cluster", context="total"}[$__interval:]), 1))))',
-      datasource=promDatasource,
-      legendFormat='{{index}}',
-      interval='1m',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'Top indices by request latency',
-  description: 'Top indices by combined fetch, query, and scroll latency across the OpenSearch cluster.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-        ],
-      },
-      unit: 's',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'single',
-      sort: 'none',
-    },
-  },
-};
-
-local topIndicesByCombinedCacheHitRatioPanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'topk(10, sort_desc(sum by(index, job, cluster) (100 * (opensearch_index_requestcache_hit_count{job=~"$job", cluster=~"$opensearch_cluster", context="total"} + opensearch_index_querycache_hit_count{job=~"$job", cluster=~"$opensearch_cluster", context="total"}) / clamp_min((opensearch_index_requestcache_hit_count{job=~"$job", cluster=~"$opensearch_cluster", context="total"} + opensearch_index_querycache_hit_count{job=~"$job", cluster=~"$opensearch_cluster", context="total"} + opensearch_index_requestcache_miss_count{job=~"$job", cluster=~"$opensearch_cluster", context="total"} + opensearch_index_querycache_miss_number{job=~"$job", cluster=~"$opensearch_cluster", context="total"}), 1))))',
-      datasource=promDatasource,
-      legendFormat='{{index}}',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'Top indices by combined cache hit ratio',
-  description: 'Top indices by cache hit ratio for the combined request and query cache across the OpenSearch cluster.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-          {
-            color: 'red',
-            value: 80,
-          },
-        ],
-      },
-      unit: 'percent',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'single',
-      sort: 'none',
-    },
-  },
-};
-
-local topNodesByIngestRatePanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'topk(10, sum by(cluster, job, node) (rate(opensearch_ingest_total_count{job=~"$job", cluster=~"$opensearch_cluster"}[$__rate_interval])))',
-      datasource=promDatasource,
-      legendFormat='{{node}}',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'Top nodes by ingest rate',
-  description: 'Top nodes by rate of ingest across the OpenSearch cluster.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-          {
-            color: 'red',
-            value: 80,
-          },
-        ],
-      },
-      unit: 'Bps',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'single',
-      sort: 'none',
-    },
-  },
-};
-
-local topNodesByIngestLatencyPanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'topk(10, sum by(job, cluster, node) (increase(opensearch_ingest_total_time_seconds{job=~"$job", cluster=~"$opensearch_cluster"}[$__interval:]) / clamp_min(increase(opensearch_ingest_total_count{job=~"$job", cluster=~"$opensearch_cluster"}[$__interval:]), 1)))',
-      datasource=promDatasource,
-      legendFormat='{{node}}',
-      interval='1m',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'Top nodes by ingest latency',
-  description: 'Top nodes by ingestion latency across the OpenSearch cluster.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-          {
-            color: 'red',
-            value: 80,
-          },
-        ],
-      },
-      unit: 's',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'single',
-      sort: 'none',
-    },
-  },
-};
-
-local topNodesByIngestErrorsPanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'topk(10, sum by(cluster, job, node) (increase(opensearch_ingest_total_failed_count{job=~"$job", cluster=~"$opensearch_cluster"}[$__interval:])))',
-      datasource=promDatasource,
-      legendFormat='{{node}}',
-      interval='1m',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'Top nodes by ingest errors',
-  description: 'Top nodes by ingestion failures across the OpenSearch cluster.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-        ],
-      },
-      unit: 'errors',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'single',
-      sort: 'none',
-    },
-  },
-};
-
-local topIndicesByIndexRatePanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'topk(10, sum by(cluster, job, index) (opensearch_index_indexing_index_current_number{job=~"$job", cluster=~"$opensearch_cluster"}))',
-      datasource=promDatasource,
-      legendFormat='{{index}}',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'Top indices by index rate',
-  description: 'Top indices by rate of document indexing across the OpenSearch cluster.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-        ],
-      },
-      unit: 'documents/s',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'single',
-      sort: 'none',
-    },
-  },
-};
-
-local topIndicesByIndexLatencyPanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'topk(10, sum by(job, cluster, index) (increase(opensearch_index_indexing_index_time_seconds{job=~"$job", cluster=~"$opensearch_cluster", context="total"}[$__interval:]) / clamp_min(increase(opensearch_index_indexing_index_count{job=~"$job", cluster=~"$opensearch_cluster", context="total"}[$__interval:]), 1)))',
-      datasource=promDatasource,
-      legendFormat='{{index}}',
-      interval='1m',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'Top indices by index latency',
-  description: 'Top indices by indexing latency across the OpenSearch cluster.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-        ],
-      },
-      unit: 's',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'single',
-      sort: 'none',
-    },
-  },
-};
-
-local topIndicesByIndexFailuresPanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'topk(10, sum by(cluster, job, index) (increase(opensearch_index_indexing_index_failed_count{job=~"$job", cluster=~"$opensearch_cluster"}[$__interval:])))',
-      datasource=promDatasource,
-      legendFormat='{{index}}',
-      interval='1m',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'Top indices by index failures',
-  description: 'Top indices by index document failures across the OpenSearch cluster.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-        ],
-      },
-      unit: 'failures',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'single',
-      sort: 'none',
-    },
-  },
-};
 
 {
+  // variables
+  local variables = (import '../variables.libsonnet').new(
+    filteringSelector=$._config.filteringSelector,
+    groupLabels=$._config.groupLabels,
+    instanceLabels=[],
+    varMetric='opensearch_cluster_status'
+  ),
+
+  local promDatasource = {
+    uid: '${%s}' % variables.datasources.prometheus.name,
+  },
+  // panels
+  local clusterStatusPanel = {
+    datasource: promDatasource,
+    targets: [
+      prometheus.target(
+        'min by(%(agg)s) (opensearch_cluster_status{%(queriesSelector)s})'
+        % {
+          queriesSelector: variables.queriesSelector,
+          agg: std.join(',', $._config.groupLabels),
+        },
+        datasource=promDatasource,
+        legendFormat=utils.labelsToPanelLegend($._config.groupLabels)
+      ),
+    ],
+    type: 'stat',
+    title: 'Cluster status',
+    description: 'The overall health and availability of the OpenSearch cluster.',
+    fieldConfig: {
+      defaults: {
+        color: {
+          mode: 'thresholds',
+        },
+        mappings: [
+          {
+            options: {
+              '0': {
+                index: 0,
+                text: 'Green',
+              },
+              '1': {
+                index: 1,
+                text: 'Yellow',
+              },
+              '2': {
+                index: 2,
+                text: 'Red',
+              },
+            },
+            type: 'value',
+          },
+        ],
+        thresholds: {
+          mode: 'absolute',
+          steps: [
+            {
+              color: 'green',
+              value: null,
+            },
+            {
+              color: 'green',
+              value: 0,
+            },
+            {
+              color: 'yellow',
+              value: 1,
+            },
+            {
+              color: 'red',
+              value: 2,
+            },
+          ],
+        },
+      },
+      overrides: [],
+    },
+    options: {
+      colorMode: 'value',
+      graphMode: 'none',
+      justifyMode: 'auto',
+      orientation: 'auto',
+      reduceOptions: {
+        calcs: [
+          'lastNotNull',
+        ],
+        fields: '',
+        values: false,
+      },
+      textMode: 'auto',
+    },
+    pluginVersion: '9.4.3',
+  },
+
+  local nodeCountPanel = {
+    datasource: promDatasource,
+    targets: [
+      prometheus.target(
+        'min by(%(agg)s) (opensearch_cluster_nodes_number{%(queriesSelector)s})'
+        % {
+          queriesSelector: variables.queriesSelector,
+          agg: std.join(',', $._config.groupLabels),
+        },
+        datasource=promDatasource,
+        legendFormat=utils.labelsToPanelLegend($._config.groupLabels)
+      ),
+    ],
+    type: 'stat',
+    title: 'Node count',
+    description: 'The number of running nodes across the OpenSearch cluster.',
+    fieldConfig: {
+      defaults: {
+        color: {
+          mode: 'thresholds',
+        },
+        mappings: [],
+        thresholds: {
+          mode: 'absolute',
+          steps: [
+            {
+              color: 'green',
+              value: null,
+            },
+            {
+              color: 'red',
+              value: 0,
+            },
+            {
+              color: 'green',
+              value: 1,
+            },
+          ],
+        },
+      },
+      overrides: [],
+    },
+    options: {
+      colorMode: 'value',
+      graphMode: 'none',
+      justifyMode: 'auto',
+      orientation: 'auto',
+      reduceOptions: {
+        calcs: [
+          'lastNotNull',
+        ],
+        fields: '',
+        values: false,
+      },
+      textMode: 'auto',
+    },
+    pluginVersion: '9.4.3',
+  },
+
+  local dataNodeCountPanel = {
+    datasource: promDatasource,
+    targets: [
+      prometheus.target(
+        'min by(%(agg)s) (opensearch_cluster_datanodes_number{%(queriesSelector)s})'
+        % {
+          queriesSelector: variables.queriesSelector,
+          agg: std.join(',', $._config.groupLabels),
+        },
+        datasource=promDatasource,
+        legendFormat=utils.labelsToPanelLegend($._config.groupLabels)
+      ),
+    ],
+    type: 'stat',
+    title: 'Data node count',
+    description: 'The number of data nodes in the OpenSearch cluster.',
+    fieldConfig: {
+      defaults: {
+        color: {
+          mode: 'thresholds',
+        },
+        mappings: [],
+        thresholds: {
+          mode: 'absolute',
+          steps: [
+            {
+              color: 'green',
+              value: null,
+            },
+            {
+              color: 'red',
+              value: 0,
+            },
+            {
+              color: 'green',
+              value: 1,
+            },
+          ],
+        },
+      },
+      overrides: [],
+    },
+    options: {
+      colorMode: 'value',
+      graphMode: 'none',
+      justifyMode: 'auto',
+      orientation: 'auto',
+      reduceOptions: {
+        calcs: [
+          'lastNotNull',
+        ],
+        fields: '',
+        values: false,
+      },
+      textMode: 'auto',
+    },
+    pluginVersion: '9.4.3',
+  },
+
+  local shardCountPanel = {
+    datasource: promDatasource,
+    targets: [
+      prometheus.target(
+        'sum(max by (type) (opensearch_cluster_shards_number{%(queriesSelector)s}))'
+        % {
+          queriesSelector: variables.queriesSelector,
+          agg: std.join(',', $._config.groupLabels),
+        },
+        datasource=promDatasource,
+        legendFormat=utils.labelsToPanelLegend($._config.groupLabels)
+      ),
+    ],
+    type: 'stat',
+    title: 'Shard count',
+    description: 'The number of shards in the OpenSearch cluster across all indices.',
+    fieldConfig: {
+      defaults: {
+        color: {
+          mode: 'thresholds',
+        },
+        mappings: [],
+        thresholds: {
+          mode: 'absolute',
+          steps: [
+            {
+              color: 'green',
+              value: null,
+            },
+            {
+              color: 'red',
+              value: 0,
+            },
+            {
+              color: 'green',
+              value: 1,
+            },
+          ],
+        },
+      },
+      overrides: [],
+    },
+    options: {
+      colorMode: 'value',
+      graphMode: 'none',
+      justifyMode: 'auto',
+      orientation: 'auto',
+      reduceOptions: {
+        calcs: [
+          'lastNotNull',
+        ],
+        fields: '',
+        values: false,
+      },
+      textMode: 'auto',
+    },
+    pluginVersion: '9.4.3',
+  },
+
+  local activeShardsPercentagePanel = {
+    datasource: promDatasource,
+    targets: [
+      prometheus.target(
+        'min by(%(agg)s) (opensearch_cluster_shards_active_percent{%(queriesSelector)s})'
+        % {
+          queriesSelector: variables.queriesSelector,
+          agg: std.join(',', $._config.groupLabels),
+        },
+        datasource=promDatasource,
+        legendFormat=utils.labelsToPanelLegend($._config.groupLabels)
+      ),
+
+    ],
+    type: 'stat',
+    title: 'Active shards %',
+    description: 'Percent of active shards across the OpenSearch cluster.',
+    fieldConfig: {
+      defaults: {
+        color: {
+          mode: 'thresholds',
+        },
+        mappings: [],
+        thresholds: {
+          mode: 'absolute',
+          steps: [
+            {
+              color: 'green',
+              value: null,
+            },
+            {
+              color: 'red',
+              value: 0,
+            },
+            {
+              color: 'yellow',
+              value: 1,
+            },
+            {
+              color: 'green',
+              value: 100,
+            },
+          ],
+        },
+        unit: 'percent',
+      },
+      overrides: [],
+    },
+    options: {
+      colorMode: 'value',
+      graphMode: 'none',
+      justifyMode: 'auto',
+      orientation: 'auto',
+      reduceOptions: {
+        calcs: [
+          'lastNotNull',
+        ],
+        fields: '',
+        values: false,
+      },
+      textMode: 'auto',
+    },
+    pluginVersion: '9.4.3',
+  },
+
+  local topNodesByCPUUsagePanel = {
+    datasource: promDatasource,
+    targets: [
+      prometheus.target(
+        'topk(10, sort_desc(sum by(node, %(agg)s) (opensearch_os_cpu_percent{%(queriesSelector)s})))'
+        % {
+          queriesSelector: variables.queriesSelector,
+          agg: std.join(',', $._config.groupLabels),
+        },
+        datasource=promDatasource,
+        legendFormat='{{node}}',
+      ),
+    ],
+    type: 'bargauge',
+    title: 'Top nodes by CPU usage',
+    description: 'Top nodes by OS CPU usage across the OpenSearch cluster.',
+    fieldConfig: {
+      defaults: {
+        color: {
+          mode: 'thresholds',
+        },
+        mappings: [],
+        max: 100,
+        min: 0,
+        thresholds: {
+          mode: 'absolute',
+          steps: [
+            {
+              color: 'green',
+              value: null,
+            },
+            {
+              color: 'red',
+              value: 80,
+            },
+          ],
+        },
+        unit: 'percent',
+      },
+      overrides: [],
+    },
+    options: {
+      displayMode: 'gradient',
+      minVizHeight: 10,
+      minVizWidth: 0,
+      orientation: 'horizontal',
+      reduceOptions: {
+        calcs: [
+          'lastNotNull',
+        ],
+        fields: '',
+        values: false,
+      },
+      showUnfilled: true,
+    },
+    pluginVersion: '9.4.3',
+  },
+
+  local breakersTrippedPanel = {
+    datasource: promDatasource,
+    targets: [
+      prometheus.target(
+        'sum by(%(agg)s, node) (increase(opensearch_circuitbreaker_tripped_count{%(queriesSelector)s}[$__interval:]))'
+        % {
+          queriesSelector: variables.queriesSelector,
+          agg: std.join(',', $._config.groupLabels),
+        },
+        datasource=promDatasource,
+        legendFormat='{{node}}',
+        interval='1m',
+      ),
+    ],
+    type: 'bargauge',
+    title: 'Breakers tripped',
+    description: 'The total count of circuit breakers tripped across the OpenSearch cluster.',
+    fieldConfig: {
+      defaults: {
+        color: {
+          mode: 'thresholds',
+        },
+        mappings: [],
+        thresholds: {
+          mode: 'absolute',
+          steps: [
+            {
+              color: 'green',
+              value: null,
+            },
+            {
+              color: 'red',
+              value: 80,
+            },
+          ],
+        },
+        unit: 'trips',
+      },
+      overrides: [],
+    },
+    options: {
+      displayMode: 'gradient',
+      minVizHeight: 10,
+      minVizWidth: 0,
+      orientation: 'horizontal',
+      reduceOptions: {
+        calcs: [
+          'lastNotNull',
+        ],
+        fields: '',
+        values: false,
+      },
+      showUnfilled: true,
+    },
+    pluginVersion: '9.4.3',
+  },
+
+  local shardStatusPanel = {
+    datasource: promDatasource,
+    targets: [
+      prometheus.target(
+        'min by(type, %(agg)s) (opensearch_cluster_shards_number{%(queriesSelector)s})'
+        % {
+          queriesSelector: variables.queriesSelector,
+          agg: std.join(',', $._config.groupLabels),
+        },
+        datasource=promDatasource,
+        legendFormat='{{type}}',
+      ),
+    ],
+    type: 'bargauge',
+    title: 'Shard status',
+    description: 'Shard status counts across the Opensearch cluster.',
+    fieldConfig: {
+      defaults: {
+        color: {
+          mode: 'thresholds',
+        },
+        mappings: [],
+        thresholds: {
+          mode: 'absolute',
+          steps: [
+            {
+              color: 'green',
+              value: null,
+            },
+            {
+              color: 'red',
+              value: 80,
+            },
+          ],
+        },
+        unit: 'shards',
+      },
+      overrides: [],
+    },
+    options: {
+      displayMode: 'gradient',
+      minVizHeight: 10,
+      minVizWidth: 0,
+      orientation: 'horizontal',
+      reduceOptions: {
+        calcs: [
+          'lastNotNull',
+        ],
+        fields: '',
+        values: false,
+      },
+      showUnfilled: true,
+    },
+    pluginVersion: '9.4.3',
+  },
+
+  local topNodesByDiskUsagePanel = {
+    datasource: promDatasource,
+    targets: [
+      prometheus.target(
+        'topk(10, sort_desc((100 * (sum by(node, %(agg)s) (opensearch_fs_path_total_bytes{%(queriesSelector)s})- sum by(node, %(agg)s) (opensearch_fs_path_free_bytes{%(queriesSelector)s})) / sum by(node, %(agg)s) (opensearch_fs_path_total_bytes{%(queriesSelector)s}))))'
+        % {
+          queriesSelector: variables.queriesSelector,
+          agg: std.join(',', $._config.groupLabels),
+        },
+        datasource=promDatasource,
+        legendFormat='{{node}}',
+      ),
+    ],
+    type: 'bargauge',
+    title: 'Top nodes by disk usage',
+    description: 'Top nodes by disk usage across the OpenSearch cluster.',
+    fieldConfig: {
+      defaults: {
+        color: {
+          mode: 'thresholds',
+        },
+        mappings: [],
+        max: 100,
+        min: 0,
+        thresholds: {
+          mode: 'absolute',
+          steps: [
+            {
+              color: 'green',
+              value: null,
+            },
+            {
+              color: 'red',
+              value: 80,
+            },
+          ],
+        },
+        unit: 'percent',
+      },
+      overrides: [],
+    },
+    options: {
+      displayMode: 'gradient',
+      minVizHeight: 10,
+      minVizWidth: 0,
+      orientation: 'horizontal',
+      reduceOptions: {
+        calcs: [
+          'lastNotNull',
+        ],
+        fields: '',
+        values: false,
+      },
+      showUnfilled: true,
+    },
+    pluginVersion: '9.4.3',
+  },
+
+  local totalDocumentsPanel = {
+    datasource: promDatasource,
+    targets: [
+      prometheus.target(
+        'avg by(%(agg)s) (opensearch_indices_indexing_index_count{%(queriesSelector)s})'
+        % {
+          queriesSelector: variables.queriesSelector,
+          agg: std.join(',', $._config.groupLabels),
+        },
+        datasource=promDatasource,
+        legendFormat=utils.labelsToPanelLegend($._config.groupLabels),
+      ),
+    ],
+    type: 'timeseries',
+    title: 'Total documents',
+    description: 'The total count of documents indexed across the OpenSearch cluster.',
+    fieldConfig: {
+      defaults: {
+        color: {
+          mode: 'palette-classic',
+        },
+        custom: {
+          axisCenteredZero: false,
+          axisColorMode: 'text',
+          axisLabel: '',
+          axisPlacement: 'auto',
+          barAlignment: 0,
+          drawStyle: 'line',
+          fillOpacity: 0,
+          gradientMode: 'none',
+          hideFrom: {
+            legend: false,
+            tooltip: false,
+            viz: false,
+          },
+          lineInterpolation: 'linear',
+          lineWidth: 1,
+          pointSize: 5,
+          scaleDistribution: {
+            type: 'linear',
+          },
+          showPoints: 'auto',
+          spanNulls: false,
+          stacking: {
+            group: 'A',
+            mode: 'none',
+          },
+          thresholdsStyle: {
+            mode: 'off',
+          },
+        },
+        mappings: [],
+        thresholds: {
+          mode: 'absolute',
+          steps: [
+            {
+              color: 'green',
+              value: null,
+            },
+          ],
+        },
+        unit: 'documents',
+      },
+      overrides: [],
+    },
+    options: {
+      legend: {
+        calcs: [],
+        displayMode: 'list',
+        placement: 'bottom',
+        showLegend: true,
+      },
+      tooltip: {
+        mode: 'single',
+        sort: 'none',
+      },
+    },
+  },
+
+  local pendingTasksPanel = {
+    datasource: promDatasource,
+    targets: [
+      prometheus.target(
+        'avg by(%(agg)s) (opensearch_cluster_pending_tasks_number{%(queriesSelector)s})'
+        % {
+          queriesSelector: variables.queriesSelector,
+          agg: std.join(',', $._config.groupLabels),
+        },
+        datasource=promDatasource,
+        legendFormat=utils.labelsToPanelLegend($._config.groupLabels),
+      ),
+    ],
+    type: 'timeseries',
+    title: 'Pending tasks',
+    description: 'The number of tasks waiting to be executed across the OpenSearch cluster.',
+    fieldConfig: {
+      defaults: {
+        color: {
+          mode: 'palette-classic',
+        },
+        custom: {
+          axisCenteredZero: false,
+          axisColorMode: 'text',
+          axisLabel: '',
+          axisPlacement: 'auto',
+          barAlignment: 0,
+          drawStyle: 'line',
+          fillOpacity: 0,
+          gradientMode: 'none',
+          hideFrom: {
+            legend: false,
+            tooltip: false,
+            viz: false,
+          },
+          lineInterpolation: 'linear',
+          lineWidth: 1,
+          pointSize: 5,
+          scaleDistribution: {
+            type: 'linear',
+          },
+          showPoints: 'auto',
+          spanNulls: false,
+          stacking: {
+            group: 'A',
+            mode: 'none',
+          },
+          thresholdsStyle: {
+            mode: 'off',
+          },
+        },
+        mappings: [],
+        thresholds: {
+          mode: 'absolute',
+          steps: [
+            {
+              color: 'green',
+              value: null,
+            },
+          ],
+        },
+        unit: 'tasks',
+      },
+      overrides: [],
+    },
+    options: {
+      legend: {
+        calcs: [],
+        displayMode: 'list',
+        placement: 'bottom',
+        showLegend: true,
+      },
+      tooltip: {
+        mode: 'single',
+        sort: 'none',
+      },
+    },
+  },
+
+  local storeSizePanel = {
+    datasource: promDatasource,
+    targets: [
+      prometheus.target(
+        'avg by(%(agg)s) (opensearch_indices_store_size_bytes{%(queriesSelector)s})'
+        % {
+          queriesSelector: variables.queriesSelector,
+          agg: std.join(',', $._config.groupLabels),
+        },
+        datasource=promDatasource,
+        legendFormat=utils.labelsToPanelLegend($._config.groupLabels),
+      ),
+    ],
+    type: 'timeseries',
+    title: 'Store size',
+    description: 'The total size of the store across the OpenSearch cluster.',
+    fieldConfig: {
+      defaults: {
+        color: {
+          mode: 'palette-classic',
+        },
+        custom: {
+          axisCenteredZero: false,
+          axisColorMode: 'text',
+          axisLabel: '',
+          axisPlacement: 'auto',
+          barAlignment: 0,
+          drawStyle: 'line',
+          fillOpacity: 0,
+          gradientMode: 'none',
+          hideFrom: {
+            legend: false,
+            tooltip: false,
+            viz: false,
+          },
+          lineInterpolation: 'linear',
+          lineWidth: 1,
+          pointSize: 5,
+          scaleDistribution: {
+            type: 'linear',
+          },
+          showPoints: 'auto',
+          spanNulls: false,
+          stacking: {
+            group: 'A',
+            mode: 'none',
+          },
+          thresholdsStyle: {
+            mode: 'off',
+          },
+        },
+        mappings: [],
+        thresholds: {
+          mode: 'absolute',
+          steps: [
+            {
+              color: 'green',
+              value: null,
+            },
+          ],
+        },
+        unit: 'bytes',
+      },
+      overrides: [],
+    },
+    options: {
+      legend: {
+        calcs: [],
+        displayMode: 'list',
+        placement: 'bottom',
+        showLegend: true,
+      },
+      tooltip: {
+        mode: 'single',
+        sort: 'none',
+      },
+    },
+  },
+
+  local maxTaskWaitTimePanel = {
+    datasource: promDatasource,
+    targets: [
+      prometheus.target(
+        'max by(%(agg)s) (opensearch_cluster_task_max_waiting_time_seconds{%(queriesSelector)s})'
+        % {
+          queriesSelector: variables.queriesSelector,
+          agg: std.join(',', $._config.groupLabels),
+        },
+        datasource=promDatasource,
+        legendFormat=utils.labelsToPanelLegend($._config.groupLabels),
+      ),
+    ],
+    type: 'timeseries',
+    title: 'Max task wait time',
+    description: 'The max wait time for tasks to be executed across the OpenSearch cluster.',
+    fieldConfig: {
+      defaults: {
+        color: {
+          mode: 'palette-classic',
+        },
+        custom: {
+          axisCenteredZero: false,
+          axisColorMode: 'text',
+          axisLabel: '',
+          axisPlacement: 'auto',
+          barAlignment: 0,
+          drawStyle: 'line',
+          fillOpacity: 0,
+          gradientMode: 'none',
+          hideFrom: {
+            legend: false,
+            tooltip: false,
+            viz: false,
+          },
+          lineInterpolation: 'linear',
+          lineWidth: 1,
+          pointSize: 5,
+          scaleDistribution: {
+            type: 'linear',
+          },
+          showPoints: 'auto',
+          spanNulls: false,
+          stacking: {
+            group: 'A',
+            mode: 'none',
+          },
+          thresholdsStyle: {
+            mode: 'off',
+          },
+        },
+        mappings: [],
+        thresholds: {
+          mode: 'absolute',
+          steps: [
+            {
+              color: 'green',
+              value: null,
+            },
+          ],
+        },
+        unit: 's',
+      },
+      overrides: [],
+    },
+    options: {
+      legend: {
+        calcs: [],
+        displayMode: 'list',
+        placement: 'bottom',
+        showLegend: true,
+      },
+      tooltip: {
+        mode: 'single',
+        sort: 'none',
+      },
+    },
+  },
+
+  local clusterSearchAndIndexSummaryRow = {
+    datasource: promDatasource,
+    targets: [],
+    type: 'row',
+    title: 'Cluster search and index summary',
+    collapsed: false,
+  },
+
+  local topIndicesByRequestRatePanel = {
+    datasource: promDatasource,
+    targets: [
+      prometheus.target(
+        |||
+          topk(10, sort_desc(avg by(index, %(agg)s) (
+            opensearch_index_search_fetch_current_number{%(queriesSelector)s, context="total"} + 
+            opensearch_index_search_query_current_number{%(queriesSelector)s, context="total"} + 
+            opensearch_index_search_scroll_current_number{%(queriesSelector)s, context="total"}
+          )))
+        |||
+        % {
+          queriesSelector: variables.queriesSelector,
+          agg: std.join(',', $._config.groupLabels),
+        },
+        datasource=promDatasource,
+        legendFormat='{{index}}',
+      ),
+    ],
+    type: 'timeseries',
+    title: 'Top indices by request rate',
+    description: 'Top indices by combined fetch, query, and scroll request rate across the OpenSearch cluster.',
+    fieldConfig: {
+      defaults: {
+        color: {
+          mode: 'palette-classic',
+        },
+        custom: {
+          axisCenteredZero: false,
+          axisColorMode: 'text',
+          axisLabel: '',
+          axisPlacement: 'auto',
+          barAlignment: 0,
+          drawStyle: 'line',
+          fillOpacity: 0,
+          gradientMode: 'none',
+          hideFrom: {
+            legend: false,
+            tooltip: false,
+            viz: false,
+          },
+          lineInterpolation: 'linear',
+          lineWidth: 1,
+          pointSize: 5,
+          scaleDistribution: {
+            type: 'linear',
+          },
+          showPoints: 'auto',
+          spanNulls: false,
+          stacking: {
+            group: 'A',
+            mode: 'none',
+          },
+          thresholdsStyle: {
+            mode: 'off',
+          },
+        },
+        mappings: [],
+        thresholds: {
+          mode: 'absolute',
+          steps: [
+            {
+              color: 'green',
+              value: null,
+            },
+            {
+              color: 'red',
+              value: 80,
+            },
+          ],
+        },
+        unit: 'reqps',
+      },
+      overrides: [],
+    },
+    options: {
+      legend: {
+        calcs: [],
+        displayMode: 'list',
+        placement: 'bottom',
+        showLegend: true,
+      },
+      tooltip: {
+        mode: 'single',
+        sort: 'none',
+      },
+    },
+  },
+
+  local topIndicesByRequestLatencyPanel = {
+    datasource: promDatasource,
+    targets: [
+      prometheus.target(
+        |||
+          topk(10, sort_desc(sum by(index, %(agg)s) ((increase(opensearch_index_search_fetch_time_seconds{%(queriesSelector)s, context="total"}[$__interval:])
+          +increase(opensearch_index_search_query_time_seconds{%(queriesSelector)s, context="total"}[$__interval:])
+          +increase(opensearch_index_search_scroll_time_seconds{%(queriesSelector)s, context="total"}[$__interval:]))
+          / clamp_min(increase(opensearch_index_search_fetch_count{%(queriesSelector)s, context="total"}[$__interval:])
+          +increase(opensearch_index_search_query_count{%(queriesSelector)s, context="total"}[$__interval:])
+          +increase(opensearch_index_search_scroll_count{%(queriesSelector)s, context="total"}[$__interval:]), 1))))
+        |||
+        % {
+          queriesSelector: variables.queriesSelector,
+          agg: std.join(',', $._config.groupLabels),
+        },
+        datasource=promDatasource,
+        legendFormat='{{index}}',
+        interval='1m',
+      ),
+    ],
+    type: 'timeseries',
+    title: 'Top indices by request latency',
+    description: 'Top indices by combined fetch, query, and scroll latency across the OpenSearch cluster.',
+    fieldConfig: {
+      defaults: {
+        color: {
+          mode: 'palette-classic',
+        },
+        custom: {
+          axisCenteredZero: false,
+          axisColorMode: 'text',
+          axisLabel: '',
+          axisPlacement: 'auto',
+          barAlignment: 0,
+          drawStyle: 'line',
+          fillOpacity: 0,
+          gradientMode: 'none',
+          hideFrom: {
+            legend: false,
+            tooltip: false,
+            viz: false,
+          },
+          lineInterpolation: 'linear',
+          lineWidth: 1,
+          pointSize: 5,
+          scaleDistribution: {
+            type: 'linear',
+          },
+          showPoints: 'auto',
+          spanNulls: false,
+          stacking: {
+            group: 'A',
+            mode: 'none',
+          },
+          thresholdsStyle: {
+            mode: 'off',
+          },
+        },
+        mappings: [],
+        thresholds: {
+          mode: 'absolute',
+          steps: [
+            {
+              color: 'green',
+              value: null,
+            },
+          ],
+        },
+        unit: 's',
+      },
+      overrides: [],
+    },
+    options: {
+      legend: {
+        calcs: [],
+        displayMode: 'list',
+        placement: 'bottom',
+        showLegend: true,
+      },
+      tooltip: {
+        mode: 'single',
+        sort: 'none',
+      },
+    },
+  },
+
+  local topIndicesByCombinedCacheHitRatioPanel = {
+    datasource: promDatasource,
+    targets: [
+      prometheus.target(
+        |||
+          topk(10, sort_desc(avg by(index, %(agg)s) (
+            100 * (opensearch_index_requestcache_hit_count{%(queriesSelector)s, context="total"} + 
+            opensearch_index_querycache_hit_count{%(queriesSelector)s, context="total"}) / 
+            clamp_min((opensearch_index_requestcache_hit_count{%(queriesSelector)s, context="total"} + 
+            opensearch_index_querycache_hit_count{%(queriesSelector)s, context="total"} + 
+            opensearch_index_requestcache_miss_count{%(queriesSelector)s, context="total"} + 
+            opensearch_index_querycache_miss_number{%(queriesSelector)s, context="total"}), 1
+            ))))
+        |||
+        % {
+          queriesSelector: variables.queriesSelector,
+          agg: std.join(',', $._config.groupLabels),
+        },
+        datasource=promDatasource,
+        legendFormat='{{index}}',
+      ),
+    ],
+    type: 'timeseries',
+    title: 'Top indices by combined cache hit ratio',
+    description: 'Top indices by cache hit ratio for the combined request and query cache across the OpenSearch cluster.',
+    fieldConfig: {
+      defaults: {
+        color: {
+          mode: 'palette-classic',
+        },
+        custom: {
+          axisCenteredZero: false,
+          axisColorMode: 'text',
+          axisLabel: '',
+          axisPlacement: 'auto',
+          barAlignment: 0,
+          drawStyle: 'line',
+          fillOpacity: 0,
+          gradientMode: 'none',
+          hideFrom: {
+            legend: false,
+            tooltip: false,
+            viz: false,
+          },
+          lineInterpolation: 'linear',
+          lineWidth: 1,
+          pointSize: 5,
+          scaleDistribution: {
+            type: 'linear',
+          },
+          showPoints: 'auto',
+          spanNulls: false,
+          stacking: {
+            group: 'A',
+            mode: 'none',
+          },
+          thresholdsStyle: {
+            mode: 'off',
+          },
+        },
+        mappings: [],
+        thresholds: {
+          mode: 'absolute',
+          steps: [
+            {
+              color: 'green',
+              value: null,
+            },
+            {
+              color: 'red',
+              value: 80,
+            },
+          ],
+        },
+        unit: 'percent',
+      },
+      overrides: [],
+    },
+    options: {
+      legend: {
+        calcs: [],
+        displayMode: 'list',
+        placement: 'bottom',
+        showLegend: true,
+      },
+      tooltip: {
+        mode: 'single',
+        sort: 'none',
+      },
+    },
+  },
+
+  local topNodesByIngestRatePanel = {
+    datasource: promDatasource,
+    targets: [
+      prometheus.target(
+        'topk(10, sum by(node, %(agg)s) (rate(opensearch_ingest_total_count{%(queriesSelector)s}[$__rate_interval])))'
+        % {
+          queriesSelector: variables.queriesSelector,
+          agg: std.join(',', $._config.groupLabels),
+        },
+        datasource=promDatasource,
+        legendFormat='{{node}}',
+      ),
+    ],
+    type: 'timeseries',
+    title: 'Top nodes by ingest rate',
+    description: 'Top nodes by rate of ingest across the OpenSearch cluster.',
+    fieldConfig: {
+      defaults: {
+        color: {
+          mode: 'palette-classic',
+        },
+        custom: {
+          axisCenteredZero: false,
+          axisColorMode: 'text',
+          axisLabel: '',
+          axisPlacement: 'auto',
+          barAlignment: 0,
+          drawStyle: 'line',
+          fillOpacity: 0,
+          gradientMode: 'none',
+          hideFrom: {
+            legend: false,
+            tooltip: false,
+            viz: false,
+          },
+          lineInterpolation: 'linear',
+          lineWidth: 1,
+          pointSize: 5,
+          scaleDistribution: {
+            type: 'linear',
+          },
+          showPoints: 'auto',
+          spanNulls: false,
+          stacking: {
+            group: 'A',
+            mode: 'none',
+          },
+          thresholdsStyle: {
+            mode: 'off',
+          },
+        },
+        mappings: [],
+        thresholds: {
+          mode: 'absolute',
+          steps: [
+            {
+              color: 'green',
+              value: null,
+            },
+            {
+              color: 'red',
+              value: 80,
+            },
+          ],
+        },
+        unit: 'Bps',
+      },
+      overrides: [],
+    },
+    options: {
+      legend: {
+        calcs: [],
+        displayMode: 'list',
+        placement: 'bottom',
+        showLegend: true,
+      },
+      tooltip: {
+        mode: 'single',
+        sort: 'none',
+      },
+    },
+  },
+
+  local topNodesByIngestLatencyPanel = {
+    datasource: promDatasource,
+    targets: [
+      prometheus.target(
+        |||
+          topk(10, sum by(%(agg)s, node) (
+            increase(opensearch_ingest_total_time_seconds{%(queriesSelector)s}[$__interval:]) / 
+            clamp_min(increase(opensearch_ingest_total_count{%(queriesSelector)s}[$__interval:]), 1)))
+        |||
+        % {
+          queriesSelector: variables.queriesSelector,
+          agg: std.join(',', $._config.groupLabels),
+        },
+        datasource=promDatasource,
+        legendFormat='{{node}}',
+        interval='1m',
+      ),
+    ],
+    type: 'timeseries',
+    title: 'Top nodes by ingest latency',
+    description: 'Top nodes by ingestion latency across the OpenSearch cluster.',
+    fieldConfig: {
+      defaults: {
+        color: {
+          mode: 'palette-classic',
+        },
+        custom: {
+          axisCenteredZero: false,
+          axisColorMode: 'text',
+          axisLabel: '',
+          axisPlacement: 'auto',
+          barAlignment: 0,
+          drawStyle: 'line',
+          fillOpacity: 0,
+          gradientMode: 'none',
+          hideFrom: {
+            legend: false,
+            tooltip: false,
+            viz: false,
+          },
+          lineInterpolation: 'linear',
+          lineWidth: 1,
+          pointSize: 5,
+          scaleDistribution: {
+            type: 'linear',
+          },
+          showPoints: 'auto',
+          spanNulls: false,
+          stacking: {
+            group: 'A',
+            mode: 'none',
+          },
+          thresholdsStyle: {
+            mode: 'off',
+          },
+        },
+        mappings: [],
+        thresholds: {
+          mode: 'absolute',
+          steps: [
+            {
+              color: 'green',
+              value: null,
+            },
+            {
+              color: 'red',
+              value: 80,
+            },
+          ],
+        },
+        unit: 's',
+      },
+      overrides: [],
+    },
+    options: {
+      legend: {
+        calcs: [],
+        displayMode: 'list',
+        placement: 'bottom',
+        showLegend: true,
+      },
+      tooltip: {
+        mode: 'single',
+        sort: 'none',
+      },
+    },
+  },
+
+  local topNodesByIngestErrorsPanel = {
+    datasource: promDatasource,
+    targets: [
+      prometheus.target(
+        'topk(10, sum by(%(agg)s, node) (increase(opensearch_ingest_total_failed_count{%(queriesSelector)s}[$__interval:])))'
+        % {
+          queriesSelector: variables.queriesSelector,
+          agg: std.join(',', $._config.groupLabels),
+        },
+        datasource=promDatasource,
+        legendFormat='{{node}}',
+        interval='1m',
+      ),
+    ],
+    type: 'timeseries',
+    title: 'Top nodes by ingest errors',
+    description: 'Top nodes by ingestion failures across the OpenSearch cluster.',
+    fieldConfig: {
+      defaults: {
+        color: {
+          mode: 'palette-classic',
+        },
+        custom: {
+          axisCenteredZero: false,
+          axisColorMode: 'text',
+          axisLabel: '',
+          axisPlacement: 'auto',
+          barAlignment: 0,
+          drawStyle: 'line',
+          fillOpacity: 0,
+          gradientMode: 'none',
+          hideFrom: {
+            legend: false,
+            tooltip: false,
+            viz: false,
+          },
+          lineInterpolation: 'linear',
+          lineWidth: 1,
+          pointSize: 5,
+          scaleDistribution: {
+            type: 'linear',
+          },
+          showPoints: 'auto',
+          spanNulls: false,
+          stacking: {
+            group: 'A',
+            mode: 'none',
+          },
+          thresholdsStyle: {
+            mode: 'off',
+          },
+        },
+        mappings: [],
+        thresholds: {
+          mode: 'absolute',
+          steps: [
+            {
+              color: 'green',
+              value: null,
+            },
+          ],
+        },
+        unit: 'errors',
+      },
+      overrides: [],
+    },
+    options: {
+      legend: {
+        calcs: [],
+        displayMode: 'list',
+        placement: 'bottom',
+        showLegend: true,
+      },
+      tooltip: {
+        mode: 'single',
+        sort: 'none',
+      },
+    },
+  },
+
+  local topIndicesByIndexRatePanel = {
+    datasource: promDatasource,
+    targets: [
+      prometheus.target(
+        'topk(10, avg by(%(agg)s, index) (opensearch_index_indexing_index_current_number{%(queriesSelector)s}))'
+        % {
+          queriesSelector: variables.queriesSelector,
+          agg: std.join(',', $._config.groupLabels),
+        },
+        datasource=promDatasource,
+        legendFormat='{{index}}',
+      ),
+    ],
+    type: 'timeseries',
+    title: 'Top indices by index rate',
+    description: 'Top indices by rate of document indexing across the OpenSearch cluster.',
+    fieldConfig: {
+      defaults: {
+        color: {
+          mode: 'palette-classic',
+        },
+        custom: {
+          axisCenteredZero: false,
+          axisColorMode: 'text',
+          axisLabel: '',
+          axisPlacement: 'auto',
+          barAlignment: 0,
+          drawStyle: 'line',
+          fillOpacity: 0,
+          gradientMode: 'none',
+          hideFrom: {
+            legend: false,
+            tooltip: false,
+            viz: false,
+          },
+          lineInterpolation: 'linear',
+          lineWidth: 1,
+          pointSize: 5,
+          scaleDistribution: {
+            type: 'linear',
+          },
+          showPoints: 'auto',
+          spanNulls: false,
+          stacking: {
+            group: 'A',
+            mode: 'none',
+          },
+          thresholdsStyle: {
+            mode: 'off',
+          },
+        },
+        mappings: [],
+        thresholds: {
+          mode: 'absolute',
+          steps: [
+            {
+              color: 'green',
+              value: null,
+            },
+          ],
+        },
+        unit: 'documents/s',
+      },
+      overrides: [],
+    },
+    options: {
+      legend: {
+        calcs: [],
+        displayMode: 'list',
+        placement: 'bottom',
+        showLegend: true,
+      },
+      tooltip: {
+        mode: 'single',
+        sort: 'none',
+      },
+    },
+  },
+
+  local topIndicesByIndexLatencyPanel = {
+    datasource: promDatasource,
+    targets: [
+      prometheus.target(
+        |||
+          topk(10, avg by(%(agg)s, index) 
+          (increase(opensearch_index_indexing_index_time_seconds{%(queriesSelector)s, context="total"}[$__interval:]) / 
+          clamp_min(increase(opensearch_index_indexing_index_count{%(queriesSelector)s, context="total"}[$__interval:]), 1)))
+        |||
+        % {
+          queriesSelector: variables.queriesSelector,
+          agg: std.join(',', $._config.groupLabels),
+        },
+        datasource=promDatasource,
+        legendFormat='{{index}}',
+        interval='1m',
+      ),
+    ],
+    type: 'timeseries',
+    title: 'Top indices by index latency',
+    description: 'Top indices by indexing latency across the OpenSearch cluster.',
+    fieldConfig: {
+      defaults: {
+        color: {
+          mode: 'palette-classic',
+        },
+        custom: {
+          axisCenteredZero: false,
+          axisColorMode: 'text',
+          axisLabel: '',
+          axisPlacement: 'auto',
+          barAlignment: 0,
+          drawStyle: 'line',
+          fillOpacity: 0,
+          gradientMode: 'none',
+          hideFrom: {
+            legend: false,
+            tooltip: false,
+            viz: false,
+          },
+          lineInterpolation: 'linear',
+          lineWidth: 1,
+          pointSize: 5,
+          scaleDistribution: {
+            type: 'linear',
+          },
+          showPoints: 'auto',
+          spanNulls: false,
+          stacking: {
+            group: 'A',
+            mode: 'none',
+          },
+          thresholdsStyle: {
+            mode: 'off',
+          },
+        },
+        mappings: [],
+        thresholds: {
+          mode: 'absolute',
+          steps: [
+            {
+              color: 'green',
+              value: null,
+            },
+          ],
+        },
+        unit: 's',
+      },
+      overrides: [],
+    },
+    options: {
+      legend: {
+        calcs: [],
+        displayMode: 'list',
+        placement: 'bottom',
+        showLegend: true,
+      },
+      tooltip: {
+        mode: 'single',
+        sort: 'none',
+      },
+    },
+  },
+
+  local topIndicesByIndexFailuresPanel = {
+    datasource: promDatasource,
+    targets: [
+      prometheus.target(
+        'topk(10, avg by(%(agg)s, index) (increase(opensearch_index_indexing_index_failed_count{%(queriesSelector)s}[$__interval:])))'
+        % {
+          queriesSelector: variables.queriesSelector,
+          agg: std.join(',', $._config.groupLabels),
+        },
+        datasource=promDatasource,
+        legendFormat='{{index}}',
+        interval='1m',
+      ),
+    ],
+    type: 'timeseries',
+    title: 'Top indices by index failures',
+    description: 'Top indices by index document failures across the OpenSearch cluster.',
+    fieldConfig: {
+      defaults: {
+        color: {
+          mode: 'palette-classic',
+        },
+        custom: {
+          axisCenteredZero: false,
+          axisColorMode: 'text',
+          axisLabel: '',
+          axisPlacement: 'auto',
+          barAlignment: 0,
+          drawStyle: 'line',
+          fillOpacity: 0,
+          gradientMode: 'none',
+          hideFrom: {
+            legend: false,
+            tooltip: false,
+            viz: false,
+          },
+          lineInterpolation: 'linear',
+          lineWidth: 1,
+          pointSize: 5,
+          scaleDistribution: {
+            type: 'linear',
+          },
+          showPoints: 'auto',
+          spanNulls: false,
+          stacking: {
+            group: 'A',
+            mode: 'none',
+          },
+          thresholdsStyle: {
+            mode: 'off',
+          },
+        },
+        mappings: [],
+        thresholds: {
+          mode: 'absolute',
+          steps: [
+            {
+              color: 'green',
+              value: null,
+            },
+          ],
+        },
+        unit: 'failures',
+      },
+      overrides: [],
+    },
+    options: {
+      legend: {
+        calcs: [],
+        displayMode: 'list',
+        placement: 'bottom',
+        showLegend: true,
+      },
+      tooltip: {
+        mode: 'single',
+        sort: 'none',
+      },
+    },
+  },
+
+
   grafanaDashboards+:: {
     'opensearch-cluster-overview.json':
       dashboard.new(
@@ -1541,7 +1670,7 @@ local topIndicesByIndexFailuresPanel = {
         timezone='%s' % $._config.dashboardTimezone,
         refresh='%s' % $._config.dashboardRefresh,
         description='',
-        uid=$._config.uid+dashboardUidSuffix,
+        uid=$._config.uid + dashboardUidSuffix,
       )
       .addLink(grafana.link.dashboards(
         asDropdown=false,
@@ -1551,36 +1680,7 @@ local topIndicesByIndexFailuresPanel = {
         tags=($._config.dashboardTags),
       ))
       .addTemplates(
-        [
-          template.datasource(
-            promDatasourceName,
-            'prometheus',
-            null,
-            label='Prometheus data source',
-            refresh='load'
-          ),
-          template.new(
-            'job',
-            promDatasource,
-            'label_values(opensearch_cluster_status{%s},job)' % $._config.filteringSelector,
-            label='Job',
-            refresh=2,
-            includeAll=true,
-            multi=true,
-            sort=1
-          ),
-          template.new(
-            'opensearch_cluster',
-            promDatasource,
-            'label_values(opensearch_cluster_status{%s, job=~"$job"}, cluster)' % $._config.filteringSelector,
-            label='OpenSearch Cluster',
-            refresh=2,
-            includeAll=true,
-            multi=true,
-            allValues='',
-            sort=1
-          ),
-        ]
+        variables.singleInstance
       )
       .addPanels(
         [

--- a/opensearch-mixin/dashboards/opensearch-cluster-overview.libsonnet
+++ b/opensearch-mixin/dashboards/opensearch-cluster-overview.libsonnet
@@ -1562,18 +1562,17 @@ local topIndicesByIndexFailuresPanel = {
           template.new(
             'job',
             promDatasource,
-            'label_values(opensearch_cluster_status,job)',
+            'label_values(opensearch_cluster_status{%s},job)' % $._config.filteringSelector,
             label='Job',
             refresh=2,
             includeAll=true,
             multi=true,
-            allValues='.+',
             sort=1
           ),
           template.new(
             'opensearch_cluster',
             promDatasource,
-            'label_values(opensearch_cluster_status{job=~"$job"}, cluster)',
+            'label_values(opensearch_cluster_status{%s, job=~"$job"}, cluster)' % $._config.filteringSelector,
             label='OpenSearch Cluster',
             refresh=2,
             includeAll=true,

--- a/opensearch-mixin/dashboards/opensearch-node-overview.libsonnet
+++ b/opensearch-mixin/dashboards/opensearch-node-overview.libsonnet
@@ -1528,18 +1528,17 @@ local errorLogsPanelPanel = {
             template.new(
               'job',
               promDatasource,
-              'label_values(opensearch_cluster_status,job)',
+              'label_values(opensearch_cluster_status{%s},job)' % $._config.filteringSelector,
               label='Job',
               refresh=2,
               includeAll=true,
               multi=true,
-              allValues='.+',
               sort=1
             ),
             template.new(
               'opensearch_cluster',
               promDatasource,
-              'label_values(opensearch_cluster_status{job=~"$job"}, cluster)',
+              'label_values(opensearch_cluster_status{%s, job=~"$job"}, cluster)' % $._config.filteringSelector,
               label='OpenSearch Cluster',
               refresh=2,
               includeAll=true,
@@ -1550,7 +1549,7 @@ local errorLogsPanelPanel = {
             template.new(
               'node',
               promDatasource,
-              'label_values(opensearch_os_cpu_percent{job=~"$job", cluster=~"$opensearch_cluster"}, node)',
+              'label_values(opensearch_os_cpu_percent{%s, job=~"$job", cluster=~"$opensearch_cluster"}, node)' % $._config.filteringSelector,
               label='Node',
               refresh=2,
               includeAll=true,

--- a/opensearch-mixin/dashboards/opensearch-node-overview.libsonnet
+++ b/opensearch-mixin/dashboards/opensearch-node-overview.libsonnet
@@ -1143,7 +1143,7 @@ local dashboardUidSuffix = '-node-overview';
 
   grafanaDashboards+:: {
     'node-overview.json':
-      g.dashboard.new('OpenSearch node overview')
+      g.dashboard.new($._config.dashboardNamePrefix +'OpenSearch node overview')
       + g.dashboard.withTags($._config.dashboardTags)
       + g.dashboard.time.withFrom($._config.dashboardPeriod)
       + g.dashboard.withTimezone($._config.dashboardTimezone)

--- a/opensearch-mixin/dashboards/opensearch-node-overview.libsonnet
+++ b/opensearch-mixin/dashboards/opensearch-node-overview.libsonnet
@@ -1,1566 +1,1606 @@
-local g = (import 'grafana-builder/grafana.libsonnet');
+local g = (import '../g.libsonnet');
 local grafana = (import 'grafonnet/grafana.libsonnet');
-local dashboard = grafana.dashboard;
-local template = grafana.template;
+local commonlib = import 'common-lib/common/main.libsonnet';
+local utils = commonlib.utils;
 local prometheus = grafana.prometheus;
 
 local dashboardUidSuffix = '-node-overview';
 
-local promDatasourceName = 'prometheus_datasource';
-local lokiDatasourceName = 'loki_datasource';
-
-local promDatasource = {
-  uid: '${%s}' % promDatasourceName,
-};
-
-local lokiDatasource = {
-  uid: '${%s}' % lokiDatasourceName,
-};
-
-local nodeHealthRow = {
-  datasource: promDatasource,
-  targets: [],
-  type: 'row',
-  title: 'Node health',
-  collapsed: false,
-};
-
-local nodeCPUUsagePanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'opensearch_os_cpu_percent{cluster=~"$opensearch_cluster", job=~"$job", node=~"$node"}',
-      datasource=promDatasource,
-      legendFormat='{{node}}',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'Node CPU usage',
-  description: "CPU usage percentage of the node's Operating System.",
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-        ],
-      },
-      unit: 'percent',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'single',
-      sort: 'none',
-    },
-  },
-};
-
-local nodeMemoryUsagePanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'opensearch_os_mem_used_percent{cluster=~"$opensearch_cluster", job=~"$job", node=~"$node"}',
-      datasource=promDatasource,
-      legendFormat='{{node}}',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'Node memory usage',
-  description: 'Memory usage percentage of the node for the Operating System and OpenSearch',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      max: 100,
-      min: 0,
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-        ],
-      },
-      unit: 'percent',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'single',
-      sort: 'none',
-    },
-  },
-};
-
-local nodeIOPanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'sum by(node, job, cluster) (opensearch_fs_io_total_read_bytes{cluster=~"$opensearch_cluster", job=~"$job", node=~"$node"})',
-      datasource=promDatasource,
-      legendFormat='{{node}} - read',
-    ),
-    prometheus.target(
-      'sum by(node, job, cluster) (opensearch_fs_io_total_write_bytes{cluster=~"$opensearch_cluster", job=~"$job", node=~"$node"})',
-      datasource=promDatasource,
-      legendFormat='{{node}} - write',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'Node I/O',
-  description: 'Node file system read and write data.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-          {
-            color: 'red',
-            value: 80,
-          },
-        ],
-      },
-      unit: 'bytes',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'single',
-      sort: 'none',
-    },
-  },
-};
-
-local nodeOpenConnectionsPanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'sum by (node, job, cluster) (opensearch_transport_server_open_number{cluster=~"$opensearch_cluster", job=~"$job", node=~"$node"})',
-      datasource=promDatasource,
-      legendFormat='{{node}}',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'Node open connections',
-  description: 'Number of open connections for the selected node.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-        ],
-      },
-      unit: 'connections',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'single',
-      sort: 'none',
-    },
-  },
-};
-
-local nodeDiskUsagePanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      '100 - (100 * opensearch_fs_path_free_bytes{cluster=~"$opensearch_cluster", job=~"$job", node=~"$node"} / clamp_min(opensearch_fs_path_total_bytes{cluster=~"$opensearch_cluster", job=~"$job", node=~"$node"}, 1))\n',
-      datasource=promDatasource,
-      legendFormat='{{node}}',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'Node disk usage',
-  description: 'Disk usage percentage of the selected node.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-          {
-            color: 'red',
-            value: 80,
-          },
-        ],
-      },
-      unit: 'percent',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'single',
-      sort: 'none',
-    },
-  },
-};
-
-local nodeMemorySwapPanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      '100 * opensearch_os_swap_used_bytes{cluster=~"$opensearch_cluster", job=~"$job", node=~"$node"} / clamp_min((opensearch_os_swap_used_bytes{cluster=~"$opensearch_cluster", job=~"$job", node=~"$node"} + opensearch_os_swap_free_bytes{cluster=~"$opensearch_cluster", job=~"$job", node=~"$node"}), 1)',
-      datasource=promDatasource,
-      legendFormat='{{node}}',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'Node memory swap',
-  description: 'Percentage of swap space used by OpenSearch and the Operating System on the selected node.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-          {
-            color: 'red',
-            value: 80,
-          },
-        ],
-      },
-      unit: 'percent',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'single',
-      sort: 'none',
-    },
-  },
-};
-
-local nodeNetworkTrafficPanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'sum by (node, job, cluster) (rate(opensearch_transport_tx_bytes_count{cluster=~"$opensearch_cluster", job=~"$job", node=~"$node"}[$__rate_interval]))',
-      datasource=promDatasource,
-      legendFormat='{{node}} - sent',
-    ),
-    prometheus.target(
-      'sum by (node, job, cluster) (rate(opensearch_transport_rx_bytes_count{cluster=~"$opensearch_cluster", job=~"$job", node=~"$node"}[$__rate_interval]))',
-      datasource=promDatasource,
-      legendFormat='{{node}} - received',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'Node network traffic',
-  description: 'Node network traffic sent and received.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-          {
-            color: 'red',
-            value: 80,
-          },
-        ],
-      },
-      unit: 'Bps',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'single',
-      sort: 'none',
-    },
-  },
-};
-
-local circuitBreakersPanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'sum by(name, job, cluster) (increase(opensearch_circuitbreaker_tripped_count{cluster=~"$opensearch_cluster", job=~"$job", node=~"$node"}[$__interval:]))',
-      datasource=promDatasource,
-      legendFormat='{{name}}',
-      interval='1m',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'Circuit breakers',
-  description: 'Circuit breakers tripped on the selected node by type',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-        ],
-      },
-      unit: 'trips',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'single',
-      sort: 'none',
-    },
-  },
-};
-
-local nodeJVMRow = {
-  datasource: promDatasource,
-  targets: [],
-  type: 'row',
-  title: 'Node JVM',
-  collapsed: false,
-};
-
-local jvmHeapUsedVsCommittedPanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'sum by (node, job, cluster) (opensearch_jvm_mem_heap_used_bytes{cluster=~"$opensearch_cluster", job=~"$job", node=~"$node"})',
-      datasource=promDatasource,
-      legendFormat='{{node}} - used',
-    ),
-    prometheus.target(
-      'sum by (node, job, cluster) (opensearch_jvm_mem_heap_committed_bytes{cluster=~"$opensearch_cluster", job=~"$job", node=~"$node"})',
-      datasource=promDatasource,
-      legendFormat='{{node}} - committed',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'JVM heap used vs. committed',
-  description: 'The amount of heap memory used vs committed on the selected node.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-        ],
-      },
-      unit: 'bytes',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'multi',
-      sort: 'none',
-    },
-  },
-};
-
-local jvmNonheapUsedVsCommittedPanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'sum by (node, job, cluster) (opensearch_jvm_mem_nonheap_used_bytes{cluster=~"$opensearch_cluster", job=~"$job", node=~"$node"})',
-      datasource=promDatasource,
-      legendFormat='{{node}} - used',
-    ),
-    prometheus.target(
-      'sum by (node, job, cluster) (opensearch_jvm_mem_nonheap_committed_bytes{cluster=~"$opensearch_cluster", job=~"$job", node=~"$node"})',
-      datasource=promDatasource,
-      legendFormat='{{node}} - committed',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'JVM non-heap used vs. committed',
-  description: 'The amount of non-heap memory used vs committed on the selected node.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-        ],
-      },
-      unit: 'bytes',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'multi',
-      sort: 'none',
-    },
-  },
-};
-
-local jvmThreadsPanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'sum by (node, job, cluster) (opensearch_jvm_threads_number{cluster=~"$opensearch_cluster", job=~"$job", node=~"$node"})',
-      datasource=promDatasource,
-      legendFormat='{{node}}',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'JVM threads',
-  description: 'The number of threads running in the JVM on the selected node.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-          {
-            color: 'red',
-            value: 80,
-          },
-        ],
-      },
-      unit: 'threads',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'single',
-      sort: 'none',
-    },
-  },
-};
-
-local jvmBufferPoolsPanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'sum by(job, cluster, bufferpool) (opensearch_jvm_bufferpool_number{cluster=~"$opensearch_cluster", job=~"$job", node=~"$node"})',
-      datasource=promDatasource,
-      legendFormat='{{bufferpool}}',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'JVM buffer pools',
-  description: 'The number of buffer pools available on the selected node.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-          {
-            color: 'red',
-            value: 80,
-          },
-        ],
-      },
-      unit: 'buffer pools',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'multi',
-      sort: 'none',
-    },
-  },
-};
-
-local jvmUptimePanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'sum by(job, cluster, node) (opensearch_jvm_uptime_seconds{cluster=~"$opensearch_cluster", job=~"$job", node=~"$node"})',
-      datasource=promDatasource,
-      legendFormat='{{node}}',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'JVM uptime',
-  description: 'The uptime of the JVM in seconds on the selected node.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-          {
-            color: 'red',
-            value: 80,
-          },
-        ],
-      },
-      unit: 's',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'single',
-      sort: 'none',
-    },
-  },
-  pluginVersion: '9.4.3',
-};
-
-local jvmGarbageCollectionsPanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'sum by (node, cluster, job) (increase(opensearch_jvm_gc_collection_count{cluster=~"$opensearch_cluster", job=~"$job", node=~"$node"}[$__interval:]))',
-      datasource=promDatasource,
-      legendFormat='{{node}}',
-      interval='1m',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'JVM garbage collections',
-  description: 'The number of garbage collection operations on the selected node.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-          {
-            color: 'red',
-            value: 80,
-          },
-        ],
-      },
-      unit: 'operations',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'single',
-      sort: 'none',
-    },
-  },
-};
-
-local jvmGarbageCollectionTimePanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'sum by (node, cluster, job) (increase(opensearch_jvm_gc_collection_time_seconds{cluster=~"$opensearch_cluster", job=~"$job", node=~"$node"}[$__interval:]))',
-      datasource=promDatasource,
-      legendFormat='{{node}}',
-      interval='1m',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'JVM garbage collection time',
-  description: 'The amount of time spent on garbage collection on the selected node.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-        ],
-      },
-      unit: 's',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'single',
-      sort: 'none',
-    },
-  },
-};
-
-local jvmBufferPoolUsagePanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      '100 * (sum by (job, bufferpool, cluster) (opensearch_jvm_bufferpool_used_bytes{cluster=~"$opensearch_cluster", job=~"$job", node=~"$node"})) / clamp_min((sum by (job, bufferpool, cluster) (opensearch_jvm_bufferpool_total_capacity_bytes{cluster=~"$opensearch_cluster", job=~"$job", node=~"$node"})),1)',
-      datasource=promDatasource,
-      legendFormat='{{bufferpool}}',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'JVM buffer pool usage',
-  description: 'The percent used of JVM buffer pool memory.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-          {
-            color: 'red',
-            value: 80,
-          },
-        ],
-      },
-      unit: 'percent',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'single',
-      sort: 'none',
-    },
-  },
-};
-
-local threadPoolsRow = {
-  datasource: promDatasource,
-  targets: [],
-  type: 'row',
-  title: 'Thread pools',
-  collapsed: false,
-};
-
-local threadPoolThreadsPanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'sum by(node, job, cluster) ((opensearch_threadpool_threads_number{cluster=~"$opensearch_cluster", job=~"$job", node=~"$node"}))',
-      datasource=promDatasource,
-      legendFormat='{{node}}',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'Thread pool threads',
-  description: 'The number of threads in the thread pool for the selected node',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-          },
-          {
-            color: 'red',
-            value: 80,
-          },
-        ],
-      },
-      unit: 'threads',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'single',
-      sort: 'none',
-    },
-  },
-};
-
-local threadPoolTasksPanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'sum by (node, job, cluster) (opensearch_threadpool_tasks_number{cluster=~"$opensearch_cluster", job=~"$job", node=~"$node"})',
-      datasource=promDatasource,
-      legendFormat='{{node}}',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'Thread pool tasks',
-  description: 'The number of tasks in the thread pool for the selected node.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-          },
-          {
-            color: 'red',
-            value: 80,
-          },
-        ],
-      },
-      unit: 'tasks',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'single',
-      sort: 'none',
-    },
-  },
-};
-
-local errorLogsPanelPanel = {
-  datasource: lokiDatasource,
-  targets: [
-    {
-      datasource: lokiDatasource,
-      editorMode: 'code',
-      expr: '{job=~"$job", node=~"$node"} |~ ""',
-      queryType: 'range',
-      refId: 'A',
-    },
-  ],
-  type: 'logs',
-  title: 'Error logs panel',
-  description: 'The recent error logs being reported by OpenSearch.',
-  options: {
-    dedupStrategy: 'none',
-    enableLogDetails: true,
-    prettifyLogMessage: false,
-    showCommonLabels: false,
-    showLabels: false,
-    showTime: false,
-    sortOrder: 'Descending',
-    wrapLogMessage: false,
-  },
-};
 
 {
+
+  // variables
+  local variables = (import '../variables.libsonnet').new(
+    filteringSelector=$._config.filteringSelector,
+    groupLabels=$._config.groupLabels,
+    instanceLabels=$._config.instanceLabels,
+    varMetric='opensearch_os_cpu_percent'
+  ),
+
+  local promDatasource = {
+    uid: '${%s}' % variables.datasources.prometheus.name,
+  },
+
+  local lokiDatasource = {
+    uid: '${%s}' % variables.datasources.loki.name,
+  },
+
+  local nodeHealthRow = {
+    datasource: promDatasource,
+    targets: [],
+    type: 'row',
+    title: 'Node health',
+    collapsed: false,
+  },
+
+  local nodeCPUUsagePanel = {
+    datasource: promDatasource,
+    targets: [
+      prometheus.target(
+        'opensearch_os_cpu_percent{%(queriesSelector)s}'
+        % {
+          queriesSelector: variables.queriesSelector,
+          agg: std.join(',', $._config.groupLabels + $._config.instanceLabels),
+        },
+        datasource=promDatasource,
+        legendFormat=utils.labelsToPanelLegend($._config.instanceLabels),
+      ),
+    ],
+    type: 'timeseries',
+    title: 'Node CPU usage',
+    description: "CPU usage percentage of the node's Operating System.",
+    fieldConfig: {
+      defaults: {
+        color: {
+          mode: 'palette-classic',
+        },
+        custom: {
+          axisCenteredZero: false,
+          axisColorMode: 'text',
+          axisLabel: '',
+          axisPlacement: 'auto',
+          barAlignment: 0,
+          drawStyle: 'line',
+          fillOpacity: 0,
+          gradientMode: 'none',
+          hideFrom: {
+            legend: false,
+            tooltip: false,
+            viz: false,
+          },
+          lineInterpolation: 'linear',
+          lineWidth: 1,
+          pointSize: 5,
+          scaleDistribution: {
+            type: 'linear',
+          },
+          showPoints: 'auto',
+          spanNulls: false,
+          stacking: {
+            group: 'A',
+            mode: 'none',
+          },
+          thresholdsStyle: {
+            mode: 'off',
+          },
+        },
+        mappings: [],
+        thresholds: {
+          mode: 'absolute',
+          steps: [
+            {
+              color: 'green',
+              value: null,
+            },
+          ],
+        },
+        unit: 'percent',
+      },
+      overrides: [],
+    },
+    options: {
+      legend: {
+        calcs: [],
+        displayMode: 'list',
+        placement: 'bottom',
+        showLegend: true,
+      },
+      tooltip: {
+        mode: 'single',
+        sort: 'none',
+      },
+    },
+  },
+
+  local nodeMemoryUsagePanel =
+    {
+      datasource: promDatasource,
+      targets: [
+        prometheus.target(
+          'opensearch_os_mem_used_percent{%(queriesSelector)s}'
+          % {
+            queriesSelector: variables.queriesSelector,
+            agg: std.join(',', $._config.groupLabels + $._config.instanceLabels),
+          },
+          datasource=promDatasource,
+          legendFormat=utils.labelsToPanelLegend($._config.instanceLabels),
+        ),
+      ],
+      type: 'timeseries',
+      title: 'Node memory usage',
+      description: 'Memory usage percentage of the node for the Operating System and OpenSearch',
+      fieldConfig: {
+        defaults: {
+          color: {
+            mode: 'palette-classic',
+          },
+          custom: {
+            axisCenteredZero: false,
+            axisColorMode: 'text',
+            axisLabel: '',
+            axisPlacement: 'auto',
+            barAlignment: 0,
+            drawStyle: 'line',
+            fillOpacity: 0,
+            gradientMode: 'none',
+            hideFrom: {
+              legend: false,
+              tooltip: false,
+              viz: false,
+            },
+            lineInterpolation: 'linear',
+            lineWidth: 1,
+            pointSize: 5,
+            scaleDistribution: {
+              type: 'linear',
+            },
+            showPoints: 'auto',
+            spanNulls: false,
+            stacking: {
+              group: 'A',
+              mode: 'none',
+            },
+            thresholdsStyle: {
+              mode: 'off',
+            },
+          },
+          mappings: [],
+          max: 100,
+          min: 0,
+          thresholds: {
+            mode: 'absolute',
+            steps: [
+              {
+                color: 'green',
+                value: null,
+              },
+            ],
+          },
+          unit: 'percent',
+        },
+        overrides: [],
+      },
+      options: {
+        legend: {
+          calcs: [],
+          displayMode: 'list',
+          placement: 'bottom',
+          showLegend: true,
+        },
+        tooltip: {
+          mode: 'single',
+          sort: 'none',
+        },
+      },
+    },
+
+  local nodeIOPanel = {
+    datasource: promDatasource,
+    targets: [
+      prometheus.target(
+        'sum by(%(agg)s) (opensearch_fs_io_total_read_bytes{%(queriesSelector)s})'
+        % {
+          queriesSelector: variables.queriesSelector,
+          agg: std.join(',', $._config.groupLabels + $._config.instanceLabels),
+        },
+        datasource=promDatasource,
+        legendFormat='%s - read' % utils.labelsToPanelLegend($._config.instanceLabels),
+      ),
+      prometheus.target(
+        'sum by(%(agg)s) (opensearch_fs_io_total_write_bytes{%(queriesSelector)s})'
+        % {
+          queriesSelector: variables.queriesSelector,
+          agg: std.join(',', $._config.groupLabels + $._config.instanceLabels),
+        },
+        datasource=promDatasource,
+        legendFormat='%s - write' % utils.labelsToPanelLegend($._config.instanceLabels),
+      ),
+    ],
+    type: 'timeseries',
+    title: 'Node I/O',
+    description: 'Node file system read and write data.',
+    fieldConfig: {
+      defaults: {
+        color: {
+          mode: 'palette-classic',
+        },
+        custom: {
+          axisCenteredZero: false,
+          axisColorMode: 'text',
+          axisLabel: '',
+          axisPlacement: 'auto',
+          barAlignment: 0,
+          drawStyle: 'line',
+          fillOpacity: 0,
+          gradientMode: 'none',
+          hideFrom: {
+            legend: false,
+            tooltip: false,
+            viz: false,
+          },
+          lineInterpolation: 'linear',
+          lineWidth: 1,
+          pointSize: 5,
+          scaleDistribution: {
+            type: 'linear',
+          },
+          showPoints: 'auto',
+          spanNulls: false,
+          stacking: {
+            group: 'A',
+            mode: 'none',
+          },
+          thresholdsStyle: {
+            mode: 'off',
+          },
+        },
+        mappings: [],
+        thresholds: {
+          mode: 'absolute',
+          steps: [
+            {
+              color: 'green',
+              value: null,
+            },
+            {
+              color: 'red',
+              value: 80,
+            },
+          ],
+        },
+        unit: 'bytes',
+      },
+      overrides: [],
+    },
+    options: {
+      legend: {
+        calcs: [],
+        displayMode: 'list',
+        placement: 'bottom',
+        showLegend: true,
+      },
+      tooltip: {
+        mode: 'single',
+        sort: 'none',
+      },
+    },
+  },
+
+  local nodeOpenConnectionsPanel = {
+    datasource: promDatasource,
+    targets: [
+      prometheus.target(
+        'sum by (%(agg)s) (opensearch_transport_server_open_number{%(queriesSelector)s})'
+        % {
+          queriesSelector: variables.queriesSelector,
+          agg: std.join(',', $._config.groupLabels + $._config.instanceLabels),
+        },
+        datasource=promDatasource,
+        legendFormat=utils.labelsToPanelLegend($._config.instanceLabels),
+      ),
+    ],
+    type: 'timeseries',
+    title: 'Node open connections',
+    description: 'Number of open connections for the selected node.',
+    fieldConfig: {
+      defaults: {
+        color: {
+          mode: 'palette-classic',
+        },
+        custom: {
+          axisCenteredZero: false,
+          axisColorMode: 'text',
+          axisLabel: '',
+          axisPlacement: 'auto',
+          barAlignment: 0,
+          drawStyle: 'line',
+          fillOpacity: 0,
+          gradientMode: 'none',
+          hideFrom: {
+            legend: false,
+            tooltip: false,
+            viz: false,
+          },
+          lineInterpolation: 'linear',
+          lineWidth: 1,
+          pointSize: 5,
+          scaleDistribution: {
+            type: 'linear',
+          },
+          showPoints: 'auto',
+          spanNulls: false,
+          stacking: {
+            group: 'A',
+            mode: 'none',
+          },
+          thresholdsStyle: {
+            mode: 'off',
+          },
+        },
+        mappings: [],
+        thresholds: {
+          mode: 'absolute',
+          steps: [
+            {
+              color: 'green',
+              value: null,
+            },
+          ],
+        },
+        unit: 'connections',
+      },
+      overrides: [],
+    },
+    options: {
+      legend: {
+        calcs: [],
+        displayMode: 'list',
+        placement: 'bottom',
+        showLegend: true,
+      },
+      tooltip: {
+        mode: 'single',
+        sort: 'none',
+      },
+    },
+  },
+
+  local nodeDiskUsagePanel = {
+    datasource: promDatasource,
+    targets: [
+      prometheus.target(
+        '100 - (100 * opensearch_fs_path_free_bytes{%(queriesSelector)s} / clamp_min(opensearch_fs_path_total_bytes{%(queriesSelector)s}, 1))'
+        % {
+          queriesSelector: variables.queriesSelector,
+          agg: std.join(',', $._config.groupLabels + $._config.instanceLabels),
+        },
+        datasource=promDatasource,
+        legendFormat=utils.labelsToPanelLegend($._config.instanceLabels),
+      ),
+    ],
+    type: 'timeseries',
+    title: 'Node disk usage',
+    description: 'Disk usage percentage of the selected node.',
+    fieldConfig: {
+      defaults: {
+        color: {
+          mode: 'palette-classic',
+        },
+        custom: {
+          axisCenteredZero: false,
+          axisColorMode: 'text',
+          axisLabel: '',
+          axisPlacement: 'auto',
+          barAlignment: 0,
+          drawStyle: 'line',
+          fillOpacity: 0,
+          gradientMode: 'none',
+          hideFrom: {
+            legend: false,
+            tooltip: false,
+            viz: false,
+          },
+          lineInterpolation: 'linear',
+          lineWidth: 1,
+          pointSize: 5,
+          scaleDistribution: {
+            type: 'linear',
+          },
+          showPoints: 'auto',
+          spanNulls: false,
+          stacking: {
+            group: 'A',
+            mode: 'none',
+          },
+          thresholdsStyle: {
+            mode: 'off',
+          },
+        },
+        mappings: [],
+        thresholds: {
+          mode: 'absolute',
+          steps: [
+            {
+              color: 'green',
+              value: null,
+            },
+            {
+              color: 'red',
+              value: 80,
+            },
+          ],
+        },
+        unit: 'percent',
+      },
+      overrides: [],
+    },
+    options: {
+      legend: {
+        calcs: [],
+        displayMode: 'list',
+        placement: 'bottom',
+        showLegend: true,
+      },
+      tooltip: {
+        mode: 'single',
+        sort: 'none',
+      },
+    },
+  },
+
+  local nodeMemorySwapPanel = {
+    datasource: promDatasource,
+    targets: [
+      prometheus.target(
+        '100 * opensearch_os_swap_used_bytes{%(queriesSelector)s} / clamp_min((opensearch_os_swap_used_bytes{%(queriesSelector)s} + opensearch_os_swap_free_bytes{%(queriesSelector)s}), 1)'
+        % {
+          queriesSelector: variables.queriesSelector,
+          agg: std.join(',', $._config.groupLabels + $._config.instanceLabels),
+        },
+        datasource=promDatasource,
+        legendFormat=utils.labelsToPanelLegend($._config.instanceLabels),
+      ),
+    ],
+    type: 'timeseries',
+    title: 'Node memory swap',
+    description: 'Percentage of swap space used by OpenSearch and the Operating System on the selected node.',
+    fieldConfig: {
+      defaults: {
+        color: {
+          mode: 'palette-classic',
+        },
+        custom: {
+          axisCenteredZero: false,
+          axisColorMode: 'text',
+          axisLabel: '',
+          axisPlacement: 'auto',
+          barAlignment: 0,
+          drawStyle: 'line',
+          fillOpacity: 0,
+          gradientMode: 'none',
+          hideFrom: {
+            legend: false,
+            tooltip: false,
+            viz: false,
+          },
+          lineInterpolation: 'linear',
+          lineWidth: 1,
+          pointSize: 5,
+          scaleDistribution: {
+            type: 'linear',
+          },
+          showPoints: 'auto',
+          spanNulls: false,
+          stacking: {
+            group: 'A',
+            mode: 'none',
+          },
+          thresholdsStyle: {
+            mode: 'off',
+          },
+        },
+        mappings: [],
+        thresholds: {
+          mode: 'absolute',
+          steps: [
+            {
+              color: 'green',
+              value: null,
+            },
+            {
+              color: 'red',
+              value: 80,
+            },
+          ],
+        },
+        unit: 'percent',
+      },
+      overrides: [],
+    },
+    options: {
+      legend: {
+        calcs: [],
+        displayMode: 'list',
+        placement: 'bottom',
+        showLegend: true,
+      },
+      tooltip: {
+        mode: 'single',
+        sort: 'none',
+      },
+    },
+  },
+
+  local nodeNetworkTrafficPanel = {
+    datasource: promDatasource,
+    targets: [
+      prometheus.target(
+        'sum by (%(agg)s) (rate(opensearch_transport_tx_bytes_count{%(queriesSelector)s}[$__rate_interval]))'
+        % {
+          queriesSelector: variables.queriesSelector,
+          agg: std.join(',', $._config.groupLabels + $._config.instanceLabels),
+        },
+        datasource=promDatasource,
+        legendFormat='%s - sent' % utils.labelsToPanelLegend($._config.instanceLabels),
+      ),
+      prometheus.target(
+        'sum by (%(agg)s) (rate(opensearch_transport_rx_bytes_count{%(queriesSelector)s}[$__rate_interval]))'
+        % {
+          queriesSelector: variables.queriesSelector,
+          agg: std.join(',', $._config.groupLabels + $._config.instanceLabels),
+        },
+        datasource=promDatasource,
+        legendFormat='%s - received' % utils.labelsToPanelLegend($._config.instanceLabels),
+      ),
+    ],
+    type: 'timeseries',
+    title: 'Node network traffic',
+    description: 'Node network traffic sent and received.',
+    fieldConfig: {
+      defaults: {
+        color: {
+          mode: 'palette-classic',
+        },
+        custom: {
+          axisCenteredZero: false,
+          axisColorMode: 'text',
+          axisLabel: '',
+          axisPlacement: 'auto',
+          barAlignment: 0,
+          drawStyle: 'line',
+          fillOpacity: 0,
+          gradientMode: 'none',
+          hideFrom: {
+            legend: false,
+            tooltip: false,
+            viz: false,
+          },
+          lineInterpolation: 'linear',
+          lineWidth: 1,
+          pointSize: 5,
+          scaleDistribution: {
+            type: 'linear',
+          },
+          showPoints: 'auto',
+          spanNulls: false,
+          stacking: {
+            group: 'A',
+            mode: 'none',
+          },
+          thresholdsStyle: {
+            mode: 'off',
+          },
+        },
+        mappings: [],
+        thresholds: {
+          mode: 'absolute',
+          steps: [
+            {
+              color: 'green',
+              value: null,
+            },
+            {
+              color: 'red',
+              value: 80,
+            },
+          ],
+        },
+        unit: 'Bps',
+      },
+      overrides: [],
+    },
+    options: {
+      legend: {
+        calcs: [],
+        displayMode: 'list',
+        placement: 'bottom',
+        showLegend: true,
+      },
+      tooltip: {
+        mode: 'single',
+        sort: 'none',
+      },
+    },
+  },
+
+  local circuitBreakersPanel = {
+    datasource: promDatasource,
+    targets: [
+      prometheus.target(
+        'sum by(name, %(agg)s) (increase(opensearch_circuitbreaker_tripped_count{%(queriesSelector)s}[$__interval:]))'
+        % {
+          queriesSelector: variables.queriesSelector,
+          agg: std.join(',', $._config.groupLabels + $._config.instanceLabels),
+        },
+        datasource=promDatasource,
+        legendFormat='%s - {{ name }}' % utils.labelsToPanelLegend($._config.instanceLabels),
+        interval='1m',
+      ),
+    ],
+    type: 'timeseries',
+    title: 'Circuit breakers',
+    description: 'Circuit breakers tripped on the selected node by type',
+    fieldConfig: {
+      defaults: {
+        color: {
+          mode: 'palette-classic',
+        },
+        custom: {
+          axisCenteredZero: false,
+          axisColorMode: 'text',
+          axisLabel: '',
+          axisPlacement: 'auto',
+          barAlignment: 0,
+          drawStyle: 'line',
+          fillOpacity: 0,
+          gradientMode: 'none',
+          hideFrom: {
+            legend: false,
+            tooltip: false,
+            viz: false,
+          },
+          lineInterpolation: 'linear',
+          lineWidth: 1,
+          pointSize: 5,
+          scaleDistribution: {
+            type: 'linear',
+          },
+          showPoints: 'auto',
+          spanNulls: false,
+          stacking: {
+            group: 'A',
+            mode: 'none',
+          },
+          thresholdsStyle: {
+            mode: 'off',
+          },
+        },
+        mappings: [],
+        thresholds: {
+          mode: 'absolute',
+          steps: [
+            {
+              color: 'green',
+              value: null,
+            },
+          ],
+        },
+        unit: 'trips',
+      },
+      overrides: [],
+    },
+    options: {
+      legend: {
+        calcs: [],
+        displayMode: 'list',
+        placement: 'bottom',
+        showLegend: true,
+      },
+      tooltip: {
+        mode: 'single',
+        sort: 'none',
+      },
+    },
+  },
+
+  local nodeJVMRow = {
+    datasource: promDatasource,
+    targets: [],
+    type: 'row',
+    title: 'Node JVM',
+    collapsed: false,
+  },
+
+  local jvmHeapUsedVsCommittedPanel = {
+    datasource: promDatasource,
+    targets: [
+      prometheus.target(
+        'sum by (%(agg)s) (opensearch_jvm_mem_heap_used_bytes{%(queriesSelector)s})'
+        % {
+          queriesSelector: variables.queriesSelector,
+          agg: std.join(',', $._config.groupLabels + $._config.instanceLabels),
+        },
+        datasource=promDatasource,
+        legendFormat='%s - used' % utils.labelsToPanelLegend($._config.instanceLabels),
+      ),
+      prometheus.target(
+        'sum by (%(agg)s) (opensearch_jvm_mem_heap_committed_bytes{%(queriesSelector)s})'
+        % {
+          queriesSelector: variables.queriesSelector,
+          agg: std.join(',', $._config.groupLabels + $._config.instanceLabels),
+        },
+        datasource=promDatasource,
+        legendFormat='%s - commited' % utils.labelsToPanelLegend($._config.instanceLabels),
+      ),
+    ],
+    type: 'timeseries',
+    title: 'JVM heap used vs. committed',
+    description: 'The amount of heap memory used vs committed on the selected node.',
+    fieldConfig: {
+      defaults: {
+        color: {
+          mode: 'palette-classic',
+        },
+        custom: {
+          axisCenteredZero: false,
+          axisColorMode: 'text',
+          axisLabel: '',
+          axisPlacement: 'auto',
+          barAlignment: 0,
+          drawStyle: 'line',
+          fillOpacity: 0,
+          gradientMode: 'none',
+          hideFrom: {
+            legend: false,
+            tooltip: false,
+            viz: false,
+          },
+          lineInterpolation: 'linear',
+          lineWidth: 1,
+          pointSize: 5,
+          scaleDistribution: {
+            type: 'linear',
+          },
+          showPoints: 'auto',
+          spanNulls: false,
+          stacking: {
+            group: 'A',
+            mode: 'none',
+          },
+          thresholdsStyle: {
+            mode: 'off',
+          },
+        },
+        mappings: [],
+        thresholds: {
+          mode: 'absolute',
+          steps: [
+            {
+              color: 'green',
+              value: null,
+            },
+          ],
+        },
+        unit: 'bytes',
+      },
+      overrides: [],
+    },
+    options: {
+      legend: {
+        calcs: [],
+        displayMode: 'list',
+        placement: 'bottom',
+        showLegend: true,
+      },
+      tooltip: {
+        mode: 'multi',
+        sort: 'none',
+      },
+    },
+  },
+
+  local jvmNonheapUsedVsCommittedPanel = {
+    datasource: promDatasource,
+    targets: [
+      prometheus.target(
+        'sum by (%(agg)s) (opensearch_jvm_mem_nonheap_used_bytes{%(queriesSelector)s})'
+        % {
+          queriesSelector: variables.queriesSelector,
+          agg: std.join(',', $._config.groupLabels + $._config.instanceLabels),
+        },
+        datasource=promDatasource,
+        legendFormat='%s - used' % utils.labelsToPanelLegend($._config.instanceLabels),
+      ),
+      prometheus.target(
+        'sum by (%(agg)s) (opensearch_jvm_mem_nonheap_committed_bytes{%(queriesSelector)s})'
+        % {
+          queriesSelector: variables.queriesSelector,
+          agg: std.join(',', $._config.groupLabels + $._config.instanceLabels),
+        },
+        datasource=promDatasource,
+        legendFormat='%s - commited' % utils.labelsToPanelLegend($._config.instanceLabels),
+      ),
+    ],
+    type: 'timeseries',
+    title: 'JVM non-heap used vs. committed',
+    description: 'The amount of non-heap memory used vs committed on the selected node.',
+    fieldConfig: {
+      defaults: {
+        color: {
+          mode: 'palette-classic',
+        },
+        custom: {
+          axisCenteredZero: false,
+          axisColorMode: 'text',
+          axisLabel: '',
+          axisPlacement: 'auto',
+          barAlignment: 0,
+          drawStyle: 'line',
+          fillOpacity: 0,
+          gradientMode: 'none',
+          hideFrom: {
+            legend: false,
+            tooltip: false,
+            viz: false,
+          },
+          lineInterpolation: 'linear',
+          lineWidth: 1,
+          pointSize: 5,
+          scaleDistribution: {
+            type: 'linear',
+          },
+          showPoints: 'auto',
+          spanNulls: false,
+          stacking: {
+            group: 'A',
+            mode: 'none',
+          },
+          thresholdsStyle: {
+            mode: 'off',
+          },
+        },
+        mappings: [],
+        thresholds: {
+          mode: 'absolute',
+          steps: [
+            {
+              color: 'green',
+              value: null,
+            },
+          ],
+        },
+        unit: 'bytes',
+      },
+      overrides: [],
+    },
+    options: {
+      legend: {
+        calcs: [],
+        displayMode: 'list',
+        placement: 'bottom',
+        showLegend: true,
+      },
+      tooltip: {
+        mode: 'multi',
+        sort: 'none',
+      },
+    },
+  },
+
+  local jvmThreadsPanel = {
+    datasource: promDatasource,
+    targets: [
+      prometheus.target(
+        'sum by (%(agg)s) (opensearch_jvm_threads_number{%(queriesSelector)s})'
+        % {
+          queriesSelector: variables.queriesSelector,
+          agg: std.join(',', $._config.groupLabels + $._config.instanceLabels),
+        },
+        datasource=promDatasource,
+        legendFormat=utils.labelsToPanelLegend($._config.instanceLabels),
+      ),
+    ],
+    type: 'timeseries',
+    title: 'JVM threads',
+    description: 'The number of threads running in the JVM on the selected node.',
+    fieldConfig: {
+      defaults: {
+        color: {
+          mode: 'palette-classic',
+        },
+        custom: {
+          axisCenteredZero: false,
+          axisColorMode: 'text',
+          axisLabel: '',
+          axisPlacement: 'auto',
+          barAlignment: 0,
+          drawStyle: 'line',
+          fillOpacity: 0,
+          gradientMode: 'none',
+          hideFrom: {
+            legend: false,
+            tooltip: false,
+            viz: false,
+          },
+          lineInterpolation: 'linear',
+          lineWidth: 1,
+          pointSize: 5,
+          scaleDistribution: {
+            type: 'linear',
+          },
+          showPoints: 'auto',
+          spanNulls: false,
+          stacking: {
+            group: 'A',
+            mode: 'none',
+          },
+          thresholdsStyle: {
+            mode: 'off',
+          },
+        },
+        mappings: [],
+        thresholds: {
+          mode: 'absolute',
+          steps: [
+            {
+              color: 'green',
+              value: null,
+            },
+            {
+              color: 'red',
+              value: 80,
+            },
+          ],
+        },
+        unit: 'threads',
+      },
+      overrides: [],
+    },
+    options: {
+      legend: {
+        calcs: [],
+        displayMode: 'list',
+        placement: 'bottom',
+        showLegend: true,
+      },
+      tooltip: {
+        mode: 'single',
+        sort: 'none',
+      },
+    },
+  },
+
+  local jvmBufferPoolsPanel = {
+    datasource: promDatasource,
+    targets: [
+      prometheus.target(
+        'sum by( %(agg)s, bufferpool) (opensearch_jvm_bufferpool_number{%(queriesSelector)s})'
+        % {
+          queriesSelector: variables.queriesSelector,
+          agg: std.join(',', $._config.groupLabels + $._config.instanceLabels),
+        },
+        datasource=promDatasource,
+        legendFormat='%s - {{bufferpool}}' % utils.labelsToPanelLegend($._config.instanceLabels),
+      ),
+    ],
+    type: 'timeseries',
+    title: 'JVM buffer pools',
+    description: 'The number of buffer pools available on the selected node.',
+    fieldConfig: {
+      defaults: {
+        color: {
+          mode: 'palette-classic',
+        },
+        custom: {
+          axisCenteredZero: false,
+          axisColorMode: 'text',
+          axisLabel: '',
+          axisPlacement: 'auto',
+          barAlignment: 0,
+          drawStyle: 'line',
+          fillOpacity: 0,
+          gradientMode: 'none',
+          hideFrom: {
+            legend: false,
+            tooltip: false,
+            viz: false,
+          },
+          lineInterpolation: 'linear',
+          lineWidth: 1,
+          pointSize: 5,
+          scaleDistribution: {
+            type: 'linear',
+          },
+          showPoints: 'auto',
+          spanNulls: false,
+          stacking: {
+            group: 'A',
+            mode: 'none',
+          },
+          thresholdsStyle: {
+            mode: 'off',
+          },
+        },
+        mappings: [],
+        thresholds: {
+          mode: 'absolute',
+          steps: [
+            {
+              color: 'green',
+              value: null,
+            },
+            {
+              color: 'red',
+              value: 80,
+            },
+          ],
+        },
+        unit: 'buffer pools',
+      },
+      overrides: [],
+    },
+    options: {
+      legend: {
+        calcs: [],
+        displayMode: 'list',
+        placement: 'bottom',
+        showLegend: true,
+      },
+      tooltip: {
+        mode: 'multi',
+        sort: 'none',
+      },
+    },
+  },
+
+  local jvmUptimePanel = {
+    datasource: promDatasource,
+    targets: [
+      prometheus.target(
+        'sum by(%(agg)s) (opensearch_jvm_uptime_seconds{%(queriesSelector)s})'
+        % {
+          queriesSelector: variables.queriesSelector,
+          agg: std.join(',', $._config.groupLabels + $._config.instanceLabels),
+        },
+        datasource=promDatasource,
+        legendFormat=utils.labelsToPanelLegend($._config.instanceLabels),
+      ),
+    ],
+    type: 'timeseries',
+    title: 'JVM uptime',
+    description: 'The uptime of the JVM in seconds on the selected node.',
+    fieldConfig: {
+      defaults: {
+        color: {
+          mode: 'palette-classic',
+        },
+        custom: {
+          axisCenteredZero: false,
+          axisColorMode: 'text',
+          axisLabel: '',
+          axisPlacement: 'auto',
+          barAlignment: 0,
+          drawStyle: 'line',
+          fillOpacity: 0,
+          gradientMode: 'none',
+          hideFrom: {
+            legend: false,
+            tooltip: false,
+            viz: false,
+          },
+          lineInterpolation: 'linear',
+          lineWidth: 1,
+          pointSize: 5,
+          scaleDistribution: {
+            type: 'linear',
+          },
+          showPoints: 'auto',
+          spanNulls: false,
+          stacking: {
+            group: 'A',
+            mode: 'none',
+          },
+          thresholdsStyle: {
+            mode: 'off',
+          },
+        },
+        mappings: [],
+        thresholds: {
+          mode: 'absolute',
+          steps: [
+            {
+              color: 'green',
+              value: null,
+            },
+            {
+              color: 'red',
+              value: 80,
+            },
+          ],
+        },
+        unit: 's',
+      },
+      overrides: [],
+    },
+    options: {
+      legend: {
+        calcs: [],
+        displayMode: 'list',
+        placement: 'bottom',
+        showLegend: true,
+      },
+      tooltip: {
+        mode: 'single',
+        sort: 'none',
+      },
+    },
+    pluginVersion: '9.4.3',
+  },
+
+  local jvmGarbageCollectionsPanel = {
+    datasource: promDatasource,
+    targets: [
+      prometheus.target(
+        'sum by (%(agg)s) (increase(opensearch_jvm_gc_collection_count{%(queriesSelector)s}[$__interval:]))'
+        % {
+          queriesSelector: variables.queriesSelector,
+          agg: std.join(',', $._config.groupLabels + $._config.instanceLabels),
+        },
+        datasource=promDatasource,
+        legendFormat=utils.labelsToPanelLegend($._config.instanceLabels),
+        interval='1m',
+      ),
+    ],
+    type: 'timeseries',
+    title: 'JVM garbage collections',
+    description: 'The number of garbage collection operations on the selected node.',
+    fieldConfig: {
+      defaults: {
+        color: {
+          mode: 'palette-classic',
+        },
+        custom: {
+          axisCenteredZero: false,
+          axisColorMode: 'text',
+          axisLabel: '',
+          axisPlacement: 'auto',
+          barAlignment: 0,
+          drawStyle: 'line',
+          fillOpacity: 0,
+          gradientMode: 'none',
+          hideFrom: {
+            legend: false,
+            tooltip: false,
+            viz: false,
+          },
+          lineInterpolation: 'linear',
+          lineWidth: 1,
+          pointSize: 5,
+          scaleDistribution: {
+            type: 'linear',
+          },
+          showPoints: 'auto',
+          spanNulls: false,
+          stacking: {
+            group: 'A',
+            mode: 'none',
+          },
+          thresholdsStyle: {
+            mode: 'off',
+          },
+        },
+        mappings: [],
+        thresholds: {
+          mode: 'absolute',
+          steps: [
+            {
+              color: 'green',
+              value: null,
+            },
+            {
+              color: 'red',
+              value: 80,
+            },
+          ],
+        },
+        unit: 'operations',
+      },
+      overrides: [],
+    },
+    options: {
+      legend: {
+        calcs: [],
+        displayMode: 'list',
+        placement: 'bottom',
+        showLegend: true,
+      },
+      tooltip: {
+        mode: 'single',
+        sort: 'none',
+      },
+    },
+  },
+
+  local jvmGarbageCollectionTimePanel = {
+    datasource: promDatasource,
+    targets: [
+      prometheus.target(
+        'sum by (%(agg)s) (increase(opensearch_jvm_gc_collection_time_seconds{%(queriesSelector)s}[$__interval:]))'
+        % {
+          queriesSelector: variables.queriesSelector,
+          agg: std.join(',', $._config.groupLabels + $._config.instanceLabels),
+        },
+        datasource=promDatasource,
+        legendFormat=utils.labelsToPanelLegend($._config.instanceLabels),
+        interval='1m',
+      ),
+    ],
+    type: 'timeseries',
+    title: 'JVM garbage collection time',
+    description: 'The amount of time spent on garbage collection on the selected node.',
+    fieldConfig: {
+      defaults: {
+        color: {
+          mode: 'palette-classic',
+        },
+        custom: {
+          axisCenteredZero: false,
+          axisColorMode: 'text',
+          axisLabel: '',
+          axisPlacement: 'auto',
+          barAlignment: 0,
+          drawStyle: 'line',
+          fillOpacity: 0,
+          gradientMode: 'none',
+          hideFrom: {
+            legend: false,
+            tooltip: false,
+            viz: false,
+          },
+          lineInterpolation: 'linear',
+          lineWidth: 1,
+          pointSize: 5,
+          scaleDistribution: {
+            type: 'linear',
+          },
+          showPoints: 'auto',
+          spanNulls: false,
+          stacking: {
+            group: 'A',
+            mode: 'none',
+          },
+          thresholdsStyle: {
+            mode: 'off',
+          },
+        },
+        mappings: [],
+        thresholds: {
+          mode: 'absolute',
+          steps: [
+            {
+              color: 'green',
+              value: null,
+            },
+          ],
+        },
+        unit: 's',
+      },
+      overrides: [],
+    },
+    options: {
+      legend: {
+        calcs: [],
+        displayMode: 'list',
+        placement: 'bottom',
+        showLegend: true,
+      },
+      tooltip: {
+        mode: 'single',
+        sort: 'none',
+      },
+    },
+  },
+
+  local jvmBufferPoolUsagePanel = {
+    datasource: promDatasource,
+    targets: [
+      prometheus.target(
+        '100 * (sum by (%(agg)s, bufferpool) (opensearch_jvm_bufferpool_used_bytes{%(queriesSelector)s})) / clamp_min((sum by (job, bufferpool, cluster) (opensearch_jvm_bufferpool_total_capacity_bytes{%(queriesSelector)s})),1)'
+        % {
+          queriesSelector: variables.queriesSelector,
+          agg: std.join(',', $._config.groupLabels + $._config.instanceLabels),
+        },
+        datasource=promDatasource,
+        legendFormat='%s - {{bufferpool}}' % utils.labelsToPanelLegend($._config.instanceLabels),
+      ),
+    ],
+    type: 'timeseries',
+    title: 'JVM buffer pool usage',
+    description: 'The percent used of JVM buffer pool memory.',
+    fieldConfig: {
+      defaults: {
+        color: {
+          mode: 'palette-classic',
+        },
+        custom: {
+          axisCenteredZero: false,
+          axisColorMode: 'text',
+          axisLabel: '',
+          axisPlacement: 'auto',
+          barAlignment: 0,
+          drawStyle: 'line',
+          fillOpacity: 0,
+          gradientMode: 'none',
+          hideFrom: {
+            legend: false,
+            tooltip: false,
+            viz: false,
+          },
+          lineInterpolation: 'linear',
+          lineWidth: 1,
+          pointSize: 5,
+          scaleDistribution: {
+            type: 'linear',
+          },
+          showPoints: 'auto',
+          spanNulls: false,
+          stacking: {
+            group: 'A',
+            mode: 'none',
+          },
+          thresholdsStyle: {
+            mode: 'off',
+          },
+        },
+        mappings: [],
+        thresholds: {
+          mode: 'absolute',
+          steps: [
+            {
+              color: 'green',
+              value: null,
+            },
+            {
+              color: 'red',
+              value: 80,
+            },
+          ],
+        },
+        unit: 'percent',
+      },
+      overrides: [],
+    },
+    options: {
+      legend: {
+        calcs: [],
+        displayMode: 'list',
+        placement: 'bottom',
+        showLegend: true,
+      },
+      tooltip: {
+        mode: 'single',
+        sort: 'none',
+      },
+    },
+  },
+
+  local threadPoolsRow = {
+    datasource: promDatasource,
+    targets: [],
+    type: 'row',
+    title: 'Thread pools',
+    collapsed: false,
+  },
+
+  local threadPoolThreadsPanel = {
+    datasource: promDatasource,
+    targets: [
+      prometheus.target(
+        'sum by(%(agg)s) ((opensearch_threadpool_threads_number{%(queriesSelector)s}))'
+        % {
+          queriesSelector: variables.queriesSelector,
+          agg: std.join(',', $._config.groupLabels + $._config.instanceLabels),
+        },
+        datasource=promDatasource,
+        legendFormat=utils.labelsToPanelLegend($._config.instanceLabels),
+      ),
+    ],
+    type: 'timeseries',
+    title: 'Thread pool threads',
+    description: 'The number of threads in the thread pool for the selected node',
+    fieldConfig: {
+      defaults: {
+        color: {
+          mode: 'palette-classic',
+        },
+        custom: {
+          axisCenteredZero: false,
+          axisColorMode: 'text',
+          axisLabel: '',
+          axisPlacement: 'auto',
+          barAlignment: 0,
+          drawStyle: 'line',
+          fillOpacity: 0,
+          gradientMode: 'none',
+          hideFrom: {
+            legend: false,
+            tooltip: false,
+            viz: false,
+          },
+          lineInterpolation: 'linear',
+          lineWidth: 1,
+          pointSize: 5,
+          scaleDistribution: {
+            type: 'linear',
+          },
+          showPoints: 'auto',
+          spanNulls: false,
+          stacking: {
+            group: 'A',
+            mode: 'none',
+          },
+          thresholdsStyle: {
+            mode: 'off',
+          },
+        },
+        mappings: [],
+        thresholds: {
+          mode: 'absolute',
+          steps: [
+            {
+              color: 'green',
+            },
+            {
+              color: 'red',
+              value: 80,
+            },
+          ],
+        },
+        unit: 'threads',
+      },
+      overrides: [],
+    },
+    options: {
+      legend: {
+        calcs: [],
+        displayMode: 'list',
+        placement: 'bottom',
+        showLegend: true,
+      },
+      tooltip: {
+        mode: 'single',
+        sort: 'none',
+      },
+    },
+  },
+
+  local threadPoolTasksPanel = {
+    datasource: promDatasource,
+    targets: [
+      prometheus.target(
+        'sum by (%(agg)s) (opensearch_threadpool_tasks_number{%(queriesSelector)s})'
+        % {
+          queriesSelector: variables.queriesSelector,
+          agg: std.join(',', $._config.groupLabels + $._config.instanceLabels),
+        },
+        datasource=promDatasource,
+        legendFormat=utils.labelsToPanelLegend($._config.instanceLabels),
+      ),
+    ],
+    type: 'timeseries',
+    title: 'Thread pool tasks',
+    description: 'The number of tasks in the thread pool for the selected node.',
+    fieldConfig: {
+      defaults: {
+        color: {
+          mode: 'palette-classic',
+        },
+        custom: {
+          axisCenteredZero: false,
+          axisColorMode: 'text',
+          axisLabel: '',
+          axisPlacement: 'auto',
+          barAlignment: 0,
+          drawStyle: 'line',
+          fillOpacity: 0,
+          gradientMode: 'none',
+          hideFrom: {
+            legend: false,
+            tooltip: false,
+            viz: false,
+          },
+          lineInterpolation: 'linear',
+          lineWidth: 1,
+          pointSize: 5,
+          scaleDistribution: {
+            type: 'linear',
+          },
+          showPoints: 'auto',
+          spanNulls: false,
+          stacking: {
+            group: 'A',
+            mode: 'none',
+          },
+          thresholdsStyle: {
+            mode: 'off',
+          },
+        },
+        mappings: [],
+        thresholds: {
+          mode: 'absolute',
+          steps: [
+            {
+              color: 'green',
+            },
+            {
+              color: 'red',
+              value: 80,
+            },
+          ],
+        },
+        unit: 'tasks',
+      },
+      overrides: [],
+    },
+    options: {
+      legend: {
+        calcs: [],
+        displayMode: 'list',
+        placement: 'bottom',
+        showLegend: true,
+      },
+      tooltip: {
+        mode: 'single',
+        sort: 'none',
+      },
+    },
+  },
+
+  local errorLogsPanelPanel = {
+    datasource: lokiDatasource,
+    targets: [
+      {
+        datasource: lokiDatasource,
+        editorMode: 'code',
+        expr: '{%(queriesSelector)s} |~ ""' % { queriesSelector: variables.queriesSelector },
+        queryType: 'range',
+        refId: 'A',
+      },
+    ],
+    type: 'logs',
+    title: 'Error logs panel',
+    description: 'The recent error logs being reported by OpenSearch.',
+    options: {
+      dedupStrategy: 'none',
+      enableLogDetails: true,
+      prettifyLogMessage: false,
+      showCommonLabels: false,
+      showLabels: false,
+      showTime: false,
+      sortOrder: 'Descending',
+      wrapLogMessage: false,
+    },
+  },
+
+
   grafanaDashboards+:: {
     'node-overview.json':
-      dashboard.new(
-        'OpenSearch node overview',
-        time_from='%s' % $._config.dashboardPeriod,
-        tags=($._config.dashboardTags),
-        timezone='%s' % $._config.dashboardTimezone,
-        refresh='%s' % $._config.dashboardRefresh,
-        description='',
-        uid=$._config.uid+dashboardUidSuffix,
+      g.dashboard.new('OpenSearch node overview')
+      + g.dashboard.withTags($._config.dashboardTags)
+      + g.dashboard.time.withFrom($._config.dashboardPeriod)
+      + g.dashboard.withTimezone($._config.dashboardTimezone)
+      + g.dashboard.withRefresh($._config.dashboardRefresh)
+      + g.dashboard.withUid($._config.uid + dashboardUidSuffix)
+      + g.dashboard.withLinks(
+        g.dashboard.link.dashboards.new(
+          'Other Opensearch dashboards',
+          $._config.dashboardTags
+        )
+        + g.dashboard.link.dashboards.options.withIncludeVars(true)
+        + g.dashboard.link.dashboards.options.withKeepTime(true)
+        + g.dashboard.link.dashboards.options.withAsDropdown(false)
       )
-      .addLink(grafana.link.dashboards(
-        asDropdown=false,
-        title='Other OpenSearch dashboards',
-        includeVars=true,
-        keepTime=true,
-        tags=($._config.dashboardTags),
-      ))
-      .addTemplates(
-        std.flattenArrays([
-          [
-            template.datasource(
-              promDatasourceName,
-              'prometheus',
-              null,
-              label='Prometheus data source',
-              refresh='load'
-            ),
-          ],
-          if $._config.enableLokiLogs then [
-            template.datasource(
-              lokiDatasourceName,
-              'loki',
-              null,
-              label='Loki data source',
-              refresh='load'
-            ),
-          ] else [],
-          [
-            template.new(
-              'job',
-              promDatasource,
-              'label_values(opensearch_cluster_status{%s},job)' % $._config.filteringSelector,
-              label='Job',
-              refresh=2,
-              includeAll=true,
-              multi=true,
-              sort=1
-            ),
-            template.new(
-              'opensearch_cluster',
-              promDatasource,
-              'label_values(opensearch_cluster_status{%s, job=~"$job"}, cluster)' % $._config.filteringSelector,
-              label='OpenSearch Cluster',
-              refresh=2,
-              includeAll=true,
-              multi=true,
-              allValues='',
-              sort=1
-            ),
-            template.new(
-              'node',
-              promDatasource,
-              'label_values(opensearch_os_cpu_percent{%s, job=~"$job", cluster=~"$opensearch_cluster"}, node)' % $._config.filteringSelector,
-              label='Node',
-              refresh=2,
-              includeAll=true,
-              multi=true,
-              allValues='',
-              sort=0
-            ),
-          ],
-        ])
-      )
-      .addPanels(
+      + g.dashboard.withPanels(
         std.flattenArrays([
           [
             nodeHealthRow { gridPos: { h: 1, w: 24, x: 0, y: 0 } },
@@ -1588,9 +1628,9 @@ local errorLogsPanelPanel = {
           if $._config.enableLokiLogs then [
             errorLogsPanelPanel { gridPos: { h: 7, w: 24, x: 0, y: 37 } },
           ] else [],
-          [
-          ],
+          [],
         ])
-      ),
+      )
+      + g.dashboard.withVariables(variables.multiInstance),
   },
 }

--- a/opensearch-mixin/dashboards/opensearch-node-overview.libsonnet
+++ b/opensearch-mixin/dashboards/opensearch-node-overview.libsonnet
@@ -17,6 +17,12 @@ local dashboardUidSuffix = '-node-overview';
     varMetric='opensearch_os_cpu_percent'
   ),
 
+  local panels = (import '../panels.libsonnet').new(
+    $._config.groupLabels,
+    $._config.instanceLabels,
+    variables,
+  ),
+
   local promDatasource = {
     uid: '${%s}' % variables.datasources.prometheus.name,
   },
@@ -1143,7 +1149,7 @@ local dashboardUidSuffix = '-node-overview';
 
   grafanaDashboards+:: {
     'node-overview.json':
-      g.dashboard.new($._config.dashboardNamePrefix +'OpenSearch node overview')
+      g.dashboard.new($._config.dashboardNamePrefix + 'OpenSearch node overview')
       + g.dashboard.withTags($._config.dashboardTags)
       + g.dashboard.time.withFrom($._config.dashboardPeriod)
       + g.dashboard.withTimezone($._config.dashboardTimezone)
@@ -1161,11 +1167,12 @@ local dashboardUidSuffix = '-node-overview';
       + g.dashboard.withPanels(
         std.flattenArrays([
           [
-            nodeHealthRow { gridPos: { h: 1, w: 24, x: 0, y: 0 } },
-            nodeCPUUsagePanel { gridPos: { h: 7, w: 6, x: 0, y: 1 } },
-            nodeMemoryUsagePanel { gridPos: { h: 7, w: 6, x: 6, y: 1 } },
-            nodeIOPanel { gridPos: { h: 7, w: 6, x: 12, y: 1 } },
-            nodeOpenConnectionsPanel { gridPos: { h: 7, w: 6, x: 18, y: 1 } },
+            panels.osRolesTimeline { gridPos: { h: 5, w: 24, x: 0, y: 0 } },
+            nodeHealthRow { gridPos: { h: 1, w: 24, x: 0, y: 1 } },
+            nodeCPUUsagePanel { gridPos: { h: 7, w: 6, x: 0, y: 2 } },
+            nodeMemoryUsagePanel { gridPos: { h: 7, w: 6, x: 6, y: 2 } },
+            nodeIOPanel { gridPos: { h: 7, w: 6, x: 12, y: 2 } },
+            nodeOpenConnectionsPanel { gridPos: { h: 7, w: 6, x: 18, y: 2 } },
             nodeDiskUsagePanel { gridPos: { h: 7, w: 6, x: 0, y: 8 } },
             nodeMemorySwapPanel { gridPos: { h: 7, w: 6, x: 6, y: 8 } },
             nodeNetworkTrafficPanel { gridPos: { h: 7, w: 6, x: 12, y: 8 } },

--- a/opensearch-mixin/dashboards/opensearch-node-overview.libsonnet
+++ b/opensearch-mixin/dashboards/opensearch-node-overview.libsonnet
@@ -82,7 +82,7 @@ local dashboardUidSuffix = '-node-overview';
       targets=[
         g.query.prometheus.new(
           promDatasource.uid,
-          'sum by(%(agg)s) (opensearch_fs_io_total_read_bytes{%(queriesSelector)s})'
+          'sum by(%(agg)s) (rate(opensearch_fs_io_total_read_bytes{%(queriesSelector)s})[$__rate_interval])'
           % {
             queriesSelector: variables.queriesSelector,
             agg: std.join(',', $._config.groupLabels + $._config.instanceLabels),
@@ -92,7 +92,7 @@ local dashboardUidSuffix = '-node-overview';
         g.query.prometheus.new(
           promDatasource.uid,
 
-          'sum by(%(agg)s) (opensearch_fs_io_total_write_bytes{%(queriesSelector)s})'
+          'sum by(%(agg)s) (rate(opensearch_fs_io_total_write_bytes{%(queriesSelector)s})[$__rate_interval])'
           % {
             queriesSelector: variables.queriesSelector,
             agg: std.join(',', $._config.groupLabels + $._config.instanceLabels),

--- a/opensearch-mixin/dashboards/opensearch-node-overview.libsonnet
+++ b/opensearch-mixin/dashboards/opensearch-node-overview.libsonnet
@@ -82,7 +82,7 @@ local dashboardUidSuffix = '-node-overview';
       targets=[
         g.query.prometheus.new(
           promDatasource.uid,
-          'sum by(%(agg)s) (rate(opensearch_fs_io_total_read_bytes{%(queriesSelector)s})[$__rate_interval])'
+          'sum by(%(agg)s) (rate(opensearch_fs_io_total_read_bytes{%(queriesSelector)s}[$__rate_interval]))'
           % {
             queriesSelector: variables.queriesSelector,
             agg: std.join(',', $._config.groupLabels + $._config.instanceLabels),
@@ -91,8 +91,7 @@ local dashboardUidSuffix = '-node-overview';
         + g.query.prometheus.withLegendFormat('%s - read' % utils.labelsToPanelLegend($._config.instanceLabels)),
         g.query.prometheus.new(
           promDatasource.uid,
-
-          'sum by(%(agg)s) (rate(opensearch_fs_io_total_write_bytes{%(queriesSelector)s})[$__rate_interval])'
+          'sum by(%(agg)s) (rate(opensearch_fs_io_total_write_bytes{%(queriesSelector)s}[$__rate_interval]))'
           % {
             queriesSelector: variables.queriesSelector,
             agg: std.join(',', $._config.groupLabels + $._config.instanceLabels),

--- a/opensearch-mixin/dashboards/opensearch-node-overview.libsonnet
+++ b/opensearch-mixin/dashboards/opensearch-node-overview.libsonnet
@@ -4,7 +4,7 @@ local dashboard = grafana.dashboard;
 local template = grafana.template;
 local prometheus = grafana.prometheus;
 
-local dashboardUid = 'node-overview';
+local dashboardUidSuffix = '-node-overview';
 
 local promDatasourceName = 'prometheus_datasource';
 local lokiDatasourceName = 'loki_datasource';
@@ -1495,7 +1495,7 @@ local errorLogsPanelPanel = {
         timezone='%s' % $._config.dashboardTimezone,
         refresh='%s' % $._config.dashboardRefresh,
         description='',
-        uid=dashboardUid,
+        uid=$._config.uid+dashboardUidSuffix,
       )
       .addLink(grafana.link.dashboards(
         asDropdown=false,

--- a/opensearch-mixin/dashboards/opensearch-search-and-index-overview.libsonnet
+++ b/opensearch-mixin/dashboards/opensearch-search-and-index-overview.libsonnet
@@ -1852,7 +1852,7 @@ local instanceLabels = ['index'];
 
   grafanaDashboards+:: {
     'search-and-index-overview.json':
-      g.dashboard.new($._config.dashboardNamePrefix +'OpenSearch search and index overview')
+      g.dashboard.new($._config.dashboardNamePrefix + 'OpenSearch search and index overview')
       + g.dashboard.withTags($._config.dashboardTags)
       + g.dashboard.time.withFrom($._config.dashboardPeriod)
       + g.dashboard.withTimezone($._config.dashboardTimezone)

--- a/opensearch-mixin/dashboards/opensearch-search-and-index-overview.libsonnet
+++ b/opensearch-mixin/dashboards/opensearch-search-and-index-overview.libsonnet
@@ -1711,18 +1711,17 @@ local shardCountPanel = {
           template.new(
             'job',
             promDatasource,
-            'label_values(opensearch_index_search_fetch_count, job)',
+            'label_values(opensearch_index_search_fetch_count{%s}, job)' % $._config.filteringSelector,
             label='Job',
             refresh=2,
             includeAll=true,
             multi=true,
-            allValues='.+',
             sort=1
           ),
           template.new(
             'opensearch_cluster',
             promDatasource,
-            'label_values(opensearch_index_search_fetch_count{job=~"$job"}, cluster)',
+            'label_values(opensearch_index_search_fetch_count{%s, job=~"$job"}, cluster)'% $._config.filteringSelector,
             label='OpenSearch Cluster',
             refresh=2,
             includeAll=true,
@@ -1733,7 +1732,7 @@ local shardCountPanel = {
           template.new(
             'opensearch_index',
             promDatasource,
-            'label_values(opensearch_index_search_fetch_count{job=~"$job", cluster=~"$opensearch_cluster"}, index)',
+            'label_values(opensearch_index_search_fetch_count{%s, job=~"$job", cluster=~"$opensearch_cluster"}, index)' % $._config.filteringSelector,
             label='Index',
             refresh=2,
             includeAll=true,

--- a/opensearch-mixin/dashboards/opensearch-search-and-index-overview.libsonnet
+++ b/opensearch-mixin/dashboards/opensearch-search-and-index-overview.libsonnet
@@ -1721,7 +1721,7 @@ local shardCountPanel = {
           template.new(
             'opensearch_cluster',
             promDatasource,
-            'label_values(opensearch_index_search_fetch_count{%s, job=~"$job"}, cluster)'% $._config.filteringSelector,
+            'label_values(opensearch_index_search_fetch_count{%s, job=~"$job"}, cluster)' % $._config.filteringSelector,
             label='OpenSearch Cluster',
             refresh=2,
             includeAll=true,

--- a/opensearch-mixin/dashboards/opensearch-search-and-index-overview.libsonnet
+++ b/opensearch-mixin/dashboards/opensearch-search-and-index-overview.libsonnet
@@ -1852,7 +1852,7 @@ local instanceLabels = ['index'];
 
   grafanaDashboards+:: {
     'search-and-index-overview.json':
-      g.dashboard.new('OpenSearch search and index overview',)
+      g.dashboard.new($._config.dashboardNamePrefix +'OpenSearch search and index overview')
       + g.dashboard.withTags($._config.dashboardTags)
       + g.dashboard.time.withFrom($._config.dashboardPeriod)
       + g.dashboard.withTimezone($._config.dashboardTimezone)

--- a/opensearch-mixin/dashboards/opensearch-search-and-index-overview.libsonnet
+++ b/opensearch-mixin/dashboards/opensearch-search-and-index-overview.libsonnet
@@ -4,7 +4,7 @@ local dashboard = grafana.dashboard;
 local template = grafana.template;
 local prometheus = grafana.prometheus;
 
-local dashboardUid = 'search-and-index-overview';
+local dashboardUidSuffix = '-search-and-index-overview';
 
 local promDatasourceName = 'prometheus_datasource';
 
@@ -1690,7 +1690,7 @@ local shardCountPanel = {
         timezone='%s' % $._config.dashboardTimezone,
         refresh='%s' % $._config.dashboardRefresh,
         description='',
-        uid=dashboardUid,
+        uid=$._config.uid+dashboardUidSuffix,
       )
       .addLink(grafana.link.dashboards(
         asDropdown=false,

--- a/opensearch-mixin/dashboards/opensearch-search-and-index-overview.libsonnet
+++ b/opensearch-mixin/dashboards/opensearch-search-and-index-overview.libsonnet
@@ -1,1748 +1,1873 @@
-local g = (import 'grafana-builder/grafana.libsonnet');
+local g = (import '../g.libsonnet');
 local grafana = (import 'grafonnet/grafana.libsonnet');
 local dashboard = grafana.dashboard;
-local template = grafana.template;
+local commonlib = import 'common-lib/common/main.libsonnet';
+local utils = commonlib.utils;
 local prometheus = grafana.prometheus;
 
 local dashboardUidSuffix = '-search-and-index-overview';
 
 local promDatasourceName = 'prometheus_datasource';
-
-local promDatasource = {
-  uid: '${%s}' % promDatasourceName,
-};
-
-local requestPerformanceRow = {
-  datasource: promDatasource,
-  targets: [],
-  type: 'row',
-  title: 'Request performance',
-  collapsed: false,
-};
-
-local requestRatePanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'sum by (job, cluster, index) (opensearch_index_search_query_current_number{cluster=~"$opensearch_cluster", job=~"$job", index=~"$opensearch_index", context=~"total"})',
-      datasource=promDatasource,
-      legendFormat='{{index}} - query',
-    ),
-    prometheus.target(
-      'sum by (job, cluster, index) (opensearch_index_search_fetch_current_number{cluster=~"$opensearch_cluster", job=~"$job", index=~"$opensearch_index", context=~"total"})',
-      datasource=promDatasource,
-      legendFormat='{{index}} - fetch',
-    ),
-    prometheus.target(
-      'sum by (job, cluster, index) (opensearch_index_search_scroll_current_number{cluster=~"$opensearch_cluster", job=~"$job", index=~"$opensearch_index", context=~"total"})',
-      datasource=promDatasource,
-      legendFormat='{{index}} - scroll',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'Request rate',
-  description: 'Rate of fetch, scroll, and query requests by selected index.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-          {
-            color: 'red',
-            value: 80,
-          },
-        ],
-      },
-      unit: 'reqps',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'multi',
-      sort: 'none',
-    },
-  },
-};
-
-local requestLatencyPanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'sum by(index, job, cluster) (increase(opensearch_index_search_query_time_seconds{job=~"$job", cluster=~"$opensearch_cluster", index=~"$opensearch_index", context="total"}[$__interval:]) / clamp_min(increase(opensearch_index_search_query_count{job=~"$job", cluster=~"$opensearch_cluster", index=~"$opensearch_index", context="total"}[$__interval:]), 1))',
-      datasource=promDatasource,
-      legendFormat='{{index}} - query',
-      interval='1m',
-    ),
-    prometheus.target(
-      'sum by(index, job, cluster) (increase(opensearch_index_search_fetch_time_seconds{job=~"$job", cluster=~"$opensearch_cluster", index=~"$opensearch_index", context="total"}[$__interval:]) / clamp_min(increase(opensearch_index_search_fetch_count{job=~"$job", cluster=~"$opensearch_cluster", index=~"$opensearch_index", context="total"}[$__interval:]), 1))',
-      datasource=promDatasource,
-      legendFormat='{{index}} - fetch',
-      interval='1m',
-    ),
-    prometheus.target(
-      'sum by(index, job, cluster) (increase(opensearch_index_search_scroll_time_seconds{job=~"$job", cluster=~"$opensearch_cluster", index=~"$opensearch_index", context="total"}[$__interval:]) / clamp_min(increase(opensearch_index_search_scroll_count{job=~"$job", cluster=~"$opensearch_cluster", index=~"$opensearch_index", context="total"}[$__interval:]), 1))',
-      datasource=promDatasource,
-      legendFormat='{{index}} - scroll',
-      interval='1m',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'Request latency',
-  description: 'Latency of fetch, scroll, and query requests by selected index.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-          {
-            color: 'red',
-            value: 80,
-          },
-        ],
-      },
-      unit: 's',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'multi',
-      sort: 'none',
-    },
-  },
-};
-
-local cacheHitRatioPanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'sum by(index, job, cluster) (100 * (opensearch_index_requestcache_hit_count{job=~"$job", cluster=~"$opensearch_cluster", index=~"$opensearch_index", context="total"}) / clamp_min(opensearch_index_requestcache_hit_count{job=~"$job", cluster=~"$opensearch_cluster", index=~"$opensearch_index", context="total"} + opensearch_index_requestcache_miss_count{job=~"$job", cluster=~"$opensearch_cluster", index=~"$opensearch_index", context="total"}, 1))',
-      datasource=promDatasource,
-      legendFormat='{{index}} - request',
-    ),
-    prometheus.target(
-      'sum by(index, job, cluster) (100 * (opensearch_index_querycache_hit_count{job=~"$job", cluster=~"$opensearch_cluster", index=~"$opensearch_index", context="total"}) / clamp_min(opensearch_index_querycache_hit_count{job=~"$job", cluster=~"$opensearch_cluster", index=~"$opensearch_index", context="total"} + opensearch_index_querycache_miss_number{job=~"$job", cluster=~"$opensearch_cluster", index=~"$opensearch_index", context="total"}, 1))',
-      datasource=promDatasource,
-      legendFormat='{{index}} - query',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'Cache hit ratio',
-  description: 'Ratio of query cache and request cache hits and misses.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-          {
-            color: 'red',
-            value: 80,
-          },
-        ],
-      },
-      unit: 'percent',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'multi',
-      sort: 'none',
-    },
-  },
-};
-
-local evictionsPanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'sum by(cluster, job, index) (increase(opensearch_index_querycache_evictions_count{job=~"$job", cluster=~"$opensearch_cluster", index=~"$opensearch_index", context="total"}[$__interval:]))',
-      datasource=promDatasource,
-      legendFormat='{{index}} - query cache',
-      interval='1m',
-    ),
-    prometheus.target(
-      'sum by(cluster, job, index) (increase(opensearch_index_requestcache_evictions_count{job=~"$job", cluster=~"$opensearch_cluster", index=~"$opensearch_index", context="total"}[$__interval:]))',
-      datasource=promDatasource,
-      legendFormat='{{index}} - request cache',
-      interval='1m',
-    ),
-    prometheus.target(
-      'sum by(cluster, job, index) (increase(opensearch_index_fielddata_evictions_count{job=~"$job", cluster=~"$opensearch_cluster", index=~"$opensearch_index", context="total"}[$__interval:]))',
-      datasource=promDatasource,
-      legendFormat='{{index}} - field data',
-      interval='1m',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'Evictions',
-  description: 'Total evictions count by cache type for the selected index.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-          {
-            color: 'red',
-            value: 80,
-          },
-        ],
-      },
-      unit: 'evictions',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'multi',
-      sort: 'none',
-    },
-  },
-};
-
-local indexPerformanceRow = {
-  datasource: promDatasource,
-  targets: [],
-  type: 'row',
-  title: 'Index performance',
-  collapsed: false,
-};
-
-local indexRatePanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'sum by(job, cluster, index) (opensearch_index_indexing_index_current_number{job=~"$job", cluster=~"$opensearch_cluster", index=~"$opensearch_index", context="total"})',
-      datasource=promDatasource,
-      legendFormat='{{index}}',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'Index rate',
-  description: 'Rate of indexed documents for the selected index.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-          {
-            color: 'red',
-            value: 80,
-          },
-        ],
-      },
-      unit: 'documents/s',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'single',
-      sort: 'none',
-    },
-  },
-};
-
-local indexLatencyPanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'sum by(job, cluster, index) (increase(opensearch_index_indexing_index_time_seconds{job=~"$job", cluster=~"$opensearch_cluster", index=~"$opensearch_index", context=~"total"}[$__interval:]) / clamp_min(increase(opensearch_index_indexing_index_count{job=~"$job", cluster=~"$opensearch_cluster", index=~"$opensearch_index", context=~"total"}[$__interval:]),1))',
-      datasource=promDatasource,
-      legendFormat='{{index}}',
-      interval='1m',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'Index latency',
-  description: 'Document indexing latency for the selected index.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-          {
-            color: 'red',
-            value: 80,
-          },
-        ],
-      },
-      unit: 's',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'single',
-      sort: 'none',
-    },
-  },
-};
-
-local indexFailuresPanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'sum by(job, cluster, index) (increase(opensearch_index_indexing_index_failed_count{job=~"$job", cluster=~"$opensearch_cluster", index=~"$opensearch_index", context="total"}[$__interval:]))',
-      datasource=promDatasource,
-      legendFormat='{{index}}',
-      interval='1m',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'Index failures',
-  description: 'Number of indexing failures for the selected index.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-          {
-            color: 'red',
-            value: 80,
-          },
-        ],
-      },
-      unit: 'failures',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'single',
-      sort: 'none',
-    },
-  },
-};
-
-local flushLatencyPanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'sum by(job, cluster, index) (increase(opensearch_index_flush_total_time_seconds{job=~"$job", cluster=~"$opensearch_cluster", index=~"$opensearch_index", context="total"}[$__interval:]) / clamp_min(increase(opensearch_index_flush_total_count{job=~"$job", cluster=~"$opensearch_cluster", index=~"$opensearch_index", context="total"}[$__interval:]),1))',
-      datasource=promDatasource,
-      legendFormat='{{index}}',
-      interval='1m',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'Flush latency',
-  description: 'Index flush latency for the selected index.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-          {
-            color: 'red',
-            value: 80,
-          },
-        ],
-      },
-      unit: 's',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'single',
-      sort: 'none',
-    },
-  },
-};
-
-local mergeTimePanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'sum by(job, cluster, index) (increase(opensearch_index_merges_total_time_seconds{job=~"$job", cluster=~"$opensearch_cluster", index=~"$opensearch_index", context="total"}[$__interval:]))',
-      datasource=promDatasource,
-      legendFormat='{{index}} - total',
-      interval='1m',
-    ),
-    prometheus.target(
-      'sum by(job, cluster, index) (increase(opensearch_index_merges_total_stopped_time_seconds{job=~"$job", cluster=~"$opensearch_cluster", index=~"$opensearch_index", context="total"}[$__interval:]))',
-      datasource=promDatasource,
-      legendFormat='{{index}} - stopped',
-      interval='1m',
-    ),
-    prometheus.target(
-      'sum by(job, cluster, index) (increase(opensearch_index_merges_total_throttled_time_seconds{job=~"$job", cluster=~"$opensearch_cluster", index=~"$opensearch_index", context="total"}[$__interval:]))',
-      datasource=promDatasource,
-      legendFormat='{{index}} - throttled',
-      interval='1m',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'Merge time',
-  description: 'Index merge time for the selected index.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-          {
-            color: 'red',
-            value: 80,
-          },
-        ],
-      },
-      unit: 's',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'multi',
-      sort: 'none',
-    },
-  },
-};
-
-local refreshLatencyPanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'sum by(job, cluster, index) (increase(opensearch_index_refresh_total_time_seconds{job=~"$job", cluster=~"$opensearch_cluster", index=~"$opensearch_index", context="total"}[$__interval:]) / clamp_min(increase(opensearch_index_refresh_total_count{job=~"$job", cluster=~"$opensearch_cluster", index=~"$opensearch_index", context="total"}[$__interval:]),1))',
-      datasource=promDatasource,
-      legendFormat='{{index}}',
-      interval='1m',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'Refresh latency',
-  description: 'Index refresh latency for the selected index.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-          {
-            color: 'red',
-            value: 80,
-          },
-        ],
-      },
-      unit: 's',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'single',
-      sort: 'none',
-    },
-  },
-};
-
-local translogOperationsPanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'sum by(job, cluster, index) (opensearch_index_translog_operations_number{job=~"$job", cluster=~"$opensearch_cluster", index=~"$opensearch_index", context="total"})',
-      datasource=promDatasource,
-      legendFormat='{{index}}',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'Translog operations',
-  description: 'Current number of translog operations for the selected index.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-          {
-            color: 'red',
-            value: 80,
-          },
-        ],
-      },
-      unit: 'operations',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'single',
-      sort: 'none',
-    },
-  },
-};
-
-local docsDeletedPanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'sum by (job, cluster, index) (opensearch_index_indexing_delete_current_number{job=~"$job", cluster=~"$opensearch_cluster", index=~"$opensearch_index", context="total"})',
-      datasource=promDatasource,
-      legendFormat='{{index}}',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'Docs deleted',
-  description: 'Rate of documents deleted for the selected index.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-          {
-            color: 'red',
-            value: 80,
-          },
-        ],
-      },
-      unit: 'documents/s',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'single',
-      sort: 'none',
-    },
-  },
-};
-
-local indexCapacityRow = {
-  datasource: promDatasource,
-  targets: [],
-  type: 'row',
-  title: 'Index capacity',
-  collapsed: false,
-};
-
-local documentsIndexedPanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'sum by (job, cluster, index) (opensearch_index_indexing_index_count{job=~"$job", cluster=~"$opensearch_cluster", index=~"$opensearch_index", context="total"})',
-      datasource=promDatasource,
-      legendFormat='{{index}}',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'Documents indexed',
-  description: 'Number of indexed documents for the selected index.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-          {
-            color: 'red',
-            value: 80,
-          },
-        ],
-      },
-      unit: 'documents',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'single',
-      sort: 'none',
-    },
-  },
-};
-
-local segmentCountPanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'sum by(job, cluster, index) (opensearch_index_segments_number{job=~"$job", cluster=~"$opensearch_cluster", index=~"$opensearch_index", context="total"})',
-      datasource=promDatasource,
-      legendFormat='{{index}}',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'Segment count',
-  description: 'Current number of segments for the selected index.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-          {
-            color: 'red',
-            value: 80,
-          },
-        ],
-      },
-      unit: 'segments',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'single',
-      sort: 'none',
-    },
-  },
-};
-
-local mergeCountPanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'sum by(job, cluster, index) (increase(opensearch_index_merges_total_docs_count{job=~"$job", cluster=~"$opensearch_cluster", index=~"$opensearch_index", context="total"}[$__interval:]))',
-      datasource=promDatasource,
-      legendFormat='{{index}}',
-      interval='1m',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'Merge count',
-  description: 'Number of merge operations for the selected index.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-          {
-            color: 'red',
-            value: 80,
-          },
-        ],
-      },
-      unit: 'merges',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'single',
-      sort: 'none',
-    },
-  },
-};
-
-local cacheSizePanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'sum by(job, cluster, index) (opensearch_index_querycache_memory_size_bytes{job=~"$job", cluster=~"$opensearch_cluster", index=~"$opensearch_index", context="total"})',
-      datasource=promDatasource,
-      legendFormat='{{index}} - query',
-    ),
-    prometheus.target(
-      'sum by(job, cluster, index) (opensearch_index_requestcache_memory_size_bytes{job=~"$job", cluster=~"$opensearch_cluster", index=~"$opensearch_index", context="total"})',
-      datasource=promDatasource,
-      legendFormat='{{index}} - request',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'Cache size',
-  description: 'Size of query cache and request cache.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-          {
-            color: 'red',
-            value: 80,
-          },
-        ],
-      },
-      unit: 'bytes',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'multi',
-      sort: 'none',
-    },
-  },
-};
-
-local storeSizePanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'sum by(job, cluster, index) (opensearch_index_store_size_bytes{job=~"$job", cluster=~"$opensearch_cluster", index=~"$opensearch_index", context="total"})',
-      datasource=promDatasource,
-      legendFormat='{{index}}',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'Store size',
-  description: 'Size of the store in bytes for the selected index.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-          {
-            color: 'red',
-            value: 80,
-          },
-        ],
-      },
-      unit: 'bytes',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'single',
-      sort: 'none',
-    },
-  },
-};
-
-local segmentSizePanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'sum by(job, cluster, index) (opensearch_index_segments_memory_bytes{job=~"$job", cluster=~"$opensearch_cluster", index=~"$opensearch_index", context="total"})',
-      datasource=promDatasource,
-      legendFormat='{{index}}',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'Segment size',
-  description: 'Memory used by segments for the selected index.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-          {
-            color: 'red',
-            value: 80,
-          },
-        ],
-      },
-      unit: 'bytes',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'single',
-      sort: 'none',
-    },
-  },
-};
-
-local mergeSizePanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'sum by(job, cluster, index) (opensearch_index_merges_current_size_bytes{job=~"$job", cluster=~"$opensearch_cluster", index=~"$opensearch_index", context="total"})',
-      datasource=promDatasource,
-      legendFormat='{{index}}',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'Merge size',
-  description: 'Size of merge operations in bytes for the selected index.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-          {
-            color: 'red',
-            value: 80,
-          },
-        ],
-      },
-      unit: 'bytes',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'single',
-      sort: 'none',
-    },
-  },
-};
-
-local shardCountPanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'sum by(job, cluster, index) (opensearch_index_shards_number{job=~"$job", cluster=~"$opensearch_cluster", index=~"$opensearch_index"})',
-      datasource=promDatasource,
-      legendFormat='{{index}}',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'Shard count',
-  description: 'The number of index shards for the selected index.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 0,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        lineInterpolation: 'linear',
-        lineWidth: 1,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'auto',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-          {
-            color: 'red',
-            value: 80,
-          },
-        ],
-      },
-      unit: 'shards',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'single',
-      sort: 'none',
-    },
-  },
-};
+local instanceLabels = ['index'];
 
 {
+
+  // override
+  local hideZeros =
+    {
+      matcher: {
+        id: 'byValue',
+        options: {
+          reducer: 'allIsZero',
+          op: 'gte',
+          value: 0,
+        },
+      },
+      properties: [
+        {
+          id: 'custom.hideFrom',
+          value: {
+            tooltip: true,
+            viz: false,
+            legend: true,
+          },
+        },
+      ],
+    },
+  // variables
+  local variables = (import '../variables.libsonnet').new(
+    filteringSelector=$._config.filteringSelector,
+    groupLabels=$._config.groupLabels,
+    instanceLabels=instanceLabels,
+    varMetric='opensearch_index_search_fetch_count'
+  ),
+
+  local promDatasource = {
+    uid: '${%s}' % variables.datasources.prometheus.name,
+  },
+
+  local requestPerformanceRow = {
+    datasource: promDatasource,
+    targets: [],
+    type: 'row',
+    title: 'Request performance',
+    collapsed: false,
+  },
+
+  local requestRatePanel = {
+                             datasource: promDatasource,
+                             targets: [
+                               prometheus.target(
+                                 'avg by (%(agg)s) (opensearch_index_search_query_current_number{%(queriesSelector)s, context=~"total"})'
+                                 % {
+                                   queriesSelector: variables.queriesSelector,
+                                   agg: std.join(',', $._config.groupLabels + instanceLabels),
+                                 },
+                                 datasource=promDatasource,
+                                 legendFormat='%s - query' % utils.labelsToPanelLegend(instanceLabels),
+                               ),
+                               prometheus.target(
+                                 'avg by (%(agg)s) (opensearch_index_search_fetch_current_number{%(queriesSelector)s, context=~"total"})'
+                                 % {
+                                   queriesSelector: variables.queriesSelector,
+                                   agg: std.join(',', $._config.groupLabels + instanceLabels),
+                                 },
+                                 datasource=promDatasource,
+                                 legendFormat='%s - fetch' % utils.labelsToPanelLegend(instanceLabels),
+                               ),
+                               prometheus.target(
+                                 'avg by (%(agg)s) (opensearch_index_search_scroll_current_number{%(queriesSelector)s, context=~"total"})'
+                                 % {
+                                   queriesSelector: variables.queriesSelector,
+                                   agg: std.join(',', $._config.groupLabels + instanceLabels),
+                                 },
+                                 datasource=promDatasource,
+                                 legendFormat='%s - scroll' % utils.labelsToPanelLegend(instanceLabels),
+                               ),
+                             ],
+                             type: 'timeseries',
+                             title: 'Request rate',
+                             description: 'Rate of fetch, scroll, and query requests by selected index.',
+                             fieldConfig: {
+                               defaults: {
+                                 color: {
+                                   mode: 'palette-classic',
+                                 },
+                                 custom: {
+                                   axisCenteredZero: false,
+                                   axisColorMode: 'text',
+                                   axisLabel: '',
+                                   axisPlacement: 'auto',
+                                   barAlignment: 0,
+                                   drawStyle: 'line',
+                                   fillOpacity: 0,
+                                   gradientMode: 'none',
+                                   hideFrom: {
+                                     legend: false,
+                                     tooltip: false,
+                                     viz: false,
+                                   },
+                                   lineInterpolation: 'linear',
+                                   lineWidth: 1,
+                                   pointSize: 5,
+                                   scaleDistribution: {
+                                     type: 'linear',
+                                   },
+                                   showPoints: 'auto',
+                                   spanNulls: false,
+                                   stacking: {
+                                     group: 'A',
+                                     mode: 'none',
+                                   },
+                                   thresholdsStyle: {
+                                     mode: 'off',
+                                   },
+                                 },
+                                 mappings: [],
+                                 thresholds: {
+                                   mode: 'absolute',
+                                   steps: [
+                                     {
+                                       color: 'green',
+                                       value: null,
+                                     },
+                                     {
+                                       color: 'red',
+                                       value: 80,
+                                     },
+                                   ],
+                                 },
+                                 unit: 'reqps',
+                               },
+                               overrides: [],
+                             },
+                             options: {
+                               legend: {
+                                 calcs: [],
+                                 displayMode: 'list',
+                                 placement: 'bottom',
+                                 showLegend: true,
+                               },
+                               tooltip: {
+                                 mode: 'multi',
+                                 sort: 'none',
+                               },
+                             },
+                           }
+                           + g.panel.timeSeries.standardOptions.withOverridesMixin(hideZeros),
+
+  local requestLatencyPanel = {
+                                datasource: promDatasource,
+                                targets: [
+                                  prometheus.target(
+                                    'avg by (%(agg)s) (increase(opensearch_index_search_query_time_seconds{%(queriesSelector)s}[$__interval:]) / clamp_min(increase(opensearch_index_search_query_count{%(queriesSelector)s, context="total"}[$__interval:]), 1))'
+                                    % {
+                                      queriesSelector: variables.queriesSelector,
+                                      agg: std.join(',', $._config.groupLabels + instanceLabels),
+                                    },
+                                    datasource=promDatasource,
+                                    legendFormat='%s - query' % utils.labelsToPanelLegend(instanceLabels),
+                                    interval='1m',
+                                  ),
+                                  prometheus.target(
+                                    'avg by (%(agg)s) (increase(opensearch_index_search_fetch_time_seconds{%(queriesSelector)s, context="total"}[$__interval:]) / clamp_min(increase(opensearch_index_search_fetch_count{%(queriesSelector)s, context="total"}[$__interval:]), 1))'
+                                    % {
+                                      queriesSelector: variables.queriesSelector,
+                                      agg: std.join(',', $._config.groupLabels + instanceLabels),
+                                    },
+                                    datasource=promDatasource,
+                                    legendFormat='%s - fetch' % utils.labelsToPanelLegend(instanceLabels),
+                                    interval='1m',
+                                  ),
+                                  prometheus.target(
+                                    'avg by (%(agg)s) (increase(opensearch_index_search_scroll_time_seconds{%(queriesSelector)s, context="total"}[$__interval:]) / clamp_min(increase(opensearch_index_search_scroll_count{%(queriesSelector)s, context="total"}[$__interval:]), 1))'
+                                    % {
+                                      queriesSelector: variables.queriesSelector,
+                                      agg: std.join(',', $._config.groupLabels + instanceLabels),
+                                    },
+                                    datasource=promDatasource,
+                                    legendFormat='%s - scroll' % utils.labelsToPanelLegend(instanceLabels),
+                                    interval='1m',
+                                  ),
+                                ],
+                                type: 'timeseries',
+                                title: 'Request latency',
+                                description: 'Latency of fetch, scroll, and query requests by selected index.',
+                                fieldConfig: {
+                                  defaults: {
+                                    color: {
+                                      mode: 'palette-classic',
+                                    },
+                                    custom: {
+                                      axisCenteredZero: false,
+                                      axisColorMode: 'text',
+                                      axisLabel: '',
+                                      axisPlacement: 'auto',
+                                      barAlignment: 0,
+                                      drawStyle: 'line',
+                                      fillOpacity: 0,
+                                      gradientMode: 'none',
+                                      hideFrom: {
+                                        legend: false,
+                                        tooltip: false,
+                                        viz: false,
+                                      },
+                                      lineInterpolation: 'linear',
+                                      lineWidth: 1,
+                                      pointSize: 5,
+                                      scaleDistribution: {
+                                        type: 'linear',
+                                      },
+                                      showPoints: 'auto',
+                                      spanNulls: false,
+                                      stacking: {
+                                        group: 'A',
+                                        mode: 'none',
+                                      },
+                                      thresholdsStyle: {
+                                        mode: 'off',
+                                      },
+                                    },
+                                    mappings: [],
+                                    thresholds: {
+                                      mode: 'absolute',
+                                      steps: [
+                                        {
+                                          color: 'green',
+                                          value: null,
+                                        },
+                                        {
+                                          color: 'red',
+                                          value: 80,
+                                        },
+                                      ],
+                                    },
+                                    unit: 's',
+                                  },
+                                  overrides: [],
+                                },
+                                options: {
+                                  legend: {
+                                    calcs: [],
+                                    displayMode: 'list',
+                                    placement: 'bottom',
+                                    showLegend: true,
+                                  },
+                                  tooltip: {
+                                    mode: 'multi',
+                                    sort: 'none',
+                                  },
+                                },
+                              }
+                              + g.panel.timeSeries.standardOptions.withOverridesMixin(hideZeros),
+
+  local cacheHitRatioPanel = {
+                               datasource: promDatasource,
+                               targets: [
+                                 prometheus.target(
+                                   'avg by(%(agg)s) (100 * (opensearch_index_requestcache_hit_count{%(queriesSelector)s, context="total"}) / clamp_min(opensearch_index_requestcache_hit_count{%(queriesSelector)s, context="total"} + opensearch_index_requestcache_miss_count{%(queriesSelector)s, context="total"}, 1))'
+                                   % {
+                                     queriesSelector: variables.queriesSelector,
+                                     agg: std.join(',', $._config.groupLabels + instanceLabels),
+                                   },
+                                   datasource=promDatasource,
+                                   legendFormat='%s - request' % utils.labelsToPanelLegend(instanceLabels),
+                                 ),
+                                 prometheus.target(
+                                   'avg by(%(agg)s) (100 * (opensearch_index_querycache_hit_count{%(queriesSelector)s, context="total"}) / clamp_min(opensearch_index_querycache_hit_count{%(queriesSelector)s, context="total"} + opensearch_index_querycache_miss_number{%(queriesSelector)s, context="total"}, 1))'
+                                   % {
+                                     queriesSelector: variables.queriesSelector,
+                                     agg: std.join(',', $._config.groupLabels + instanceLabels),
+                                   },
+                                   datasource=promDatasource,
+                                   legendFormat='%s - query' % utils.labelsToPanelLegend(instanceLabels),
+                                 ),
+                               ],
+                               type: 'timeseries',
+                               title: 'Cache hit ratio',
+                               description: 'Ratio of query cache and request cache hits and misses.',
+                               fieldConfig: {
+                                 defaults: {
+                                   color: {
+                                     mode: 'palette-classic',
+                                   },
+                                   custom: {
+                                     axisCenteredZero: false,
+                                     axisColorMode: 'text',
+                                     axisLabel: '',
+                                     axisPlacement: 'auto',
+                                     barAlignment: 0,
+                                     drawStyle: 'line',
+                                     fillOpacity: 0,
+                                     gradientMode: 'none',
+                                     hideFrom: {
+                                       legend: false,
+                                       tooltip: false,
+                                       viz: false,
+                                     },
+                                     lineInterpolation: 'linear',
+                                     lineWidth: 1,
+                                     pointSize: 5,
+                                     scaleDistribution: {
+                                       type: 'linear',
+                                     },
+                                     showPoints: 'auto',
+                                     spanNulls: false,
+                                     stacking: {
+                                       group: 'A',
+                                       mode: 'none',
+                                     },
+                                     thresholdsStyle: {
+                                       mode: 'off',
+                                     },
+                                   },
+                                   mappings: [],
+                                   thresholds: {
+                                     mode: 'absolute',
+                                     steps: [
+                                       {
+                                         color: 'green',
+                                         value: null,
+                                       },
+                                       {
+                                         color: 'red',
+                                         value: 80,
+                                       },
+                                     ],
+                                   },
+                                   unit: 'percent',
+                                 },
+                                 overrides: [],
+                               },
+                               options: {
+                                 legend: {
+                                   calcs: [],
+                                   displayMode: 'list',
+                                   placement: 'bottom',
+                                   showLegend: true,
+                                 },
+                                 tooltip: {
+                                   mode: 'multi',
+                                   sort: 'none',
+                                 },
+                               },
+                             }
+                             + g.panel.timeSeries.standardOptions.withOverridesMixin(hideZeros),
+
+  local evictionsPanel = {
+                           datasource: promDatasource,
+                           targets: [
+                             prometheus.target(
+                               'avg by(%(agg)s) (increase(opensearch_index_querycache_evictions_count{%(queriesSelector)s, context="total"}[$__interval:]))'
+                               % {
+                                 queriesSelector: variables.queriesSelector,
+                                 agg: std.join(',', $._config.groupLabels + instanceLabels),
+                               },
+                               datasource=promDatasource,
+                               legendFormat='%s - query cache' % utils.labelsToPanelLegend(instanceLabels),
+                               interval='1m',
+                             ),
+                             prometheus.target(
+                               'avg by(%(agg)s) (increase(opensearch_index_requestcache_evictions_count{%(queriesSelector)s, context="total"}[$__interval:]))'
+                               % {
+                                 queriesSelector: variables.queriesSelector,
+                                 agg: std.join(',', $._config.groupLabels + instanceLabels),
+                               },
+                               datasource=promDatasource,
+                               legendFormat='%s - request cache' % utils.labelsToPanelLegend(instanceLabels),
+                               interval='1m',
+                             ),
+                             prometheus.target(
+                               'avg by(%(agg)s) (increase(opensearch_index_fielddata_evictions_count{%(queriesSelector)s, context="total"}[$__interval:]))'
+                               % {
+                                 queriesSelector: variables.queriesSelector,
+                                 agg: std.join(',', $._config.groupLabels + instanceLabels),
+                               },
+                               datasource=promDatasource,
+                               legendFormat='%s - field data' % utils.labelsToPanelLegend(instanceLabels),
+                               interval='1m',
+                             ),
+                           ],
+                           type: 'timeseries',
+                           title: 'Evictions',
+                           description: 'Total evictions count by cache type for the selected index.',
+                           fieldConfig: {
+                             defaults: {
+                               color: {
+                                 mode: 'palette-classic',
+                               },
+                               custom: {
+                                 axisCenteredZero: false,
+                                 axisColorMode: 'text',
+                                 axisLabel: '',
+                                 axisPlacement: 'auto',
+                                 barAlignment: 0,
+                                 drawStyle: 'line',
+                                 fillOpacity: 0,
+                                 gradientMode: 'none',
+                                 hideFrom: {
+                                   legend: false,
+                                   tooltip: false,
+                                   viz: false,
+                                 },
+                                 lineInterpolation: 'linear',
+                                 lineWidth: 1,
+                                 pointSize: 5,
+                                 scaleDistribution: {
+                                   type: 'linear',
+                                 },
+                                 showPoints: 'auto',
+                                 spanNulls: false,
+                                 stacking: {
+                                   group: 'A',
+                                   mode: 'none',
+                                 },
+                                 thresholdsStyle: {
+                                   mode: 'off',
+                                 },
+                               },
+                               mappings: [],
+                               thresholds: {
+                                 mode: 'absolute',
+                                 steps: [
+                                   {
+                                     color: 'green',
+                                     value: null,
+                                   },
+                                   {
+                                     color: 'red',
+                                     value: 80,
+                                   },
+                                 ],
+                               },
+                               unit: 'evictions',
+                             },
+                             overrides: [],
+                           },
+                           options: {
+                             legend: {
+                               calcs: [],
+                               displayMode: 'list',
+                               placement: 'bottom',
+                               showLegend: true,
+                             },
+                             tooltip: {
+                               mode: 'multi',
+                               sort: 'none',
+                             },
+                           },
+                         }
+                         + g.panel.timeSeries.standardOptions.withOverridesMixin(hideZeros),
+
+  local indexPerformanceRow = {
+    datasource: promDatasource,
+    targets: [],
+    type: 'row',
+    title: 'Index performance',
+    collapsed: false,
+  },
+
+  local indexRatePanel = {
+    datasource: promDatasource,
+    targets: [
+      prometheus.target(
+        'avg by(%(agg)s) (opensearch_index_indexing_index_current_number{%(queriesSelector)s, context="total"})'
+        % {
+          queriesSelector: variables.queriesSelector,
+          agg: std.join(',', $._config.groupLabels + instanceLabels),
+        },
+        datasource=promDatasource,
+        legendFormat='%s' % utils.labelsToPanelLegend(instanceLabels),
+      ),
+    ],
+    type: 'timeseries',
+    title: 'Index rate',
+    description: 'Rate of indexed documents for the selected index.',
+    fieldConfig: {
+      defaults: {
+        color: {
+          mode: 'palette-classic',
+        },
+        custom: {
+          axisCenteredZero: false,
+          axisColorMode: 'text',
+          axisLabel: '',
+          axisPlacement: 'auto',
+          barAlignment: 0,
+          drawStyle: 'line',
+          fillOpacity: 0,
+          gradientMode: 'none',
+          hideFrom: {
+            legend: false,
+            tooltip: false,
+            viz: false,
+          },
+          lineInterpolation: 'linear',
+          lineWidth: 1,
+          pointSize: 5,
+          scaleDistribution: {
+            type: 'linear',
+          },
+          showPoints: 'auto',
+          spanNulls: false,
+          stacking: {
+            group: 'A',
+            mode: 'none',
+          },
+          thresholdsStyle: {
+            mode: 'off',
+          },
+        },
+        mappings: [],
+        thresholds: {
+          mode: 'absolute',
+          steps: [
+            {
+              color: 'green',
+              value: null,
+            },
+            {
+              color: 'red',
+              value: 80,
+            },
+          ],
+        },
+        unit: 'documents/s',
+      },
+      overrides: [],
+    },
+    options: {
+      legend: {
+        calcs: [],
+        displayMode: 'list',
+        placement: 'bottom',
+        showLegend: true,
+      },
+      tooltip: {
+        mode: 'single',
+        sort: 'none',
+      },
+    },
+  } + g.panel.timeSeries.standardOptions.withOverridesMixin(hideZeros),
+
+  local indexLatencyPanel = {
+                              datasource: promDatasource,
+                              targets: [
+                                prometheus.target(
+                                  'avg by(%(agg)s) (increase(opensearch_index_indexing_index_time_seconds{%(queriesSelector)s, context=~"total"}[$__interval:]) / clamp_min(increase(opensearch_index_indexing_index_count{%(queriesSelector)s, context=~"total"}[$__interval:]),1))'
+                                  % {
+                                    queriesSelector: variables.queriesSelector,
+                                    agg: std.join(',', $._config.groupLabels + instanceLabels),
+                                  },
+                                  datasource=promDatasource,
+                                  legendFormat='%s' % utils.labelsToPanelLegend(instanceLabels),
+                                  interval='1m',
+                                ),
+                              ],
+                              type: 'timeseries',
+                              title: 'Index latency',
+                              description: 'Document indexing latency for the selected index.',
+                              fieldConfig: {
+                                defaults: {
+                                  color: {
+                                    mode: 'palette-classic',
+                                  },
+                                  custom: {
+                                    axisCenteredZero: false,
+                                    axisColorMode: 'text',
+                                    axisLabel: '',
+                                    axisPlacement: 'auto',
+                                    barAlignment: 0,
+                                    drawStyle: 'line',
+                                    fillOpacity: 0,
+                                    gradientMode: 'none',
+                                    hideFrom: {
+                                      legend: false,
+                                      tooltip: false,
+                                      viz: false,
+                                    },
+                                    lineInterpolation: 'linear',
+                                    lineWidth: 1,
+                                    pointSize: 5,
+                                    scaleDistribution: {
+                                      type: 'linear',
+                                    },
+                                    showPoints: 'auto',
+                                    spanNulls: false,
+                                    stacking: {
+                                      group: 'A',
+                                      mode: 'none',
+                                    },
+                                    thresholdsStyle: {
+                                      mode: 'off',
+                                    },
+                                  },
+                                  mappings: [],
+                                  thresholds: {
+                                    mode: 'absolute',
+                                    steps: [
+                                      {
+                                        color: 'green',
+                                        value: null,
+                                      },
+                                      {
+                                        color: 'red',
+                                        value: 80,
+                                      },
+                                    ],
+                                  },
+                                  unit: 's',
+                                },
+                                overrides: [],
+                              },
+                              options: {
+                                legend: {
+                                  calcs: [],
+                                  displayMode: 'list',
+                                  placement: 'bottom',
+                                  showLegend: true,
+                                },
+                                tooltip: {
+                                  mode: 'single',
+                                  sort: 'none',
+                                },
+                              },
+                            }
+                            + g.panel.timeSeries.standardOptions.withOverridesMixin(hideZeros),
+
+  local indexFailuresPanel = {
+                               datasource: promDatasource,
+                               targets: [
+                                 prometheus.target(
+                                   'avg by(%(agg)s) (increase(opensearch_index_indexing_index_failed_count{%(queriesSelector)s, context="total"}[$__interval:]))'
+                                   % {
+                                     queriesSelector: variables.queriesSelector,
+                                     agg: std.join(',', $._config.groupLabels + instanceLabels),
+                                   },
+                                   datasource=promDatasource,
+                                   legendFormat='%s' % utils.labelsToPanelLegend(instanceLabels),
+                                   interval='1m',
+                                 ),
+                               ],
+                               type: 'timeseries',
+                               title: 'Index failures',
+                               description: 'Number of indexing failures for the selected index.',
+                               fieldConfig: {
+                                 defaults: {
+                                   color: {
+                                     mode: 'palette-classic',
+                                   },
+                                   custom: {
+                                     axisCenteredZero: false,
+                                     axisColorMode: 'text',
+                                     axisLabel: '',
+                                     axisPlacement: 'auto',
+                                     barAlignment: 0,
+                                     drawStyle: 'line',
+                                     fillOpacity: 0,
+                                     gradientMode: 'none',
+                                     hideFrom: {
+                                       legend: false,
+                                       tooltip: false,
+                                       viz: false,
+                                     },
+                                     lineInterpolation: 'linear',
+                                     lineWidth: 1,
+                                     pointSize: 5,
+                                     scaleDistribution: {
+                                       type: 'linear',
+                                     },
+                                     showPoints: 'auto',
+                                     spanNulls: false,
+                                     stacking: {
+                                       group: 'A',
+                                       mode: 'none',
+                                     },
+                                     thresholdsStyle: {
+                                       mode: 'off',
+                                     },
+                                   },
+                                   mappings: [],
+                                   thresholds: {
+                                     mode: 'absolute',
+                                     steps: [
+                                       {
+                                         color: 'green',
+                                         value: null,
+                                       },
+                                       {
+                                         color: 'red',
+                                         value: 80,
+                                       },
+                                     ],
+                                   },
+                                   unit: 'failures',
+                                 },
+                                 overrides: [],
+                               },
+                               options: {
+                                 legend: {
+                                   calcs: [],
+                                   displayMode: 'list',
+                                   placement: 'bottom',
+                                   showLegend: true,
+                                 },
+                                 tooltip: {
+                                   mode: 'single',
+                                   sort: 'none',
+                                 },
+                               },
+                             }
+                             + g.panel.timeSeries.standardOptions.withOverridesMixin(hideZeros),
+
+  local flushLatencyPanel = {
+    datasource: promDatasource,
+    targets: [
+      prometheus.target(
+        'avg by(%(agg)s) (increase(opensearch_index_flush_total_time_seconds{%(queriesSelector)s, context="total"}[$__interval:]) / clamp_min(increase(opensearch_index_flush_total_count{%(queriesSelector)s, context="total"}[$__interval:]),1))'
+        % {
+          queriesSelector: variables.queriesSelector,
+          agg: std.join(',', $._config.groupLabels + instanceLabels),
+        },
+        datasource=promDatasource,
+        legendFormat='%s' % utils.labelsToPanelLegend(instanceLabels),
+      ),
+    ],
+    type: 'timeseries',
+    title: 'Flush latency',
+    description: 'Index flush latency for the selected index.',
+    fieldConfig: {
+      defaults: {
+        color: {
+          mode: 'palette-classic',
+        },
+        custom: {
+          axisCenteredZero: false,
+          axisColorMode: 'text',
+          axisLabel: '',
+          axisPlacement: 'auto',
+          barAlignment: 0,
+          drawStyle: 'line',
+          fillOpacity: 0,
+          gradientMode: 'none',
+          hideFrom: {
+            legend: false,
+            tooltip: false,
+            viz: false,
+          },
+          lineInterpolation: 'linear',
+          lineWidth: 1,
+          pointSize: 5,
+          scaleDistribution: {
+            type: 'linear',
+          },
+          showPoints: 'auto',
+          spanNulls: false,
+          stacking: {
+            group: 'A',
+            mode: 'none',
+          },
+          thresholdsStyle: {
+            mode: 'off',
+          },
+        },
+        mappings: [],
+        thresholds: {
+          mode: 'absolute',
+          steps: [
+            {
+              color: 'green',
+              value: null,
+            },
+            {
+              color: 'red',
+              value: 80,
+            },
+          ],
+        },
+        unit: 's',
+      },
+      overrides: [],
+    },
+    options: {
+      legend: {
+        calcs: [],
+        displayMode: 'list',
+        placement: 'bottom',
+        showLegend: true,
+      },
+      tooltip: {
+        mode: 'single',
+        sort: 'none',
+      },
+    },
+  } + g.panel.timeSeries.standardOptions.withOverridesMixin(hideZeros),
+
+  local mergeTimePanel = {
+                           datasource: promDatasource,
+                           targets: [
+                             prometheus.target(
+                               'avg by(%(agg)s) (increase(opensearch_index_merges_total_time_seconds{%(queriesSelector)s, context="total"}[$__interval:])) > 0'
+                               % {
+                                 queriesSelector: variables.queriesSelector,
+                                 agg: std.join(',', $._config.groupLabels + instanceLabels),
+                               },
+                               datasource=promDatasource,
+                               legendFormat='%s - total' % utils.labelsToPanelLegend(instanceLabels),
+                             ),
+                             prometheus.target(
+                               'avg by(%(agg)s) (increase(opensearch_index_merges_total_stopped_time_seconds{%(queriesSelector)s, context="total"}[$__interval:])) > 0'
+                               % {
+                                 queriesSelector: variables.queriesSelector,
+                                 agg: std.join(',', $._config.groupLabels + instanceLabels),
+                               },
+                               datasource=promDatasource,
+                               legendFormat='%s - stopped' % utils.labelsToPanelLegend(instanceLabels),
+                             ),
+                             prometheus.target(
+                               'avg by(%(agg)s) (increase(opensearch_index_merges_total_throttled_time_seconds{%(queriesSelector)s, context="total"}[$__interval:])) > 0'
+                               % {
+                                 queriesSelector: variables.queriesSelector,
+                                 agg: std.join(',', $._config.groupLabels + instanceLabels),
+                               },
+                               datasource=promDatasource,
+                               legendFormat='%s - throttled' % utils.labelsToPanelLegend(instanceLabels),
+                             ),
+                           ],
+                           type: 'timeseries',
+                           title: 'Merge time',
+                           description: 'Index merge time for the selected index.',
+                           fieldConfig: {
+                             defaults: {
+                               color: {
+                                 mode: 'palette-classic',
+                               },
+                               custom: {
+                                 axisCenteredZero: false,
+                                 axisColorMode: 'text',
+                                 axisLabel: '',
+                                 axisPlacement: 'auto',
+                                 barAlignment: 0,
+                                 drawStyle: 'line',
+                                 fillOpacity: 0,
+                                 gradientMode: 'none',
+                                 hideFrom: {
+                                   legend: false,
+                                   tooltip: false,
+                                   viz: false,
+                                 },
+                                 lineInterpolation: 'linear',
+                                 lineWidth: 1,
+                                 pointSize: 5,
+                                 scaleDistribution: {
+                                   type: 'linear',
+                                 },
+                                 showPoints: 'auto',
+                                 spanNulls: false,
+                                 stacking: {
+                                   group: 'A',
+                                   mode: 'none',
+                                 },
+                                 thresholdsStyle: {
+                                   mode: 'off',
+                                 },
+                               },
+                               mappings: [],
+                               thresholds: {
+                                 mode: 'absolute',
+                                 steps: [
+                                   {
+                                     color: 'green',
+                                     value: null,
+                                   },
+                                   {
+                                     color: 'red',
+                                     value: 80,
+                                   },
+                                 ],
+                               },
+                               unit: 's',
+                             },
+                             overrides: [],
+                           },
+                           options: {
+                             legend: {
+                               calcs: [],
+                               displayMode: 'list',
+                               placement: 'bottom',
+                               showLegend: true,
+                             },
+                             tooltip: {
+                               mode: 'multi',
+                               sort: 'none',
+                             },
+                           },
+                         }
+                         + g.panel.timeSeries.fieldConfig.defaults.custom.withDrawStyle('points')
+                         + g.panel.timeSeries.standardOptions.withOverridesMixin(hideZeros),
+
+  local refreshLatencyPanel = {
+                                datasource: promDatasource,
+                                targets: [
+                                  prometheus.target(
+                                    'avg by(%(agg)s) (increase(opensearch_index_refresh_total_time_seconds{%(queriesSelector)s, context="total"}[$__interval:]) / clamp_min(increase(opensearch_index_refresh_total_count{%(queriesSelector)s, context="total"}[$__interval:]),1))'
+                                    % {
+                                      queriesSelector: variables.queriesSelector,
+                                      agg: std.join(',', $._config.groupLabels + instanceLabels),
+                                    },
+                                    datasource=promDatasource,
+                                    legendFormat='%s' % utils.labelsToPanelLegend(instanceLabels),
+                                  ),
+                                ],
+                                type: 'timeseries',
+                                title: 'Refresh latency',
+                                description: 'Index refresh latency for the selected index.',
+                                fieldConfig: {
+                                  defaults: {
+                                    color: {
+                                      mode: 'palette-classic',
+                                    },
+                                    custom: {
+                                      axisCenteredZero: false,
+                                      axisColorMode: 'text',
+                                      axisLabel: '',
+                                      axisPlacement: 'auto',
+                                      barAlignment: 0,
+                                      drawStyle: 'line',
+                                      fillOpacity: 0,
+                                      gradientMode: 'none',
+                                      hideFrom: {
+                                        legend: false,
+                                        tooltip: false,
+                                        viz: false,
+                                      },
+                                      lineInterpolation: 'linear',
+                                      lineWidth: 1,
+                                      pointSize: 5,
+                                      scaleDistribution: {
+                                        type: 'linear',
+                                      },
+                                      showPoints: 'auto',
+                                      spanNulls: false,
+                                      stacking: {
+                                        group: 'A',
+                                        mode: 'none',
+                                      },
+                                      thresholdsStyle: {
+                                        mode: 'off',
+                                      },
+                                    },
+                                    mappings: [],
+                                    thresholds: {
+                                      mode: 'absolute',
+                                      steps: [
+                                        {
+                                          color: 'green',
+                                          value: null,
+                                        },
+                                        {
+                                          color: 'red',
+                                          value: 80,
+                                        },
+                                      ],
+                                    },
+                                    unit: 's',
+                                  },
+                                  overrides: [],
+                                },
+                                options: {
+                                  legend: {
+                                    calcs: [],
+                                    displayMode: 'list',
+                                    placement: 'bottom',
+                                    showLegend: true,
+                                  },
+                                  tooltip: {
+                                    mode: 'single',
+                                    sort: 'none',
+                                  },
+                                },
+                              }
+                              + g.panel.timeSeries.standardOptions.withOverridesMixin(hideZeros),
+
+  local translogOperationsPanel = {
+                                    datasource: promDatasource,
+                                    targets: [
+                                      prometheus.target(
+                                        'avg by(%(agg)s) (opensearch_index_translog_operations_number{%(queriesSelector)s, context="total"})'
+                                        % {
+                                          queriesSelector: variables.queriesSelector,
+                                          agg: std.join(',', $._config.groupLabels + instanceLabels),
+                                        },
+                                        datasource=promDatasource,
+                                        legendFormat='%s' % utils.labelsToPanelLegend(instanceLabels),
+                                      ),
+                                    ],
+                                    type: 'timeseries',
+                                    title: 'Translog operations',
+                                    description: 'Current number of translog operations for the selected index.',
+                                    fieldConfig: {
+                                      defaults: {
+                                        color: {
+                                          mode: 'palette-classic',
+                                        },
+                                        custom: {
+                                          axisCenteredZero: false,
+                                          axisColorMode: 'text',
+                                          axisLabel: '',
+                                          axisPlacement: 'auto',
+                                          barAlignment: 0,
+                                          drawStyle: 'line',
+                                          fillOpacity: 0,
+                                          gradientMode: 'none',
+                                          hideFrom: {
+                                            legend: false,
+                                            tooltip: false,
+                                            viz: false,
+                                          },
+                                          lineInterpolation: 'linear',
+                                          lineWidth: 1,
+                                          pointSize: 5,
+                                          scaleDistribution: {
+                                            type: 'linear',
+                                          },
+                                          showPoints: 'auto',
+                                          spanNulls: false,
+                                          stacking: {
+                                            group: 'A',
+                                            mode: 'none',
+                                          },
+                                          thresholdsStyle: {
+                                            mode: 'off',
+                                          },
+                                        },
+                                        mappings: [],
+                                        thresholds: {
+                                          mode: 'absolute',
+                                          steps: [
+                                            {
+                                              color: 'green',
+                                              value: null,
+                                            },
+                                            {
+                                              color: 'red',
+                                              value: 80,
+                                            },
+                                          ],
+                                        },
+                                        unit: 'operations',
+                                      },
+                                      overrides: [],
+                                    },
+                                    options: {
+                                      legend: {
+                                        calcs: [],
+                                        displayMode: 'list',
+                                        placement: 'bottom',
+                                        showLegend: true,
+                                      },
+                                      tooltip: {
+                                        mode: 'single',
+                                        sort: 'none',
+                                      },
+                                    },
+                                  }
+                                  + g.panel.timeSeries.standardOptions.withOverridesMixin(hideZeros),
+
+  local docsDeletedPanel = {
+                             datasource: promDatasource,
+                             targets: [
+                               prometheus.target(
+                                 'avg by (%(agg)s) (opensearch_index_indexing_delete_current_number{%(queriesSelector)s, context="total"})'
+                                 % {
+                                   queriesSelector: variables.queriesSelector,
+                                   agg: std.join(',', $._config.groupLabels + instanceLabels),
+                                 },
+                                 datasource=promDatasource,
+                                 legendFormat='%s' % utils.labelsToPanelLegend(instanceLabels),
+                               ),
+                             ],
+                             type: 'timeseries',
+                             title: 'Docs deleted',
+                             description: 'Rate of documents deleted for the selected index.',
+                             fieldConfig: {
+                               defaults: {
+                                 color: {
+                                   mode: 'palette-classic',
+                                 },
+                                 custom: {
+                                   axisCenteredZero: false,
+                                   axisColorMode: 'text',
+                                   axisLabel: '',
+                                   axisPlacement: 'auto',
+                                   barAlignment: 0,
+                                   drawStyle: 'line',
+                                   fillOpacity: 0,
+                                   gradientMode: 'none',
+                                   hideFrom: {
+                                     legend: false,
+                                     tooltip: false,
+                                     viz: false,
+                                   },
+                                   lineInterpolation: 'linear',
+                                   lineWidth: 1,
+                                   pointSize: 5,
+                                   scaleDistribution: {
+                                     type: 'linear',
+                                   },
+                                   showPoints: 'auto',
+                                   spanNulls: false,
+                                   stacking: {
+                                     group: 'A',
+                                     mode: 'none',
+                                   },
+                                   thresholdsStyle: {
+                                     mode: 'off',
+                                   },
+                                 },
+                                 mappings: [],
+                                 thresholds: {
+                                   mode: 'absolute',
+                                   steps: [
+                                     {
+                                       color: 'green',
+                                       value: null,
+                                     },
+                                     {
+                                       color: 'red',
+                                       value: 80,
+                                     },
+                                   ],
+                                 },
+                                 unit: 'documents/s',
+                               },
+                               overrides: [],
+                             },
+                             options: {
+                               legend: {
+                                 calcs: [],
+                                 displayMode: 'list',
+                                 placement: 'bottom',
+                                 showLegend: true,
+                               },
+                               tooltip: {
+                                 mode: 'single',
+                                 sort: 'none',
+                               },
+                             },
+                           }
+                           + g.panel.timeSeries.standardOptions.withOverridesMixin(hideZeros),
+
+  local indexCapacityRow = {
+    datasource: promDatasource,
+    targets: [],
+    type: 'row',
+    title: 'Index capacity',
+    collapsed: false,
+  },
+
+  local documentsIndexedPanel = {
+                                  datasource: promDatasource,
+                                  targets: [
+                                    prometheus.target(
+                                      'avg by (%(agg)s) (opensearch_index_indexing_index_count{%(queriesSelector)s, context="total"})'
+                                      % {
+                                        queriesSelector: variables.queriesSelector,
+                                        agg: std.join(',', $._config.groupLabels + instanceLabels),
+                                      },
+                                      datasource=promDatasource,
+                                      legendFormat='%s' % utils.labelsToPanelLegend(instanceLabels),
+                                    ),
+                                  ],
+                                  type: 'timeseries',
+                                  title: 'Documents indexed',
+                                  description: 'Number of indexed documents for the selected index.',
+                                  fieldConfig: {
+                                    defaults: {
+                                      color: {
+                                        mode: 'palette-classic',
+                                      },
+                                      custom: {
+                                        axisCenteredZero: false,
+                                        axisColorMode: 'text',
+                                        axisLabel: '',
+                                        axisPlacement: 'auto',
+                                        barAlignment: 0,
+                                        drawStyle: 'line',
+                                        fillOpacity: 0,
+                                        gradientMode: 'none',
+                                        hideFrom: {
+                                          legend: false,
+                                          tooltip: false,
+                                          viz: false,
+                                        },
+                                        lineInterpolation: 'linear',
+                                        lineWidth: 1,
+                                        pointSize: 5,
+                                        scaleDistribution: {
+                                          type: 'linear',
+                                        },
+                                        showPoints: 'auto',
+                                        spanNulls: false,
+                                        stacking: {
+                                          group: 'A',
+                                          mode: 'none',
+                                        },
+                                        thresholdsStyle: {
+                                          mode: 'off',
+                                        },
+                                      },
+                                      mappings: [],
+                                      thresholds: {
+                                        mode: 'absolute',
+                                        steps: [
+                                          {
+                                            color: 'green',
+                                            value: null,
+                                          },
+                                          {
+                                            color: 'red',
+                                            value: 80,
+                                          },
+                                        ],
+                                      },
+                                      unit: 'documents',
+                                    },
+                                    overrides: [],
+                                  },
+                                  options: {
+                                    legend: {
+                                      calcs: [],
+                                      displayMode: 'list',
+                                      placement: 'bottom',
+                                      showLegend: true,
+                                    },
+                                    tooltip: {
+                                      mode: 'single',
+                                      sort: 'none',
+                                    },
+                                  },
+                                }
+                                + g.panel.timeSeries.standardOptions.withOverridesMixin(hideZeros),
+
+  local segmentCountPanel = {
+                              datasource: promDatasource,
+                              targets: [
+                                prometheus.target(
+                                  'avg by(%(agg)s) (opensearch_index_segments_number{%(queriesSelector)s, context="total"})'
+                                  % {
+                                    queriesSelector: variables.queriesSelector,
+                                    agg: std.join(',', $._config.groupLabels + instanceLabels),
+                                  },
+                                  datasource=promDatasource,
+                                  legendFormat='%s' % utils.labelsToPanelLegend(instanceLabels),
+                                ),
+                              ],
+                              type: 'timeseries',
+                              title: 'Segment count',
+                              description: 'Current number of segments for the selected index.',
+                              fieldConfig: {
+                                defaults: {
+                                  color: {
+                                    mode: 'palette-classic',
+                                  },
+                                  custom: {
+                                    axisCenteredZero: false,
+                                    axisColorMode: 'text',
+                                    axisLabel: '',
+                                    axisPlacement: 'auto',
+                                    barAlignment: 0,
+                                    drawStyle: 'line',
+                                    fillOpacity: 0,
+                                    gradientMode: 'none',
+                                    hideFrom: {
+                                      legend: false,
+                                      tooltip: false,
+                                      viz: false,
+                                    },
+                                    lineInterpolation: 'linear',
+                                    lineWidth: 1,
+                                    pointSize: 5,
+                                    scaleDistribution: {
+                                      type: 'linear',
+                                    },
+                                    showPoints: 'auto',
+                                    spanNulls: false,
+                                    stacking: {
+                                      group: 'A',
+                                      mode: 'none',
+                                    },
+                                    thresholdsStyle: {
+                                      mode: 'off',
+                                    },
+                                  },
+                                  mappings: [],
+                                  thresholds: {
+                                    mode: 'absolute',
+                                    steps: [
+                                      {
+                                        color: 'green',
+                                        value: null,
+                                      },
+                                      {
+                                        color: 'red',
+                                        value: 80,
+                                      },
+                                    ],
+                                  },
+                                  unit: 'segments',
+                                },
+                                overrides: [],
+                              },
+                              options: {
+                                legend: {
+                                  calcs: [],
+                                  displayMode: 'list',
+                                  placement: 'bottom',
+                                  showLegend: true,
+                                },
+                                tooltip: {
+                                  mode: 'single',
+                                  sort: 'none',
+                                },
+                              },
+                            }
+                            + g.panel.timeSeries.standardOptions.withOverridesMixin(hideZeros),
+
+  local mergeCountPanel = {
+                            datasource: promDatasource,
+                            targets: [
+                              prometheus.target(
+                                'avg by(%(agg)s) (increase(opensearch_index_merges_total_docs_count{%(queriesSelector)s, context="total"}[$__interval:])) > 0'
+                                % {
+                                  queriesSelector: variables.queriesSelector,
+                                  agg: std.join(',', $._config.groupLabels + instanceLabels),
+                                },
+                                datasource=promDatasource,
+                                legendFormat='%s' % utils.labelsToPanelLegend(instanceLabels),
+                              ),
+                            ],
+                            type: 'timeseries',
+                            title: 'Merge count',
+                            description: 'Number of merge operations for the selected index.',
+                            fieldConfig: {
+                              defaults: {
+                                color: {
+                                  mode: 'palette-classic',
+                                },
+                                custom: {
+                                  axisCenteredZero: false,
+                                  axisColorMode: 'text',
+                                  axisLabel: '',
+                                  axisPlacement: 'auto',
+                                  barAlignment: 0,
+                                  drawStyle: 'line',
+                                  fillOpacity: 0,
+                                  gradientMode: 'none',
+                                  hideFrom: {
+                                    legend: false,
+                                    tooltip: false,
+                                    viz: false,
+                                  },
+                                  lineInterpolation: 'linear',
+                                  lineWidth: 1,
+                                  pointSize: 5,
+                                  scaleDistribution: {
+                                    type: 'linear',
+                                  },
+                                  showPoints: 'auto',
+                                  spanNulls: false,
+                                  stacking: {
+                                    group: 'A',
+                                    mode: 'none',
+                                  },
+                                  thresholdsStyle: {
+                                    mode: 'off',
+                                  },
+                                },
+                                mappings: [],
+                                thresholds: {
+                                  mode: 'absolute',
+                                  steps: [
+                                    {
+                                      color: 'green',
+                                      value: null,
+                                    },
+                                    {
+                                      color: 'red',
+                                      value: 80,
+                                    },
+                                  ],
+                                },
+                                unit: 'merges',
+                              },
+                              overrides: [],
+                            },
+                            options: {
+                              legend: {
+                                calcs: [],
+                                displayMode: 'list',
+                                placement: 'bottom',
+                                showLegend: true,
+                              },
+                              tooltip: {
+                                mode: 'single',
+                                sort: 'none',
+                              },
+                            },
+                          }
+                          + g.panel.timeSeries.fieldConfig.defaults.custom.withDrawStyle('points')
+                          + g.panel.timeSeries.standardOptions.withOverridesMixin(hideZeros),
+
+  local cacheSizePanel = {
+                           datasource: promDatasource,
+                           targets: [
+                             prometheus.target(
+                               'avg by(%(agg)s) (opensearch_index_querycache_memory_size_bytes{%(queriesSelector)s, context="total"})'
+                               % {
+                                 queriesSelector: variables.queriesSelector,
+                                 agg: std.join(',', $._config.groupLabels + instanceLabels),
+                               },
+                               datasource=promDatasource,
+                               legendFormat='%s - query' % utils.labelsToPanelLegend(instanceLabels),
+                             ),
+                             prometheus.target(
+                               'avg by(%(agg)s) (opensearch_index_requestcache_memory_size_bytes{%(queriesSelector)s, context="total"})'
+                               % {
+                                 queriesSelector: variables.queriesSelector,
+                                 agg: std.join(',', $._config.groupLabels + instanceLabels),
+                               },
+                               datasource=promDatasource,
+                               legendFormat='%s - request' % utils.labelsToPanelLegend(instanceLabels),
+                             ),
+                           ],
+                           type: 'timeseries',
+                           title: 'Cache size',
+                           description: 'Size of query cache and request cache.',
+                           fieldConfig: {
+                             defaults: {
+                               color: {
+                                 mode: 'palette-classic',
+                               },
+                               custom: {
+                                 axisCenteredZero: false,
+                                 axisColorMode: 'text',
+                                 axisLabel: '',
+                                 axisPlacement: 'auto',
+                                 barAlignment: 0,
+                                 drawStyle: 'line',
+                                 fillOpacity: 0,
+                                 gradientMode: 'none',
+                                 hideFrom: {
+                                   legend: false,
+                                   tooltip: false,
+                                   viz: false,
+                                 },
+                                 lineInterpolation: 'linear',
+                                 lineWidth: 1,
+                                 pointSize: 5,
+                                 scaleDistribution: {
+                                   type: 'linear',
+                                 },
+                                 showPoints: 'auto',
+                                 spanNulls: false,
+                                 stacking: {
+                                   group: 'A',
+                                   mode: 'none',
+                                 },
+                                 thresholdsStyle: {
+                                   mode: 'off',
+                                 },
+                               },
+                               mappings: [],
+                               thresholds: {
+                                 mode: 'absolute',
+                                 steps: [
+                                   {
+                                     color: 'green',
+                                     value: null,
+                                   },
+                                   {
+                                     color: 'red',
+                                     value: 80,
+                                   },
+                                 ],
+                               },
+                               unit: 'bytes',
+                             },
+                             overrides: [],
+                           },
+                           options: {
+                             legend: {
+                               calcs: [],
+                               displayMode: 'list',
+                               placement: 'bottom',
+                               showLegend: true,
+                             },
+                             tooltip: {
+                               mode: 'multi',
+                               sort: 'none',
+                             },
+                           },
+                         }
+                         + g.panel.timeSeries.standardOptions.withOverridesMixin(hideZeros),
+
+  local storeSizePanel = {
+                           datasource: promDatasource,
+                           targets: [
+                             prometheus.target(
+                               'avg by(%(agg)s) (opensearch_index_store_size_bytes{%(queriesSelector)s, context="total"})'
+                               % {
+                                 queriesSelector: variables.queriesSelector,
+                                 agg: std.join(',', $._config.groupLabels + instanceLabels),
+                               },
+                               datasource=promDatasource,
+                               legendFormat='%s' % utils.labelsToPanelLegend(instanceLabels),
+                             ),
+                           ],
+                           type: 'timeseries',
+                           title: 'Store size',
+                           description: 'Size of the store in bytes for the selected index.',
+                           fieldConfig: {
+                             defaults: {
+                               color: {
+                                 mode: 'palette-classic',
+                               },
+                               custom: {
+                                 axisCenteredZero: false,
+                                 axisColorMode: 'text',
+                                 axisLabel: '',
+                                 axisPlacement: 'auto',
+                                 barAlignment: 0,
+                                 drawStyle: 'line',
+                                 fillOpacity: 0,
+                                 gradientMode: 'none',
+                                 hideFrom: {
+                                   legend: false,
+                                   tooltip: false,
+                                   viz: false,
+                                 },
+                                 lineInterpolation: 'linear',
+                                 lineWidth: 1,
+                                 pointSize: 5,
+                                 scaleDistribution: {
+                                   type: 'linear',
+                                 },
+                                 showPoints: 'auto',
+                                 spanNulls: false,
+                                 stacking: {
+                                   group: 'A',
+                                   mode: 'none',
+                                 },
+                                 thresholdsStyle: {
+                                   mode: 'off',
+                                 },
+                               },
+                               mappings: [],
+                               thresholds: {
+                                 mode: 'absolute',
+                                 steps: [
+                                   {
+                                     color: 'green',
+                                     value: null,
+                                   },
+                                   {
+                                     color: 'red',
+                                     value: 80,
+                                   },
+                                 ],
+                               },
+                               unit: 'bytes',
+                             },
+                             overrides: [],
+                           },
+                           options: {
+                             legend: {
+                               calcs: [],
+                               displayMode: 'list',
+                               placement: 'bottom',
+                               showLegend: true,
+                             },
+                             tooltip: {
+                               mode: 'single',
+                               sort: 'none',
+                             },
+                           },
+                         }
+                         + g.panel.timeSeries.standardOptions.withOverridesMixin(hideZeros),
+
+  local segmentSizePanel = {
+                             datasource: promDatasource,
+                             targets: [
+                               prometheus.target(
+                                 'avg by(%(agg)s) (opensearch_index_segments_memory_bytes{%(queriesSelector)s, context="total"})'
+                                 % {
+                                   queriesSelector: variables.queriesSelector,
+                                   agg: std.join(',', $._config.groupLabels + instanceLabels),
+                                 },
+                                 datasource=promDatasource,
+                                 legendFormat='%s' % utils.labelsToPanelLegend(instanceLabels),
+                               ),
+                             ],
+                             type: 'timeseries',
+                             title: 'Segment size',
+                             description: 'Memory used by segments for the selected index.',
+                             fieldConfig: {
+                               defaults: {
+                                 color: {
+                                   mode: 'palette-classic',
+                                 },
+                                 custom: {
+                                   axisCenteredZero: false,
+                                   axisColorMode: 'text',
+                                   axisLabel: '',
+                                   axisPlacement: 'auto',
+                                   barAlignment: 0,
+                                   drawStyle: 'line',
+                                   fillOpacity: 0,
+                                   gradientMode: 'none',
+                                   hideFrom: {
+                                     legend: false,
+                                     tooltip: false,
+                                     viz: false,
+                                   },
+                                   lineInterpolation: 'linear',
+                                   lineWidth: 1,
+                                   pointSize: 5,
+                                   scaleDistribution: {
+                                     type: 'linear',
+                                   },
+                                   showPoints: 'auto',
+                                   spanNulls: false,
+                                   stacking: {
+                                     group: 'A',
+                                     mode: 'none',
+                                   },
+                                   thresholdsStyle: {
+                                     mode: 'off',
+                                   },
+                                 },
+                                 mappings: [],
+                                 thresholds: {
+                                   mode: 'absolute',
+                                   steps: [
+                                     {
+                                       color: 'green',
+                                       value: null,
+                                     },
+                                     {
+                                       color: 'red',
+                                       value: 80,
+                                     },
+                                   ],
+                                 },
+                                 unit: 'bytes',
+                               },
+                               overrides: [],
+                             },
+                             options: {
+                               legend: {
+                                 calcs: [],
+                                 displayMode: 'list',
+                                 placement: 'bottom',
+                                 showLegend: true,
+                               },
+                               tooltip: {
+                                 mode: 'single',
+                                 sort: 'none',
+                               },
+                             },
+                           }
+                           + g.panel.timeSeries.standardOptions.withOverridesMixin(hideZeros),
+
+  local mergeSizePanel = {
+                           datasource: promDatasource,
+                           targets: [
+                             prometheus.target(
+                               'avg by(%(agg)s) (opensearch_index_merges_current_size_bytes{%(queriesSelector)s, context="total"}) > 0'
+                               % {
+                                 queriesSelector: variables.queriesSelector,
+                                 agg: std.join(',', $._config.groupLabels + instanceLabels),
+                               },
+                               datasource=promDatasource,
+                               legendFormat='%s' % utils.labelsToPanelLegend(instanceLabels),
+                             ),
+                           ],
+                           type: 'timeseries',
+                           title: 'Merge size',
+                           description: 'Size of merge operations in bytes for the selected index.',
+                           fieldConfig: {
+                             defaults: {
+                               color: {
+                                 mode: 'palette-classic',
+                               },
+                               custom: {
+                                 axisCenteredZero: false,
+                                 axisColorMode: 'text',
+                                 axisLabel: '',
+                                 axisPlacement: 'auto',
+                                 barAlignment: 0,
+                                 drawStyle: 'line',
+                                 fillOpacity: 0,
+                                 gradientMode: 'none',
+                                 hideFrom: {
+                                   legend: false,
+                                   tooltip: false,
+                                   viz: false,
+                                 },
+                                 lineInterpolation: 'linear',
+                                 lineWidth: 1,
+                                 pointSize: 5,
+                                 scaleDistribution: {
+                                   type: 'linear',
+                                 },
+                                 showPoints: 'auto',
+                                 spanNulls: false,
+                                 stacking: {
+                                   group: 'A',
+                                   mode: 'none',
+                                 },
+                                 thresholdsStyle: {
+                                   mode: 'off',
+                                 },
+                               },
+                               mappings: [],
+                               thresholds: {
+                                 mode: 'absolute',
+                                 steps: [
+                                   {
+                                     color: 'green',
+                                     value: null,
+                                   },
+                                   {
+                                     color: 'red',
+                                     value: 80,
+                                   },
+                                 ],
+                               },
+                               unit: 'bytes',
+                             },
+                             overrides: [],
+                           },
+                           options: {
+                             legend: {
+                               calcs: [],
+                               displayMode: 'list',
+                               placement: 'bottom',
+                               showLegend: true,
+                             },
+                             tooltip: {
+                               mode: 'single',
+                               sort: 'none',
+                             },
+                           },
+                         }
+                         + g.panel.timeSeries.fieldConfig.defaults.custom.withDrawStyle('points')
+                         + g.panel.timeSeries.standardOptions.withOverridesMixin(hideZeros),
+  local shardCountPanel =
+    {
+      datasource: promDatasource,
+      targets: [
+        prometheus.target(
+          'sum by (index) (avg by(%(agg)s) (opensearch_index_shards_number{%(queriesSelector)s, type=~"active|active_primary"}))'
+          % {
+            queriesSelector: variables.queriesSelector,
+            agg: std.join(',', $._config.groupLabels + instanceLabels),
+          },
+          datasource=promDatasource,
+          legendFormat='%s' % utils.labelsToPanelLegend(instanceLabels),
+        ),
+      ],
+      type: 'timeseries',
+      title: 'Shard count',
+      description: 'The number of index shards for the selected index.',
+      fieldConfig: {
+        defaults: {
+          color: {
+            mode: 'palette-classic',
+          },
+          custom: {
+            axisCenteredZero: false,
+            axisColorMode: 'text',
+            axisLabel: '',
+            axisPlacement: 'auto',
+            barAlignment: 0,
+            drawStyle: 'line',
+            fillOpacity: 0,
+            gradientMode: 'none',
+            hideFrom: {
+              legend: false,
+              tooltip: false,
+              viz: false,
+            },
+            lineInterpolation: 'linear',
+            lineWidth: 1,
+            pointSize: 5,
+            scaleDistribution: {
+              type: 'linear',
+            },
+            showPoints: 'auto',
+            spanNulls: false,
+            stacking: {
+              group: 'A',
+              mode: 'none',
+            },
+            thresholdsStyle: {
+              mode: 'off',
+            },
+          },
+          mappings: [],
+          thresholds: {
+            mode: 'absolute',
+            steps: [
+              {
+                color: 'green',
+                value: null,
+              },
+              {
+                color: 'red',
+                value: 80,
+              },
+            ],
+          },
+          unit: 'shards',
+        },
+        overrides: [],
+      },
+      options: {
+        legend: {
+          calcs: [],
+          displayMode: 'list',
+          placement: 'bottom',
+          showLegend: true,
+        },
+        tooltip: {
+          mode: 'single',
+          sort: 'none',
+        },
+      },
+    }
+    + g.panel.timeSeries.standardOptions.withOverridesMixin(hideZeros),
+
+
   grafanaDashboards+:: {
     'search-and-index-overview.json':
-      dashboard.new(
-        'OpenSearch search and index overview',
-        time_from='%s' % $._config.dashboardPeriod,
-        tags=($._config.dashboardTags),
-        timezone='%s' % $._config.dashboardTimezone,
-        refresh='%s' % $._config.dashboardRefresh,
-        description='',
-        uid=$._config.uid+dashboardUidSuffix,
+      g.dashboard.new('OpenSearch search and index overview',)
+      + g.dashboard.withTags($._config.dashboardTags)
+      + g.dashboard.time.withFrom($._config.dashboardPeriod)
+      + g.dashboard.withTimezone($._config.dashboardTimezone)
+      + g.dashboard.withRefresh($._config.dashboardRefresh)
+      + g.dashboard.withUid($._config.uid + dashboardUidSuffix)
+      + g.dashboard.withLinks(
+        g.dashboard.link.dashboards.new(
+          'Other Opensearch dashboards',
+          $._config.dashboardTags
+        )
+        + g.dashboard.link.dashboards.options.withIncludeVars(true)
+        + g.dashboard.link.dashboards.options.withKeepTime(true)
+        + g.dashboard.link.dashboards.options.withAsDropdown(false)
       )
-      .addLink(grafana.link.dashboards(
-        asDropdown=false,
-        title='Other OpenSearch dashboards',
-        includeVars=true,
-        keepTime=true,
-        tags=($._config.dashboardTags),
-      ))
-      .addTemplates(
-        [
-          template.datasource(
-            promDatasourceName,
-            'prometheus',
-            null,
-            label='Prometheus data source',
-            refresh='load'
-          ),
-          template.new(
-            'job',
-            promDatasource,
-            'label_values(opensearch_index_search_fetch_count{%s}, job)' % $._config.filteringSelector,
-            label='Job',
-            refresh=2,
-            includeAll=true,
-            multi=true,
-            sort=1
-          ),
-          template.new(
-            'opensearch_cluster',
-            promDatasource,
-            'label_values(opensearch_index_search_fetch_count{%s, job=~"$job"}, cluster)' % $._config.filteringSelector,
-            label='OpenSearch Cluster',
-            refresh=2,
-            includeAll=true,
-            multi=true,
-            allValues='',
-            sort=1
-          ),
-          template.new(
-            'opensearch_index',
-            promDatasource,
-            'label_values(opensearch_index_search_fetch_count{%s, job=~"$job", cluster=~"$opensearch_cluster"}, index)' % $._config.filteringSelector,
-            label='Index',
-            refresh=2,
-            includeAll=true,
-            multi=true,
-            allValues='',
-            sort=1
-          ),
-        ]
-      )
-      .addPanels(
+      + g.dashboard.withPanels(
         [
           requestPerformanceRow { gridPos: { h: 1, w: 24, x: 0, y: 0 } },
           requestRatePanel { gridPos: { h: 8, w: 6, x: 0, y: 1 } },
@@ -1768,6 +1893,7 @@ local shardCountPanel = {
           mergeSizePanel { gridPos: { h: 8, w: 6, x: 12, y: 35 } },
           shardCountPanel { gridPos: { h: 8, w: 6, x: 18, y: 35 } },
         ]
-      ),
+      )
+      + g.dashboard.withVariables(variables.multiInstance),
   },
 }

--- a/opensearch-mixin/g.libsonnet
+++ b/opensearch-mixin/g.libsonnet
@@ -1,0 +1,1 @@
+import 'github.com/grafana/grafonnet/gen/grafonnet-v10.0.0/main.libsonnet'

--- a/opensearch-mixin/jsonnetfile.json
+++ b/opensearch-mixin/jsonnetfile.json
@@ -9,6 +9,15 @@
         }
       },
       "version": "master"
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": "common-lib"
+        }
+      },
+      "version": "master"
     }
   ],
   "legacyImports": true

--- a/opensearch-mixin/jsonnetfile.json
+++ b/opensearch-mixin/jsonnetfile.json
@@ -18,6 +18,15 @@
         }
       },
       "version": "master"
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/grafonnet.git",
+          "subdir": "gen/grafonnet-v10.0.0"
+        }
+      },
+      "version": "main"
     }
   ],
   "legacyImports": true

--- a/opensearch-mixin/panels.libsonnet
+++ b/opensearch-mixin/panels.libsonnet
@@ -1,0 +1,229 @@
+// variables.libsonnet
+local g = import './g.libsonnet';
+local var = g.dashboard.variable;
+local commonlib = import 'common-lib/common/main.libsonnet';
+local utils = commonlib.utils;
+
+{
+  new(
+    groupLabels,
+    instanceLabels,
+    variables,
+  ): {
+
+    local promDatasource = {
+      uid: '${%s}' % variables.datasources.prometheus.name,
+    },
+    osRolesTimeline:
+      g.panel.statusHistory.new('Roles timeline')
+      + g.panel.statusHistory.panelOptions.withDescription('OpenSearch node roles over time.')
+      + g.panel.statusHistory.options.withShowValue('never')
+      + g.panel.statusHistory.options.withLegend(false)
+      + g.panel.statusHistory.queryOptions.withMaxDataPoints(100)
+      + g.panel.statusHistory.queryOptions.withTargets(
+        [
+          g.query.prometheus.new(
+            promDatasource.uid,
+            |||
+              max by (node,role) (
+                  max_over_time(opensearch_node_role_bool{%(queriesSelector)s, role="data"}[1m]) == 1
+              ) * 2
+            |||
+            % {
+              queriesSelector: variables.queriesSelector,
+            },
+          )
+          + g.query.prometheus.withLegendFormat('{{node}}'),
+          g.query.prometheus.new(
+            promDatasource.uid,
+            |||
+              max by (node,role) (
+                  max_over_time(opensearch_node_role_bool{%(queriesSelector)s, role="master"}[1m]) == 1
+              ) * 3
+            |||
+            % { queriesSelector: variables.queriesSelector },
+          )
+          + g.query.prometheus.withLegendFormat('{{node}}'),
+          g.query.prometheus.new(
+            promDatasource.uid,
+            |||
+              max by (node,role) (
+                  max_over_time(opensearch_node_role_bool{%(queriesSelector)s, role="ingest"}[1m]) == 1
+              ) * 4
+            |||
+            % { queriesSelector: variables.queriesSelector },
+          )
+          + g.query.prometheus.withLegendFormat('{{node}}'),
+          g.query.prometheus.new(
+            promDatasource.uid,
+            |||
+              max by (node,role) (
+                  max_over_time(opensearch_node_role_bool{%(queriesSelector)s, role="cluster_manager"}[1m]) == 1
+              ) * 5
+            |||
+            % { queriesSelector: variables.queriesSelector },
+          )
+          + g.query.prometheus.withLegendFormat('{{node}}'),
+          g.query.prometheus.new(
+            promDatasource.uid,
+            |||
+              max by (node,role) (
+                  max_over_time(opensearch_node_role_bool{%(queriesSelector)s, role="remote_cluster_client"}[1m]) == 1
+              ) * 6
+            |||
+            % { queriesSelector: variables.queriesSelector },
+          )
+          + g.query.prometheus.withLegendFormat('{{node}}'),
+        ]
+      )
+      + g.panel.statusHistory.standardOptions.withMappings([
+        {
+          type: 'value',
+          options: {
+            '2': {
+              color: 'light-purple',
+              index: 0,
+              text: 'data',
+            },
+            '3': {
+              color: 'light-green',
+              index: 1,
+              text: 'master',
+            },
+            '4': {
+              color: 'light-blue',
+              index: 2,
+              text: 'ingest',
+            },
+            '5': {
+              text: 'cluster_manager',
+              color: 'light-yellow',
+              index: 3,
+            },
+            '6': {
+              text: 'remote_cluster_client',
+              color: 'super-light-red',
+              index: 4,
+            },
+          },
+        },
+      ]),
+
+
+    osRoles:
+      g.panel.table.new('Roles')
+      + g.panel.table.panelOptions.withDescription('OpenSearch node roles.')
+      + g.panel.table.queryOptions.withTargets([
+        g.query.prometheus.new(
+          promDatasource.uid,
+          'max by (%(agg)s) (last_over_time(opensearch_node_role_bool{%(queriesSelector)s}[1d]))'
+          % {
+            queriesSelector: variables.queriesSelector,
+            agg: std.join(',', groupLabels + instanceLabels + ['node', 'nodeid', 'role', 'primary_ip']),
+          },
+        )
+        + g.query.prometheus.withLegendFormat(utils.labelsToPanelLegend(instanceLabels))
+        + g.query.prometheus.withInstant(true),
+      ])
+      + g.panel.table.standardOptions.withMappings([
+        {
+          options: {
+            '0': {
+              color: 'super-light-orange',
+              index: 5,
+              text: 'False',
+            },
+            '1': {
+              color: 'light-green',
+              index: 3,
+              text: 'True',
+            },
+            Data: {
+              color: 'light-purple',
+              index: 0,
+              text: 'data',
+            },
+            Ingest: {
+              color: 'light-blue',
+              index: 2,
+              text: 'ingest',
+            },
+            Master: {
+              color: 'light-green',
+              index: 1,
+              text: 'master',
+            },
+            'Remote cluster client': {
+              color: 'light-orange',
+              index: 4,
+              text: 'remote_cluster_client',
+            },
+          },
+          type: 'value',
+        },
+      ])
+      + g.panel.table.standardOptions.withOverrides([
+        {
+          matcher: {
+            id: 'byRegexp',
+            options: '/Data|Master|Ingest|Remote.+|Cluster.+/',
+          },
+          properties: [
+            {
+              id: 'custom.cellOptions',
+              value: {
+                type: 'color-text',
+              },
+            },
+          ],
+        },
+      ])
+      + g.panel.table.queryOptions.withTransformations([
+        {
+          id: 'labelsToFields',
+          options: {
+            mode: 'columns',
+            valueLabel: 'role',
+          },
+        },
+        {
+          id: 'merge',
+          options: {},
+        },
+        {
+          id: 'organize',
+          options: {
+            excludeByName: {
+              Time: true,
+            },
+            indexByName: {
+              Time: 0,  // hide time
+              node: 3,
+              nodeid: 3,
+              master: 104,
+              data: 105,
+              ingest: 106,
+              remote_cluster_client: 107,
+              cluster_manager: 108,
+            } + {
+              [k]: 3
+              for k in groupLabels + instanceLabels
+            }
+            ,
+            renameByName: {
+              Time: '',
+              cluster: 'Cluster',
+              //roles:
+              cluster_manager: 'Cluster manager',
+              data: 'Data',
+              ingest: 'Ingest',
+              master: 'Master',
+              node: 'Node',
+              nodeid: 'Nodeid',
+              remote_cluster_client: 'Remote cluster client',
+            },
+          },
+        },
+      ]),
+  },
+}

--- a/opensearch-mixin/variables.libsonnet
+++ b/opensearch-mixin/variables.libsonnet
@@ -11,55 +11,55 @@ local utils = commonlib.utils;
     instanceLabels,
     varMetric
   ): {
-       local root = self,
-       local variablesFromLabels(groupLabels, instanceLabels, filteringSelector, multiInstance=true) =
-         local chainVarProto(index, chainVar) =
-           var.query.new(chainVar.label)
-           + var.query.withDatasourceFromVariable(root.datasources.prometheus)
-           + var.query.queryTypes.withLabelValues(
-             chainVar.label,
-             '%s{%s}' % [varMetric, chainVar.chainSelector],
-           )
-           + var.query.generalOptions.withLabel(utils.toSentenceCase(chainVar.label))
-           + var.query.selectionOptions.withIncludeAll(
-             value=if (!multiInstance && std.member(instanceLabels, chainVar.label)) then false else true,
-             customAllValue='.+'
-           )
-           + var.query.selectionOptions.withMulti(
-             if (!multiInstance && std.member(instanceLabels, chainVar.label)) then false else true,
-           )
-           + var.query.refresh.onTime()
-           + var.query.withSort(
-             i=1,
-             type='alphabetical',
-             asc=true,
-             caseInsensitive=false
-           );
-         std.mapWithIndex(chainVarProto, utils.chainLabels(groupLabels + instanceLabels, [filteringSelector])),
-       datasources: {
-         prometheus:
-           var.datasource.new('datasource', 'prometheus')
-           + var.datasource.generalOptions.withLabel('Data source')
-           + var.datasource.withRegex(''),
-         loki:
-           var.datasource.new('loki_datasource', 'loki')
-           + var.datasource.generalOptions.withLabel('Loki data source')
-           + var.datasource.withRegex('')
-           + var.datasource.generalOptions.showOnDashboard.withNothing(),
-       },
-       // Use on dashboards where multiple entities can be selected, like fleet dashboards
-       multiInstance:
-         [root.datasources.prometheus]
-         + variablesFromLabels(groupLabels, instanceLabels, filteringSelector),
-       // Use on dashboards where only single entity can be selected
-       singleInstance:
-         [root.datasources.prometheus]
-         + variablesFromLabels(groupLabels, instanceLabels, filteringSelector, multiInstance=false),
+    local root = self,
+    local variablesFromLabels(groupLabels, instanceLabels, filteringSelector, multiInstance=true) =
+      local chainVarProto(index, chainVar) =
+        var.query.new(chainVar.label)
+        + var.query.withDatasourceFromVariable(root.datasources.prometheus)
+        + var.query.queryTypes.withLabelValues(
+          chainVar.label,
+          '%s{%s}' % [varMetric, chainVar.chainSelector],
+        )
+        + var.query.generalOptions.withLabel(utils.toSentenceCase(chainVar.label))
+        + var.query.selectionOptions.withIncludeAll(
+          value=if (!multiInstance && std.member(instanceLabels, chainVar.label)) then false else true,
+          customAllValue='.+'
+        )
+        + var.query.selectionOptions.withMulti(
+          if (!multiInstance && std.member(instanceLabels, chainVar.label)) then false else true,
+        )
+        + var.query.refresh.onTime()
+        + var.query.withSort(
+          i=1,
+          type='alphabetical',
+          asc=true,
+          caseInsensitive=false
+        );
+      std.mapWithIndex(chainVarProto, utils.chainLabels(groupLabels + instanceLabels, [filteringSelector])),
+    datasources: {
+      prometheus:
+        var.datasource.new('datasource', 'prometheus')
+        + var.datasource.generalOptions.withLabel('Data source')
+        + var.datasource.withRegex(''),
+      loki:
+        var.datasource.new('loki_datasource', 'loki')
+        + var.datasource.generalOptions.withLabel('Loki data source')
+        + var.datasource.withRegex('')
+        + var.datasource.generalOptions.showOnDashboard.withNothing(),
+    },
+    // Use on dashboards where multiple entities can be selected, like fleet dashboards
+    multiInstance:
+      [root.datasources.prometheus]
+      + variablesFromLabels(groupLabels, instanceLabels, filteringSelector),
+    // Use on dashboards where only single entity can be selected
+    singleInstance:
+      [root.datasources.prometheus]
+      + variablesFromLabels(groupLabels, instanceLabels, filteringSelector, multiInstance=false),
 
-       queriesSelector:
-         '%s,%s' % [
-           filteringSelector,
-           utils.labelsToPromQLSelector(groupLabels + instanceLabels),
-         ],
-     }
+    queriesSelector:
+      '%s,%s' % [
+        filteringSelector,
+        utils.labelsToPromQLSelector(groupLabels + instanceLabels),
+      ],
+  },
 }

--- a/opensearch-mixin/variables.libsonnet
+++ b/opensearch-mixin/variables.libsonnet
@@ -1,4 +1,5 @@
 // variables.libsonnet
+local g = import './g.libsonnet';
 local var = g.dashboard.variable;
 local commonlib = import 'common-lib/common/main.libsonnet';
 local utils = commonlib.utils;

--- a/opensearch-mixin/variables.libsonnet
+++ b/opensearch-mixin/variables.libsonnet
@@ -1,0 +1,64 @@
+// variables.libsonnet
+local var = g.dashboard.variable;
+local commonlib = import 'common-lib/common/main.libsonnet';
+local utils = commonlib.utils;
+
+{
+  new(
+    filteringSelector,
+    groupLabels,
+    instanceLabels,
+    varMetric
+  ): {
+       local root = self,
+       local variablesFromLabels(groupLabels, instanceLabels, filteringSelector, multiInstance=true) =
+         local chainVarProto(index, chainVar) =
+           var.query.new(chainVar.label)
+           + var.query.withDatasourceFromVariable(root.datasources.prometheus)
+           + var.query.queryTypes.withLabelValues(
+             chainVar.label,
+             '%s{%s}' % [varMetric, chainVar.chainSelector],
+           )
+           + var.query.generalOptions.withLabel(utils.toSentenceCase(chainVar.label))
+           + var.query.selectionOptions.withIncludeAll(
+             value=if (!multiInstance && std.member(instanceLabels, chainVar.label)) then false else true,
+             customAllValue='.+'
+           )
+           + var.query.selectionOptions.withMulti(
+             if (!multiInstance && std.member(instanceLabels, chainVar.label)) then false else true,
+           )
+           + var.query.refresh.onTime()
+           + var.query.withSort(
+             i=1,
+             type='alphabetical',
+             asc=true,
+             caseInsensitive=false
+           );
+         std.mapWithIndex(chainVarProto, utils.chainLabels(groupLabels + instanceLabels, [filteringSelector])),
+       datasources: {
+         prometheus:
+           var.datasource.new('datasource', 'prometheus')
+           + var.datasource.generalOptions.withLabel('Data source')
+           + var.datasource.withRegex(''),
+         loki:
+           var.datasource.new('loki_datasource', 'loki')
+           + var.datasource.generalOptions.withLabel('Loki data source')
+           + var.datasource.withRegex('')
+           + var.datasource.generalOptions.showOnDashboard.withNothing(),
+       },
+       // Use on dashboards where multiple entities can be selected, like fleet dashboards
+       multiInstance:
+         [root.datasources.prometheus]
+         + variablesFromLabels(groupLabels, instanceLabels, filteringSelector),
+       // Use on dashboards where only single entity can be selected
+       singleInstance:
+         [root.datasources.prometheus]
+         + variablesFromLabels(groupLabels, instanceLabels, filteringSelector, multiInstance=false),
+
+       queriesSelector:
+         '%s,%s' % [
+           filteringSelector,
+           utils.labelsToPromQLSelector(groupLabels + instanceLabels),
+         ],
+     }
+}


### PR DESCRIPTION
To use as submodule, helping to avoid overlaps in alert rules or dashboard results.
1) Adds config params:
- filteringSelector
- groupLabels
- instanceLabels
- uid (used in dashboard uids, alert group uids)
- dashboardNamePrefix

2) Use commonlib for CPU/memory/disk/network panel styles
3) Change aggregations from sum to avg on cluster level (to avoid miscalculations where cluster-wide data is gathered multiple times (from different nodes))

In other words, this mixin was refactored, bringing it closer to modular-observ-lib format, and is ready to be instantiated twice in single Grafana instance.