### PR TITLE
[istio-mixin] Fix: typo

### DIFF
--- a/istio-mixin/dashboards/istio-overview.json
+++ b/istio-mixin/dashboards/istio-overview.json
@@ -2746,7 +2746,7 @@
           "editorMode": "code",
           "expr": "galley_validation_config_updates{job=~\"$job\", cluster=~\"$cluster\", instance=~\"$instance\"}",
           "instant": false,
-          "legendFormat": "Updates"
+          "legendFormat": "Updates",
           "range": true,
           "refId": "A"
         }


### PR DESCRIPTION
without this fix, i've got this error:

```
❯ make
mixtool generate dashboards mixin.libsonnet -d dashboards_out
2023/08/23 09:01:55 RUNTIME ERROR: dashboards/istio-overview.json:2750:11-18 Expected a comma before next field
        mixin.libsonnet:3:29-68 object <anonymous>
        Field "istio-overview.json"
        During manifestation
make: *** [dashboards_out] Error 1
```