### PR TITLE
Get rid of `std.native("parseYaml")`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@ JSONNET_FMT := jsonnetfmt -n 2 --max-blank-lines 2 --string-style s --comment-st
 SHELL := /bin/bash
 
 install-ci-deps:
-	go install github.com/google/go-jsonnet/cmd/jsonnet@v0.18.0
-	go install github.com/google/go-jsonnet/cmd/jsonnetfmt@v0.18.0
-	go install github.com/google/go-jsonnet/cmd/jsonnet-lint@v0.18.0
+	go install github.com/google/go-jsonnet/cmd/jsonnet@v0.20.0
+	go install github.com/google/go-jsonnet/cmd/jsonnetfmt@v0.20.0
+	go install github.com/google/go-jsonnet/cmd/jsonnet-lint@v0.20.0
 	go install github.com/monitoring-mixins/mixtool/cmd/mixtool@ae18e31161ea
 	go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@v0.4.0
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ install-ci-deps:
 	go install github.com/google/go-jsonnet/cmd/jsonnet@v0.20.0
 	go install github.com/google/go-jsonnet/cmd/jsonnetfmt@v0.20.0
 	go install github.com/google/go-jsonnet/cmd/jsonnet-lint@v0.20.0
-	go install github.com/monitoring-mixins/mixtool/cmd/mixtool@ae18e31161ea
+	go install github.com/monitoring-mixins/mixtool/cmd/mixtool@44b4f22e0b5f1af611743503da95d2c64d0e71d3
 	go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@v0.4.0
 
 fmt:

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ install-ci-deps:
 	go install github.com/google/go-jsonnet/cmd/jsonnet@v0.20.0
 	go install github.com/google/go-jsonnet/cmd/jsonnetfmt@v0.20.0
 	go install github.com/google/go-jsonnet/cmd/jsonnet-lint@v0.20.0
-	go install github.com/monitoring-mixins/mixtool/cmd/mixtool@44b4f22e0b5f1af611743503da95d2c64d0e71d3
+	go install github.com/monitoring-mixins/mixtool/cmd/mixtool@cfce6b9c258e188e6c8f0d6e0dbb3e1f8c5a7f63
 	go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@v0.4.0
 
 fmt:

--- a/argocd-mixin/mixin.libsonnet
+++ b/argocd-mixin/mixin.libsonnet
@@ -6,7 +6,7 @@
   // Helper function to ensure that we don't override other rules, by forcing
   // the patching of the groups list, and not the overall rules object.
   local importRules(rules) = {
-    groups+: std.native('parseYaml')(rules)[0].groups,
+    groups+: std.parseYaml(rules).groups,
   },
 
   prometheusAlerts+:

--- a/asterisk-mixin/mixin.libsonnet
+++ b/asterisk-mixin/mixin.libsonnet
@@ -7,7 +7,7 @@
   // Helper function to ensure that we don't override other rules, by forcing
   // the patching of the groups list, and not the overall rules object.
   local importRules(rules) = {
-    groups+: std.native('parseYaml')(rules)[0].groups,
+    groups+: std.parseYaml(rules).groups,
   },
 
   prometheusAlerts+:

--- a/ceph-mixin/mixin.libsonnet
+++ b/ceph-mixin/mixin.libsonnet
@@ -6,7 +6,7 @@
   // Helper function to ensure that we don't override other rules, by forcing
   // the patching of the groups list, and not the overall rules object.
   local importRules(rules) = {
-    groups+: std.native('parseYaml')(rules)[0].groups,
+    groups+: std.parseYaml(rules).groups,
   },
 
   prometheusAlerts+:

--- a/cert-manager/main.libsonnet
+++ b/cert-manager/main.libsonnet
@@ -92,7 +92,7 @@ local helm = tanka.helm.new(std.thisFile);
 
   crds:
     if $._config.custom_crds
-    then std.native('parseYaml')(importstr 'files/00-crds.yaml')
+    then std.parseYaml(importstr 'files/00-crds.yaml')
     else {},
 } + {
   local _containers = super.labeled.deployment_cert_manager.spec.template.spec.containers,

--- a/cilium-enterprise-mixin/mixin.libsonnet
+++ b/cilium-enterprise-mixin/mixin.libsonnet
@@ -27,6 +27,6 @@
   // Helper function to ensure that we don't override other rules, by forcing
   // the patching of the groups list, and not the overall rules object.
   local importRules(rules) = {
-    groups+: std.native('parseYaml')(rules)[0].groups,
+    groups+: std.parseYaml(rules).groups,
   },
 }

--- a/confluent-kafka-mixin/mixin.libsonnet
+++ b/confluent-kafka-mixin/mixin.libsonnet
@@ -6,6 +6,6 @@
   // Helper function to ensure that we don't override other rules, by forcing
   // the patching of the groups list, and not the overall rules object.
   local importRules(rules) = {
-    groups+: std.native('parseYaml')(rules)[0].groups,
+    groups+: std.parseYaml(rules).groups,
   },
 }

--- a/harbor-mixin/mixin.libsonnet
+++ b/harbor-mixin/mixin.libsonnet
@@ -6,7 +6,7 @@
   // Helper function to ensure that we don't override other rules, by forcing
   // the patching of the groups list, and not the overall rules object.
   local importRules(rules) = {
-    groups+: std.native('parseYaml')(rules)[0].groups,
+    groups+: std.parseYaml(rules).groups,
   },
 
   prometheusAlerts+:

--- a/istio-mixin/mixin.libsonnet
+++ b/istio-mixin/mixin.libsonnet
@@ -7,7 +7,7 @@
   // Helper function to ensure that we don't override other rules, by forcing
   // the patching of the groups list, and not the overall rules object.
   local importRules(rules) = {
-    groups+: std.native('parseYaml')(rules)[0].groups,
+    groups+: std.parseYaml(rules).groups,
   },
 
   prometheusAlerts+:

--- a/jira-mixin/mixin.libsonnet
+++ b/jira-mixin/mixin.libsonnet
@@ -6,7 +6,7 @@
   // Helper function to ensure that we don't override other rules, by forcing
   // the patching of the groups list, and not the overall rules object.
   local importRules(rules) = {
-    groups+: std.native('parseYaml')(rules)[0].groups,
+    groups+: std.parseYaml(rules).groups,
   },
 
   prometheusAlerts+: importRules(importstr 'alerts/general.yaml'),

--- a/kafka-mixin/mixin.libsonnet
+++ b/kafka-mixin/mixin.libsonnet
@@ -12,7 +12,7 @@
   // Helper function to ensure that we don't override other rules, by forcing
   // the patching of the groups list, and not the overall rules object.
   local importRules(rules) = {
-    groups+: std.native('parseYaml')(rules)[0].groups,
+    groups+: std.parseYaml(rules).groups,
   },
 
   prometheusAlerts+:

--- a/kubescape-mixin/mixin.libsonnet
+++ b/kubescape-mixin/mixin.libsonnet
@@ -6,7 +6,7 @@
   // Helper function to ensure that we don't override other rules, by forcing
   // the patching of the groups list, and not the overall rules object.
   local importRules(rules) = {
-    groups+: std.native('parseYaml')(rules)[0].groups,
+    groups+: std.parseYaml('parseYaml')(rules).groups,
   },
 
   prometheusAlerts+:

--- a/mongodb-mixin/mixin.libsonnet
+++ b/mongodb-mixin/mixin.libsonnet
@@ -8,7 +8,7 @@
   // Helper function to ensure that we don't override other rules, by forcing
   // the patching of the groups list, and not the overall rules object.
   local importRules(rules) = {
-    groups+: std.native('parseYaml')(rules)[0].groups,
+    groups+: std.parseYaml(rules).groups,
   },
 
   prometheusAlerts+:

--- a/nodejs-mixin/mixin.libsonnet
+++ b/nodejs-mixin/mixin.libsonnet
@@ -6,7 +6,7 @@
   // Helper function to ensure that we don't override other rules, by forcing
   // the patching of the groups list, and not the overall rules object.
   local importRules(rules) = {
-    groups+: std.native('parseYaml')(rules)[0].groups,
+    groups+: std.parseYaml(rules).groups,
   },
 
   prometheusAlerts+: importRules(importstr 'alerts/alerts.yaml'),

--- a/rabbitmq-mixin/mixin.libsonnet
+++ b/rabbitmq-mixin/mixin.libsonnet
@@ -7,7 +7,7 @@
   // Helper function to ensure that we don't override other rules, by forcing
   // the patching of the groups list, and not the overall rules object.
   local importRules(rules) = {
-    groups+: std.native('parseYaml')(rules)[0].groups,
+    groups+: std.parseYaml(rules).groups,
   },
 
   prometheusAlerts+:

--- a/spark-mixin/mixin.libsonnet
+++ b/spark-mixin/mixin.libsonnet
@@ -6,6 +6,6 @@
   // Helper function to ensure that we don't override other rules, by forcing
   // the patching of the groups list, and not the overall rules object.
   local importRules(rules) = {
-    groups+: std.native('parseYaml')(rules)[0].groups,
+    groups+: std.parseYaml(rules).groups,
   },
 }

--- a/velero-mixin/mixin.libsonnet
+++ b/velero-mixin/mixin.libsonnet
@@ -6,7 +6,7 @@
   // Helper function to ensure that we don't override other rules, by forcing
   // the patching of the groups list, and not the overall rules object.
   local importRules(rules) = {
-    groups+: std.native('parseYaml')(rules)[0].groups,
+    groups+: std.parseYaml(rules).groups,
   },
 
   prometheusAlerts+:

--- a/wso2-enterprise-integrator-mixin/mixin.libsonnet
+++ b/wso2-enterprise-integrator-mixin/mixin.libsonnet
@@ -10,7 +10,7 @@
   // Helper function to ensure that we don't override other rules, by forcing
   // the patching of the groups list, and not the overall rules object.
   local importRules(rules) = {
-    groups+: std.native('parseYaml')(rules)[0].groups,
+    groups+: std.parseYaml(rules).groups,
   },
 
 }

--- a/wso2-streaming-integrator-mixin/mixin.libsonnet
+++ b/wso2-streaming-integrator-mixin/mixin.libsonnet
@@ -13,7 +13,7 @@
     'StreamingIntegrator_overall.json': (import 'dashboards/StreamingIntegrator_overall.json'),
   },
   local importRules(rules) = {
-    groups+: std.native('parseYaml')(rules)[0].groups,
+    groups+: std.parseYaml(rules).groups,
   },
 
 }


### PR DESCRIPTION
It's part of the std lib since jsonnet 0.18