### PR TITLE
Apache Activemq mixin

### DIFF
--- a/apache-activemq-mixin/.lint
+++ b/apache-activemq-mixin/.lint
@@ -16,3 +16,7 @@ exclusions:
   panel-units-rule:
     reason: "Custom units are used for better user experience in these panels"
     entries:
+  target-promql-rule:
+    reason: "Linter does not support selector variable value as a scalar in top-k PromQL queries."
+  template-label-promql-rule:
+    reason: "Defining a selector for the value of top-k requires a predefined label that the linter considers invalid."

--- a/apache-activemq-mixin/.lint
+++ b/apache-activemq-mixin/.lint
@@ -1,0 +1,18 @@
+exclusions:
+  template-job-rule:
+    reason: "Prometheus datasource variable is being named as prometheus_datasource now while linter expects 'datasource'"
+  panel-datasource-rule:
+    reason: "Loki datasource variable is being named as loki_datasource now while linter expects 'datasource'"
+  template-datasource-rule:
+    reason: "Based on new convention we are using variable names prometheus_datasource and loki_datasource where as linter expects 'datasource'"
+  template-instance-rule:
+    reason: "Based on new convention we are using variable names prometheus_datasource and loki_datasource where as linter expects 'datasource'"
+  target-instance-rule:
+    reason: "Instance selector is not needed for this dashboard, but certain panels take use of the instance variable for querying purposes"
+  panel-title-description-rule:
+    reason: "Not required for logs volume"
+    entries:
+      - panel: "Logs volume" 
+  panel-units-rule:
+    reason: "Custom units are used for better user experience in these panels"
+    entries:

--- a/apache-activemq-mixin/.lint
+++ b/apache-activemq-mixin/.lint
@@ -11,8 +11,6 @@ exclusions:
     reason: "Instance selector is not needed for this dashboard, but certain panels take use of the instance variable for querying purposes"
   panel-title-description-rule:
     reason: "Not required for logs volume"
-    entries:
-      - panel: "Logs volume" 
   panel-units-rule:
     reason: "Custom units are used for better user experience in these panels"
     entries:

--- a/apache-activemq-mixin/Makefile
+++ b/apache-activemq-mixin/Makefile
@@ -1,0 +1,34 @@
+JSONNET_FMT := jsonnetfmt -n 2 --max-blank-lines 1 --string-style s --comment-style s
+
+.PHONY: all
+all: build dashboards_out prometheus_alerts.yaml
+
+vendor: jsonnetfile.json
+	jb install
+
+.PHONY: build
+build: vendor
+
+.PHONY: fmt
+fmt:
+	find . -name 'vendor' -prune -o -name '*.libsonnet' -print -o -name '*.jsonnet' -print | \
+		xargs -n 1 -- $(JSONNET_FMT) -i
+
+.PHONY: lint
+lint: build
+	find . -name 'vendor' -prune -o -name '*.libsonnet' -print -o -name '*.jsonnet' -print | \
+		while read f; do \
+			$(JSONNET_FMT) "$$f" | diff -u "$$f" -; \
+		done
+	mixtool lint mixin.libsonnet
+
+dashboards_out: mixin.libsonnet config.libsonnet $(wildcard dashboards/*)
+	@mkdir -p dashboards_out
+	mixtool generate dashboards mixin.libsonnet -d dashboards_out
+
+prometheus_alerts.yaml: mixin.libsonnet alerts/*.libsonnet
+	mixtool generate alerts mixin.libsonnet -a prometheus_alerts.yaml
+
+.PHONY: clean
+clean:
+	rm -rf dashboards_out prometheus_alerts.yaml

--- a/apache-activemq-mixin/README.md
+++ b/apache-activemq-mixin/README.md
@@ -1,0 +1,103 @@
+# Apache ActiveMQ mixin
+
+The Apache ActiveMQ mixin is a set of configurable Grafana dashboards and alerts.
+
+The Apache ActiveMQ mixin contains the following dashboards:
+
+- Apache ActiveMQ cluster overview
+- Apache ActiveMQ instance overview
+- Apache ActiveMQ queue overview
+- Apache ActiveMQ topic overview
+- Apache ActiveMQ logs overview
+
+and the following alerts:
+
+- ApacheActiveMQHighTopicMemoryUsage
+- ApacheActiveMQHighQueueMemoryUsage
+- ApacheActiveMQHighStoreMemoryUsage
+- ApacheActiveMQHighTemporaryMemoryUsage
+
+## Apache ActiveMQ cluster overview
+
+The Apache ActiveMQ cluster overview provides cluster level statistics showing cluster count, broker count, producer count and consumer counts, overall memory level usage, and a general look into enqueue/dequeue counts.
+![Screenshot of the Apache ActiveMQ cluster overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/aerospike/screenshots/apache_activemq_cluster_overview.png)
+
+## Apache ActiveMQ instance overview
+
+The Apache ActiveMQ instance overview provides instance level statistics showing memory levels, producer and consumer counts, queue sizes, enqueue/dequeue counts, average enqueue times, expired message counts, jvm garabage collection info, and alerts.
+![First screenshot of the Apache ActiveMQ instance overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/aerospike/screenshots/apache_activemq_instance_overview_1.png)
+![Second screenshot of the Apache ActiveMQ instance overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/aerospike/screenshots/apache_activemq_instance_overview_2.png)
+
+## Apache ActiveMQ queue overview
+
+The Apache ActiveMQ queue overview provides queue level statistics showing number of queues, message size, producer and consumer count, enqueue/dequeue rates, average enqueue times, expired message rates, and average size of messages.
+![Screenshot of the Apache ActiveMQ queue overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/aerospike/screenshots/apache_activemq_queue_overview.png)
+
+## Apache ActiveMQ queue overview
+
+The Apache ActiveMQ topic overview provides queue level statistics showing number of topics, message size, producer and consumer count, enqueue/dequeue rates, average enqueue times, expired message rates, and average size of messages.
+![Screenshot of the Apache ActiveMQ topic overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/aerospike/screenshots/apache_activemq_topic_overview.png)
+
+## Apache ActiveMQ logs overview
+
+The Apache ActiveMQ logs overview provides logs of the ActiveMQ environmnet that is able to be parsed by severity.
+![Screenshot of the Apache ActiveMQ logs overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/aerospike/screenshots/apache_activemq_logs_overview.png)
+
+## Alerts Overview
+
+- ApacheActiveMQHighTopicMemoryUsage: Topic destination memory usage high which may result in a reduction of the rate at which producers send messages.
+- ApacheActiveMQHighQueueMemoryUsage: Queue destination memory usage high which may result in a reduction of the rate at which producers send messages.
+- ApacheActiveMQHighStoreMemoryUsage: Store memory usage high which may result in producers unable to send messages.
+- ApacheActiveMQHighTemporaryMemoryUsage: Temporary memory usage high which may result in saturation of messaging throughput.
+
+Default thresholds can be configured in `config.libsonnet`.
+
+```js
+{
+  _config+:: {
+    dashboardTags: ['apache-activemq-mixin'],
+    dashboardPeriod: 'now-1h',
+    dashboardTimezone: 'default',
+    dashboardRefresh: '1m',
+
+    // alerts thresholds
+    alertsHighTopicMemoryUsage: 70,  // %
+    alertsHighQueueMemoryUsage: 70,  // %
+    alertsHighStoreMemoryUsage: 70,  // %
+    alertsHighTemporaryMemoryUsage: 70,  // %
+
+    enableLokiLogs: false,
+    filterSelector: 'job=~"integrations/activemq"',
+  },
+}
+```
+
+## Install tools
+
+```bash
+go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@latest
+go install github.com/monitoring-mixins/mixtool/cmd/mixtool@latest
+```
+
+For linting and formatting, you would also need `jsonnetfmt` installed. If you
+have a working Go development environment, it's easiest to run the following:
+
+```bash
+go install github.com/google/go-jsonnet/cmd/jsonnetfmt@latest
+```
+
+The files in `dashboards_out` need to be imported
+into your Grafana server. The exact details will be depending on your environment.
+
+`prometheus_alerts.yaml` needs to be imported into Prometheus.
+
+## Generate dashboards and alerts
+
+Edit `config.libsonnet` if required and then build JSON dashboard files for Grafana:
+
+```bash
+make
+```
+
+For more advanced uses of mixins, see
+https://github.com/monitoring-mixins/docs.

--- a/apache-activemq-mixin/README.md
+++ b/apache-activemq-mixin/README.md
@@ -40,7 +40,7 @@ The Apache ActiveMQ topic overview provides queue level statistics showing numbe
 
 ## Apache ActiveMQ logs overview
 
-The Apache ActiveMQ logs overview provides logs of the ActiveMQ environmnet that is able to be parsed by severity.
+The Apache ActiveMQ logs overview provides logs of the ActiveMQ environment that is able to be parsed by severity.
 ![Screenshot of the Apache ActiveMQ logs overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/aerospike/screenshots/apache_activemq_logs_overview.png)
 
 ## Alerts Overview

--- a/apache-activemq-mixin/README.md
+++ b/apache-activemq-mixin/README.md
@@ -41,7 +41,7 @@ The Apache ActiveMQ topic overview provides queue level statistics showing numbe
 ## Apache ActiveMQ logs overview
 
 The Apache ActiveMQ logs overview provides logs of the ActiveMQ environment that is able to be parsed by severity.
-![Screenshot of the Apache ActiveMQ logs overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/aerospike/screenshots/apache_activemq_logs_overview.png)
+#![Screenshot of the Apache ActiveMQ logs overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/aerospike/screenshots/apache_activemq_logs_overview.png)
 
 ## Alerts Overview
 
@@ -71,7 +71,19 @@ Default thresholds can be configured in `config.libsonnet`.
   },
 }
 ```
+## Logs configuration
+In order to get logs parsing multiple lines and levels correctly you will need to add the following lines to your grafana-agent.yaml file in the logs section
 
+```yaml
+pipeline_stages:
+        - multiline:
+            firstline: '^[\d]{4}-[\d]{2}-[\d]{2} [\d]{2}:[\d]{2}:[\d]{2},[\d]{3}'
+        - regex:
+            expression: '(?P<timestamp>[\d]{4}-[\d]{2}-[\d]{2} [\d]{2}:[\d]{2}:[\d]{2},[\d]{3}) \| (?P<level>\w+)  \| (?P<message>.*?) \| (
+  ?P<class>[\w\.]+) \| (?P<thread>\w+)'
+        - labels:
+            level:
+```
 ## Install tools
 
 ```bash

--- a/apache-activemq-mixin/README.md
+++ b/apache-activemq-mixin/README.md
@@ -19,23 +19,23 @@ and the following alerts:
 
 ## Apache ActiveMQ cluster overview
 
-The Apache ActiveMQ cluster overview provides cluster level statistics showing cluster count, broker count, producer count and consumer counts, overall memory level usage, and a general look into enqueue/dequeue counts.
+The Apache ActiveMQ cluster overview provides cluster level statistics showing cluster count, broker count, producer counts, consumer counts, overall memory level usage, and a general look into enqueue/dequeue counts.
 ![Screenshot of the Apache ActiveMQ cluster overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/aerospike/screenshots/apache_activemq_cluster_overview.png)
 
 ## Apache ActiveMQ instance overview
 
-The Apache ActiveMQ instance overview provides instance level statistics showing memory levels, producer and consumer counts, queue sizes, enqueue/dequeue counts, average enqueue times, expired message counts, jvm garabage collection info, and alerts.
+The Apache ActiveMQ instance overview provides instance level statistics showing memory levels, producer counts, consumer counts, queue sizes, enqueue/dequeue counts, average enqueue times, expired message counts, jvm garabage collection info, and alerts.
 ![First screenshot of the Apache ActiveMQ instance overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/aerospike/screenshots/apache_activemq_instance_overview_1.png)
 ![Second screenshot of the Apache ActiveMQ instance overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/aerospike/screenshots/apache_activemq_instance_overview_2.png)
 
 ## Apache ActiveMQ queue overview
 
-The Apache ActiveMQ queue overview provides queue level statistics showing number of queues, message size, producer and consumer count, enqueue/dequeue rates, average enqueue times, expired message rates, and average size of messages.
+The Apache ActiveMQ queue overview provides queue level statistics showing number of queues, message size, producer counts, consumer counts, enqueue/dequeue rates, average enqueue times, expired message rates, and average size of messages.
 ![Screenshot of the Apache ActiveMQ queue overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/aerospike/screenshots/apache_activemq_queue_overview.png)
 
 ## Apache ActiveMQ queue overview
 
-The Apache ActiveMQ topic overview provides queue level statistics showing number of topics, message size, producer and consumer count, enqueue/dequeue rates, average enqueue times, expired message rates, and average size of messages.
+The Apache ActiveMQ topic overview provides queue level statistics showing number of topics, message size, producer counts, consumer counts, enqueue/dequeue rates, average enqueue times, expired message rates, and average size of messages.
 ![Screenshot of the Apache ActiveMQ topic overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/aerospike/screenshots/apache_activemq_topic_overview.png)
 
 ## Apache ActiveMQ logs overview
@@ -45,10 +45,10 @@ The Apache ActiveMQ logs overview provides logs of the ActiveMQ environmnet that
 
 ## Alerts Overview
 
-- ApacheActiveMQHighTopicMemoryUsage: Topic destination memory usage high which may result in a reduction of the rate at which producers send messages.
-- ApacheActiveMQHighQueueMemoryUsage: Queue destination memory usage high which may result in a reduction of the rate at which producers send messages.
-- ApacheActiveMQHighStoreMemoryUsage: Store memory usage high which may result in producers unable to send messages.
-- ApacheActiveMQHighTemporaryMemoryUsage: Temporary memory usage high which may result in saturation of messaging throughput.
+- ApacheActiveMQHighTopicMemoryUsage: Topic destination memory usage is high which may result in a reduction of the rate at which producers send messages.
+- ApacheActiveMQHighQueueMemoryUsage: Queue destination memory usage is high which may result in a reduction of the rate at which producers send messages.
+- ApacheActiveMQHighStoreMemoryUsage: Store memory usage is high which may result in producers unable to send messages.
+- ApacheActiveMQHighTemporaryMemoryUsage: Temporary memory usage is high which may result in saturation of messaging throughput.
 
 Default thresholds can be configured in `config.libsonnet`.
 

--- a/apache-activemq-mixin/alerts/alerts.libsonnet
+++ b/apache-activemq-mixin/alerts/alerts.libsonnet
@@ -17,7 +17,7 @@
               summary: 'Topic destination memory usage high which may result in a reduction of the rate at which producers send messages.',
               description:
                 (
-                  '{{ printf "%%.0f" $value }} percent of memory used by topic {{$labels.destination}} on {{$labels.instance}}, ' +
+                  '{{ printf "%%.0f" $value }} percent of memory used by topic {{$labels.destination}} on {{$labels.instance}} in cluster {{$labels.activemq_cluster}}, ' +
                   'which is above the threshold of %(alertsHighTopicMemoryUsage)s percent.'
                 ) % $._config,
             },
@@ -35,7 +35,7 @@
               summary: 'Queue destination memory usage high which may result in a reduction of the rate at which producers send messages.',
               description:
                 (
-                  '{{ printf "%%.0f" $value }} percent of memory used by queue {{$labels.destination}} on {{$labels.instance}}, ' +
+                  '{{ printf "%%.0f" $value }} percent of memory used by queue {{$labels.destination}} on {{$labels.instance}} in cluster {{$labels.activemq_cluster}}, ' +
                   'which is above the threshold of %(alertsHighQueueMemoryUsage)s percent.'
                 ) % $._config,
             },
@@ -53,7 +53,7 @@
               summary: 'Store memory usage high which may result in producers unable to send messages.',
               description:
                 (
-                  '{{ printf "%%.0f" $value }} percent of store memory used on {{$labels.instance}}, ' +
+                  '{{ printf "%%.0f" $value }} percent of store memory used on {{$labels.instance}} in cluster {{$labels.activemq_cluster}}, ' +
                   'which is above the threshold of %(alertsHighStoreMemoryUsage)s percent.'
                 ) % $._config,
             },
@@ -71,7 +71,7 @@
               summary: 'Temporary memory usage high which may result in saturation of messaging throughput.',
               description:
                 (
-                  '{{ printf "%%.0f" $value }} percent of temporary memory used on {{$labels.instance}}, ' +
+                  '{{ printf "%%.0f" $value }} percent of temporary memory used on {{$labels.instance}} in cluster {{$labels.activemq_cluster}}, ' +
                   'which is above the threshold of %(alertsHighTemporaryMemoryUsage)s percent.'
                 ) % $._config,
             },

--- a/apache-activemq-mixin/alerts/alerts.libsonnet
+++ b/apache-activemq-mixin/alerts/alerts.libsonnet
@@ -14,7 +14,7 @@
               severity: 'warning',
             },
             annotations: {
-              summary: 'Topic destination memory usage high which may result in a reduction of the rate at which producers send messages.',
+              summary: 'Topic destination memory usage is high, which may result in a reduction of the rate at which producers send messages.',
               description:
                 (
                   '{{ printf "%%.0f" $value }} percent of memory used by topic {{$labels.destination}} on {{$labels.instance}} in cluster {{$labels.activemq_cluster}}, ' +
@@ -32,7 +32,7 @@
               severity: 'warning',
             },
             annotations: {
-              summary: 'Queue destination memory usage high which may result in a reduction of the rate at which producers send messages.',
+              summary: 'Queue destination memory usage is high, which may result in a reduction of the rate at which producers send messages.',
               description:
                 (
                   '{{ printf "%%.0f" $value }} percent of memory used by queue {{$labels.destination}} on {{$labels.instance}} in cluster {{$labels.activemq_cluster}}, ' +
@@ -50,7 +50,7 @@
               severity: 'warning',
             },
             annotations: {
-              summary: 'Store memory usage high which may result in producers unable to send messages.',
+              summary: 'Store memory usage is high, which may result in producers unable to send messages.',
               description:
                 (
                   '{{ printf "%%.0f" $value }} percent of store memory used on {{$labels.instance}} in cluster {{$labels.activemq_cluster}}, ' +
@@ -68,7 +68,7 @@
               severity: 'warning',
             },
             annotations: {
-              summary: 'Temporary memory usage high which may result in saturation of messaging throughput.',
+              summary: 'Temporary memory usage is high, which may result in saturation of messaging throughput.',
               description:
                 (
                   '{{ printf "%%.0f" $value }} percent of temporary memory used on {{$labels.instance}} in cluster {{$labels.activemq_cluster}}, ' +

--- a/apache-activemq-mixin/alerts/alerts.libsonnet
+++ b/apache-activemq-mixin/alerts/alerts.libsonnet
@@ -1,0 +1,83 @@
+{
+  prometheusAlerts+:: {
+    groups+: [
+      {
+        name: 'apache-activemq-alerts',
+        rules: [
+          {
+            alert: 'ApacheActiveMQHighTopicMemoryUsage',
+            expr: |||
+              activemq_topic_memory_percent_usage > %(alertsHighTopicMemoryUsage)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              summary: 'Topic destination memory usage high which may result in a reduction of the rate at which producers send messages.',
+              description:
+                (
+                  '{{ printf "%%.0f" $value }} percent of memory used by topic {{$labels.destination}} on {{$labels.instance}}, ' +
+                  'which is above the threshold of %(alertsHighTopicMemoryUsage)s percent.'
+                ) % $._config,
+            },
+          },
+          {
+            alert: 'ApacheActiveMQHighQueueMemoryUsage',
+            expr: |||
+              activemq_queue_memory_percent_usage > %(alertsHighQueueMemoryUsage)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              summary: 'Queue destination memory usage high which may result in a reduction of the rate at which producers send messages.',
+              description:
+                (
+                  '{{ printf "%%.0f" $value }} percent of memory used by queue {{$labels.destination}} on {{$labels.instance}}, ' +
+                  'which is above the threshold of %(alertsHighQueueMemoryUsage)s percent.'
+                ) % $._config,
+            },
+          },
+          {
+            alert: 'ApacheActiveMQHighStoreMemoryUsage',
+            expr: |||
+              activemq_store_usage_ratio > %(alertsHighStoreMemoryUsage)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              summary: 'Store memory usage high which may result in producers unable to send messages.',
+              description:
+                (
+                  '{{ printf "%%.0f" $value }} percent of store memory used on {{$labels.instance}}, ' +
+                  'which is above the threshold of %(alertsHighStoreMemoryUsage)s percent.'
+                ) % $._config,
+            },
+          },
+          {
+            alert: 'ApacheActiveMQHighTemporaryMemoryUsage',
+            expr: |||
+              activemq_temp_usage_ratio > %(alertsHighTemporaryMemoryUsage)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              summary: 'Temporary memory usage high which may result in saturation of messaging throughput.',
+              description:
+                (
+                  '{{ printf "%%.0f" $value }} percent of temporary memory used on {{$labels.instance}}, ' +
+                  'which is above the threshold of %(alertsHighTemporaryMemoryUsage)s percent.'
+                ) % $._config,
+            },
+          },
+        ],
+      },
+    ],
+  },
+}

--- a/apache-activemq-mixin/config.libsonnet
+++ b/apache-activemq-mixin/config.libsonnet
@@ -2,11 +2,11 @@
   _config+:: {
     enableMultiCluster: false,
     activemqSelector: if self.enableMultiCluster then 'job=~"$job", cluster=~"$cluster"' else 'job=~"$job"',
+    activemqAlertsSelector: if self.enableMultiCluster then 'job=~"${job:regex}", cluster=~"${cluster:regex}"' else 'job=~"${job:regex}"',
     dashboardTags: ['apache-activemq-mixin'],
     dashboardPeriod: 'now-30m',
     dashboardTimezone: 'default',
     dashboardRefresh: '1m',
-
     grafanaDashboardIDs: {
       'apache-activemq-logs-overview.json': 'apache-activemq-logs',
     },

--- a/apache-activemq-mixin/config.libsonnet
+++ b/apache-activemq-mixin/config.libsonnet
@@ -2,7 +2,6 @@
   _config+:: {
     enableMultiCluster: false,
     activemqSelector: if self.enableMultiCluster then 'job=~"$job", cluster=~"$cluster"' else 'job=~"$job"',
-
     dashboardTags: ['apache-activemq-mixin'],
     dashboardPeriod: 'now-30m',
     dashboardTimezone: 'default',

--- a/apache-activemq-mixin/config.libsonnet
+++ b/apache-activemq-mixin/config.libsonnet
@@ -5,6 +5,10 @@
     dashboardTimezone: 'default',
     dashboardRefresh: '1m',
 
+    grafanaDashboardIDs: {
+      'apache-activemq-logs-overview.json': 'apache-activemq-logs',
+    },
+
     // alerts thresholds
     alertsHighTopicMemoryUsage: 70,  // %
     alertsHighQueueMemoryUsage: 70,  // %

--- a/apache-activemq-mixin/config.libsonnet
+++ b/apache-activemq-mixin/config.libsonnet
@@ -1,7 +1,10 @@
 {
   _config+:: {
+    enableMultiCluster: false,
+    activemqSelector: if self.enableMultiCluster then 'job=~"$job", cluster=~"$cluster"' else 'job=~"$job"',
+
     dashboardTags: ['apache-activemq-mixin'],
-    dashboardPeriod: 'now-1h',
+    dashboardPeriod: 'now-30m',
     dashboardTimezone: 'default',
     dashboardRefresh: '1m',
 

--- a/apache-activemq-mixin/config.libsonnet
+++ b/apache-activemq-mixin/config.libsonnet
@@ -1,0 +1,17 @@
+{
+  _config+:: {
+    dashboardTags: ['apache-activemq-mixin'],
+    dashboardPeriod: 'now-1h',
+    dashboardTimezone: 'default',
+    dashboardRefresh: '1m',
+
+    // alerts thresholds
+    alertsHighTopicMemoryUsage: 70,  // %
+    alertsHighQueueMemoryUsage: 70,  // %
+    alertsHighStoreMemoryUsage: 70,  // %
+    alertsHighTemporaryMemoryUsage: 70,  // %
+
+    enableLokiLogs: false,
+    filterSelector: 'job=~"integrations/activemq"',
+  },
+}

--- a/apache-activemq-mixin/config.libsonnet
+++ b/apache-activemq-mixin/config.libsonnet
@@ -17,7 +17,7 @@
     alertsHighStoreMemoryUsage: 70,  // %
     alertsHighTemporaryMemoryUsage: 70,  // %
 
-    enableLokiLogs: false,
+    enableLokiLogs: true,
     filterSelector: 'job=~"integrations/activemq"',
   },
 }

--- a/apache-activemq-mixin/dashboards/addlogs.libsonnet
+++ b/apache-activemq-mixin/dashboards/addlogs.libsonnet
@@ -1,0 +1,34 @@
+local g = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';
+local logsDashboard = import 'github.com/grafana/jsonnet-libs/logs-lib/logs/main.libsonnet';
+
+{
+  grafanaDashboards+::
+    {
+      local activemqLogs =
+        logsDashboard.new(
+          'Apache ActiveMQ logs',
+          datasourceName='loki_datasource',
+          datasourceRegex='',
+          filterSelector=$._config.filterSelector,
+          labels=['job', 'activemq_cluster', 'instance', 'level'],
+          formatParser=null,
+          showLogsVolume=true
+        )
+        {
+          panels+:
+            {
+              logs+:
+                // ActiveMQ logs already have timestamp
+                g.panel.logs.options.withShowTime(false),
+            },
+          dashboards+:
+            {
+              logs+:
+                // copy links from another dashboard
+                g.dashboard.withLinksMixin($.grafanaDashboards['apache-activemq-cluster-overview.json'].links),
+            },
+        },
+      'apache-activemq-logs.json': activemqLogs.dashboards.logs,
+    },
+
+}

--- a/apache-activemq-mixin/dashboards/apache-activemq-cluster-overview.libsonnet
+++ b/apache-activemq-mixin/dashboards/apache-activemq-cluster-overview.libsonnet
@@ -581,7 +581,7 @@ local getMatcher(cfg) = '%(activemqSelector)s, activemq_cluster=~"$activemq_clus
           template.new(
             'activemq_cluster',
             promDatasource,
-            'label_values(activemq_memory_usage_ratio{%(activemqSelector)s},activemq_cluster)',
+            'label_values(activemq_memory_usage_ratio{%(activemqSelector)s},activemq_cluster)' % $._config,
             label='ActiveMQ cluster',
             refresh=2,
             includeAll=true,

--- a/apache-activemq-mixin/dashboards/apache-activemq-cluster-overview.libsonnet
+++ b/apache-activemq-mixin/dashboards/apache-activemq-cluster-overview.libsonnet
@@ -44,7 +44,7 @@ local clusterCountPanel = {
     overrides: [],
   },
   options: {
-    colorMode: 'value',
+    colorMode: 'none',
     graphMode: 'none',
     justifyMode: 'auto',
     orientation: 'auto',
@@ -57,7 +57,7 @@ local clusterCountPanel = {
     },
     textMode: 'auto',
   },
-  pluginVersion: '10.2.0-59585pre',
+  pluginVersion: '10.2.0-59981',
 };
 
 local brokerCountPanel = {
@@ -92,7 +92,7 @@ local brokerCountPanel = {
     overrides: [],
   },
   options: {
-    colorMode: 'value',
+    colorMode: 'none',
     graphMode: 'none',
     justifyMode: 'auto',
     orientation: 'auto',
@@ -105,7 +105,7 @@ local brokerCountPanel = {
     },
     textMode: 'auto',
   },
-  pluginVersion: '10.2.0-59585pre',
+  pluginVersion: '10.2.0-59981',
 };
 
 local producerCountPanel = {
@@ -140,7 +140,7 @@ local producerCountPanel = {
     overrides: [],
   },
   options: {
-    colorMode: 'value',
+    colorMode: 'none',
     graphMode: 'none',
     justifyMode: 'auto',
     orientation: 'auto',
@@ -153,7 +153,7 @@ local producerCountPanel = {
     },
     textMode: 'auto',
   },
-  pluginVersion: '10.2.0-59585pre',
+  pluginVersion: '10.2.0-59981',
 };
 
 local consumerCountPanel = {
@@ -188,7 +188,7 @@ local consumerCountPanel = {
     overrides: [],
   },
   options: {
-    colorMode: 'value',
+    colorMode: 'none',
     graphMode: 'none',
     justifyMode: 'auto',
     orientation: 'auto',
@@ -201,14 +201,14 @@ local consumerCountPanel = {
     },
     textMode: 'auto',
   },
-  pluginVersion: '10.2.0-59585pre',
+  pluginVersion: '10.2.0-59981',
 };
 
 local enqueueCountPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by (activemq_cluster) (activemq_enqueue_total{job=~"$job", activemq_cluster=~"$activemq_cluster"})',
+      'sum by (activemq_cluster) (increase(activemq_enqueue_total{job=~"$job", activemq_cluster=~"$activemq_cluster"}[$__interval:]))',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}}',
     ),
@@ -219,6 +219,7 @@ local enqueueCountPanel = {
   fieldConfig: {
     defaults: {
       color: {
+        fixedColor: '#C8F2C2',
         mode: 'palette-classic',
       },
       custom: {
@@ -236,8 +237,8 @@ local enqueueCountPanel = {
           viz: false,
         },
         insertNulls: false,
-        lineInterpolation: 'linear',
-        lineWidth: 1,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
         pointSize: 5,
         scaleDistribution: {
           type: 'linear',
@@ -284,7 +285,7 @@ local dequeueCountPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by (activemq_cluster) (activemq_dequeue_total{job=~"$job", activemq_cluster=~"$activemq_cluster"})',
+      'sum by (activemq_cluster) (increase(activemq_dequeue_total{job=~"$job", activemq_cluster=~"$activemq_cluster"}[$__interval:]))',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}}',
     ),
@@ -312,8 +313,8 @@ local dequeueCountPanel = {
           viz: false,
         },
         insertNulls: false,
-        lineInterpolation: 'linear',
-        lineWidth: 1,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
         pointSize: 5,
         scaleDistribution: {
           type: 'linear',
@@ -382,6 +383,10 @@ local averageTemporaryMemoryUsagePanel = {
             value: null,
           },
           {
+            color: '#EAB839',
+            value: 50,
+          },
+          {
             color: 'red',
             value: 70,
           },
@@ -407,7 +412,7 @@ local averageTemporaryMemoryUsagePanel = {
     text: {},
     valueMode: 'color',
   },
-  pluginVersion: '10.2.0-59585pre',
+  pluginVersion: '10.2.0-59981',
 };
 
 local averageStoreMemoryUsagePanel = {
@@ -436,6 +441,10 @@ local averageStoreMemoryUsagePanel = {
             value: null,
           },
           {
+            color: '#EAB839',
+            value: 50,
+          },
+          {
             color: 'red',
             value: 70,
           },
@@ -460,7 +469,7 @@ local averageStoreMemoryUsagePanel = {
     showUnfilled: false,
     valueMode: 'color',
   },
-  pluginVersion: '10.2.0-59585pre',
+  pluginVersion: '10.2.0-59981',
 };
 
 local averageBrokerMemoryUsagePanel = {
@@ -489,6 +498,10 @@ local averageBrokerMemoryUsagePanel = {
             value: null,
           },
           {
+            color: '#EAB839',
+            value: 50,
+          },
+          {
             color: 'red',
             value: 70,
           },
@@ -513,7 +526,7 @@ local averageBrokerMemoryUsagePanel = {
     showUnfilled: false,
     valueMode: 'color',
   },
-  pluginVersion: '10.2.0-59585pre',
+  pluginVersion: '10.2.0-59981',
 };
 
 {

--- a/apache-activemq-mixin/dashboards/apache-activemq-cluster-overview.libsonnet
+++ b/apache-activemq-mixin/dashboards/apache-activemq-cluster-overview.libsonnet
@@ -112,7 +112,7 @@ local producerCountPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by (activemq_cluster, job) (activemq_producer_total{' + matcher + '})',
+      'sum by (activemq_cluster, job) (activemq_queue_producer_count{' + matcher + '}) + sum by (activemq_cluster, job) (activemq_topic_producer_count{' + matcher + ',destination!~"ActiveMQ.Advisory.*"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}}',
     ),
@@ -160,7 +160,7 @@ local consumerCountPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by (activemq_cluster, job) (activemq_consumer_total{' + matcher + '})',
+      'sum by (activemq_cluster, job) (activemq_queue_consumer_count{' + matcher + '}) + sum by (activemq_cluster, job) (activemq_topic_consumer_count{' + matcher + ',destination!~"ActiveMQ.Advisory.*"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}}',
     ),
@@ -208,7 +208,7 @@ local enqueueCountPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by (activemq_cluster, job) (increase(activemq_enqueue_total{' + matcher + '}[$__interval:]))',
+      'sum by (activemq_cluster, job) (increase(activemq_queue_enqueue_count{' + matcher + '}[$__interval:])) + sum by (activemq_cluster, job) (increase(activemq_topic_enqueue_count{' + matcher + ', destination!~"ActiveMQ.Advisory.*"}[$__interval:]))',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}}',
     ),
@@ -286,7 +286,7 @@ local dequeueCountPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by (activemq_cluster, job) (increase(activemq_dequeue_total{' + matcher + '}[$__interval:]))',
+      'sum by (activemq_cluster, job) (increase(activemq_queue_dequeue_count{' + matcher + '}[$__interval:])) + sum by (activemq_cluster, job) (increase(activemq_topic_dequeue_count{' + matcher + ', destination!~"ActiveMQ.Advisory.*"}[$__interval:]))',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}}',
     ),

--- a/apache-activemq-mixin/dashboards/apache-activemq-cluster-overview.libsonnet
+++ b/apache-activemq-mixin/dashboards/apache-activemq-cluster-overview.libsonnet
@@ -16,7 +16,7 @@ local clusterCountPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'count by (activemq_cluster) (activemq_memory_usage_ratio{job=~"$job"})',
+      'count by (activemq_cluster, job) (activemq_memory_usage_ratio{job=~"$job"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}}',
     ),
@@ -57,14 +57,14 @@ local clusterCountPanel = {
     },
     textMode: 'auto',
   },
-  pluginVersion: '10.2.0-59981',
+  pluginVersion: '10.2.0-60139',
 };
 
 local brokerCountPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'count by (instance, activemq_cluster) (activemq_memory_usage_ratio{job=~"$job", activemq_cluster=~"$activemq_cluster"})',
+      'count by (instance, activemq_cluster, job) (activemq_memory_usage_ratio{job=~"$job", activemq_cluster=~"$activemq_cluster"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}}',
     ),
@@ -105,14 +105,14 @@ local brokerCountPanel = {
     },
     textMode: 'auto',
   },
-  pluginVersion: '10.2.0-59981',
+  pluginVersion: '10.2.0-60139',
 };
 
 local producerCountPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by (activemq_cluster) (activemq_producer_total{job=~"$job", activemq_cluster="$activemq_cluster"})',
+      'sum by (activemq_cluster, job) (activemq_producer_total{job=~"$job", activemq_cluster="$activemq_cluster"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}}',
     ),
@@ -153,14 +153,14 @@ local producerCountPanel = {
     },
     textMode: 'auto',
   },
-  pluginVersion: '10.2.0-59981',
+  pluginVersion: '10.2.0-60139',
 };
 
 local consumerCountPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by (activemq_cluster) (activemq_consumer_total{job=~"$job", activemq_cluster=~"$activemq_cluster"})',
+      'sum by (activemq_cluster, job) (activemq_consumer_total{job=~"$job", activemq_cluster=~"$activemq_cluster"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}}',
     ),
@@ -201,14 +201,14 @@ local consumerCountPanel = {
     },
     textMode: 'auto',
   },
-  pluginVersion: '10.2.0-59981',
+  pluginVersion: '10.2.0-60139',
 };
 
 local enqueueCountPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by (activemq_cluster) (increase(activemq_enqueue_total{job=~"$job", activemq_cluster=~"$activemq_cluster"}[$__interval:]))',
+      'sum by (activemq_cluster, job) (increase(activemq_enqueue_total{job=~"$job", activemq_cluster=~"$activemq_cluster"}[$__interval:]))',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}}',
     ),
@@ -227,6 +227,7 @@ local enqueueCountPanel = {
         axisColorMode: 'text',
         axisLabel: '',
         axisPlacement: 'auto',
+        axisShow: false,
         barAlignment: 0,
         drawStyle: 'line',
         fillOpacity: 25,
@@ -285,7 +286,7 @@ local dequeueCountPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by (activemq_cluster) (increase(activemq_dequeue_total{job=~"$job", activemq_cluster=~"$activemq_cluster"}[$__interval:]))',
+      'sum by (activemq_cluster, job) (increase(activemq_dequeue_total{job=~"$job", activemq_cluster=~"$activemq_cluster"}[$__interval:]))',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}}',
     ),
@@ -303,6 +304,7 @@ local dequeueCountPanel = {
         axisColorMode: 'text',
         axisLabel: '',
         axisPlacement: 'auto',
+        axisShow: false,
         barAlignment: 0,
         drawStyle: 'line',
         fillOpacity: 25,
@@ -361,7 +363,7 @@ local averageTemporaryMemoryUsagePanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'avg by (activemq_cluster) (activemq_temp_usage_ratio{job=~"$job", activemq_cluster=~"$activemq_cluster"})',
+      'avg by (activemq_cluster, job) (activemq_temp_usage_ratio{job=~"$job", activemq_cluster=~"$activemq_cluster"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}}',
     ),
@@ -412,14 +414,14 @@ local averageTemporaryMemoryUsagePanel = {
     text: {},
     valueMode: 'color',
   },
-  pluginVersion: '10.2.0-59981',
+  pluginVersion: '10.2.0-60139',
 };
 
 local averageStoreMemoryUsagePanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'avg by (activemq_cluster) (activemq_store_usage_ratio{job=~"$job", activemq_cluster=~"$activemq_cluster"})',
+      'avg by (activemq_cluster, job) (activemq_store_usage_ratio{job=~"$job", activemq_cluster=~"$activemq_cluster"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}}',
     ),
@@ -469,14 +471,14 @@ local averageStoreMemoryUsagePanel = {
     showUnfilled: false,
     valueMode: 'color',
   },
-  pluginVersion: '10.2.0-59981',
+  pluginVersion: '10.2.0-60139',
 };
 
 local averageBrokerMemoryUsagePanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'avg by (activemq_cluster) (activemq_memory_usage_ratio{job=~"$job", activemq_cluster=~"$activemq_cluster"})',
+      'avg by (activemq_cluster, job) (activemq_memory_usage_ratio{job=~"$job", activemq_cluster=~"$activemq_cluster"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}}',
     ),
@@ -526,7 +528,7 @@ local averageBrokerMemoryUsagePanel = {
     showUnfilled: false,
     valueMode: 'color',
   },
-  pluginVersion: '10.2.0-59981',
+  pluginVersion: '10.2.0-60139',
 };
 
 {
@@ -563,9 +565,20 @@ local averageBrokerMemoryUsagePanel = {
             sort=0
           ),
           template.new(
+            'cluster',
+            promDatasource,
+            'label_values(activemq_memory_usage_ratio{job=~"$job", cluster=~"$cluster"},cluster)',
+            label='Cluster',
+            refresh=2,
+            includeAll=true,
+            multi=true,
+            allValues='',
+            sort=0
+          ),
+          template.new(
             'activemq_cluster',
             promDatasource,
-            'label_values(activemq_memory_usage_ratio{job=~"$job"},activemq_cluster)',
+            'label_values(activemq_memory_usage_ratio{cluster=~"$cluster"},activemq_cluster)',
             label='ActiveMQ cluster',
             refresh=2,
             includeAll=true,
@@ -575,6 +588,13 @@ local averageBrokerMemoryUsagePanel = {
           ),
         ]
       )
+      .addLink(grafana.link.dashboards(
+        asDropdown=false,
+        title='Other Apache ActiveMQ dashboards',
+        includeVars=true,
+        keepTime=true,
+        tags=($._config.dashboardTags),
+      ))
       .addPanels(
         [
           clusterCountPanel { gridPos: { h: 6, w: 6, x: 0, y: 0 } },

--- a/apache-activemq-mixin/dashboards/apache-activemq-cluster-overview.libsonnet
+++ b/apache-activemq-mixin/dashboards/apache-activemq-cluster-overview.libsonnet
@@ -1,0 +1,579 @@
+local g = (import 'grafana-builder/grafana.libsonnet');
+local grafana = (import 'grafonnet/grafana.libsonnet');
+local dashboard = grafana.dashboard;
+local template = grafana.template;
+local prometheus = grafana.prometheus;
+
+local dashboardUid = 'apache-activemq-cluster-overview';
+
+local promDatasourceName = 'prometheus_datasource';
+
+local promDatasource = {
+  uid: '${%s}' % promDatasourceName,
+};
+
+local clusterCountPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'count by (activemq_cluster) (activemq_memory_usage_ratio{job=~"$job"})',
+      datasource=promDatasource,
+      legendFormat='{{activemq_cluster}}',
+    ),
+  ],
+  type: 'stat',
+  title: 'Cluster count',
+  description: 'Number of clusters that are reporting metrics from ActiveMQ.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    colorMode: 'value',
+    graphMode: 'none',
+    justifyMode: 'auto',
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    textMode: 'auto',
+  },
+  pluginVersion: '10.2.0-59585pre',
+};
+
+local brokerCountPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'count by (instance, activemq_cluster) (activemq_memory_usage_ratio{job=~"$job", activemq_cluster=~"$activemq_cluster"})',
+      datasource=promDatasource,
+      legendFormat='{{activemq_cluster}}',
+    ),
+  ],
+  type: 'stat',
+  title: 'Broker count',
+  description: 'Number of broker instances across clusters.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    colorMode: 'value',
+    graphMode: 'none',
+    justifyMode: 'auto',
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    textMode: 'auto',
+  },
+  pluginVersion: '10.2.0-59585pre',
+};
+
+local producerCountPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by (activemq_cluster) (activemq_producer_total{job=~"$job", activemq_cluster="$activemq_cluster"})',
+      datasource=promDatasource,
+      legendFormat='{{activemq_cluster}}',
+    ),
+  ],
+  type: 'stat',
+  title: 'Producer count',
+  description: 'Number of message producers active on destinations across clusters.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    colorMode: 'value',
+    graphMode: 'none',
+    justifyMode: 'auto',
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    textMode: 'auto',
+  },
+  pluginVersion: '10.2.0-59585pre',
+};
+
+local consumerCountPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by (activemq_cluster) (activemq_consumer_total{job=~"$job", activemq_cluster=~"$activemq_cluster"})',
+      datasource=promDatasource,
+      legendFormat='{{activemq_cluster}}',
+    ),
+  ],
+  type: 'stat',
+  title: 'Consumer count',
+  description: 'The number of consumers subscribed to destinations across clusters.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    colorMode: 'value',
+    graphMode: 'none',
+    justifyMode: 'auto',
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    textMode: 'auto',
+  },
+  pluginVersion: '10.2.0-59585pre',
+};
+
+local enqueueCountPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by (activemq_cluster) (activemq_enqueue_total{job=~"$job", activemq_cluster=~"$activemq_cluster"})',
+      datasource=promDatasource,
+      legendFormat='{{activemq_cluster}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Enqueue count',
+  description: 'Number of messages that have been sent to destinations in a cluster',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 25,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local dequeueCountPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by (activemq_cluster) (activemq_dequeue_total{job=~"$job", activemq_cluster=~"$activemq_cluster"})',
+      datasource=promDatasource,
+      legendFormat='{{activemq_cluster}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Dequeue count',
+  description: 'Number of messages that have been acknowledged (and removed) from destinations in a cluster.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 25,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local averageTemporaryMemoryUsagePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'avg by (activemq_cluster) (activemq_temp_usage_ratio{job=~"$job", activemq_cluster=~"$activemq_cluster"})',
+      datasource=promDatasource,
+      legendFormat='{{activemq_cluster}}',
+    ),
+  ],
+  type: 'bargauge',
+  title: 'Average temporary memory usage',
+  description: 'Average percentage of temporary memory used across clusters.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 70,
+          },
+        ],
+      },
+      unit: 'percent',
+    },
+    overrides: [],
+  },
+  options: {
+    displayMode: 'gradient',
+    minVizHeight: 10,
+    minVizWidth: 0,
+    orientation: 'horizontal',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    showUnfilled: false,
+    text: {},
+    valueMode: 'color',
+  },
+  pluginVersion: '10.2.0-59585pre',
+};
+
+local averageStoreMemoryUsagePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'avg by (activemq_cluster) (activemq_store_usage_ratio{job=~"$job", activemq_cluster=~"$activemq_cluster"})',
+      datasource=promDatasource,
+      legendFormat='{{activemq_cluster}}',
+    ),
+  ],
+  type: 'bargauge',
+  title: 'Average store memory usage',
+  description: 'Average percentage of store memory used across clusters.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 70,
+          },
+        ],
+      },
+      unit: 'percent',
+    },
+    overrides: [],
+  },
+  options: {
+    displayMode: 'gradient',
+    minVizHeight: 10,
+    minVizWidth: 0,
+    orientation: 'horizontal',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    showUnfilled: false,
+    valueMode: 'color',
+  },
+  pluginVersion: '10.2.0-59585pre',
+};
+
+local averageBrokerMemoryUsagePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'avg by (activemq_cluster) (activemq_memory_usage_ratio{job=~"$job", activemq_cluster=~"$activemq_cluster"})',
+      datasource=promDatasource,
+      legendFormat='{{activemq_cluster}}',
+    ),
+  ],
+  type: 'bargauge',
+  title: 'Average broker memory usage',
+  description: 'Average percentage of broker memory used across clusters.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 70,
+          },
+        ],
+      },
+      unit: 'percent',
+    },
+    overrides: [],
+  },
+  options: {
+    displayMode: 'gradient',
+    minVizHeight: 10,
+    minVizWidth: 0,
+    orientation: 'horizontal',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    showUnfilled: false,
+    valueMode: 'color',
+  },
+  pluginVersion: '10.2.0-59585pre',
+};
+
+{
+  grafanaDashboards+:: {
+    'apache-activemq-cluster-overview.json':
+      dashboard.new(
+        'Apache ActiveMQ cluster overview',
+        time_from='%s' % $._config.dashboardPeriod,
+        tags=($._config.dashboardTags),
+        timezone='%s' % $._config.dashboardTimezone,
+        refresh='%s' % $._config.dashboardRefresh,
+        description='',
+        uid=dashboardUid,
+      )
+
+      .addTemplates(
+        [
+          template.datasource(
+            promDatasourceName,
+            'prometheus',
+            null,
+            label='Data Source',
+            refresh='load'
+          ),
+          template.new(
+            'job',
+            promDatasource,
+            'label_values(activemq_topic_producer_count,job)',
+            label='Job',
+            refresh=2,
+            includeAll=true,
+            multi=true,
+            allValues='',
+            sort=0
+          ),
+          template.new(
+            'activemq_cluster',
+            promDatasource,
+            'label_values(activemq_memory_usage_ratio{job=~"$job"},activemq_cluster)',
+            label='ActiveMQ cluster',
+            refresh=2,
+            includeAll=true,
+            multi=true,
+            allValues='',
+            sort=0
+          ),
+        ]
+      )
+      .addPanels(
+        [
+          clusterCountPanel { gridPos: { h: 6, w: 6, x: 0, y: 0 } },
+          brokerCountPanel { gridPos: { h: 6, w: 6, x: 6, y: 0 } },
+          producerCountPanel { gridPos: { h: 6, w: 6, x: 12, y: 0 } },
+          consumerCountPanel { gridPos: { h: 6, w: 6, x: 18, y: 0 } },
+          enqueueCountPanel { gridPos: { h: 8, w: 12, x: 0, y: 6 } },
+          dequeueCountPanel { gridPos: { h: 8, w: 12, x: 12, y: 6 } },
+          averageTemporaryMemoryUsagePanel { gridPos: { h: 10, w: 8, x: 0, y: 14 } },
+          averageStoreMemoryUsagePanel { gridPos: { h: 10, w: 8, x: 8, y: 14 } },
+          averageBrokerMemoryUsagePanel { gridPos: { h: 10, w: 8, x: 16, y: 14 } },
+        ]
+      ),
+  },
+}

--- a/apache-activemq-mixin/dashboards/apache-activemq-cluster-overview.libsonnet
+++ b/apache-activemq-mixin/dashboards/apache-activemq-cluster-overview.libsonnet
@@ -22,12 +22,12 @@ local clusterCountPanel(matcher) = {
     ),
   ],
   type: 'stat',
-  title: 'Cluster count',
+  title: 'Clusters',
   description: 'Number of clusters that are reporting metrics from ActiveMQ.',
   fieldConfig: {
     defaults: {
       color: {
-        mode: 'thresholds',
+        mode: 'fixed',
       },
       mappings: [],
       thresholds: {
@@ -45,7 +45,7 @@ local clusterCountPanel(matcher) = {
   },
   options: {
     colorMode: 'none',
-    graphMode: 'none',
+    graphMode: 'area',
     justifyMode: 'auto',
     orientation: 'auto',
     reduceOptions: {
@@ -70,12 +70,12 @@ local brokerCountPanel(matcher) = {
     ),
   ],
   type: 'stat',
-  title: 'Broker count',
+  title: 'Broker',
   description: 'Number of broker instances across clusters.',
   fieldConfig: {
     defaults: {
       color: {
-        mode: 'thresholds',
+        mode: 'fixed',
       },
       mappings: [],
       thresholds: {
@@ -93,7 +93,7 @@ local brokerCountPanel(matcher) = {
   },
   options: {
     colorMode: 'none',
-    graphMode: 'none',
+    graphMode: 'area',
     justifyMode: 'auto',
     orientation: 'auto',
     reduceOptions: {
@@ -118,12 +118,12 @@ local producerCountPanel(matcher) = {
     ),
   ],
   type: 'stat',
-  title: 'Producer count',
+  title: 'Producers',
   description: 'Number of message producers active on destinations across clusters.',
   fieldConfig: {
     defaults: {
       color: {
-        mode: 'thresholds',
+        mode: 'fixed',
       },
       mappings: [],
       thresholds: {
@@ -141,7 +141,7 @@ local producerCountPanel(matcher) = {
   },
   options: {
     colorMode: 'none',
-    graphMode: 'none',
+    graphMode: 'area',
     justifyMode: 'auto',
     orientation: 'auto',
     reduceOptions: {
@@ -166,12 +166,12 @@ local consumerCountPanel(matcher) = {
     ),
   ],
   type: 'stat',
-  title: 'Consumer count',
+  title: 'Consumers',
   description: 'The number of consumers subscribed to destinations across clusters.',
   fieldConfig: {
     defaults: {
       color: {
-        mode: 'thresholds',
+        mode: 'fixed',
       },
       mappings: [],
       thresholds: {
@@ -189,7 +189,7 @@ local consumerCountPanel(matcher) = {
   },
   options: {
     colorMode: 'none',
-    graphMode: 'none',
+    graphMode: 'area',
     justifyMode: 'auto',
     orientation: 'auto',
     reduceOptions: {
@@ -214,7 +214,7 @@ local enqueueCountPanel(matcher) = {
     ),
   ],
   type: 'timeseries',
-  title: 'Enqueue count / $__interval',
+  title: 'Enqueue / $__interval',
   description: 'Number of messages that have been sent to destinations in a cluster',
   fieldConfig: {
     defaults: {
@@ -292,7 +292,7 @@ local dequeueCountPanel(matcher) = {
     ),
   ],
   type: 'timeseries',
-  title: 'Dequeue count / $__interval',
+  title: 'Dequeue / $__interval',
   description: 'Number of messages that have been acknowledged (and removed) from destinations in a cluster.',
   fieldConfig: {
     defaults: {
@@ -394,7 +394,7 @@ local averageTemporaryMemoryUsagePanel(matcher) = {
           },
         ],
       },
-      unit: 'percent',
+      unit: 'percentunit',
     },
     overrides: [],
   },
@@ -452,7 +452,7 @@ local averageStoreMemoryUsagePanel(matcher) = {
           },
         ],
       },
-      unit: 'percent',
+      unit: 'percentunit',
     },
     overrides: [],
   },
@@ -509,7 +509,7 @@ local averageBrokerMemoryUsagePanel(matcher) = {
           },
         ],
       },
-      unit: 'percent',
+      unit: 'percentunit',
     },
     overrides: [],
   },
@@ -600,10 +600,10 @@ local getMatcher(cfg) = '%(activemqSelector)s, activemq_cluster=~"$activemq_clus
       ))
       .addPanels(
         [
-          clusterCountPanel(getMatcher($._config)) { gridPos: { h: 6, w: 6, x: 0, y: 0 } },
-          brokerCountPanel(getMatcher($._config)) { gridPos: { h: 6, w: 6, x: 6, y: 0 } },
-          producerCountPanel(getMatcher($._config)) { gridPos: { h: 6, w: 6, x: 12, y: 0 } },
-          consumerCountPanel(getMatcher($._config)) { gridPos: { h: 6, w: 6, x: 18, y: 0 } },
+          clusterCountPanel(getMatcher($._config)) { gridPos: { h: 4, w: 6, x: 0, y: 0 } },
+          brokerCountPanel(getMatcher($._config)) { gridPos: { h: 4, w: 6, x: 6, y: 0 } },
+          producerCountPanel(getMatcher($._config)) { gridPos: { h: 4, w: 6, x: 12, y: 0 } },
+          consumerCountPanel(getMatcher($._config)) { gridPos: { h: 4, w: 6, x: 18, y: 0 } },
           enqueueCountPanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 0, y: 6 } },
           dequeueCountPanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 12, y: 6 } },
           averageTemporaryMemoryUsagePanel(getMatcher($._config)) { gridPos: { h: 10, w: 8, x: 0, y: 14 } },

--- a/apache-activemq-mixin/dashboards/apache-activemq-cluster-overview.libsonnet
+++ b/apache-activemq-mixin/dashboards/apache-activemq-cluster-overview.libsonnet
@@ -16,7 +16,7 @@ local clusterCountPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'count by (activemq_cluster, job) (activemq_memory_usage_ratio{' + matcher + ')',
+      'count by (activemq_cluster, job) (activemq_memory_usage_ratio{' + matcher + '})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}}',
     ),
@@ -214,7 +214,7 @@ local enqueueCountPanel(matcher) = {
     ),
   ],
   type: 'timeseries',
-  title: 'Enqueue count',
+  title: 'Enqueue count / $__interval',
   description: 'Number of messages that have been sent to destinations in a cluster',
   fieldConfig: {
     defaults: {
@@ -292,7 +292,7 @@ local dequeueCountPanel(matcher) = {
     ),
   ],
   type: 'timeseries',
-  title: 'Dequeue count',
+  title: 'Dequeue count / $__interval',
   description: 'Number of messages that have been acknowledged (and removed) from destinations in a cluster.',
   fieldConfig: {
     defaults: {

--- a/apache-activemq-mixin/dashboards/apache-activemq-instance-overview.libsonnet
+++ b/apache-activemq-mixin/dashboards/apache-activemq-instance-overview.libsonnet
@@ -330,7 +330,7 @@ local queueSizePanel(matcher) = {
     prometheus.target(
       'sum by(instance, activemq_cluster, job) (activemq_queue_queue_size{' + matcher + ', instance=~"$instance"})',
       datasource=promDatasource,
-      legendFormat='{{activemq_cluster}} - {{instance}} - queue',
+      legendFormat='{{activemq_cluster}} - {{instance}}',
     ),
   ],
   type: 'timeseries',
@@ -665,7 +665,7 @@ local averageEnqueueTimePanel(matcher) = {
   ],
   type: 'timeseries',
   title: 'Average enqueue time',
-  description: 'Average time a message was held on all destinations.',
+  description: 'Average time a message was held across all destinations.',
   fieldConfig: {
     defaults: {
       color: {
@@ -832,7 +832,7 @@ local garbageCollectionDurationPanel(matcher) = {
   ],
   type: 'timeseries',
   title: 'Garbage collection duration',
-  description: 'The amount of time spent performing the most recent garbage collection.',
+  description: 'The average time spent performing recent garbage collections',
   fieldConfig: {
     defaults: {
       color: {

--- a/apache-activemq-mixin/dashboards/apache-activemq-instance-overview.libsonnet
+++ b/apache-activemq-mixin/dashboards/apache-activemq-instance-overview.libsonnet
@@ -1000,6 +1000,7 @@ local activemqAlertsPanel(matcher) = {
 };
 
 local getMatcher(cfg) = '%(activemqSelector)s, activemq_cluster=~"$activemq_cluster"' % cfg;
+local getAlertsMatcher(cfg) = '%(activemqAlertsSelector)s, activemq_cluster=~"${activemq_cluster:regex}"' % cfg;
 
 {
   grafanaDashboards+:: {
@@ -1083,7 +1084,7 @@ local getMatcher(cfg) = '%(activemqSelector)s, activemq_cluster=~"$activemq_clus
           averageStoreMemoryUsagePanel(getMatcher($._config)) { gridPos: { h: 4, w: 6, x: 6, y: 0 } },
           averageTemporaryMemoryUsagePanel(getMatcher($._config)) { gridPos: { h: 4, w: 6, x: 12, y: 0 } },
           unacknowledgedMessagesPanel(getMatcher($._config)) { gridPos: { h: 4, w: 6, x: 18, y: 0 } },
-          activemqAlertsPanel(getMatcher($._config)) { gridPos: { h: 6, w: 12, x: 0, y: 4 } },
+          activemqAlertsPanel(getAlertsMatcher($._config)) { gridPos: { h: 6, w: 12, x: 0, y: 4 } },
           producerCountPanel(getMatcher($._config)) { gridPos: { h: 6, w: 6, x: 12, y: 4 } },
           consumerCountPanel(getMatcher($._config)) { gridPos: { h: 6, w: 6, x: 18, y: 4 } },
           queueSizePanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 0, y: 10 } },

--- a/apache-activemq-mixin/dashboards/apache-activemq-instance-overview.libsonnet
+++ b/apache-activemq-mixin/dashboards/apache-activemq-instance-overview.libsonnet
@@ -184,7 +184,7 @@ local producerCountPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(instance, activemq_cluster, job) (activemq_producer_total{' + matcher + ', instance=~"$instance"})',
+      'sum by(instance, activemq_cluster, job) (activemq_queue_producer_count{' + matcher + ', instance=~"$instance"}) + sum by(instance, activemq_cluster, job) (activemq_topic_producer_count{' + matcher + ', instance=~"$instance", destination!~"ActiveMQ.Advisory.*"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}}',
     ),
@@ -232,7 +232,7 @@ local consumerCountPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(instance, activemq_cluster, job) (activemq_consumer_total{' + matcher + ', instance=~"$instance"})',
+      'sum by(instance, activemq_cluster, job) (activemq_queue_consumer_count{' + matcher + ', instance=~"$instance"}) + sum by(instance, activemq_cluster, job) (activemq_topic_consumer_count{' + matcher + ', instance=~"$instance", destination!~"ActiveMQ.Advisory.*"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}}',
     ),
@@ -410,7 +410,7 @@ local destinationMemoryUsagePanel(matcher) = {
       legendFormat='{{activemq_cluster}} - {{instance}} - queue',
     ),
     prometheus.target(
-      'sum by(instance, activemq_cluster, job) (activemq_topic_memory_percent_usage{' + matcher + ', instance=~"$instance"})',
+      'sum by(instance, activemq_cluster, job) (activemq_topic_memory_percent_usage{' + matcher + ', instance=~"$instance", destination!~"ActiveMQ.Advisory.*"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - topic',
     ),
@@ -494,7 +494,7 @@ local enqueueCountPanel(matcher) = {
       legendFormat='{{activemq_cluster}} - {{instance}} - queue',
     ),
     prometheus.target(
-      'sum by(instance, activemq_cluster, job) (increase(activemq_topic_enqueue_count{' + matcher + ', instance=~"$instance"}[$__interval:]))',
+      'sum by(instance, activemq_cluster, job) (increase(activemq_topic_enqueue_count{' + matcher + ', instance=~"$instance", destination!~"ActiveMQ.Advisory.*"}[$__interval:]))',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - topic',
     ),
@@ -576,7 +576,7 @@ local dequeueCountPanel(matcher) = {
       legendFormat='{{activemq_cluster}} - {{instance}} - queue',
     ),
     prometheus.target(
-      'sum by(instance, activemq_cluster) (increase(activemq_topic_dequeue_count{' + matcher + ', instance=~"$instance"}[$__interval:]))',
+      'sum by(instance, activemq_cluster) (increase(activemq_topic_dequeue_count{' + matcher + ', instance=~"$instance", destination!~"ActiveMQ.Advisory.*"}[$__interval:]))',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - topic',
     ),
@@ -658,7 +658,7 @@ local averageEnqueueTimePanel(matcher) = {
       legendFormat='{{activemq_cluster}} - {{instance}} - queue',
     ),
     prometheus.target(
-      'avg by (activemq_cluster, instance, job) (activemq_topic_average_enqueue_time{' + matcher + ', instance=~"$instance"})',
+      'avg by (activemq_cluster, instance, job) (activemq_topic_average_enqueue_time{' + matcher + ', instance=~"$instance", destination!~"ActiveMQ.Advisory.*"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - topic',
     ),
@@ -740,7 +740,7 @@ local expiredMessagesPanel(matcher) = {
       legendFormat='{{activemq_cluster}} - {{instance}} - queue',
     ),
     prometheus.target(
-      'sum by(instance, activemq_cluster, job) (increase(activemq_topic_expired_count{' + matcher + ', instance=~"$instance"}[$__interval:]))',
+      'sum by(instance, activemq_cluster, job) (increase(activemq_topic_expired_count{' + matcher + ', instance=~"$instance", destination!~"ActiveMQ.Advisory.*"}[$__interval:]))',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - topic',
     ),
@@ -982,7 +982,7 @@ local activemqAlertsPanel(matcher) = {
   options: {
     alertName: '',
     dashboardAlerts: false,
-    alertInstanceLabelFilter: '{' + matcher + ', instance=~"${instance:regex}"}',
+    alertInstanceLabelFilter: '{' + matcher + ', instance=~"${instance:regex}", destination!~"ActiveMQ.Advisory.*"}',
     datasource: promDatasource,
     groupBy: [],
     groupMode: 'default',

--- a/apache-activemq-mixin/dashboards/apache-activemq-instance-overview.libsonnet
+++ b/apache-activemq-mixin/dashboards/apache-activemq-instance-overview.libsonnet
@@ -65,7 +65,7 @@ local averageBrokerMemoryUsagePanel = {
     showThresholdLabels: false,
     showThresholdMarkers: true,
   },
-  pluginVersion: '10.2.0-59981',
+  pluginVersion: '10.2.0-60139',
 };
 
 local averageStoreMemoryUsagePanel = {
@@ -121,7 +121,7 @@ local averageStoreMemoryUsagePanel = {
     showThresholdLabels: false,
     showThresholdMarkers: true,
   },
-  pluginVersion: '10.2.0-59981',
+  pluginVersion: '10.2.0-60139',
 };
 
 local averageTemporaryMemoryUsagePanel = {
@@ -177,7 +177,7 @@ local averageTemporaryMemoryUsagePanel = {
     showThresholdLabels: false,
     showThresholdMarkers: true,
   },
-  pluginVersion: '10.2.0-59981',
+  pluginVersion: '10.2.0-60139',
 };
 
 local producerCountPanel = {
@@ -225,7 +225,7 @@ local producerCountPanel = {
     },
     textMode: 'auto',
   },
-  pluginVersion: '10.2.0-59981',
+  pluginVersion: '10.2.0-60139',
 };
 
 local consumerCountPanel = {
@@ -273,7 +273,7 @@ local consumerCountPanel = {
     },
     textMode: 'auto',
   },
-  pluginVersion: '10.2.0-59981',
+  pluginVersion: '10.2.0-60139',
 };
 
 local averageUnacknowledgedMessagesPanel = {
@@ -321,14 +321,14 @@ local averageUnacknowledgedMessagesPanel = {
     },
     textMode: 'auto',
   },
-  pluginVersion: '10.2.0-59981',
+  pluginVersion: '10.2.0-60139',
 };
 
 local queueSizePanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(instance, activemq_cluster) (activemq_queue_queue_size{instance=~"$instance", activemq_cluster=~"$activemq_cluster", job=~"$job"})',
+      'sum by(instance, activemq_cluster, job) (activemq_queue_queue_size{instance=~"$instance", activemq_cluster=~"$activemq_cluster", job=~"$job"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - queue',
     ),
@@ -346,6 +346,7 @@ local queueSizePanel = {
         axisColorMode: 'text',
         axisLabel: '',
         axisPlacement: 'auto',
+        axisShow: false,
         barAlignment: 0,
         drawStyle: 'line',
         fillOpacity: 25,
@@ -404,12 +405,12 @@ local destinationMemoryUsagePanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(instance, activemq_cluster) (activemq_queue_memory_percent_usage{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"})',
+      'sum by(instance, activemq_cluster, job) (activemq_queue_memory_percent_usage{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - queue',
     ),
     prometheus.target(
-      'sum by(instance, activemq_cluster) (activemq_topic_memory_percent_usage{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"})',
+      'sum by(instance, activemq_cluster, job) (activemq_topic_memory_percent_usage{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - topic',
     ),
@@ -427,6 +428,7 @@ local destinationMemoryUsagePanel = {
         axisColorMode: 'text',
         axisLabel: '',
         axisPlacement: 'auto',
+        axisShow: false,
         barAlignment: 0,
         drawStyle: 'line',
         fillOpacity: 25,
@@ -487,12 +489,12 @@ local enqueueCountPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(instance, activemq_cluster) (increase(activemq_queue_enqueue_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"}[$__interval:]))',
+      'sum by(instance, activemq_cluster, job) (increase(activemq_queue_enqueue_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"}[$__interval:]))',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - queue',
     ),
     prometheus.target(
-      'sum by(instance, activemq_cluster) (increase(activemq_topic_enqueue_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"}[$__interval:]))',
+      'sum by(instance, activemq_cluster, job) (increase(activemq_topic_enqueue_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"}[$__interval:]))',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - topic',
     ),
@@ -510,6 +512,7 @@ local enqueueCountPanel = {
         axisColorMode: 'text',
         axisLabel: '',
         axisPlacement: 'auto',
+        axisShow: false,
         barAlignment: 0,
         drawStyle: 'line',
         fillOpacity: 25,
@@ -591,6 +594,7 @@ local dequeueCountPanel = {
         axisColorMode: 'text',
         axisLabel: '',
         axisPlacement: 'auto',
+        axisShow: false,
         barAlignment: 0,
         drawStyle: 'line',
         fillOpacity: 25,
@@ -649,12 +653,12 @@ local averageEnqueueTimePanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'avg by (activemq_cluster, instance) (activemq_queue_average_enqueue_time{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"})',
+      'avg by (activemq_cluster, instance, job) (activemq_queue_average_enqueue_time{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - queue',
     ),
     prometheus.target(
-      'avg by (activemq_cluster, instance) (activemq_topic_average_enqueue_time{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"})',
+      'avg by (activemq_cluster, instance, job) (activemq_topic_average_enqueue_time{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - topic',
     ),
@@ -672,6 +676,7 @@ local averageEnqueueTimePanel = {
         axisColorMode: 'text',
         axisLabel: '',
         axisPlacement: 'auto',
+        axisShow: false,
         barAlignment: 0,
         drawStyle: 'line',
         fillOpacity: 25,
@@ -730,12 +735,12 @@ local expiredMessagesPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(instance, activemq_cluster) (activemq_queue_expired_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"})',
+      'sum by(instance, activemq_cluster, job) (activemq_queue_expired_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - queue',
     ),
     prometheus.target(
-      'sum by(instance, activemq_cluster) (activemq_topic_expired_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"})',
+      'sum by(instance, activemq_cluster, job) (activemq_topic_expired_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - topic',
     ),
@@ -753,6 +758,7 @@ local expiredMessagesPanel = {
         axisColorMode: 'text',
         axisLabel: '',
         axisPlacement: 'auto',
+        axisShow: false,
         barAlignment: 0,
         drawStyle: 'line',
         fillOpacity: 25,
@@ -837,6 +843,7 @@ local garbageCollectionDurationPanel = {
         axisColorMode: 'text',
         axisLabel: '',
         axisPlacement: 'auto',
+        axisShow: false,
         barAlignment: 0,
         drawStyle: 'line',
         fillOpacity: 25,
@@ -869,7 +876,6 @@ local garbageCollectionDurationPanel = {
         steps: [
           {
             color: 'green',
-            value: null,
           },
         ],
       },
@@ -913,6 +919,7 @@ local garbageCollectionCountPanel = {
         axisColorMode: 'text',
         axisLabel: '',
         axisPlacement: 'auto',
+        axisShow: false,
         barAlignment: 0,
         drawStyle: 'line',
         fillOpacity: 25,
@@ -945,7 +952,6 @@ local garbageCollectionCountPanel = {
         steps: [
           {
             color: 'green',
-            value: null,
           },
         ],
       },
@@ -1038,9 +1044,20 @@ local activemqAlertsPanel = {
             sort=0
           ),
           template.new(
+            'cluster',
+            promDatasource,
+            'label_values(activemq_memory_usage_ratio{job=~"$job"},cluster)',
+            label='Cluster',
+            refresh=2,
+            includeAll=true,
+            multi=true,
+            allValues='',
+            sort=0
+          ),
+          template.new(
             'activemq_cluster',
             promDatasource,
-            'label_values(activemq_memory_usage_ratio{job=~"$job"},activemq_cluster)',
+            'label_values(activemq_memory_usage_ratio{job=~"$job", cluster=~"$cluster"},activemq_cluster)',
             label='ActiveMQ cluster',
             refresh=2,
             includeAll=true,
@@ -1061,6 +1078,13 @@ local activemqAlertsPanel = {
           ),
         ]
       )
+      .addLink(grafana.link.dashboards(
+        asDropdown=false,
+        title='Other Apache ActiveMQ dashboards',
+        includeVars=true,
+        keepTime=true,
+        tags=($._config.dashboardTags),
+      ))
       .addPanels(
         [
           averageBrokerMemoryUsagePanel { gridPos: { h: 4, w: 4, x: 0, y: 0 } },

--- a/apache-activemq-mixin/dashboards/apache-activemq-instance-overview.libsonnet
+++ b/apache-activemq-mixin/dashboards/apache-activemq-instance-overview.libsonnet
@@ -190,7 +190,7 @@ local producerCountPanel(matcher) = {
     ),
   ],
   type: 'stat',
-  title: 'Producer count',
+  title: 'Producers',
   description: 'The number of producers attached to destinations.',
   fieldConfig: {
     defaults: {
@@ -238,7 +238,7 @@ local consumerCountPanel(matcher) = {
     ),
   ],
   type: 'stat',
-  title: 'Consumer count',
+  title: 'Consumers',
   description: 'The number of consumers subscribed to destinations on the broker.',
   fieldConfig: {
     defaults: {
@@ -500,7 +500,7 @@ local enqueueCountPanel(matcher) = {
     ),
   ],
   type: 'timeseries',
-  title: 'Enqueue count / $__interval',
+  title: 'Enqueue / $__interval',
   description: 'Number of messages that have been sent to the destination.',
   fieldConfig: {
     defaults: {
@@ -582,7 +582,7 @@ local dequeueCountPanel(matcher) = {
     ),
   ],
   type: 'timeseries',
-  title: 'Dequeue count / $__interval',
+  title: 'Dequeue / $__interval',
   description: 'Number of messages that have been acknowledged (and removed) from the destinations.',
   fieldConfig: {
     defaults: {
@@ -713,7 +713,7 @@ local averageEnqueueTimePanel(matcher) = {
           },
         ],
       },
-      unit: 's',
+      unit: 'ms',
     },
     overrides: [],
   },

--- a/apache-activemq-mixin/dashboards/apache-activemq-instance-overview.libsonnet
+++ b/apache-activemq-mixin/dashboards/apache-activemq-instance-overview.libsonnet
@@ -195,7 +195,7 @@ local producerCountPanel(matcher) = {
   fieldConfig: {
     defaults: {
       color: {
-        mode: 'thresholds',
+        mode: 'fixed',
       },
       mappings: [],
       thresholds: {
@@ -213,7 +213,7 @@ local producerCountPanel(matcher) = {
   },
   options: {
     colorMode: 'none',
-    graphMode: 'none',
+    graphMode: 'area',
     justifyMode: 'auto',
     orientation: 'auto',
     reduceOptions: {
@@ -243,7 +243,7 @@ local consumerCountPanel(matcher) = {
   fieldConfig: {
     defaults: {
       color: {
-        mode: 'thresholds',
+        mode: 'fixed',
       },
       mappings: [],
       thresholds: {
@@ -261,7 +261,7 @@ local consumerCountPanel(matcher) = {
   },
   options: {
     colorMode: 'none',
-    graphMode: 'none',
+    graphMode: 'area',
     justifyMode: 'auto',
     orientation: 'auto',
     reduceOptions: {
@@ -291,7 +291,7 @@ local unacknowledgedMessagesPanel(matcher) = {
   fieldConfig: {
     defaults: {
       color: {
-        mode: 'thresholds',
+        mode: 'fixed',
       },
       mappings: [],
       thresholds: {
@@ -309,7 +309,7 @@ local unacknowledgedMessagesPanel(matcher) = {
   },
   options: {
     colorMode: 'none',
-    graphMode: 'none',
+    graphMode: 'area',
     justifyMode: 'auto',
     orientation: 'auto',
     reduceOptions: {
@@ -421,7 +421,7 @@ local destinationMemoryUsagePanel(matcher) = {
   fieldConfig: {
     defaults: {
       color: {
-        mode: 'continuous-BlYlRd',
+        mode: 'palette-classic',
       },
       custom: {
         axisCenteredZero: false,
@@ -973,28 +973,17 @@ local garbageCollectionCountPanel(matcher) = {
   },
 };
 
-local alertsRow = {
-  datasource: promDatasource,
-  targets: [],
-  type: 'row',
-  title: 'Alerts',
-  collapsed: false,
-};
-
-local activemqAlertsPanel = {
+local activemqAlertsPanel(matcher) = {
   datasource: promDatasource,
   targets: [],
   type: 'alertlist',
-  title: 'ActiveMQ Alerts',
-  description: 'Alerts for Apache ActiveMQ environment.',
+  title: 'ActiveMQ alerts',
+  description: 'Firing alerts for Apache ActiveMQ environment.',
   options: {
-    alertInstanceLabelFilter: '',
     alertName: '',
     dashboardAlerts: false,
-    folder: {
-      title: 'Integrations - ActiveMQ',
-      uid: 'ac912ae2-f603-4a05-878f-42033c5b96f3',
-    },
+    alertInstanceLabelFilter: '{' + matcher + ', instance=~"${instance:regex}"}',
+    datasource: promDatasource,
     groupBy: [],
     groupMode: 'default',
     maxItems: 5,
@@ -1090,23 +1079,22 @@ local getMatcher(cfg) = '%(activemqSelector)s, activemq_cluster=~"$activemq_clus
       ))
       .addPanels(
         [
-          averageBrokerMemoryUsagePanel(getMatcher($._config)) { gridPos: { h: 4, w: 4, x: 0, y: 0 } },
-          averageStoreMemoryUsagePanel(getMatcher($._config)) { gridPos: { h: 4, w: 4, x: 4, y: 0 } },
-          averageTemporaryMemoryUsagePanel(getMatcher($._config)) { gridPos: { h: 4, w: 4, x: 8, y: 0 } },
-          producerCountPanel(getMatcher($._config)) { gridPos: { h: 4, w: 4, x: 12, y: 0 } },
-          consumerCountPanel(getMatcher($._config)) { gridPos: { h: 4, w: 4, x: 16, y: 0 } },
-          unacknowledgedMessagesPanel(getMatcher($._config)) { gridPos: { h: 4, w: 4, x: 20, y: 0 } },
-          queueSizePanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 0, y: 4 } },
-          destinationMemoryUsagePanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 12, y: 4 } },
-          enqueueCountPanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 0, y: 12 } },
-          dequeueCountPanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 12, y: 12 } },
-          averageEnqueueTimePanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 0, y: 20 } },
-          expiredMessagesPanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 12, y: 20 } },
-          jvmResourcesRow { gridPos: { h: 1, w: 24, x: 0, y: 28 } },
-          garbageCollectionDurationPanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 0, y: 29 } },
-          garbageCollectionCountPanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 12, y: 29 } },
-          alertsRow { gridPos: { h: 1, w: 24, x: 0, y: 37 } },
-          activemqAlertsPanel { gridPos: { h: 8, w: 24, x: 0, y: 38 } },
+          averageBrokerMemoryUsagePanel(getMatcher($._config)) { gridPos: { h: 4, w: 6, x: 0, y: 0 } },
+          averageStoreMemoryUsagePanel(getMatcher($._config)) { gridPos: { h: 4, w: 6, x: 6, y: 0 } },
+          averageTemporaryMemoryUsagePanel(getMatcher($._config)) { gridPos: { h: 4, w: 6, x: 12, y: 0 } },
+          unacknowledgedMessagesPanel(getMatcher($._config)) { gridPos: { h: 4, w: 6, x: 18, y: 0 } },
+          activemqAlertsPanel(getMatcher($._config)) { gridPos: { h: 6, w: 12, x: 0, y: 4 } },
+          producerCountPanel(getMatcher($._config)) { gridPos: { h: 6, w: 6, x: 12, y: 4 } },
+          consumerCountPanel(getMatcher($._config)) { gridPos: { h: 6, w: 6, x: 18, y: 4 } },
+          queueSizePanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 0, y: 10 } },
+          destinationMemoryUsagePanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 12, y: 10 } },
+          enqueueCountPanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 0, y: 18 } },
+          dequeueCountPanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 12, y: 18 } },
+          averageEnqueueTimePanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 0, y: 26 } },
+          expiredMessagesPanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 12, y: 26 } },
+          jvmResourcesRow { gridPos: { h: 1, w: 24, x: 0, y: 34 } },
+          garbageCollectionDurationPanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 0, y: 35 } },
+          garbageCollectionCountPanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 12, y: 35 } },
         ]
       ),
   },

--- a/apache-activemq-mixin/dashboards/apache-activemq-instance-overview.libsonnet
+++ b/apache-activemq-mixin/dashboards/apache-activemq-instance-overview.libsonnet
@@ -1,0 +1,1025 @@
+local g = (import 'grafana-builder/grafana.libsonnet');
+local grafana = (import 'grafonnet/grafana.libsonnet');
+local dashboard = grafana.dashboard;
+local template = grafana.template;
+local prometheus = grafana.prometheus;
+
+local dashboardUid = 'apache-activemq-instance-overview';
+
+local promDatasourceName = 'prometheus_datasource';
+
+local promDatasource = {
+  uid: '${%s}' % promDatasourceName,
+};
+
+local averageBrokerMemoryUsagePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'avg by (instance, activemq_cluster) (activemq_memory_usage_ratio{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"})',
+      datasource=promDatasource,
+      legendFormat='{{activemq_cluster}} - {{instance}}',
+    ),
+  ],
+  type: 'gauge',
+  title: 'Average broker memory usage',
+  description: 'The percentage of memory used by both topics and queues across brokers.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 70,
+          },
+        ],
+      },
+      unit: 'percentunit',
+    },
+    overrides: [],
+  },
+  options: {
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    showThresholdLabels: false,
+    showThresholdMarkers: true,
+  },
+  pluginVersion: '10.2.0-59585pre',
+};
+
+local averageStoreMemoryUsagePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'avg by (instance, activemq_cluster) (activemq_store_usage_ratio{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"})',
+      datasource=promDatasource,
+      legendFormat='{{activemq_cluster}} - {{instance}}',
+    ),
+  ],
+  type: 'gauge',
+  title: 'Average store memory usage',
+  description: 'The percentage of store memory used by both topics and queues across brokers.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 70,
+          },
+        ],
+      },
+      unit: 'percentunit',
+    },
+    overrides: [],
+  },
+  options: {
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    showThresholdLabels: false,
+    showThresholdMarkers: true,
+  },
+  pluginVersion: '10.2.0-59585pre',
+};
+
+local averageTemporaryMemoryUsagePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'avg by (instance, activemq_cluster) (activemq_temp_usage_ratio{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"})',
+      datasource=promDatasource,
+      legendFormat='{{activemq_cluster}} - {{instance}}',
+    ),
+  ],
+  type: 'gauge',
+  title: 'Average temporary memory usage',
+  description: 'The percentage of temporary memory used by both topics and queues across brokers.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 70,
+          },
+        ],
+      },
+      unit: 'percentunit',
+    },
+    overrides: [],
+  },
+  options: {
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    showThresholdLabels: false,
+    showThresholdMarkers: true,
+  },
+  pluginVersion: '10.2.0-59585pre',
+};
+
+local producerCountPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by(instance) (activemq_producer_total{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"})',
+      datasource=promDatasource,
+      legendFormat='{{activemq_cluster}} - {{instance}}',
+    ),
+  ],
+  type: 'stat',
+  title: 'Producer count',
+  description: 'The number of producers attached to destinations.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    colorMode: 'value',
+    graphMode: 'none',
+    justifyMode: 'auto',
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    textMode: 'auto',
+  },
+  pluginVersion: '10.2.0-59585pre',
+};
+
+local consumerCountPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by(instance) (activemq_consumer_total{instance=~"$instance",activemq_cluster=~"$activemq_cluster", job=~"$job"})',
+      datasource=promDatasource,
+      legendFormat='{{activemq_cluster}} - {{instance}}',
+    ),
+  ],
+  type: 'stat',
+  title: 'Consumer count',
+  description: 'The number of consumers subscribed to destinations on the broker.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    colorMode: 'value',
+    graphMode: 'none',
+    justifyMode: 'auto',
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    textMode: 'auto',
+  },
+  pluginVersion: '10.2.0-59585pre',
+};
+
+local averageUnacknowledgedMessagesPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'avg by (instance) (activemq_message_total{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"})',
+      datasource=promDatasource,
+      legendFormat='{{activemq_cluster}} - {{instance}}',
+    ),
+  ],
+  type: 'stat',
+  title: 'Average unacknowledged messages',
+  description: 'Average number of unacknowledged messages on the broker.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    colorMode: 'value',
+    graphMode: 'none',
+    justifyMode: 'auto',
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    textMode: 'auto',
+  },
+  pluginVersion: '10.2.0-59585pre',
+};
+
+local queueSizePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by(instance, activemq_cluster) (activemq_queue_queue_size{instance=~"$instance", activemq_cluster=~"$activemq_cluster", job=~"$job"})',
+      datasource=promDatasource,
+      legendFormat='{{activemq_cluster}} - {{instance}} - queue',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Queue size',
+  description: 'Number of messages on queue destinations, including any that have been dispatched but not acknowledged.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 25,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local destinationMemoryUsagePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by(instance, activemq_cluster) (activemq_queue_memory_percent_usage{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"})',
+      datasource=promDatasource,
+      legendFormat='{{activemq_cluster}} - {{instance}} - queue',
+    ),
+    prometheus.target(
+      'sum by(instance, activemq_cluster) (activemq_topic_memory_percent_usage{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"})',
+      datasource=promDatasource,
+      legendFormat='{{activemq_cluster}} - {{instance}} - topic',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Destination memory usage',
+  description: 'The percentage of memory being used by topic and queue destinations.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 25,
+        gradientMode: 'opacity',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'percent',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local enqueueCountPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by(instance, activemq_cluster) (activemq_queue_enqueue_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"})',
+      datasource=promDatasource,
+      legendFormat='{{activemq_cluster}} - {{instance}} - queue',
+    ),
+    prometheus.target(
+      'sum by(instance, activemq_cluster) (activemq_topic_enqueue_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"})',
+      datasource=promDatasource,
+      legendFormat='{{activemq_cluster}} - {{instance}} - topic',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Enqueue count',
+  description: 'Number of messages that have been sent to the destination.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 25,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local dequeueCountPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by(instance, activemq_cluster) (activemq_queue_dequeue_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"})',
+      datasource=promDatasource,
+      legendFormat='{{activemq_cluster}} - {{instance}} - queue',
+    ),
+    prometheus.target(
+      'sum by(instance, activemq_cluster) (activemq_topic_dequeue_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"})',
+      datasource=promDatasource,
+      legendFormat='{{activemq_cluster}} - {{instance}} - topic',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Dequeue count',
+  description: 'Number of messages that have been acknowledged (and removed) from the destinations.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 25,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local averageEnqueueTimePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'avg by (activemq_cluster, instance) (activemq_queue_average_enqueue_time{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"})',
+      datasource=promDatasource,
+      legendFormat='{{activemq_cluster}} - {{instance}} - queue',
+    ),
+    prometheus.target(
+      'avg by (activemq_cluster, instance) (activemq_topic_average_enqueue_time{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"})',
+      datasource=promDatasource,
+      legendFormat='{{activemq_cluster}} - {{instance}} - topic',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Average enqueue time',
+  description: 'Average time a message was held on all destinations.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 25,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 's',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local expiredMessagesPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by(instance, activemq_cluster) (activemq_queue_expired_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"})',
+      datasource=promDatasource,
+      legendFormat='{{activemq_cluster}} - {{instance}} - queue',
+    ),
+    prometheus.target(
+      'sum by(instance, activemq_cluster) (activemq_topic_expired_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"})',
+      datasource=promDatasource,
+      legendFormat='{{activemq_cluster}} - {{instance}} - topic',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Expired messages',
+  description: 'Number of messages across destinations that are expired.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 25,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local jvmResourcesRow = {
+  datasource: promDatasource,
+  targets: [],
+  type: 'row',
+  title: 'JVM resources',
+  collapsed: false,
+};
+
+local garbageCollectionDurationPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by (instance, activemq_cluster) (increase(jvm_gc_collection_seconds_count{job=~"$job", instance=~"$instance", activemq_cluster=~"$activemq_cluster"}[$__interval:])) / clamp_min(sum by (instance, activemq_cluster ) (increase(java_lang_g1_young_generation_collectioncount{job=~"$job", instance=~"$instance", activemq_cluster=~"$activemq_cluster"}[$__interval:])), 1)',
+      datasource=promDatasource,
+      legendFormat='{{activemq_cluster}} - {{instance}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Garbage collection duration',
+  description: 'The amount of time spent performing the most recent garbage collection.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 25,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+        ],
+      },
+      unit: 's',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local garbageCollectionCountPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'increase(java_lang_g1_young_generation_collectioncount{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"}[$__interval:])',
+      datasource=promDatasource,
+      legendFormat='{{activemq_cluster}} - {{instance}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Garbage collection count',
+  description: 'The recent increase in the number of garbage collection events for the JVM.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 25,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+{
+  grafanaDashboards+:: {
+    'apache-activemq-instance-overview.json':
+      dashboard.new(
+        'Apache ActiveMQ instance overview',
+        time_from='%s' % $._config.dashboardPeriod,
+        tags=($._config.dashboardTags),
+        timezone='%s' % $._config.dashboardTimezone,
+        refresh='%s' % $._config.dashboardRefresh,
+        description='',
+        uid=dashboardUid,
+      )
+
+      .addTemplates(
+        [
+          template.datasource(
+            promDatasourceName,
+            'prometheus',
+            null,
+            label='Data Source',
+            refresh='load'
+          ),
+          template.new(
+            'job',
+            promDatasource,
+            'label_values(activemq_topic_producer_count,job)',
+            label='Job',
+            refresh=2,
+            includeAll=true,
+            multi=true,
+            allValues='',
+            sort=0
+          ),
+          template.new(
+            'activemq_cluster',
+            promDatasource,
+            'label_values(activemq_memory_usage_ratio{job=~"$job"},activemq_cluster)',
+            label='ActiveMQ cluster',
+            refresh=2,
+            includeAll=false,
+            multi=false,
+            allValues='',
+            sort=0
+          ),
+          template.new(
+            'instance',
+            promDatasource,
+            'label_values(activemq_topic_producer_count{activemq_cluster=~"$activemq_cluster"},instance)',
+            label='Instance',
+            refresh=2,
+            includeAll=true,
+            multi=true,
+            allValues='',
+            sort=0
+          ),
+        ]
+      )
+      .addPanels(
+        [
+          averageBrokerMemoryUsagePanel { gridPos: { h: 4, w: 4, x: 0, y: 0 } },
+          averageStoreMemoryUsagePanel { gridPos: { h: 4, w: 4, x: 4, y: 0 } },
+          averageTemporaryMemoryUsagePanel { gridPos: { h: 4, w: 4, x: 8, y: 0 } },
+          producerCountPanel { gridPos: { h: 4, w: 4, x: 12, y: 0 } },
+          consumerCountPanel { gridPos: { h: 4, w: 4, x: 16, y: 0 } },
+          averageUnacknowledgedMessagesPanel { gridPos: { h: 4, w: 4, x: 20, y: 0 } },
+          queueSizePanel { gridPos: { h: 8, w: 12, x: 0, y: 4 } },
+          destinationMemoryUsagePanel { gridPos: { h: 8, w: 12, x: 12, y: 4 } },
+          enqueueCountPanel { gridPos: { h: 8, w: 12, x: 0, y: 12 } },
+          dequeueCountPanel { gridPos: { h: 8, w: 12, x: 12, y: 12 } },
+          averageEnqueueTimePanel { gridPos: { h: 8, w: 12, x: 0, y: 20 } },
+          expiredMessagesPanel { gridPos: { h: 8, w: 12, x: 12, y: 20 } },
+          jvmResourcesRow { gridPos: { h: 1, w: 24, x: 0, y: 28 } },
+          garbageCollectionDurationPanel { gridPos: { h: 8, w: 12, x: 0, y: 29 } },
+          garbageCollectionCountPanel { gridPos: { h: 8, w: 12, x: 12, y: 29 } },
+        ]
+      ),
+  },
+}

--- a/apache-activemq-mixin/dashboards/apache-activemq-instance-overview.libsonnet
+++ b/apache-activemq-mixin/dashboards/apache-activemq-instance-overview.libsonnet
@@ -276,18 +276,18 @@ local consumerCountPanel(matcher) = {
   pluginVersion: '10.2.0-60139',
 };
 
-local averageUnacknowledgedMessagesPanel(matcher) = {
+local unacknowledgedMessagesPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'avg by (instance, activemq_cluster, job) (activemq_message_total{' + matcher + ', instance=~"$instance"})',
+      'sum by (instance, activemq_cluster, job) (increase(activemq_message_total{' + matcher + ', instance=~"$instance"}[$__interval:]))',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}}',
     ),
   ],
   type: 'stat',
-  title: 'Average unacknowledged messages',
-  description: 'Average number of unacknowledged messages on the broker.',
+  title: 'Unacknowledged messages / $__interval',
+  description: 'Recent number of unacknowledged messages on the broker.',
   fieldConfig: {
     defaults: {
       color: {
@@ -500,7 +500,7 @@ local enqueueCountPanel(matcher) = {
     ),
   ],
   type: 'timeseries',
-  title: 'Enqueue count',
+  title: 'Enqueue count / $__interval',
   description: 'Number of messages that have been sent to the destination.',
   fieldConfig: {
     defaults: {
@@ -571,12 +571,12 @@ local dequeueCountPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(instance, activemq_cluster) (activemq_queue_dequeue_count{' + matcher + ', instance=~"$instance"})',
+      'sum by(instance, activemq_cluster) (increase(activemq_queue_dequeue_count{' + matcher + ', instance=~"$instance"}[$__interval:]))',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - queue',
     ),
     prometheus.target(
-      'sum by(instance, activemq_cluster) (activemq_topic_dequeue_count{' + matcher + ', instance=~"$instance"})',
+      'sum by(instance, activemq_cluster) (increase(activemq_topic_dequeue_count{' + matcher + ', instance=~"$instance"}[$__interval:]))',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - topic',
     ),
@@ -735,18 +735,18 @@ local expiredMessagesPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(instance, activemq_cluster, job) (activemq_queue_expired_count{' + matcher + ', instance=~"$instance"})',
+      'sum by(instance, activemq_cluster, job) (increase(activemq_queue_expired_count{' + matcher + ', instance=~"$instance"}[$__interval:]))',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - queue',
     ),
     prometheus.target(
-      'sum by(instance, activemq_cluster, job) (activemq_topic_expired_count{' + matcher + ', instance=~"$instance"})',
+      'sum by(instance, activemq_cluster, job) (increase(activemq_topic_expired_count{' + matcher + ', instance=~"$instance"}[$__interval:]))',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - topic',
     ),
   ],
   type: 'timeseries',
-  title: 'Expired messages',
+  title: 'Expired messages / $__interval',
   description: 'Number of messages across destinations that are expired.',
   fieldConfig: {
     defaults: {
@@ -831,7 +831,7 @@ local garbageCollectionDurationPanel(matcher) = {
     ),
   ],
   type: 'timeseries',
-  title: 'Garbage collection duration',
+  title: 'Garbage collection duration / $__interval',
   description: 'The average time spent performing recent garbage collections',
   fieldConfig: {
     defaults: {
@@ -907,7 +907,7 @@ local garbageCollectionCountPanel(matcher) = {
     ),
   ],
   type: 'timeseries',
-  title: 'Garbage collection count',
+  title: 'Garbage collection count / $__interval',
   description: 'The recent increase in the number of garbage collection events for the JVM.',
   fieldConfig: {
     defaults: {
@@ -1060,7 +1060,7 @@ local getMatcher(cfg) = '%(activemqSelector)s, activemq_cluster=~"$activemq_clus
           template.new(
             'activemq_cluster',
             promDatasource,
-            'label_values(activemq_memory_usage_ratio{%(activemqSelector)s},activemq_cluster)',
+            'label_values(activemq_memory_usage_ratio{%(activemqSelector)s},activemq_cluster)' % $._config,
             label='ActiveMQ cluster',
             refresh=2,
             includeAll=true,
@@ -1071,7 +1071,7 @@ local getMatcher(cfg) = '%(activemqSelector)s, activemq_cluster=~"$activemq_clus
           template.new(
             'instance',
             promDatasource,
-            'label_values(activemq_topic_producer_count{%(activemqSelector)s, activemq_cluster=~"$activemq_cluster"},instance)',
+            'label_values(activemq_topic_producer_count{%(activemqSelector)s, activemq_cluster=~"$activemq_cluster"},instance)' % $._config,
             label='Instance',
             refresh=2,
             includeAll=true,
@@ -1095,7 +1095,7 @@ local getMatcher(cfg) = '%(activemqSelector)s, activemq_cluster=~"$activemq_clus
           averageTemporaryMemoryUsagePanel(getMatcher($._config)) { gridPos: { h: 4, w: 4, x: 8, y: 0 } },
           producerCountPanel(getMatcher($._config)) { gridPos: { h: 4, w: 4, x: 12, y: 0 } },
           consumerCountPanel(getMatcher($._config)) { gridPos: { h: 4, w: 4, x: 16, y: 0 } },
-          averageUnacknowledgedMessagesPanel(getMatcher($._config)) { gridPos: { h: 4, w: 4, x: 20, y: 0 } },
+          unacknowledgedMessagesPanel(getMatcher($._config)) { gridPos: { h: 4, w: 4, x: 20, y: 0 } },
           queueSizePanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 0, y: 4 } },
           destinationMemoryUsagePanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 12, y: 4 } },
           enqueueCountPanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 0, y: 12 } },

--- a/apache-activemq-mixin/dashboards/apache-activemq-instance-overview.libsonnet
+++ b/apache-activemq-mixin/dashboards/apache-activemq-instance-overview.libsonnet
@@ -582,7 +582,7 @@ local dequeueCountPanel(matcher) = {
     ),
   ],
   type: 'timeseries',
-  title: 'Dequeue count',
+  title: 'Dequeue count / $__interval',
   description: 'Number of messages that have been acknowledged (and removed) from the destinations.',
   fieldConfig: {
     defaults: {

--- a/apache-activemq-mixin/dashboards/apache-activemq-instance-overview.libsonnet
+++ b/apache-activemq-mixin/dashboards/apache-activemq-instance-overview.libsonnet
@@ -12,11 +12,11 @@ local promDatasource = {
   uid: '${%s}' % promDatasourceName,
 };
 
-local averageBrokerMemoryUsagePanel = {
+local averageBrokerMemoryUsagePanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'avg by (instance, activemq_cluster) (activemq_memory_usage_ratio{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"})',
+      'avg by (instance, activemq_cluster) (activemq_memory_usage_ratio{' + matcher + ', instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}}',
     ),
@@ -68,11 +68,11 @@ local averageBrokerMemoryUsagePanel = {
   pluginVersion: '10.2.0-60139',
 };
 
-local averageStoreMemoryUsagePanel = {
+local averageStoreMemoryUsagePanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'avg by (instance, activemq_cluster) (activemq_store_usage_ratio{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"})',
+      'avg by (instance, activemq_cluster) (activemq_store_usage_ratio{' + matcher + ', instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}}',
     ),
@@ -124,11 +124,11 @@ local averageStoreMemoryUsagePanel = {
   pluginVersion: '10.2.0-60139',
 };
 
-local averageTemporaryMemoryUsagePanel = {
+local averageTemporaryMemoryUsagePanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'avg by (instance, activemq_cluster) (activemq_temp_usage_ratio{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"})',
+      'avg by (instance, activemq_cluster) (activemq_temp_usage_ratio{' + matcher + ', instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}}',
     ),
@@ -180,11 +180,11 @@ local averageTemporaryMemoryUsagePanel = {
   pluginVersion: '10.2.0-60139',
 };
 
-local producerCountPanel = {
+local producerCountPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(instance) (activemq_producer_total{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"})',
+      'sum by(instance) (activemq_producer_total{' + matcher + ', instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}}',
     ),
@@ -228,11 +228,11 @@ local producerCountPanel = {
   pluginVersion: '10.2.0-60139',
 };
 
-local consumerCountPanel = {
+local consumerCountPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(instance) (activemq_consumer_total{instance=~"$instance",activemq_cluster=~"$activemq_cluster", job=~"$job"})',
+      'sum by(instance) (activemq_consumer_total{' + matcher + ', instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}}',
     ),
@@ -276,11 +276,11 @@ local consumerCountPanel = {
   pluginVersion: '10.2.0-60139',
 };
 
-local averageUnacknowledgedMessagesPanel = {
+local averageUnacknowledgedMessagesPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'avg by (instance) (activemq_message_total{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"})',
+      'avg by (instance) (activemq_message_total{' + matcher + ', instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}}',
     ),
@@ -324,11 +324,11 @@ local averageUnacknowledgedMessagesPanel = {
   pluginVersion: '10.2.0-60139',
 };
 
-local queueSizePanel = {
+local queueSizePanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(instance, activemq_cluster, job) (activemq_queue_queue_size{instance=~"$instance", activemq_cluster=~"$activemq_cluster", job=~"$job"})',
+      'sum by(instance, activemq_cluster, job) (activemq_queue_queue_size{' + matcher + ', instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - queue',
     ),
@@ -401,16 +401,16 @@ local queueSizePanel = {
   },
 };
 
-local destinationMemoryUsagePanel = {
+local destinationMemoryUsagePanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(instance, activemq_cluster, job) (activemq_queue_memory_percent_usage{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"})',
+      'sum by(instance, activemq_cluster, job) (activemq_queue_memory_percent_usage{' + matcher + ', instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - queue',
     ),
     prometheus.target(
-      'sum by(instance, activemq_cluster, job) (activemq_topic_memory_percent_usage{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"})',
+      'sum by(instance, activemq_cluster, job) (activemq_topic_memory_percent_usage{' + matcher + ', instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - topic',
     ),
@@ -485,16 +485,16 @@ local destinationMemoryUsagePanel = {
   },
 };
 
-local enqueueCountPanel = {
+local enqueueCountPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(instance, activemq_cluster, job) (increase(activemq_queue_enqueue_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"}[$__interval:]))',
+      'sum by(instance, activemq_cluster, job) (increase(activemq_queue_enqueue_count{' + matcher + ', instance=~"$instance"}[$__interval:]))',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - queue',
     ),
     prometheus.target(
-      'sum by(instance, activemq_cluster, job) (increase(activemq_topic_enqueue_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"}[$__interval:]))',
+      'sum by(instance, activemq_cluster, job) (increase(activemq_topic_enqueue_count{' + matcher + ', instance=~"$instance"}[$__interval:]))',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - topic',
     ),
@@ -567,16 +567,16 @@ local enqueueCountPanel = {
   },
 };
 
-local dequeueCountPanel = {
+local dequeueCountPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(instance, activemq_cluster) (activemq_queue_dequeue_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"})',
+      'sum by(instance, activemq_cluster) (activemq_queue_dequeue_count{' + matcher + ', instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - queue',
     ),
     prometheus.target(
-      'sum by(instance, activemq_cluster) (activemq_topic_dequeue_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"})',
+      'sum by(instance, activemq_cluster) (activemq_topic_dequeue_count{' + matcher + ', instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - topic',
     ),
@@ -649,16 +649,16 @@ local dequeueCountPanel = {
   },
 };
 
-local averageEnqueueTimePanel = {
+local averageEnqueueTimePanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'avg by (activemq_cluster, instance, job) (activemq_queue_average_enqueue_time{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"})',
+      'avg by (activemq_cluster, instance, job) (activemq_queue_average_enqueue_time{' + matcher + ', instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - queue',
     ),
     prometheus.target(
-      'avg by (activemq_cluster, instance, job) (activemq_topic_average_enqueue_time{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"})',
+      'avg by (activemq_cluster, instance, job) (activemq_topic_average_enqueue_time{' + matcher + ', instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - topic',
     ),
@@ -731,16 +731,16 @@ local averageEnqueueTimePanel = {
   },
 };
 
-local expiredMessagesPanel = {
+local expiredMessagesPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(instance, activemq_cluster, job) (activemq_queue_expired_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"})',
+      'sum by(instance, activemq_cluster, job) (activemq_queue_expired_count{' + matcher + ', instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - queue',
     ),
     prometheus.target(
-      'sum by(instance, activemq_cluster, job) (activemq_topic_expired_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"})',
+      'sum by(instance, activemq_cluster, job) (activemq_topic_expired_count{' + matcher + ', instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - topic',
     ),
@@ -821,11 +821,11 @@ local jvmResourcesRow = {
   collapsed: false,
 };
 
-local garbageCollectionDurationPanel = {
+local garbageCollectionDurationPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by (instance, activemq_cluster) (increase(jvm_gc_collection_seconds_count{job=~"$job", instance=~"$instance", activemq_cluster=~"$activemq_cluster"}[$__interval:])) / clamp_min(sum by (instance, activemq_cluster ) (increase(java_lang_g1_young_generation_collectioncount{job=~"$job", instance=~"$instance", activemq_cluster=~"$activemq_cluster"}[$__interval:])), 1)',
+      'sum by (instance, activemq_cluster) (increase(jvm_gc_collection_seconds_count{' + matcher + ', instance=~"$instance"}[$__interval:])) / clamp_min(sum by (instance, activemq_cluster ) (increase(java_lang_g1_young_generation_collectioncount{' + matcher + ', instance=~"$instance"}[$__interval:])), 1)',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}}',
     ),
@@ -897,11 +897,11 @@ local garbageCollectionDurationPanel = {
   },
 };
 
-local garbageCollectionCountPanel = {
+local garbageCollectionCountPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'increase(java_lang_g1_young_generation_collectioncount{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"}[$__interval:])',
+      'increase(java_lang_g1_young_generation_collectioncount{' + matcher + ', instance=~"$instance"}[$__interval:])',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}}',
     ),
@@ -1010,6 +1010,8 @@ local activemqAlertsPanel = {
   },
 };
 
+local getMatcher(cfg) = '%(activemqSelector)s, activemq_cluster=~"$activemq_cluster"' % cfg;
+
 {
   grafanaDashboards+:: {
     'apache-activemq-instance-overview.json':
@@ -1052,12 +1054,13 @@ local activemqAlertsPanel = {
             includeAll=true,
             multi=true,
             allValues='',
+            hide=if $._config.enableMultiCluster then '' else 'variable',
             sort=0
           ),
           template.new(
             'activemq_cluster',
             promDatasource,
-            'label_values(activemq_memory_usage_ratio{job=~"$job", cluster=~"$cluster"},activemq_cluster)',
+            'label_values(activemq_memory_usage_ratio{%(activemqSelector)s},activemq_cluster)',
             label='ActiveMQ cluster',
             refresh=2,
             includeAll=true,
@@ -1068,7 +1071,7 @@ local activemqAlertsPanel = {
           template.new(
             'instance',
             promDatasource,
-            'label_values(activemq_topic_producer_count{activemq_cluster=~"$activemq_cluster"},instance)',
+            'label_values(activemq_topic_producer_count{%(activemqSelector)s, activemq_cluster=~"$activemq_cluster"},instance)',
             label='Instance',
             refresh=2,
             includeAll=true,
@@ -1087,21 +1090,21 @@ local activemqAlertsPanel = {
       ))
       .addPanels(
         [
-          averageBrokerMemoryUsagePanel { gridPos: { h: 4, w: 4, x: 0, y: 0 } },
-          averageStoreMemoryUsagePanel { gridPos: { h: 4, w: 4, x: 4, y: 0 } },
-          averageTemporaryMemoryUsagePanel { gridPos: { h: 4, w: 4, x: 8, y: 0 } },
-          producerCountPanel { gridPos: { h: 4, w: 4, x: 12, y: 0 } },
-          consumerCountPanel { gridPos: { h: 4, w: 4, x: 16, y: 0 } },
-          averageUnacknowledgedMessagesPanel { gridPos: { h: 4, w: 4, x: 20, y: 0 } },
-          queueSizePanel { gridPos: { h: 8, w: 12, x: 0, y: 4 } },
-          destinationMemoryUsagePanel { gridPos: { h: 8, w: 12, x: 12, y: 4 } },
-          enqueueCountPanel { gridPos: { h: 8, w: 12, x: 0, y: 12 } },
-          dequeueCountPanel { gridPos: { h: 8, w: 12, x: 12, y: 12 } },
-          averageEnqueueTimePanel { gridPos: { h: 8, w: 12, x: 0, y: 20 } },
-          expiredMessagesPanel { gridPos: { h: 8, w: 12, x: 12, y: 20 } },
+          averageBrokerMemoryUsagePanel(getMatcher($._config)) { gridPos: { h: 4, w: 4, x: 0, y: 0 } },
+          averageStoreMemoryUsagePanel(getMatcher($._config)) { gridPos: { h: 4, w: 4, x: 4, y: 0 } },
+          averageTemporaryMemoryUsagePanel(getMatcher($._config)) { gridPos: { h: 4, w: 4, x: 8, y: 0 } },
+          producerCountPanel(getMatcher($._config)) { gridPos: { h: 4, w: 4, x: 12, y: 0 } },
+          consumerCountPanel(getMatcher($._config)) { gridPos: { h: 4, w: 4, x: 16, y: 0 } },
+          averageUnacknowledgedMessagesPanel(getMatcher($._config)) { gridPos: { h: 4, w: 4, x: 20, y: 0 } },
+          queueSizePanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 0, y: 4 } },
+          destinationMemoryUsagePanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 12, y: 4 } },
+          enqueueCountPanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 0, y: 12 } },
+          dequeueCountPanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 12, y: 12 } },
+          averageEnqueueTimePanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 0, y: 20 } },
+          expiredMessagesPanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 12, y: 20 } },
           jvmResourcesRow { gridPos: { h: 1, w: 24, x: 0, y: 28 } },
-          garbageCollectionDurationPanel { gridPos: { h: 8, w: 12, x: 0, y: 29 } },
-          garbageCollectionCountPanel { gridPos: { h: 8, w: 12, x: 12, y: 29 } },
+          garbageCollectionDurationPanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 0, y: 29 } },
+          garbageCollectionCountPanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 12, y: 29 } },
           alertsRow { gridPos: { h: 1, w: 24, x: 0, y: 37 } },
           activemqAlertsPanel { gridPos: { h: 8, w: 24, x: 0, y: 38 } },
         ]

--- a/apache-activemq-mixin/dashboards/apache-activemq-instance-overview.libsonnet
+++ b/apache-activemq-mixin/dashboards/apache-activemq-instance-overview.libsonnet
@@ -38,6 +38,10 @@ local averageBrokerMemoryUsagePanel = {
             value: null,
           },
           {
+            color: '#EAB839',
+            value: 50,
+          },
+          {
             color: 'red',
             value: 70,
           },
@@ -48,6 +52,8 @@ local averageBrokerMemoryUsagePanel = {
     overrides: [],
   },
   options: {
+    minVizHeight: 75,
+    minVizWidth: 75,
     orientation: 'auto',
     reduceOptions: {
       calcs: [
@@ -59,7 +65,7 @@ local averageBrokerMemoryUsagePanel = {
     showThresholdLabels: false,
     showThresholdMarkers: true,
   },
-  pluginVersion: '10.2.0-59585pre',
+  pluginVersion: '10.2.0-59981',
 };
 
 local averageStoreMemoryUsagePanel = {
@@ -88,6 +94,10 @@ local averageStoreMemoryUsagePanel = {
             value: null,
           },
           {
+            color: '#EAB839',
+            value: 50,
+          },
+          {
             color: 'red',
             value: 70,
           },
@@ -98,6 +108,8 @@ local averageStoreMemoryUsagePanel = {
     overrides: [],
   },
   options: {
+    minVizHeight: 75,
+    minVizWidth: 75,
     orientation: 'auto',
     reduceOptions: {
       calcs: [
@@ -109,7 +121,7 @@ local averageStoreMemoryUsagePanel = {
     showThresholdLabels: false,
     showThresholdMarkers: true,
   },
-  pluginVersion: '10.2.0-59585pre',
+  pluginVersion: '10.2.0-59981',
 };
 
 local averageTemporaryMemoryUsagePanel = {
@@ -138,6 +150,10 @@ local averageTemporaryMemoryUsagePanel = {
             value: null,
           },
           {
+            color: '#EAB839',
+            value: 50,
+          },
+          {
             color: 'red',
             value: 70,
           },
@@ -148,6 +164,8 @@ local averageTemporaryMemoryUsagePanel = {
     overrides: [],
   },
   options: {
+    minVizHeight: 75,
+    minVizWidth: 75,
     orientation: 'auto',
     reduceOptions: {
       calcs: [
@@ -159,7 +177,7 @@ local averageTemporaryMemoryUsagePanel = {
     showThresholdLabels: false,
     showThresholdMarkers: true,
   },
-  pluginVersion: '10.2.0-59585pre',
+  pluginVersion: '10.2.0-59981',
 };
 
 local producerCountPanel = {
@@ -194,7 +212,7 @@ local producerCountPanel = {
     overrides: [],
   },
   options: {
-    colorMode: 'value',
+    colorMode: 'none',
     graphMode: 'none',
     justifyMode: 'auto',
     orientation: 'auto',
@@ -207,7 +225,7 @@ local producerCountPanel = {
     },
     textMode: 'auto',
   },
-  pluginVersion: '10.2.0-59585pre',
+  pluginVersion: '10.2.0-59981',
 };
 
 local consumerCountPanel = {
@@ -242,7 +260,7 @@ local consumerCountPanel = {
     overrides: [],
   },
   options: {
-    colorMode: 'value',
+    colorMode: 'none',
     graphMode: 'none',
     justifyMode: 'auto',
     orientation: 'auto',
@@ -255,7 +273,7 @@ local consumerCountPanel = {
     },
     textMode: 'auto',
   },
-  pluginVersion: '10.2.0-59585pre',
+  pluginVersion: '10.2.0-59981',
 };
 
 local averageUnacknowledgedMessagesPanel = {
@@ -290,7 +308,7 @@ local averageUnacknowledgedMessagesPanel = {
     overrides: [],
   },
   options: {
-    colorMode: 'value',
+    colorMode: 'none',
     graphMode: 'none',
     justifyMode: 'auto',
     orientation: 'auto',
@@ -303,7 +321,7 @@ local averageUnacknowledgedMessagesPanel = {
     },
     textMode: 'auto',
   },
-  pluginVersion: '10.2.0-59585pre',
+  pluginVersion: '10.2.0-59981',
 };
 
 local queueSizePanel = {
@@ -338,8 +356,8 @@ local queueSizePanel = {
           viz: false,
         },
         insertNulls: false,
-        lineInterpolation: 'linear',
-        lineWidth: 1,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
         pointSize: 5,
         scaleDistribution: {
           type: 'linear',
@@ -402,7 +420,7 @@ local destinationMemoryUsagePanel = {
   fieldConfig: {
     defaults: {
       color: {
-        mode: 'palette-classic',
+        mode: 'continuous-BlYlRd',
       },
       custom: {
         axisCenteredZero: false,
@@ -419,8 +437,8 @@ local destinationMemoryUsagePanel = {
           viz: false,
         },
         insertNulls: false,
-        lineInterpolation: 'linear',
-        lineWidth: 1,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
         pointSize: 5,
         scaleDistribution: {
           type: 'linear',
@@ -436,6 +454,8 @@ local destinationMemoryUsagePanel = {
         },
       },
       mappings: [],
+      max: 100,
+      min: 0,
       thresholds: {
         mode: 'absolute',
         steps: [
@@ -467,12 +487,12 @@ local enqueueCountPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(instance, activemq_cluster) (activemq_queue_enqueue_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"})',
+      'sum by(instance, activemq_cluster) (increase(activemq_queue_enqueue_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"}[$__interval:]))',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - queue',
     ),
     prometheus.target(
-      'sum by(instance, activemq_cluster) (activemq_topic_enqueue_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"})',
+      'sum by(instance, activemq_cluster) (increase(activemq_topic_enqueue_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"}[$__interval:]))',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - topic',
     ),
@@ -500,8 +520,8 @@ local enqueueCountPanel = {
           viz: false,
         },
         insertNulls: false,
-        lineInterpolation: 'linear',
-        lineWidth: 1,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
         pointSize: 5,
         scaleDistribution: {
           type: 'linear',
@@ -662,8 +682,8 @@ local averageEnqueueTimePanel = {
           viz: false,
         },
         insertNulls: false,
-        lineInterpolation: 'linear',
-        lineWidth: 1,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
         pointSize: 5,
         scaleDistribution: {
           type: 'linear',
@@ -743,8 +763,8 @@ local expiredMessagesPanel = {
           viz: false,
         },
         insertNulls: false,
-        lineInterpolation: 'linear',
-        lineWidth: 1,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
         pointSize: 5,
         scaleDistribution: {
           type: 'linear',
@@ -827,8 +847,8 @@ local garbageCollectionDurationPanel = {
           viz: false,
         },
         insertNulls: false,
-        lineInterpolation: 'linear',
-        lineWidth: 1,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
         pointSize: 5,
         scaleDistribution: {
           type: 'linear',
@@ -849,6 +869,7 @@ local garbageCollectionDurationPanel = {
         steps: [
           {
             color: 'green',
+            value: null,
           },
         ],
       },
@@ -902,8 +923,8 @@ local garbageCollectionCountPanel = {
           viz: false,
         },
         insertNulls: false,
-        lineInterpolation: 'linear',
-        lineWidth: 1,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
         pointSize: 5,
         scaleDistribution: {
           type: 'linear',
@@ -924,6 +945,7 @@ local garbageCollectionCountPanel = {
         steps: [
           {
             color: 'green',
+            value: null,
           },
         ],
       },
@@ -942,6 +964,43 @@ local garbageCollectionCountPanel = {
       mode: 'multi',
       sort: 'desc',
     },
+  },
+};
+
+local alertsRow = {
+  datasource: promDatasource,
+  targets: [],
+  type: 'row',
+  title: 'Alerts',
+  collapsed: false,
+};
+
+local activemqAlertsPanel = {
+  datasource: promDatasource,
+  targets: [],
+  type: 'alertlist',
+  title: 'ActiveMQ Alerts',
+  description: 'Alerts for Apache ActiveMQ environment.',
+  options: {
+    alertInstanceLabelFilter: '',
+    alertName: '',
+    dashboardAlerts: false,
+    folder: {
+      title: 'Integrations - ActiveMQ',
+      uid: 'ac912ae2-f603-4a05-878f-42033c5b96f3',
+    },
+    groupBy: [],
+    groupMode: 'default',
+    maxItems: 5,
+    sortOrder: 1,
+    stateFilter: {
+      'error': true,
+      firing: true,
+      noData: true,
+      normal: true,
+      pending: true,
+    },
+    viewMode: 'list',
   },
 };
 
@@ -984,8 +1043,8 @@ local garbageCollectionCountPanel = {
             'label_values(activemq_memory_usage_ratio{job=~"$job"},activemq_cluster)',
             label='ActiveMQ cluster',
             refresh=2,
-            includeAll=false,
-            multi=false,
+            includeAll=true,
+            multi=true,
             allValues='',
             sort=0
           ),
@@ -1019,6 +1078,8 @@ local garbageCollectionCountPanel = {
           jvmResourcesRow { gridPos: { h: 1, w: 24, x: 0, y: 28 } },
           garbageCollectionDurationPanel { gridPos: { h: 8, w: 12, x: 0, y: 29 } },
           garbageCollectionCountPanel { gridPos: { h: 8, w: 12, x: 12, y: 29 } },
+          alertsRow { gridPos: { h: 1, w: 24, x: 0, y: 37 } },
+          activemqAlertsPanel { gridPos: { h: 8, w: 24, x: 0, y: 38 } },
         ]
       ),
   },

--- a/apache-activemq-mixin/dashboards/apache-activemq-instance-overview.libsonnet
+++ b/apache-activemq-mixin/dashboards/apache-activemq-instance-overview.libsonnet
@@ -72,7 +72,7 @@ local averageStoreMemoryUsagePanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'avg by (instance, activemq_cluster) (activemq_store_usage_ratio{' + matcher + ', instance=~"$instance"})',
+      'avg by (instance, activemq_cluster, job) (activemq_store_usage_ratio{' + matcher + ', instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}}',
     ),
@@ -128,7 +128,7 @@ local averageTemporaryMemoryUsagePanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'avg by (instance, activemq_cluster) (activemq_temp_usage_ratio{' + matcher + ', instance=~"$instance"})',
+      'avg by (instance, activemq_cluster, job) (activemq_temp_usage_ratio{' + matcher + ', instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}}',
     ),
@@ -184,7 +184,7 @@ local producerCountPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(instance) (activemq_producer_total{' + matcher + ', instance=~"$instance"})',
+      'sum by(instance, activemq_cluster, job) (activemq_producer_total{' + matcher + ', instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}}',
     ),
@@ -232,7 +232,7 @@ local consumerCountPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(instance) (activemq_consumer_total{' + matcher + ', instance=~"$instance"})',
+      'sum by(instance, activemq_cluster, job) (activemq_consumer_total{' + matcher + ', instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}}',
     ),
@@ -280,7 +280,7 @@ local averageUnacknowledgedMessagesPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'avg by (instance) (activemq_message_total{' + matcher + ', instance=~"$instance"})',
+      'avg by (instance, activemq_cluster, job) (activemq_message_total{' + matcher + ', instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}}',
     ),

--- a/apache-activemq-mixin/dashboards/apache-activemq-logs-overview.libsonnet
+++ b/apache-activemq-mixin/dashboards/apache-activemq-logs-overview.libsonnet
@@ -2,34 +2,32 @@ local g = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonn
 local logsDashboard = import 'github.com/grafana/jsonnet-libs/logs-lib/logs/main.libsonnet';
 
 {
-  grafanaDashboards+::
+  local activemqLogs =
+    logsDashboard.new(
+      'Apache ActiveMQ logs',
+      datasourceName='loki_datasource',
+      datasourceRegex='',
+      filterSelector=$._config.filterSelector,
+      labels=['job', 'activemq_cluster', 'instance', 'level'],
+      formatParser=null,
+      showLogsVolume=true
+    )
     {
-      local activemqLogs =
-        logsDashboard.new(
-          'Apache ActiveMQ logs',
-          datasourceName='loki_datasource',
-          datasourceRegex='',
-          filterSelector=$._config.filterSelector,
-          labels=['job', 'activemq_cluster', 'instance', 'level'],
-          formatParser=null,
-          showLogsVolume=true
-        )
+      panels+:
         {
-          panels+:
-            {
-              logs+:
-                // ActiveMQ logs already have timestamp
-                g.panel.logs.options.withShowTime(false),
-            },
-          dashboards+:
-            {
-              logs+: g.dashboard.withLinksMixin($.grafanaDashboards['apache-activemq-cluster-overview.json'].links)
-                     + g.dashboard.withUid($._config.grafanaDashboardIDs['apache-activemq-logs-overview.json'])
-                     + g.dashboard.withTags($._config.dashboardTags)
-                     + g.dashboard.withRefresh($._config.dashboardRefresh),
-            },
+          logs+:
+            // ActiveMQ logs already have timestamp
+            g.panel.logs.options.withShowTime(false),
         },
-      'apache-activemq-logs.json': activemqLogs.dashboards.logs,
+      dashboards+:
+        {
+          logs+: g.dashboard.withLinksMixin($.grafanaDashboards['apache-activemq-cluster-overview.json'].links)
+                 + g.dashboard.withUid($._config.grafanaDashboardIDs['apache-activemq-logs-overview.json'])
+                 + g.dashboard.withTags($._config.dashboardTags)
+                 + g.dashboard.withRefresh($._config.dashboardRefresh),
+        },
     },
-
+  grafanaDashboards+:: if $._config.enableLokiLogs then {
+    'apache-activemq-logs.json': activemqLogs.dashboards.logs,
+  } else {},
 }

--- a/apache-activemq-mixin/dashboards/apache-activemq-logs-overview.libsonnet
+++ b/apache-activemq-mixin/dashboards/apache-activemq-logs-overview.libsonnet
@@ -23,9 +23,10 @@ local logsDashboard = import 'github.com/grafana/jsonnet-libs/logs-lib/logs/main
             },
           dashboards+:
             {
-              logs+:
-                // copy links from another dashboard
-                g.dashboard.withLinksMixin($.grafanaDashboards['apache-activemq-cluster-overview.json'].links),
+              logs+: g.dashboard.withLinksMixin($.grafanaDashboards['apache-activemq-cluster-overview.json'].links)
+                     + g.dashboard.withUid($._config.grafanaDashboardIDs['apache-activemq-logs-overview.json'])
+                     + g.dashboard.withTags($._config.dashboardTags)
+                     + g.dashboard.withRefresh($._config.dashboardRefresh),
             },
         },
       'apache-activemq-logs.json': activemqLogs.dashboards.logs,

--- a/apache-activemq-mixin/dashboards/apache-activemq-queue-overview.libsonnet
+++ b/apache-activemq-mixin/dashboards/apache-activemq-queue-overview.libsonnet
@@ -16,9 +16,9 @@ local numberOfQueuesPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'count by(instance) (activemq_queue_queue_size{instance=~"$instance", job=~"$job"})',
+      'count by(instance, activemq_cluster) (activemq_queue_queue_size{activemq_cluster=~"$activemq_cluster", instance=~"$instance", job=~"$job"})',
       datasource=promDatasource,
-      legendFormat='{{instance}}',
+      legendFormat='{{activemq_cluster}} - {{instance}}',
     ),
   ],
   type: 'stat',
@@ -44,7 +44,7 @@ local numberOfQueuesPanel = {
     overrides: [],
   },
   options: {
-    colorMode: 'value',
+    colorMode: 'none',
     graphMode: 'none',
     justifyMode: 'auto',
     orientation: 'auto',
@@ -57,16 +57,63 @@ local numberOfQueuesPanel = {
     },
     textMode: 'auto',
   },
-  pluginVersion: '10.2.0-59542pre',
+  pluginVersion: '10.2.0-59981',
+};
+
+local queueSizePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by (instance, activemq_cluster) (activemq_queue_queue_size{job=~"$job",activemq_cluster=~"$activemq_cluster",instance=~"$instance"})',
+      datasource=promDatasource,
+      legendFormat='{{activemq_cluster}} - {{instance}}',
+    ),
+  ],
+  type: 'stat',
+  title: 'Queue size',
+  description: 'Number of messages in queue destinations.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+    },
+    overrides: [],
+  },
+  options: {
+    colorMode: 'none',
+    graphMode: 'none',
+    justifyMode: 'auto',
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    textMode: 'auto',
+  },
+  pluginVersion: '10.2.0-59981',
 };
 
 local producerCountPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(instance) (activemq_queue_producer_count{job=~"$job", instance=~"$instance"})',
+      'sum by(instance, activemq_cluster) (activemq_queue_producer_count{activemq_cluster=~"$activemq_cluster", job=~"$job", instance=~"$instance"})',
       datasource=promDatasource,
-      legendFormat='{{instance}}',
+      legendFormat='{{activemq_cluster}} - {{instance}}',
     ),
   ],
   type: 'stat',
@@ -92,7 +139,7 @@ local producerCountPanel = {
     overrides: [],
   },
   options: {
-    colorMode: 'value',
+    colorMode: 'none',
     graphMode: 'none',
     justifyMode: 'auto',
     orientation: 'auto',
@@ -105,16 +152,16 @@ local producerCountPanel = {
     },
     textMode: 'auto',
   },
-  pluginVersion: '10.2.0-59542pre',
+  pluginVersion: '10.2.0-59981',
 };
 
 local consumerCountPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(instance) (activemq_queue_consumer_count{instance=~"$instance", job=~"$job"})',
+      'sum by(instance,activemq_cluster) (activemq_queue_consumer_count{activemq_cluster=~"$activemq_cluster", instance=~"$instance", job=~"$job"})',
       datasource=promDatasource,
-      legendFormat='{{instance}}',
+      legendFormat='{{activemq_cluster}} - {{instance}}',
     ),
   ],
   type: 'stat',
@@ -140,7 +187,7 @@ local consumerCountPanel = {
     overrides: [],
   },
   options: {
-    colorMode: 'value',
+    colorMode: 'none',
     graphMode: 'none',
     justifyMode: 'auto',
     orientation: 'auto',
@@ -153,64 +200,16 @@ local consumerCountPanel = {
     },
     textMode: 'auto',
   },
-  pluginVersion: '10.2.0-59542pre',
-};
-
-local deadLetterQueuePanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'sum by (instance) (activemq_queue_dlq{job=~"$job", instance=~"$instance"})',
-      datasource=promDatasource,
-      legendFormat='{{instance}}',
-    ),
-  ],
-  type: 'stat',
-  title: 'Dead letter queue',
-  description: 'The number of messages in dead letter queue.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'thresholds',
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-        ],
-      },
-      unit: 'none',
-    },
-    overrides: [],
-  },
-  options: {
-    colorMode: 'value',
-    graphMode: 'none',
-    justifyMode: 'auto',
-    orientation: 'auto',
-    reduceOptions: {
-      calcs: [
-        'lastNotNull',
-      ],
-      fields: '',
-      values: false,
-    },
-    textMode: 'auto',
-  },
-  pluginVersion: '10.2.0-59542pre',
+  pluginVersion: '10.2.0-59981',
 };
 
 local topQueuesByEnqueueRatePanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'topk by(instance) (5, rate(activemq_queue_enqueue_count{job=~"$job", instance=~"$instance"}[$__rate_interval]))',
+      'topk by(instance, activemq_cluster) ($k_selector, rate(activemq_queue_enqueue_count{job=~"$job", activemq_cluster=~"$activemq_cluster",instance=~"$instance", destination=~".*$name.*"}[$__rate_interval]))',
       datasource=promDatasource,
-      legendFormat='{{instance}} - {{destination}}',
+      legendFormat='{{activemq_cluster}} - {{instance}} - {{destination}}',
     ),
   ],
   type: 'timeseries',
@@ -236,8 +235,8 @@ local topQueuesByEnqueueRatePanel = {
           viz: false,
         },
         insertNulls: false,
-        lineInterpolation: 'linear',
-        lineWidth: 1,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
         pointSize: 5,
         scaleDistribution: {
           type: 'linear',
@@ -246,7 +245,7 @@ local topQueuesByEnqueueRatePanel = {
         spanNulls: false,
         stacking: {
           group: 'A',
-          mode: 'normal',
+          mode: 'none',
         },
         thresholdsStyle: {
           mode: 'off',
@@ -284,9 +283,9 @@ local topQueuesByDequeueRatePanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'topk by(instance) (5, rate(activemq_queue_dequeue_count{job=~"$job", instance=~"$instance"}[$__rate_interval]))',
+      'topk by(instance, activemq_cluster) ($k_selector, rate(activemq_queue_dequeue_count{job=~"$job", instance=~"$instance", activemq_cluster=~"$activemq_cluster", destination=~".*$name.*"}[$__rate_interval]))',
       datasource=promDatasource,
-      legendFormat='{{instance}} - {{destination}}',
+      legendFormat='{{activemq_cluster}} - {{instance}} - {{destination}}',
     ),
   ],
   type: 'timeseries',
@@ -312,8 +311,8 @@ local topQueuesByDequeueRatePanel = {
           viz: false,
         },
         insertNulls: false,
-        lineInterpolation: 'linear',
-        lineWidth: 1,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
         pointSize: 5,
         scaleDistribution: {
           type: 'linear',
@@ -322,7 +321,7 @@ local topQueuesByDequeueRatePanel = {
         spanNulls: false,
         stacking: {
           group: 'A',
-          mode: 'normal',
+          mode: 'none',
         },
         thresholdsStyle: {
           mode: 'off',
@@ -360,9 +359,9 @@ local topQueuesByAverageEnqueueTimePanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'topk by(instance) (5, activemq_queue_average_enqueue_time{job=~"$job", instance=~"$instance"})',
+      'topk by(instance, activemq_cluster) ($k_selector, activemq_queue_average_enqueue_time{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance", destination=~".*$name.*"})',
       datasource=promDatasource,
-      legendFormat='{{instance}} - {{destination}}',
+      legendFormat='{{activemq_cluster}} - {{instance}} - {{destination}}',
     ),
   ],
   type: 'timeseries',
@@ -388,8 +387,8 @@ local topQueuesByAverageEnqueueTimePanel = {
           viz: false,
         },
         insertNulls: false,
-        lineInterpolation: 'linear',
-        lineWidth: 1,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
         pointSize: 5,
         scaleDistribution: {
           type: 'linear',
@@ -398,7 +397,7 @@ local topQueuesByAverageEnqueueTimePanel = {
         spanNulls: false,
         stacking: {
           group: 'A',
-          mode: 'normal',
+          mode: 'none',
         },
         thresholdsStyle: {
           mode: 'off',
@@ -436,9 +435,9 @@ local topQueuesByExpiredMessageRatePanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'topk by(instance) (5, rate(activemq_queue_expired_count{job=~"$job", instance=~"$instance"}[$__rate_interval]))',
+      'topk by(instance, activemq_cluster) ($k_selector, rate(activemq_queue_expired_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance", destination=~".*$name.*"}[$__rate_interval]))',
       datasource=promDatasource,
-      legendFormat='{{instance}} - {{destination}}',
+      legendFormat='{{activemq_cluster}} - {{instance}} - {{destination}}',
     ),
   ],
   type: 'timeseries',
@@ -464,8 +463,8 @@ local topQueuesByExpiredMessageRatePanel = {
           viz: false,
         },
         insertNulls: false,
-        lineInterpolation: 'linear',
-        lineWidth: 1,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
         pointSize: 5,
         scaleDistribution: {
           type: 'linear',
@@ -474,7 +473,7 @@ local topQueuesByExpiredMessageRatePanel = {
         spanNulls: false,
         stacking: {
           group: 'A',
-          mode: 'normal',
+          mode: 'none',
         },
         thresholdsStyle: {
           mode: 'off',
@@ -512,9 +511,9 @@ local topQueuesByAverageMessageSizePanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'topk by(instance) (5, activemq_queue_average_message_size{job=~"$job", instance=~"$instance"})',
+      'topk by(instance, activemq_cluster) ($k_selector, activemq_queue_average_message_size{job=~"$job",activemq_cluster=~"$activemq_cluster", instance=~"$instance", destination=~".*$name.*"})',
       datasource=promDatasource,
-      legendFormat='{{instance}} - {{destination}}',
+      legendFormat='{{activemq_cluster}} - {{instance}} - {{destination}}',
     ),
   ],
   type: 'timeseries',
@@ -541,8 +540,8 @@ local topQueuesByAverageMessageSizePanel = {
           viz: false,
         },
         insertNulls: false,
-        lineInterpolation: 'linear',
-        lineWidth: 1,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
         pointSize: 5,
         scaleDistribution: {
           type: 'linear',
@@ -551,7 +550,7 @@ local topQueuesByAverageMessageSizePanel = {
         spanNulls: false,
         stacking: {
           group: 'A',
-          mode: 'normal',
+          mode: 'none',
         },
         thresholdsStyle: {
           mode: 'off',
@@ -584,6 +583,176 @@ local topQueuesByAverageMessageSizePanel = {
       sort: 'desc',
     },
   },
+};
+
+local queueSummaryPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'rate(activemq_queue_enqueue_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance", destination=~".*$name.*"}[$__rate_interval:])',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+      format='table',
+    ),
+    prometheus.target(
+      'rate(activemq_queue_dequeue_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance", destination=~".*$name.*"}[$__rate_interval:])',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+      format='table',
+    ),
+    prometheus.target(
+      'activemq_queue_average_enqueue_time{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance", destination=~".*$name.*"}',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+      format='table',
+    ),
+    prometheus.target(
+      'activemq_queue_average_message_size{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance", destination=~".*$name.*"}',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+      format='table',
+    ),
+  ],
+  type: 'table',
+  title: 'Queue summary',
+  description: 'Summary of queues showing queue name, enqueue and dequeue rate, average enqueue time, and average message size.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      custom: {
+        align: 'center',
+        cellOptions: {
+          type: 'auto',
+        },
+        inspect: false,
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+    },
+    overrides: [
+      {
+        matcher: {
+          id: 'byName',
+          options: 'Average message size',
+        },
+        properties: [
+          {
+            id: 'unit',
+            value: 'decbytes',
+          },
+        ],
+      },
+      {
+        matcher: {
+          id: 'byName',
+          options: 'Enqueue rate',
+        },
+        properties: [
+          {
+            id: 'unit',
+            value: 'mps',
+          },
+        ],
+      },
+      {
+        matcher: {
+          id: 'byName',
+          options: 'Dequeue rate',
+        },
+        properties: [
+          {
+            id: 'unit',
+            value: 'mps',
+          },
+        ],
+      },
+      {
+        matcher: {
+          id: 'byName',
+          options: 'Average enqueue time',
+        },
+        properties: [
+          {
+            id: 'unit',
+            value: 'ms',
+          },
+        ],
+      },
+    ],
+  },
+  options: {
+    cellHeight: 'sm',
+    footer: {
+      countRows: false,
+      fields: '',
+      reducer: [
+        'sum',
+      ],
+      show: false,
+    },
+    showHeader: true,
+    sortBy: [
+      {
+        desc: false,
+        displayName: '{activemq_cluster="cluster-a", destination="TEST", instance="localhost:12345", job="integrations/activemq"}',
+      },
+    ],
+  },
+  pluginVersion: '10.2.0-59981',
+  transformations: [
+    {
+      id: 'joinByField',
+      options: {
+        byField: 'destination',
+        mode: 'outer',
+      },
+    },
+    {
+      id: 'organize',
+      options: {
+        excludeByName: {
+          'Time 1': true,
+          'Time 2': true,
+          'Time 3': true,
+          'Time 4': true,
+          '__name__ 1': true,
+          '__name__ 2': true,
+          'activemq_cluster 1': true,
+          'activemq_cluster 2': true,
+          'activemq_cluster 3': true,
+          'activemq_cluster 4': true,
+          'instance 1': true,
+          'instance 2': true,
+          'instance 3': true,
+          'instance 4': true,
+          'job 1': true,
+          'job 2': true,
+          'job 3': true,
+          'job 4': true,
+        },
+        indexByName: {},
+        renameByName: {
+          'Time 1': '',
+          'Value #A': 'Enqueue rate',
+          'Value #B': 'Dequeue rate',
+          'Value #C': 'Average enqueue time',
+          'Value #D': 'Average message size',
+          'activemq_cluster 1': '',
+          destination: 'Destination',
+        },
+      },
+    },
+  ],
 };
 
 {
@@ -620,13 +789,46 @@ local topQueuesByAverageMessageSizePanel = {
             sort=0
           ),
           template.new(
+            'activemq_cluster',
+            promDatasource,
+            'label_values(activemq_memory_usage_ratio{job=~"$job"},activemq_cluster)',
+            label='ActiveMQ cluster',
+            refresh=2,
+            includeAll=true,
+            multi=true,
+            allValues='',
+            sort=0
+          ),
+          template.new(
             'instance',
             promDatasource,
-            'label_values(activemq_topic_producer_count{job=~"$job"},instance)',
+            'label_values(activemq_topic_producer_count{activemq_cluster=~"$activemq_cluster"},instance)',
             label='Instance',
             refresh=2,
             includeAll=true,
             multi=true,
+            allValues='',
+            sort=0
+          ),
+          template.new(
+            'k_selector',
+            promDatasource,
+            '2,4,6,8,10',
+            label='Top k count',
+            refresh=0,
+            includeAll=false,
+            multi=false,
+            allValues='',
+            sort=0
+          ),
+          template.new(
+            'name',
+            promDatasource,
+            '.*',
+            label='Queue by name',
+            refresh=0,
+            includeAll=false,
+            multi=false,
             allValues='',
             sort=0
           ),
@@ -635,14 +837,15 @@ local topQueuesByAverageMessageSizePanel = {
       .addPanels(
         [
           numberOfQueuesPanel { gridPos: { h: 4, w: 6, x: 0, y: 0 } },
-          producerCountPanel { gridPos: { h: 4, w: 6, x: 6, y: 0 } },
-          consumerCountPanel { gridPos: { h: 4, w: 6, x: 12, y: 0 } },
-          deadLetterQueuePanel { gridPos: { h: 4, w: 6, x: 18, y: 0 } },
+          queueSizePanel { gridPos: { h: 4, w: 6, x: 6, y: 0 } },
+          producerCountPanel { gridPos: { h: 4, w: 6, x: 12, y: 0 } },
+          consumerCountPanel { gridPos: { h: 4, w: 6, x: 18, y: 0 } },
           topQueuesByEnqueueRatePanel { gridPos: { h: 8, w: 12, x: 0, y: 4 } },
           topQueuesByDequeueRatePanel { gridPos: { h: 8, w: 12, x: 12, y: 4 } },
           topQueuesByAverageEnqueueTimePanel { gridPos: { h: 8, w: 12, x: 0, y: 12 } },
           topQueuesByExpiredMessageRatePanel { gridPos: { h: 8, w: 12, x: 12, y: 12 } },
           topQueuesByAverageMessageSizePanel { gridPos: { h: 7, w: 24, x: 0, y: 20 } },
+          queueSummaryPanel { gridPos: { h: 7, w: 24, x: 0, y: 27 } },
         ]
       ),
   },

--- a/apache-activemq-mixin/dashboards/apache-activemq-queue-overview.libsonnet
+++ b/apache-activemq-mixin/dashboards/apache-activemq-queue-overview.libsonnet
@@ -809,7 +809,7 @@ local getMatcher(cfg) = '%(activemqSelector)s, activemq_cluster=~"$activemq_clus
           template.new(
             'activemq_cluster',
             promDatasource,
-            'label_values(activemq_memory_usage_ratio{%(activemqSelector)s},activemq_cluster)',
+            'label_values(activemq_memory_usage_ratio{%(activemqSelector)s},activemq_cluster)' % $._config,
             label='ActiveMQ cluster',
             refresh=2,
             includeAll=true,
@@ -820,7 +820,7 @@ local getMatcher(cfg) = '%(activemqSelector)s, activemq_cluster=~"$activemq_clus
           template.new(
             'instance',
             promDatasource,
-            'label_values(activemq_topic_producer_count{%(activemqSelector)s, activemq_cluster=~"$activemq_cluster"},instance)',
+            'label_values(activemq_topic_producer_count{%(activemqSelector)s, activemq_cluster=~"$activemq_cluster"},instance)' % $._config,
             label='Instance',
             refresh=2,
             includeAll=true,

--- a/apache-activemq-mixin/dashboards/apache-activemq-queue-overview.libsonnet
+++ b/apache-activemq-mixin/dashboards/apache-activemq-queue-overview.libsonnet
@@ -214,7 +214,7 @@ local topQueuesByEnqueueRatePanel(matcher) = {
   ],
   type: 'timeseries',
   title: 'Top queues by enqueue rate',
-  description: 'The rate messages sent to the top k queue destinations.',
+  description: 'The rate messages sent to queue destinations.',
   fieldConfig: {
     defaults: {
       color: {
@@ -291,7 +291,7 @@ local topQueuesByDequeueRatePanel(matcher) = {
   ],
   type: 'timeseries',
   title: 'Top queues by dequeue rate',
-  description: 'The rate messages have been acknowledged (and removed) from the top k queue destinations.',
+  description: 'The rate messages have been acknowledged (and removed) from queue destinations.',
   fieldConfig: {
     defaults: {
       color: {
@@ -368,7 +368,7 @@ local topQueuesByAverageEnqueueTimePanel(matcher) = {
   ],
   type: 'timeseries',
   title: 'Top queues by average enqueue time',
-  description: 'Average time a message was held on top k queue destinations.',
+  description: 'Average time a message was held on queue destinations.',
   fieldConfig: {
     defaults: {
       color: {
@@ -445,7 +445,7 @@ local topQueuesByExpiredMessageRatePanel(matcher) = {
   ],
   type: 'timeseries',
   title: 'Top queues by expired message rate',
-  description: 'The rate messages have expired on the top k queue destinations.',
+  description: 'The rate messages have expired on queue destinations.',
   fieldConfig: {
     defaults: {
       color: {
@@ -832,7 +832,7 @@ local getMatcher(cfg) = '%(activemqSelector)s, activemq_cluster=~"$activemq_clus
             'k_selector',
             promDatasource,
             '2,4,6,8,10',
-            label='Top k count',
+            label='Top queue count',
             refresh=0,
             includeAll=false,
             multi=false,

--- a/apache-activemq-mixin/dashboards/apache-activemq-queue-overview.libsonnet
+++ b/apache-activemq-mixin/dashboards/apache-activemq-queue-overview.libsonnet
@@ -828,27 +828,19 @@ local getMatcher(cfg) = '%(activemqSelector)s, activemq_cluster=~"$activemq_clus
             allValues='',
             sort=0
           ),
-          template.new(
+          template.custom(
             'k_selector',
-            promDatasource,
-            '2,4,6,8,10',
+            query='2,4,6,8,10',
+            current='4',
             label='Top queue count',
-            refresh=0,
+            refresh='never',
             includeAll=false,
             multi=false,
-            allValues='',
-            sort=0
+            allValues=''
           ),
-          template.new(
+          template.text(
             'name',
-            promDatasource,
-            '.*',
             label='Queue by name',
-            refresh=0,
-            includeAll=false,
-            multi=false,
-            allValues='',
-            sort=0
           ),
         ]
       )

--- a/apache-activemq-mixin/dashboards/apache-activemq-queue-overview.libsonnet
+++ b/apache-activemq-mixin/dashboards/apache-activemq-queue-overview.libsonnet
@@ -16,7 +16,7 @@ local numberOfQueuesPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'count by(instance, activemq_cluster) (activemq_queue_queue_size{activemq_cluster=~"$activemq_cluster", instance=~"$instance", job=~"$job"})',
+      'count by(instance, activemq_cluster, job) (activemq_queue_queue_size{activemq_cluster=~"$activemq_cluster", instance=~"$instance", job=~"$job"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}}',
     ),
@@ -57,14 +57,14 @@ local numberOfQueuesPanel = {
     },
     textMode: 'auto',
   },
-  pluginVersion: '10.2.0-59981',
+  pluginVersion: '10.2.0-60139',
 };
 
 local queueSizePanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by (instance, activemq_cluster) (activemq_queue_queue_size{job=~"$job",activemq_cluster=~"$activemq_cluster",instance=~"$instance"})',
+      'sum by (instance, activemq_cluster, job) (activemq_queue_queue_size{job=~"$job",activemq_cluster=~"$activemq_cluster",instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}}',
     ),
@@ -104,14 +104,14 @@ local queueSizePanel = {
     },
     textMode: 'auto',
   },
-  pluginVersion: '10.2.0-59981',
+  pluginVersion: '10.2.0-60139',
 };
 
 local producerCountPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(instance, activemq_cluster) (activemq_queue_producer_count{activemq_cluster=~"$activemq_cluster", job=~"$job", instance=~"$instance"})',
+      'sum by(instance, activemq_cluster, job) (activemq_queue_producer_count{activemq_cluster=~"$activemq_cluster", job=~"$job", instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}}',
     ),
@@ -152,14 +152,14 @@ local producerCountPanel = {
     },
     textMode: 'auto',
   },
-  pluginVersion: '10.2.0-59981',
+  pluginVersion: '10.2.0-60139',
 };
 
 local consumerCountPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(instance,activemq_cluster) (activemq_queue_consumer_count{activemq_cluster=~"$activemq_cluster", instance=~"$instance", job=~"$job"})',
+      'sum by(instance,activemq_cluster, job) (activemq_queue_consumer_count{activemq_cluster=~"$activemq_cluster", instance=~"$instance", job=~"$job"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}}',
     ),
@@ -200,14 +200,14 @@ local consumerCountPanel = {
     },
     textMode: 'auto',
   },
-  pluginVersion: '10.2.0-59981',
+  pluginVersion: '10.2.0-60139',
 };
 
 local topQueuesByEnqueueRatePanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'topk by(instance, activemq_cluster) ($k_selector, rate(activemq_queue_enqueue_count{job=~"$job", activemq_cluster=~"$activemq_cluster",instance=~"$instance", destination=~".*$name.*"}[$__rate_interval]))',
+      'topk by(instance, activemq_cluster, job) ($k_selector, rate(activemq_queue_enqueue_count{job=~"$job", activemq_cluster=~"$activemq_cluster",instance=~"$instance", destination=~".*$name.*"}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - {{destination}}',
     ),
@@ -225,6 +225,7 @@ local topQueuesByEnqueueRatePanel = {
         axisColorMode: 'text',
         axisLabel: '',
         axisPlacement: 'auto',
+        axisShow: false,
         barAlignment: 0,
         drawStyle: 'line',
         fillOpacity: 25,
@@ -301,6 +302,7 @@ local topQueuesByDequeueRatePanel = {
         axisColorMode: 'text',
         axisLabel: '',
         axisPlacement: 'auto',
+        axisShow: false,
         barAlignment: 0,
         drawStyle: 'line',
         fillOpacity: 25,
@@ -377,6 +379,7 @@ local topQueuesByAverageEnqueueTimePanel = {
         axisColorMode: 'text',
         axisLabel: '',
         axisPlacement: 'auto',
+        axisShow: false,
         barAlignment: 0,
         drawStyle: 'line',
         fillOpacity: 25,
@@ -435,7 +438,7 @@ local topQueuesByExpiredMessageRatePanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'topk by(instance, activemq_cluster) ($k_selector, rate(activemq_queue_expired_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance", destination=~".*$name.*"}[$__rate_interval]))',
+      'topk by(instance, activemq_cluster, job) ($k_selector, rate(activemq_queue_expired_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance", destination=~".*$name.*"}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - {{destination}}',
     ),
@@ -453,6 +456,7 @@ local topQueuesByExpiredMessageRatePanel = {
         axisColorMode: 'text',
         axisLabel: '',
         axisPlacement: 'auto',
+        axisShow: false,
         barAlignment: 0,
         drawStyle: 'line',
         fillOpacity: 25,
@@ -511,7 +515,7 @@ local topQueuesByAverageMessageSizePanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'topk by(instance, activemq_cluster) ($k_selector, activemq_queue_average_message_size{job=~"$job",activemq_cluster=~"$activemq_cluster", instance=~"$instance", destination=~".*$name.*"})',
+      'topk by(instance, activemq_cluster, job) ($k_selector, activemq_queue_average_message_size{job=~"$job",activemq_cluster=~"$activemq_cluster", instance=~"$instance", destination=~".*$name.*"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - {{destination}}',
     ),
@@ -529,6 +533,7 @@ local topQueuesByAverageMessageSizePanel = {
         axisColorMode: 'text',
         axisLabel: '',
         axisPlacement: 'auto',
+        axisShow: false,
         axisSoftMin: 0,
         barAlignment: 0,
         drawStyle: 'line',
@@ -634,7 +639,6 @@ local queueSummaryPanel = {
         steps: [
           {
             color: 'green',
-            value: null,
           },
         ],
       },
@@ -708,7 +712,7 @@ local queueSummaryPanel = {
       },
     ],
   },
-  pluginVersion: '10.2.0-59981',
+  pluginVersion: '10.2.0-60139',
   transformations: [
     {
       id: 'joinByField',
@@ -789,9 +793,20 @@ local queueSummaryPanel = {
             sort=0
           ),
           template.new(
+            'cluster',
+            promDatasource,
+            'label_values(activemq_memory_usage_ratio{job=~"$job"},cluster)',
+            label='Cluster',
+            refresh=2,
+            includeAll=true,
+            multi=true,
+            allValues='',
+            sort=0
+          ),
+          template.new(
             'activemq_cluster',
             promDatasource,
-            'label_values(activemq_memory_usage_ratio{job=~"$job"},activemq_cluster)',
+            'label_values(activemq_memory_usage_ratio{job=~"$job", cluster=~"$cluster"},activemq_cluster)',
             label='ActiveMQ cluster',
             refresh=2,
             includeAll=true,
@@ -834,6 +849,13 @@ local queueSummaryPanel = {
           ),
         ]
       )
+      .addLink(grafana.link.dashboards(
+        asDropdown=false,
+        title='Other Apache ActiveMQ dashboards',
+        includeVars=true,
+        keepTime=true,
+        tags=($._config.dashboardTags),
+      ))
       .addPanels(
         [
           numberOfQueuesPanel { gridPos: { h: 4, w: 6, x: 0, y: 0 } },

--- a/apache-activemq-mixin/dashboards/apache-activemq-queue-overview.libsonnet
+++ b/apache-activemq-mixin/dashboards/apache-activemq-queue-overview.libsonnet
@@ -22,12 +22,12 @@ local numberOfQueuesPanel(matcher) = {
     ),
   ],
   type: 'stat',
-  title: 'Number of queues',
+  title: 'Queues',
   description: 'Number of queues connected with the broker instance.',
   fieldConfig: {
     defaults: {
       color: {
-        mode: 'thresholds',
+        mode: 'fixed',
       },
       mappings: [],
       thresholds: {
@@ -45,7 +45,7 @@ local numberOfQueuesPanel(matcher) = {
   },
   options: {
     colorMode: 'none',
-    graphMode: 'none',
+    graphMode: 'area',
     justifyMode: 'auto',
     orientation: 'auto',
     reduceOptions: {
@@ -75,7 +75,7 @@ local queueSizePanel(matcher) = {
   fieldConfig: {
     defaults: {
       color: {
-        mode: 'thresholds',
+        mode: 'fixed',
       },
       mappings: [],
       thresholds: {
@@ -92,7 +92,7 @@ local queueSizePanel(matcher) = {
   },
   options: {
     colorMode: 'none',
-    graphMode: 'none',
+    graphMode: 'area',
     justifyMode: 'auto',
     orientation: 'auto',
     reduceOptions: {
@@ -117,12 +117,12 @@ local producerCountPanel(matcher) = {
     ),
   ],
   type: 'stat',
-  title: 'Producer count',
+  title: 'Producers',
   description: 'The number of producers attached to queue destinations.',
   fieldConfig: {
     defaults: {
       color: {
-        mode: 'thresholds',
+        mode: 'fixed',
       },
       mappings: [],
       thresholds: {
@@ -140,7 +140,7 @@ local producerCountPanel(matcher) = {
   },
   options: {
     colorMode: 'none',
-    graphMode: 'none',
+    graphMode: 'area',
     justifyMode: 'auto',
     orientation: 'auto',
     reduceOptions: {
@@ -165,12 +165,12 @@ local consumerCountPanel(matcher) = {
     ),
   ],
   type: 'stat',
-  title: 'Consumer count',
+  title: 'Consumers',
   description: 'The number of consumers subscribed to queue destinations.',
   fieldConfig: {
     defaults: {
       color: {
-        mode: 'thresholds',
+        mode: 'fixed',
       },
       mappings: [],
       thresholds: {
@@ -188,7 +188,7 @@ local consumerCountPanel(matcher) = {
   },
   options: {
     colorMode: 'none',
-    graphMode: 'none',
+    graphMode: 'area',
     justifyMode: 'auto',
     orientation: 'auto',
     reduceOptions: {

--- a/apache-activemq-mixin/dashboards/apache-activemq-queue-overview.libsonnet
+++ b/apache-activemq-mixin/dashboards/apache-activemq-queue-overview.libsonnet
@@ -12,11 +12,11 @@ local promDatasource = {
   uid: '${%s}' % promDatasourceName,
 };
 
-local numberOfQueuesPanel = {
+local numberOfQueuesPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'count by(instance, activemq_cluster, job) (activemq_queue_queue_size{activemq_cluster=~"$activemq_cluster", instance=~"$instance", job=~"$job"})',
+      'count by(instance, activemq_cluster, job) (activemq_queue_queue_size{' + matcher + ', instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}}',
     ),
@@ -60,11 +60,11 @@ local numberOfQueuesPanel = {
   pluginVersion: '10.2.0-60139',
 };
 
-local queueSizePanel = {
+local queueSizePanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by (instance, activemq_cluster, job) (activemq_queue_queue_size{job=~"$job",activemq_cluster=~"$activemq_cluster",instance=~"$instance"})',
+      'sum by (instance, activemq_cluster, job) (activemq_queue_queue_size{' + matcher + ', instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}}',
     ),
@@ -107,11 +107,11 @@ local queueSizePanel = {
   pluginVersion: '10.2.0-60139',
 };
 
-local producerCountPanel = {
+local producerCountPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(instance, activemq_cluster, job) (activemq_queue_producer_count{activemq_cluster=~"$activemq_cluster", job=~"$job", instance=~"$instance"})',
+      'sum by(instance, activemq_cluster, job) (activemq_queue_producer_count{' + matcher + ', instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}}',
     ),
@@ -155,11 +155,11 @@ local producerCountPanel = {
   pluginVersion: '10.2.0-60139',
 };
 
-local consumerCountPanel = {
+local consumerCountPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(instance,activemq_cluster, job) (activemq_queue_consumer_count{activemq_cluster=~"$activemq_cluster", instance=~"$instance", job=~"$job"})',
+      'sum by(instance,activemq_cluster, job) (activemq_queue_consumer_count{' + matcher + ', instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}}',
     ),
@@ -203,11 +203,11 @@ local consumerCountPanel = {
   pluginVersion: '10.2.0-60139',
 };
 
-local topQueuesByEnqueueRatePanel = {
+local topQueuesByEnqueueRatePanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'topk by(instance, activemq_cluster, job) ($k_selector, rate(activemq_queue_enqueue_count{job=~"$job", activemq_cluster=~"$activemq_cluster",instance=~"$instance", destination=~".*$name.*"}[$__rate_interval]))',
+      'topk by(instance, activemq_cluster, job) ($k_selector, rate(activemq_queue_enqueue_count{' + matcher + ', instance=~"$instance", destination=~".*$name.*"}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - {{destination}}',
     ),
@@ -280,11 +280,11 @@ local topQueuesByEnqueueRatePanel = {
   },
 };
 
-local topQueuesByDequeueRatePanel = {
+local topQueuesByDequeueRatePanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'topk by(instance, activemq_cluster) ($k_selector, rate(activemq_queue_dequeue_count{job=~"$job", instance=~"$instance", activemq_cluster=~"$activemq_cluster", destination=~".*$name.*"}[$__rate_interval]))',
+      'topk by(instance, activemq_cluster) ($k_selector, rate(activemq_queue_dequeue_count{' + matcher + ',instance=~"$instance", destination=~".*$name.*"}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - {{destination}}',
     ),
@@ -357,11 +357,11 @@ local topQueuesByDequeueRatePanel = {
   },
 };
 
-local topQueuesByAverageEnqueueTimePanel = {
+local topQueuesByAverageEnqueueTimePanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'topk by(instance, activemq_cluster) ($k_selector, activemq_queue_average_enqueue_time{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance", destination=~".*$name.*"})',
+      'topk by(instance, activemq_cluster) ($k_selector, activemq_queue_average_enqueue_time{' + matcher + ', instance=~"$instance", destination=~".*$name.*"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - {{destination}}',
     ),
@@ -434,11 +434,11 @@ local topQueuesByAverageEnqueueTimePanel = {
   },
 };
 
-local topQueuesByExpiredMessageRatePanel = {
+local topQueuesByExpiredMessageRatePanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'topk by(instance, activemq_cluster, job) ($k_selector, rate(activemq_queue_expired_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance", destination=~".*$name.*"}[$__rate_interval]))',
+      'topk by(instance, activemq_cluster, job) ($k_selector, rate(activemq_queue_expired_count{' + matcher + ', instance=~"$instance", destination=~".*$name.*"}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - {{destination}}',
     ),
@@ -511,11 +511,11 @@ local topQueuesByExpiredMessageRatePanel = {
   },
 };
 
-local topQueuesByAverageMessageSizePanel = {
+local topQueuesByAverageMessageSizePanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'topk by(instance, activemq_cluster, job) ($k_selector, activemq_queue_average_message_size{job=~"$job",activemq_cluster=~"$activemq_cluster", instance=~"$instance", destination=~".*$name.*"})',
+      'topk by(instance, activemq_cluster, job) ($k_selector, activemq_queue_average_message_size{' + matcher + ', instance=~"$instance", destination=~".*$name.*"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - {{destination}}',
     ),
@@ -590,29 +590,29 @@ local topQueuesByAverageMessageSizePanel = {
   },
 };
 
-local queueSummaryPanel = {
+local queueSummaryPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'rate(activemq_queue_enqueue_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance", destination=~".*$name.*"}[$__rate_interval:])',
+      'rate(activemq_queue_enqueue_count{' + matcher + ', instance=~"$instance", destination=~".*$name.*"}[$__rate_interval:])',
       datasource=promDatasource,
       legendFormat='{{instance}}',
       format='table',
     ),
     prometheus.target(
-      'rate(activemq_queue_dequeue_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance", destination=~".*$name.*"}[$__rate_interval:])',
+      'rate(activemq_queue_dequeue_count{' + matcher + ', instance=~"$instance", destination=~".*$name.*"}[$__rate_interval:])',
       datasource=promDatasource,
       legendFormat='{{instance}}',
       format='table',
     ),
     prometheus.target(
-      'activemq_queue_average_enqueue_time{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance", destination=~".*$name.*"}',
+      'activemq_queue_average_enqueue_time{' + matcher + ', instance=~"$instance", destination=~".*$name.*"}',
       datasource=promDatasource,
       legendFormat='{{instance}}',
       format='table',
     ),
     prometheus.target(
-      'activemq_queue_average_message_size{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance", destination=~".*$name.*"}',
+      'activemq_queue_average_message_size{' + matcher + ', instance=~"$instance", destination=~".*$name.*"}',
       datasource=promDatasource,
       legendFormat='{{instance}}',
       format='table',
@@ -759,6 +759,8 @@ local queueSummaryPanel = {
   ],
 };
 
+local getMatcher(cfg) = '%(activemqSelector)s, activemq_cluster=~"$activemq_cluster"' % cfg;
+
 {
   grafanaDashboards+:: {
     'apache-activemq-queue-overview.json':
@@ -801,12 +803,13 @@ local queueSummaryPanel = {
             includeAll=true,
             multi=true,
             allValues='',
+            hide=if $._config.enableMultiCluster then '' else 'variable',
             sort=0
           ),
           template.new(
             'activemq_cluster',
             promDatasource,
-            'label_values(activemq_memory_usage_ratio{job=~"$job", cluster=~"$cluster"},activemq_cluster)',
+            'label_values(activemq_memory_usage_ratio{%(activemqSelector)s},activemq_cluster)',
             label='ActiveMQ cluster',
             refresh=2,
             includeAll=true,
@@ -817,7 +820,7 @@ local queueSummaryPanel = {
           template.new(
             'instance',
             promDatasource,
-            'label_values(activemq_topic_producer_count{activemq_cluster=~"$activemq_cluster"},instance)',
+            'label_values(activemq_topic_producer_count{%(activemqSelector)s, activemq_cluster=~"$activemq_cluster"},instance)',
             label='Instance',
             refresh=2,
             includeAll=true,
@@ -858,16 +861,16 @@ local queueSummaryPanel = {
       ))
       .addPanels(
         [
-          numberOfQueuesPanel { gridPos: { h: 4, w: 6, x: 0, y: 0 } },
-          queueSizePanel { gridPos: { h: 4, w: 6, x: 6, y: 0 } },
-          producerCountPanel { gridPos: { h: 4, w: 6, x: 12, y: 0 } },
-          consumerCountPanel { gridPos: { h: 4, w: 6, x: 18, y: 0 } },
-          topQueuesByEnqueueRatePanel { gridPos: { h: 8, w: 12, x: 0, y: 4 } },
-          topQueuesByDequeueRatePanel { gridPos: { h: 8, w: 12, x: 12, y: 4 } },
-          topQueuesByAverageEnqueueTimePanel { gridPos: { h: 8, w: 12, x: 0, y: 12 } },
-          topQueuesByExpiredMessageRatePanel { gridPos: { h: 8, w: 12, x: 12, y: 12 } },
-          topQueuesByAverageMessageSizePanel { gridPos: { h: 7, w: 24, x: 0, y: 20 } },
-          queueSummaryPanel { gridPos: { h: 7, w: 24, x: 0, y: 27 } },
+          numberOfQueuesPanel(getMatcher($._config)) { gridPos: { h: 4, w: 6, x: 0, y: 0 } },
+          queueSizePanel(getMatcher($._config)) { gridPos: { h: 4, w: 6, x: 6, y: 0 } },
+          producerCountPanel(getMatcher($._config)) { gridPos: { h: 4, w: 6, x: 12, y: 0 } },
+          consumerCountPanel(getMatcher($._config)) { gridPos: { h: 4, w: 6, x: 18, y: 0 } },
+          topQueuesByEnqueueRatePanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 0, y: 4 } },
+          topQueuesByDequeueRatePanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 12, y: 4 } },
+          topQueuesByAverageEnqueueTimePanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 0, y: 12 } },
+          topQueuesByExpiredMessageRatePanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 12, y: 12 } },
+          topQueuesByAverageMessageSizePanel(getMatcher($._config)) { gridPos: { h: 7, w: 24, x: 0, y: 20 } },
+          queueSummaryPanel(getMatcher($._config)) { gridPos: { h: 7, w: 24, x: 0, y: 27 } },
         ]
       ),
   },

--- a/apache-activemq-mixin/dashboards/apache-activemq-queue-overview.libsonnet
+++ b/apache-activemq-mixin/dashboards/apache-activemq-queue-overview.libsonnet
@@ -1,0 +1,649 @@
+local g = (import 'grafana-builder/grafana.libsonnet');
+local grafana = (import 'grafonnet/grafana.libsonnet');
+local dashboard = grafana.dashboard;
+local template = grafana.template;
+local prometheus = grafana.prometheus;
+
+local dashboardUid = 'apache-activemq-queue-overview';
+
+local promDatasourceName = 'prometheus_datasource';
+
+local promDatasource = {
+  uid: '${%s}' % promDatasourceName,
+};
+
+local numberOfQueuesPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'count by(instance) (activemq_queue_queue_size{instance=~"$instance", job=~"$job"})',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+    ),
+  ],
+  type: 'stat',
+  title: 'Number of queues',
+  description: 'Number of queues connected with the broker instance.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    colorMode: 'value',
+    graphMode: 'none',
+    justifyMode: 'auto',
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    textMode: 'auto',
+  },
+  pluginVersion: '10.2.0-59542pre',
+};
+
+local producerCountPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by(instance) (activemq_queue_producer_count{job=~"$job", instance=~"$instance"})',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+    ),
+  ],
+  type: 'stat',
+  title: 'Producer count',
+  description: 'The number of producers attached to queue destinations.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    colorMode: 'value',
+    graphMode: 'none',
+    justifyMode: 'auto',
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    textMode: 'auto',
+  },
+  pluginVersion: '10.2.0-59542pre',
+};
+
+local consumerCountPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by(instance) (activemq_queue_consumer_count{instance=~"$instance", job=~"$job"})',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+    ),
+  ],
+  type: 'stat',
+  title: 'Consumer count',
+  description: 'The number of consumers subscribed to queue destinations.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    colorMode: 'value',
+    graphMode: 'none',
+    justifyMode: 'auto',
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    textMode: 'auto',
+  },
+  pluginVersion: '10.2.0-59542pre',
+};
+
+local deadLetterQueuePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by (instance) (activemq_queue_dlq{job=~"$job", instance=~"$instance"})',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+    ),
+  ],
+  type: 'stat',
+  title: 'Dead letter queue',
+  description: 'The number of messages in dead letter queue.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    colorMode: 'value',
+    graphMode: 'none',
+    justifyMode: 'auto',
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    textMode: 'auto',
+  },
+  pluginVersion: '10.2.0-59542pre',
+};
+
+local topQueuesByEnqueueRatePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'topk by(instance) (5, rate(activemq_queue_enqueue_count{job=~"$job", instance=~"$instance"}[$__rate_interval]))',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - {{destination}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Top queues by enqueue rate',
+  description: 'The rate messages sent to the top k queue destinations.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 25,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'mps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local topQueuesByDequeueRatePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'topk by(instance) (5, rate(activemq_queue_dequeue_count{job=~"$job", instance=~"$instance"}[$__rate_interval]))',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - {{destination}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Top queues by dequeue rate',
+  description: 'The rate messages have been acknowledged (and removed) from the top k queue destinations.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 25,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'mps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local topQueuesByAverageEnqueueTimePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'topk by(instance) (5, activemq_queue_average_enqueue_time{job=~"$job", instance=~"$instance"})',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - {{destination}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Top queues by average enqueue time',
+  description: 'Average time a message was held on top k queue destinations.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 25,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'ms',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local topQueuesByExpiredMessageRatePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'topk by(instance) (5, rate(activemq_queue_expired_count{job=~"$job", instance=~"$instance"}[$__rate_interval]))',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - {{destination}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Top queues by expired message rate',
+  description: 'The rate messages have expired on the top k queue destinations.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 25,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'mps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local topQueuesByAverageMessageSizePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'topk by(instance) (5, activemq_queue_average_message_size{job=~"$job", instance=~"$instance"})',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - {{destination}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Top queues by average message size',
+  description: 'Average message size on queue destinations.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        axisSoftMin: 0,
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 25,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      min: 0,
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'decbytes',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+{
+  grafanaDashboards+:: {
+    'apache-activemq-queue-overview.json':
+      dashboard.new(
+        'Apache ActiveMQ queue overview',
+        time_from='%s' % $._config.dashboardPeriod,
+        tags=($._config.dashboardTags),
+        timezone='%s' % $._config.dashboardTimezone,
+        refresh='%s' % $._config.dashboardRefresh,
+        description='',
+        uid=dashboardUid,
+      )
+
+      .addTemplates(
+        [
+          template.datasource(
+            promDatasourceName,
+            'prometheus',
+            null,
+            label='Data Source',
+            refresh='load'
+          ),
+          template.new(
+            'job',
+            promDatasource,
+            'label_values(activemq_topic_producer_count,job)',
+            label='Job',
+            refresh=2,
+            includeAll=true,
+            multi=true,
+            allValues='',
+            sort=0
+          ),
+          template.new(
+            'instance',
+            promDatasource,
+            'label_values(activemq_topic_producer_count{job=~"$job"},instance)',
+            label='Instance',
+            refresh=2,
+            includeAll=true,
+            multi=true,
+            allValues='',
+            sort=0
+          ),
+        ]
+      )
+      .addPanels(
+        [
+          numberOfQueuesPanel { gridPos: { h: 4, w: 6, x: 0, y: 0 } },
+          producerCountPanel { gridPos: { h: 4, w: 6, x: 6, y: 0 } },
+          consumerCountPanel { gridPos: { h: 4, w: 6, x: 12, y: 0 } },
+          deadLetterQueuePanel { gridPos: { h: 4, w: 6, x: 18, y: 0 } },
+          topQueuesByEnqueueRatePanel { gridPos: { h: 8, w: 12, x: 0, y: 4 } },
+          topQueuesByDequeueRatePanel { gridPos: { h: 8, w: 12, x: 12, y: 4 } },
+          topQueuesByAverageEnqueueTimePanel { gridPos: { h: 8, w: 12, x: 0, y: 12 } },
+          topQueuesByExpiredMessageRatePanel { gridPos: { h: 8, w: 12, x: 12, y: 12 } },
+          topQueuesByAverageMessageSizePanel { gridPos: { h: 7, w: 24, x: 0, y: 20 } },
+        ]
+      ),
+  },
+}

--- a/apache-activemq-mixin/dashboards/apache-activemq-topic-overview.libsonnet
+++ b/apache-activemq-mixin/dashboards/apache-activemq-topic-overview.libsonnet
@@ -215,7 +215,7 @@ local topTopicsByEnqueueRatePanel(matcher) = {
   ],
   type: 'timeseries',
   title: 'Top topics by enqueue rate',
-  description: 'The rate messages are sent to the top k topic destinations.',
+  description: 'The rate messages are sent to topic destinations.',
   fieldConfig: {
     defaults: {
       color: {
@@ -292,7 +292,7 @@ local topTopicsByDequeueRatePanel(matcher) = {
   ],
   type: 'timeseries',
   title: 'Top topics by dequeue rate',
-  description: 'The rate messages have been acknowledged (and removed) from the top k topic destinations',
+  description: 'The rate messages have been acknowledged (and removed) from topic destinations',
   fieldConfig: {
     defaults: {
       color: {
@@ -369,7 +369,7 @@ local topTopicsByAverageEnqueueTimePanel(matcher) = {
   ],
   type: 'timeseries',
   title: 'Top topics by average enqueue time',
-  description: 'Average time a message was held on top k topic destinations.',
+  description: 'Average time a message was held across all topic destinations.',
   fieldConfig: {
     defaults: {
       color: {
@@ -446,7 +446,7 @@ local topTopicsByExpiredMessageRatePanel(matcher) = {
   ],
   type: 'timeseries',
   title: 'Top topics by expired message rate',
-  description: 'The rate messages have expired on the top k topic destinations.',
+  description: 'The rate messages have expired on topic destinations.',
   fieldConfig: {
     defaults: {
       color: {
@@ -875,7 +875,7 @@ local getMatcher(cfg) = '%(activemqSelector)s, activemq_cluster=~"$activemq_clus
             'k_selector',
             promDatasource,
             '2,4,6,8,10',
-            label='Top k count',
+            label='Top topic count',
             refresh=0,
             includeAll=false,
             multi=false,

--- a/apache-activemq-mixin/dashboards/apache-activemq-topic-overview.libsonnet
+++ b/apache-activemq-mixin/dashboards/apache-activemq-topic-overview.libsonnet
@@ -22,12 +22,12 @@ local numberOfTopicsPanel(matcher) = {
     ),
   ],
   type: 'stat',
-  title: 'Number of topics',
+  title: 'Topics',
   description: 'Number of topics connected with the broker instance.',
   fieldConfig: {
     defaults: {
       color: {
-        mode: 'thresholds',
+        mode: 'fixed',
       },
       mappings: [],
       thresholds: {
@@ -45,7 +45,7 @@ local numberOfTopicsPanel(matcher) = {
   },
   options: {
     colorMode: 'none',
-    graphMode: 'none',
+    graphMode: 'area',
     justifyMode: 'auto',
     orientation: 'auto',
     reduceOptions: {
@@ -70,12 +70,12 @@ local producerCountPanel(matcher) = {
     ),
   ],
   type: 'stat',
-  title: 'Producer count',
+  title: 'Producers',
   description: 'The number of producers attached to topic destinations.',
   fieldConfig: {
     defaults: {
       color: {
-        mode: 'thresholds',
+        mode: 'fixed',
       },
       mappings: [],
       thresholds: {
@@ -93,7 +93,7 @@ local producerCountPanel(matcher) = {
   },
   options: {
     colorMode: 'none',
-    graphMode: 'none',
+    graphMode: 'area',
     justifyMode: 'auto',
     orientation: 'auto',
     reduceOptions: {
@@ -118,12 +118,12 @@ local consumerCountPanel(matcher) = {
     ),
   ],
   type: 'stat',
-  title: 'Consumer count',
+  title: 'Consumers',
   description: 'The number of consumers subscribed to topic destinations.',
   fieldConfig: {
     defaults: {
       color: {
-        mode: 'thresholds',
+        mode: 'fixed',
       },
       mappings: [],
       thresholds: {
@@ -141,7 +141,7 @@ local consumerCountPanel(matcher) = {
   },
   options: {
     colorMode: 'none',
-    graphMode: 'none',
+    graphMode: 'area',
     justifyMode: 'auto',
     orientation: 'auto',
     reduceOptions: {
@@ -171,7 +171,7 @@ local averageConsumersPerTopicPanel(matcher) = {
   fieldConfig: {
     defaults: {
       color: {
-        mode: 'thresholds',
+        mode: 'fixed',
       },
       mappings: [],
       thresholds: {
@@ -189,7 +189,7 @@ local averageConsumersPerTopicPanel(matcher) = {
   },
   options: {
     colorMode: 'none',
-    graphMode: 'none',
+    graphMode: 'area',
     justifyMode: 'auto',
     orientation: 'auto',
     reduceOptions: {

--- a/apache-activemq-mixin/dashboards/apache-activemq-topic-overview.libsonnet
+++ b/apache-activemq-mixin/dashboards/apache-activemq-topic-overview.libsonnet
@@ -12,11 +12,11 @@ local promDatasource = {
   uid: '${%s}' % promDatasourceName,
 };
 
-local numberOfTopicsPanel = {
+local numberOfTopicsPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'count by(instance, activemq_cluster, job) (activemq_topic_queue_size{instance=~"$instance",activemq_cluster=~"$activemq_cluster", job=~"$job"})',
+      'count by(instance, activemq_cluster, job) (activemq_topic_queue_size{' + matcher + ', instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{instance}}',
     ),
@@ -60,11 +60,11 @@ local numberOfTopicsPanel = {
   pluginVersion: '10.2.0-60139',
 };
 
-local producerCountPanel = {
+local producerCountPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(instance, activemq_cluster, job) (activemq_topic_producer_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"})',
+      'sum by(instance, activemq_cluster, job) (activemq_topic_producer_count{' + matcher + ', instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{instance}}',
     ),
@@ -108,11 +108,11 @@ local producerCountPanel = {
   pluginVersion: '10.2.0-60139',
 };
 
-local consumerCountPanel = {
+local consumerCountPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(instance, activemq_cluster, job) (activemq_topic_consumer_count{instance=~"$instance", activemq_cluster=~"$activemq_cluster", job=~"$job"})',
+      'sum by(instance, activemq_cluster, job) (activemq_topic_consumer_count{' + matcher + ', instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{instance}}',
     ),
@@ -156,11 +156,11 @@ local consumerCountPanel = {
   pluginVersion: '10.2.0-60139',
 };
 
-local averageConsumersPerTopicPanel = {
+local averageConsumersPerTopicPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'avg by (instance, activemq_cluster, job) (activemq_topic_consumer_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"})',
+      'avg by (instance, activemq_cluster, job) (activemq_topic_consumer_count{' + matcher + ', instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{instance}}',
     ),
@@ -204,11 +204,11 @@ local averageConsumersPerTopicPanel = {
   pluginVersion: '10.2.0-60139',
 };
 
-local topTopicsByEnqueueRatePanel = {
+local topTopicsByEnqueueRatePanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'topk by(instance, activemq_cluster, job) ($k_selector, rate(activemq_topic_enqueue_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance", destination=~".*$name.*"}[$__rate_interval]))',
+      'topk by(instance, activemq_cluster, job) ($k_selector, rate(activemq_topic_enqueue_count{' + matcher + ', instance=~"$instance", destination=~".*$name.*"}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - {{destination}}',
     ),
@@ -281,11 +281,11 @@ local topTopicsByEnqueueRatePanel = {
   },
 };
 
-local topTopicsByDequeueRatePanel = {
+local topTopicsByDequeueRatePanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'topk by(instance, activemq_cluster, job) ($k_selector, rate(activemq_topic_dequeue_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance", destination=~".*$name.*"}[$__rate_interval]))',
+      'topk by(instance, activemq_cluster, job) ($k_selector, rate(activemq_topic_dequeue_count{' + matcher + ', instance=~"$instance", destination=~".*$name.*"}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - {{destination}}',
     ),
@@ -358,11 +358,11 @@ local topTopicsByDequeueRatePanel = {
   },
 };
 
-local topTopicsByAverageEnqueueTimePanel = {
+local topTopicsByAverageEnqueueTimePanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'topk by(instance, activemq_cluster, job) ($k_selector, activemq_topic_average_enqueue_time{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance", destination=~".*$name.*"})',
+      'topk by(instance, activemq_cluster, job) ($k_selector, activemq_topic_average_enqueue_time{' + matcher + ', instance=~"$instance", destination=~".*$name.*"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - {{destination}}',
     ),
@@ -435,11 +435,11 @@ local topTopicsByAverageEnqueueTimePanel = {
   },
 };
 
-local topTopicsByExpiredMessageRatePanel = {
+local topTopicsByExpiredMessageRatePanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'topk by(instance, activemq_cluster, job) ($k_selector, rate(activemq_topic_expired_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance", destination=~".*$name.*"}[$__rate_interval]))',
+      'topk by(instance, activemq_cluster, job) ($k_selector, rate(activemq_topic_expired_count{' + matcher + ', instance=~"$instance", destination=~".*$name.*"}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - {{destination}}',
     ),
@@ -512,11 +512,11 @@ local topTopicsByExpiredMessageRatePanel = {
   },
 };
 
-local topTopicsByConsumersPanel = {
+local topTopicsByConsumersPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'topk by(instance, activemq_cluster, job) (5, activemq_topic_consumer_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance", destination=~".*$name.*"})',
+      'topk by(instance, activemq_cluster, job) (5, activemq_topic_consumer_count{' + matcher + ', instance=~"$instance", destination=~".*$name.*"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - {{destination}}',
     ),
@@ -561,11 +561,11 @@ local topTopicsByConsumersPanel = {
   pluginVersion: '10.2.0-60139',
 };
 
-local topTopicsByAverageMessageSizePanel = {
+local topTopicsByAverageMessageSizePanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'topk by(instance, activemq_cluster, job) (5, activemq_topic_average_message_size{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance", destination=~".*$name.*"})',
+      'topk by(instance, activemq_cluster, job) (5, activemq_topic_average_message_size{' + matcher + ', instance=~"$instance", destination=~".*$name.*"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - {{destination}}',
     ),
@@ -640,29 +640,29 @@ local topTopicsByAverageMessageSizePanel = {
   },
 };
 
-local topicSummaryPanel = {
+local topicSummaryPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'rate(activemq_topic_enqueue_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance", destination=~".*$name.*"}[$__rate_interval])',
+      'rate(activemq_topic_enqueue_count{' + matcher + ', instance=~"$instance", destination=~".*$name.*"}[$__rate_interval])',
       datasource=promDatasource,
       legendFormat='{{instance}}',
       format='table',
     ),
     prometheus.target(
-      'rate(activemq_topic_dequeue_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance", destination=~".*$name.*"}[$__rate_interval])',
+      'rate(activemq_topic_dequeue_count{' + matcher + ', instance=~"$instance", destination=~".*$name.*"}[$__rate_interval])',
       datasource=promDatasource,
       legendFormat='{{instance}}',
       format='table',
     ),
     prometheus.target(
-      'activemq_topic_average_enqueue_time{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance", destination=~".*$name.*"}',
+      'activemq_topic_average_enqueue_time{' + matcher + ', instance=~"$instance", destination=~".*$name.*"}',
       datasource=promDatasource,
       legendFormat='{{instance}}',
       format='table',
     ),
     prometheus.target(
-      'activemq_topic_average_message_size{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance", destination=~".*$name.*"}',
+      'activemq_topic_average_message_size{' + matcher + ', instance=~"$instance", destination=~".*$name.*"}',
       datasource=promDatasource,
       legendFormat='{{instance}}',
       format='table',
@@ -802,6 +802,8 @@ local topicSummaryPanel = {
   ],
 };
 
+local getMatcher(cfg) = '%(activemqSelector)s, activemq_cluster=~"$activemq_cluster"' % cfg;
+
 {
   grafanaDashboards+:: {
     'apache-activemq-topic-overview.json':
@@ -844,12 +846,13 @@ local topicSummaryPanel = {
             includeAll=true,
             multi=true,
             allValues='',
+            hide=if $._config.enableMultiCluster then '' else 'variable',
             sort=0
           ),
           template.new(
             'activemq_cluster',
             promDatasource,
-            'label_values(activemq_memory_usage_ratio{job=~"$job", cluster=~"$cluster"},activemq_cluster)',
+            'label_values(activemq_memory_usage_ratio{%(activemqSelector)s},activemq_cluster)',
             label='ActiveMQ cluster',
             refresh=2,
             includeAll=true,
@@ -860,7 +863,7 @@ local topicSummaryPanel = {
           template.new(
             'instance',
             promDatasource,
-            'label_values(activemq_topic_producer_count{activemq_cluster=~"$activemq_cluster"},instance)',
+            'label_values(activemq_topic_producer_count{%(activemqSelector)s,activemq_cluster=~"$activemq_cluster"},instance)',
             label='Instance',
             refresh=2,
             includeAll=true,
@@ -901,17 +904,17 @@ local topicSummaryPanel = {
       ))
       .addPanels(
         [
-          numberOfTopicsPanel { gridPos: { h: 4, w: 6, x: 0, y: 0 } },
-          producerCountPanel { gridPos: { h: 4, w: 6, x: 6, y: 0 } },
-          consumerCountPanel { gridPos: { h: 4, w: 6, x: 12, y: 0 } },
-          averageConsumersPerTopicPanel { gridPos: { h: 4, w: 6, x: 18, y: 0 } },
-          topTopicsByEnqueueRatePanel { gridPos: { h: 8, w: 12, x: 0, y: 4 } },
-          topTopicsByDequeueRatePanel { gridPos: { h: 8, w: 12, x: 12, y: 4 } },
-          topTopicsByAverageEnqueueTimePanel { gridPos: { h: 8, w: 12, x: 0, y: 12 } },
-          topTopicsByExpiredMessageRatePanel { gridPos: { h: 8, w: 12, x: 12, y: 12 } },
-          topTopicsByConsumersPanel { gridPos: { h: 8, w: 12, x: 0, y: 20 } },
-          topTopicsByAverageMessageSizePanel { gridPos: { h: 8, w: 12, x: 12, y: 20 } },
-          topicSummaryPanel { gridPos: { h: 8, w: 24, x: 0, y: 28 } },
+          numberOfTopicsPanel(getMatcher($._config)) { gridPos: { h: 4, w: 6, x: 0, y: 0 } },
+          producerCountPanel(getMatcher($._config)) { gridPos: { h: 4, w: 6, x: 6, y: 0 } },
+          consumerCountPanel(getMatcher($._config)) { gridPos: { h: 4, w: 6, x: 12, y: 0 } },
+          averageConsumersPerTopicPanel(getMatcher($._config)) { gridPos: { h: 4, w: 6, x: 18, y: 0 } },
+          topTopicsByEnqueueRatePanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 0, y: 4 } },
+          topTopicsByDequeueRatePanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 12, y: 4 } },
+          topTopicsByAverageEnqueueTimePanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 0, y: 12 } },
+          topTopicsByExpiredMessageRatePanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 12, y: 12 } },
+          topTopicsByConsumersPanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 0, y: 20 } },
+          topTopicsByAverageMessageSizePanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 12, y: 20 } },
+          topicSummaryPanel(getMatcher($._config)) { gridPos: { h: 8, w: 24, x: 0, y: 28 } },
         ]
       ),
   },

--- a/apache-activemq-mixin/dashboards/apache-activemq-topic-overview.libsonnet
+++ b/apache-activemq-mixin/dashboards/apache-activemq-topic-overview.libsonnet
@@ -16,7 +16,7 @@ local numberOfTopicsPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'count by(instance) (activemq_topic_queue_size{instance=~"$instance", job=~"$job"})',
+      'count by(instance, activemq_cluster) (activemq_topic_queue_size{instance=~"$instance",activemq_cluster=~"$activemq_cluster", job=~"$job"})',
       datasource=promDatasource,
       legendFormat='{{instance}}',
     ),
@@ -44,7 +44,7 @@ local numberOfTopicsPanel = {
     overrides: [],
   },
   options: {
-    colorMode: 'value',
+    colorMode: 'none',
     graphMode: 'none',
     justifyMode: 'auto',
     orientation: 'auto',
@@ -57,14 +57,14 @@ local numberOfTopicsPanel = {
     },
     textMode: 'auto',
   },
-  pluginVersion: '10.2.0-59542pre',
+  pluginVersion: '10.2.0-59981',
 };
 
 local producerCountPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(instance) (activemq_topic_producer_count{job=~"$job", instance=~"$instance"})',
+      'sum by(instance, activemq_cluster) (activemq_topic_producer_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{instance}}',
     ),
@@ -92,7 +92,7 @@ local producerCountPanel = {
     overrides: [],
   },
   options: {
-    colorMode: 'value',
+    colorMode: 'none',
     graphMode: 'none',
     justifyMode: 'auto',
     orientation: 'auto',
@@ -105,14 +105,14 @@ local producerCountPanel = {
     },
     textMode: 'auto',
   },
-  pluginVersion: '10.2.0-59542pre',
+  pluginVersion: '10.2.0-59981',
 };
 
 local consumerCountPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(instance) (activemq_topic_consumer_count{instance=~"$instance", job=~"$job"})',
+      'sum by(instance, activemq_cluster) (activemq_topic_consumer_count{instance=~"$instance", activemq_cluster=~"$activemq_cluster", job=~"$job"})',
       datasource=promDatasource,
       legendFormat='{{instance}}',
     ),
@@ -140,7 +140,7 @@ local consumerCountPanel = {
     overrides: [],
   },
   options: {
-    colorMode: 'value',
+    colorMode: 'none',
     graphMode: 'none',
     justifyMode: 'auto',
     orientation: 'auto',
@@ -153,14 +153,14 @@ local consumerCountPanel = {
     },
     textMode: 'auto',
   },
-  pluginVersion: '10.2.0-59542pre',
+  pluginVersion: '10.2.0-59981',
 };
 
 local averageConsumersPerTopicPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'avg by (instance) (activemq_topic_consumer_count{job=~"$job", instance=~"$instance"})',
+      'avg by (instance, activemq_cluster) (activemq_topic_consumer_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{instance}}',
     ),
@@ -188,7 +188,7 @@ local averageConsumersPerTopicPanel = {
     overrides: [],
   },
   options: {
-    colorMode: 'value',
+    colorMode: 'none',
     graphMode: 'none',
     justifyMode: 'auto',
     orientation: 'auto',
@@ -201,16 +201,16 @@ local averageConsumersPerTopicPanel = {
     },
     textMode: 'auto',
   },
-  pluginVersion: '10.2.0-59542pre',
+  pluginVersion: '10.2.0-59981',
 };
 
 local topTopicsByEnqueueRatePanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'topk by(instance) (5, rate(activemq_topic_enqueue_count{job=~"$job", instance=~"$instance"}[$__rate_interval]))',
+      'topk by(instance, activemq_cluster) ($k_selector, rate(activemq_topic_enqueue_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance", destination=~".*$name.*"}[$__rate_interval]))',
       datasource=promDatasource,
-      legendFormat='{{instance}} - {{destination}}',
+      legendFormat='{{activemq_cluster}} - {{instance}} - {{destination}}',
     ),
   ],
   type: 'timeseries',
@@ -236,8 +236,8 @@ local topTopicsByEnqueueRatePanel = {
           viz: false,
         },
         insertNulls: false,
-        lineInterpolation: 'linear',
-        lineWidth: 1,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
         pointSize: 5,
         scaleDistribution: {
           type: 'linear',
@@ -246,7 +246,7 @@ local topTopicsByEnqueueRatePanel = {
         spanNulls: false,
         stacking: {
           group: 'A',
-          mode: 'normal',
+          mode: 'none',
         },
         thresholdsStyle: {
           mode: 'off',
@@ -284,9 +284,9 @@ local topTopicsByDequeueRatePanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'topk by(instance) (5, rate(activemq_topic_dequeue_count{job=~"$job", instance=~"$instance"}[$__rate_interval]))',
+      'topk by(instance, activemq_cluster) ($k_selector, rate(activemq_topic_dequeue_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance", destination=~".*$name.*"}[$__rate_interval]))',
       datasource=promDatasource,
-      legendFormat='{{instance}} - {{destination}}',
+      legendFormat='{{activemq_cluster}} - {{instance}} - {{destination}}',
     ),
   ],
   type: 'timeseries',
@@ -312,8 +312,8 @@ local topTopicsByDequeueRatePanel = {
           viz: false,
         },
         insertNulls: false,
-        lineInterpolation: 'linear',
-        lineWidth: 1,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
         pointSize: 5,
         scaleDistribution: {
           type: 'linear',
@@ -322,7 +322,7 @@ local topTopicsByDequeueRatePanel = {
         spanNulls: false,
         stacking: {
           group: 'A',
-          mode: 'normal',
+          mode: 'none',
         },
         thresholdsStyle: {
           mode: 'off',
@@ -360,9 +360,9 @@ local topTopicsByAverageEnqueueTimePanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'topk by(instance) (5, activemq_topic_average_enqueue_time{job=~"$job", instance=~"$instance"})',
+      'topk by(instance, activemq_cluster) ($k_selector, activemq_topic_average_enqueue_time{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance", destination=~".*$name.*"})',
       datasource=promDatasource,
-      legendFormat='{{instance}} - {{destination}}',
+      legendFormat='{{activemq_cluster}} - {{instance}} - {{destination}}',
     ),
   ],
   type: 'timeseries',
@@ -388,8 +388,8 @@ local topTopicsByAverageEnqueueTimePanel = {
           viz: false,
         },
         insertNulls: false,
-        lineInterpolation: 'linear',
-        lineWidth: 1,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
         pointSize: 5,
         scaleDistribution: {
           type: 'linear',
@@ -398,7 +398,7 @@ local topTopicsByAverageEnqueueTimePanel = {
         spanNulls: false,
         stacking: {
           group: 'A',
-          mode: 'normal',
+          mode: 'none',
         },
         thresholdsStyle: {
           mode: 'off',
@@ -436,9 +436,9 @@ local topTopicsByExpiredMessageRatePanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'topk by(instance) (5, rate(activemq_topic_expired_count{job=~"$job", instance=~"$instance"}[$__rate_interval]))',
+      'topk by(instance, activemq_cluster) ($k_selector, rate(activemq_topic_expired_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance", destination=~".*$name.*"}[$__rate_interval]))',
       datasource=promDatasource,
-      legendFormat='{{instance}} - {{destination}}',
+      legendFormat='{{activemq_cluster}} - {{instance}} - {{destination}}',
     ),
   ],
   type: 'timeseries',
@@ -464,8 +464,8 @@ local topTopicsByExpiredMessageRatePanel = {
           viz: false,
         },
         insertNulls: false,
-        lineInterpolation: 'linear',
-        lineWidth: 1,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
         pointSize: 5,
         scaleDistribution: {
           type: 'linear',
@@ -474,7 +474,7 @@ local topTopicsByExpiredMessageRatePanel = {
         spanNulls: false,
         stacking: {
           group: 'A',
-          mode: 'normal',
+          mode: 'none',
         },
         thresholdsStyle: {
           mode: 'off',
@@ -512,9 +512,9 @@ local topTopicsByConsumersPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'topk by(instance) (5, activemq_topic_consumer_count{job=~"$job", instance=~"$instance"})',
+      'topk by(instance, activemq_cluster) (5, activemq_topic_consumer_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance", destination=~".*$name.*"})',
       datasource=promDatasource,
-      legendFormat='{{instance}} - {{destination}}',
+      legendFormat='{{activemq_cluster}} - {{instance}} - {{destination}}',
     ),
   ],
   type: 'bargauge',
@@ -523,7 +523,7 @@ local topTopicsByConsumersPanel = {
   fieldConfig: {
     defaults: {
       color: {
-        mode: 'thresholds',
+        mode: 'fixed',
       },
       mappings: [],
       thresholds: {
@@ -554,16 +554,16 @@ local topTopicsByConsumersPanel = {
     showUnfilled: true,
     valueMode: 'color',
   },
-  pluginVersion: '10.2.0-59542pre',
+  pluginVersion: '10.2.0-59981',
 };
 
 local topTopicsByAverageMessageSizePanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'topk by(instance) (5, activemq_topic_average_message_size{job=~"$job", instance=~"$instance"})',
+      'topk by(instance, activemq_cluster) (5, activemq_topic_average_message_size{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance", destination=~".*$name.*"})',
       datasource=promDatasource,
-      legendFormat='{{instance}} - {{destination}}',
+      legendFormat='{{activemq_cluster}} - {{instance}} - {{destination}}',
     ),
   ],
   type: 'timeseries',
@@ -590,8 +590,8 @@ local topTopicsByAverageMessageSizePanel = {
           viz: false,
         },
         insertNulls: false,
-        lineInterpolation: 'linear',
-        lineWidth: 1,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
         pointSize: 5,
         scaleDistribution: {
           type: 'linear',
@@ -635,6 +635,169 @@ local topTopicsByAverageMessageSizePanel = {
   },
 };
 
+local topicSummaryPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'rate(activemq_topic_enqueue_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance", destination=~".*$name.*"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+      format='table',
+    ),
+    prometheus.target(
+      'rate(activemq_topic_dequeue_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance", destination=~".*$name.*"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+      format='table',
+    ),
+    prometheus.target(
+      'activemq_topic_average_enqueue_time{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance", destination=~".*$name.*"}',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+      format='table',
+    ),
+    prometheus.target(
+      'activemq_topic_average_message_size{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance", destination=~".*$name.*"}',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+      format='table',
+    ),
+  ],
+  type: 'table',
+  title: 'Topic summary',
+  description: 'Summary of topics showing topic name, enqueue and dequeue rate, average enqueue time, and average message size.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      custom: {
+        align: 'left',
+        cellOptions: {
+          type: 'auto',
+        },
+        inspect: false,
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+    },
+    overrides: [
+      {
+        matcher: {
+          id: 'byName',
+          options: 'Enqueue rate',
+        },
+        properties: [
+          {
+            id: 'unit',
+            value: 'mps',
+          },
+        ],
+      },
+      {
+        matcher: {
+          id: 'byName',
+          options: 'Dequeue rate',
+        },
+        properties: [
+          {
+            id: 'unit',
+            value: 'mps',
+          },
+        ],
+      },
+      {
+        matcher: {
+          id: 'byName',
+          options: 'Average enqueue time',
+        },
+        properties: [
+          {
+            id: 'unit',
+            value: 'ms',
+          },
+        ],
+      },
+      {
+        matcher: {
+          id: 'byName',
+          options: 'Average message size',
+        },
+        properties: [
+          {
+            id: 'unit',
+            value: 'decbytes',
+          },
+        ],
+      },
+    ],
+  },
+  options: {
+    cellHeight: 'sm',
+    footer: {
+      countRows: false,
+      fields: '',
+      reducer: [
+        'sum',
+      ],
+      show: false,
+    },
+    showHeader: true,
+  },
+  pluginVersion: '10.2.0-59981',
+  transformations: [
+    {
+      id: 'joinByField',
+      options: {
+        byField: 'destination',
+        mode: 'outer',
+      },
+    },
+    {
+      id: 'organize',
+      options: {
+        excludeByName: {
+          'Time 1': true,
+          'Time 2': true,
+          'Time 3': true,
+          'Time 4': true,
+          '__name__ 1': true,
+          '__name__ 2': true,
+          'activemq_cluster 1': true,
+          'activemq_cluster 2': true,
+          'activemq_cluster 3': true,
+          'activemq_cluster 4': true,
+          'instance 1': true,
+          'instance 2': true,
+          'instance 3': true,
+          'instance 4': true,
+          'job 1': true,
+          'job 2': true,
+          'job 3': true,
+          'job 4': true,
+        },
+        indexByName: {},
+        renameByName: {
+          'Time 3': '',
+          'Value #A': 'Enqueue rate',
+          'Value #B': 'Dequeue rate',
+          'Value #C': 'Average enqueue time',
+          'Value #D': 'Average message size',
+          destination: 'Destination',
+        },
+      },
+    },
+  ],
+};
+
 {
   grafanaDashboards+:: {
     'apache-activemq-topic-overview.json':
@@ -669,13 +832,46 @@ local topTopicsByAverageMessageSizePanel = {
             sort=0
           ),
           template.new(
+            'activemq_cluster',
+            promDatasource,
+            'label_values(activemq_memory_usage_ratio{job=~"$job"},activemq_cluster)',
+            label='ActiveMQ cluster',
+            refresh=2,
+            includeAll=true,
+            multi=true,
+            allValues='',
+            sort=0
+          ),
+          template.new(
             'instance',
             promDatasource,
-            'label_values(activemq_topic_producer_count{job=~"$job"},instance)',
+            'label_values(activemq_topic_producer_count{activemq_cluster=~"$activemq_cluster"},instance)',
             label='Instance',
             refresh=2,
             includeAll=true,
             multi=true,
+            allValues='',
+            sort=0
+          ),
+          template.new(
+            'k_selector',
+            promDatasource,
+            '2,4,6,8,10',
+            label='Top k count',
+            refresh=0,
+            includeAll=false,
+            multi=false,
+            allValues='',
+            sort=0
+          ),
+          template.new(
+            'name',
+            promDatasource,
+            '',
+            label='Topic by name',
+            refresh=0,
+            includeAll=false,
+            multi=false,
             allValues='',
             sort=0
           ),
@@ -693,6 +889,7 @@ local topTopicsByAverageMessageSizePanel = {
           topTopicsByExpiredMessageRatePanel { gridPos: { h: 8, w: 12, x: 12, y: 12 } },
           topTopicsByConsumersPanel { gridPos: { h: 8, w: 12, x: 0, y: 20 } },
           topTopicsByAverageMessageSizePanel { gridPos: { h: 8, w: 12, x: 12, y: 20 } },
+          topicSummaryPanel { gridPos: { h: 8, w: 24, x: 0, y: 28 } },
         ]
       ),
   },

--- a/apache-activemq-mixin/dashboards/apache-activemq-topic-overview.libsonnet
+++ b/apache-activemq-mixin/dashboards/apache-activemq-topic-overview.libsonnet
@@ -852,7 +852,7 @@ local getMatcher(cfg) = '%(activemqSelector)s, activemq_cluster=~"$activemq_clus
           template.new(
             'activemq_cluster',
             promDatasource,
-            'label_values(activemq_memory_usage_ratio{%(activemqSelector)s},activemq_cluster)',
+            'label_values(activemq_memory_usage_ratio{%(activemqSelector)s},activemq_cluster)' % $._config,
             label='ActiveMQ cluster',
             refresh=2,
             includeAll=true,
@@ -863,7 +863,7 @@ local getMatcher(cfg) = '%(activemqSelector)s, activemq_cluster=~"$activemq_clus
           template.new(
             'instance',
             promDatasource,
-            'label_values(activemq_topic_producer_count{%(activemqSelector)s,activemq_cluster=~"$activemq_cluster"},instance)',
+            'label_values(activemq_topic_producer_count{%(activemqSelector)s,activemq_cluster=~"$activemq_cluster"},instance)' % $._config,
             label='Instance',
             refresh=2,
             includeAll=true,

--- a/apache-activemq-mixin/dashboards/apache-activemq-topic-overview.libsonnet
+++ b/apache-activemq-mixin/dashboards/apache-activemq-topic-overview.libsonnet
@@ -16,7 +16,7 @@ local numberOfTopicsPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'count by(instance, activemq_cluster) (activemq_topic_queue_size{instance=~"$instance",activemq_cluster=~"$activemq_cluster", job=~"$job"})',
+      'count by(instance, activemq_cluster, job) (activemq_topic_queue_size{instance=~"$instance",activemq_cluster=~"$activemq_cluster", job=~"$job"})',
       datasource=promDatasource,
       legendFormat='{{instance}}',
     ),
@@ -57,14 +57,14 @@ local numberOfTopicsPanel = {
     },
     textMode: 'auto',
   },
-  pluginVersion: '10.2.0-59981',
+  pluginVersion: '10.2.0-60139',
 };
 
 local producerCountPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(instance, activemq_cluster) (activemq_topic_producer_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"})',
+      'sum by(instance, activemq_cluster, job) (activemq_topic_producer_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{instance}}',
     ),
@@ -105,14 +105,14 @@ local producerCountPanel = {
     },
     textMode: 'auto',
   },
-  pluginVersion: '10.2.0-59981',
+  pluginVersion: '10.2.0-60139',
 };
 
 local consumerCountPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(instance, activemq_cluster) (activemq_topic_consumer_count{instance=~"$instance", activemq_cluster=~"$activemq_cluster", job=~"$job"})',
+      'sum by(instance, activemq_cluster, job) (activemq_topic_consumer_count{instance=~"$instance", activemq_cluster=~"$activemq_cluster", job=~"$job"})',
       datasource=promDatasource,
       legendFormat='{{instance}}',
     ),
@@ -153,14 +153,14 @@ local consumerCountPanel = {
     },
     textMode: 'auto',
   },
-  pluginVersion: '10.2.0-59981',
+  pluginVersion: '10.2.0-60139',
 };
 
 local averageConsumersPerTopicPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'avg by (instance, activemq_cluster) (activemq_topic_consumer_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"})',
+      'avg by (instance, activemq_cluster, job) (activemq_topic_consumer_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{instance}}',
     ),
@@ -201,14 +201,14 @@ local averageConsumersPerTopicPanel = {
     },
     textMode: 'auto',
   },
-  pluginVersion: '10.2.0-59981',
+  pluginVersion: '10.2.0-60139',
 };
 
 local topTopicsByEnqueueRatePanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'topk by(instance, activemq_cluster) ($k_selector, rate(activemq_topic_enqueue_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance", destination=~".*$name.*"}[$__rate_interval]))',
+      'topk by(instance, activemq_cluster, job) ($k_selector, rate(activemq_topic_enqueue_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance", destination=~".*$name.*"}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - {{destination}}',
     ),
@@ -226,6 +226,7 @@ local topTopicsByEnqueueRatePanel = {
         axisColorMode: 'text',
         axisLabel: '',
         axisPlacement: 'auto',
+        axisShow: false,
         barAlignment: 0,
         drawStyle: 'line',
         fillOpacity: 25,
@@ -284,7 +285,7 @@ local topTopicsByDequeueRatePanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'topk by(instance, activemq_cluster) ($k_selector, rate(activemq_topic_dequeue_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance", destination=~".*$name.*"}[$__rate_interval]))',
+      'topk by(instance, activemq_cluster, job) ($k_selector, rate(activemq_topic_dequeue_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance", destination=~".*$name.*"}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - {{destination}}',
     ),
@@ -302,6 +303,7 @@ local topTopicsByDequeueRatePanel = {
         axisColorMode: 'text',
         axisLabel: '',
         axisPlacement: 'auto',
+        axisShow: false,
         barAlignment: 0,
         drawStyle: 'line',
         fillOpacity: 25,
@@ -360,7 +362,7 @@ local topTopicsByAverageEnqueueTimePanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'topk by(instance, activemq_cluster) ($k_selector, activemq_topic_average_enqueue_time{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance", destination=~".*$name.*"})',
+      'topk by(instance, activemq_cluster, job) ($k_selector, activemq_topic_average_enqueue_time{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance", destination=~".*$name.*"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - {{destination}}',
     ),
@@ -378,6 +380,7 @@ local topTopicsByAverageEnqueueTimePanel = {
         axisColorMode: 'text',
         axisLabel: '',
         axisPlacement: 'auto',
+        axisShow: false,
         barAlignment: 0,
         drawStyle: 'line',
         fillOpacity: 25,
@@ -436,7 +439,7 @@ local topTopicsByExpiredMessageRatePanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'topk by(instance, activemq_cluster) ($k_selector, rate(activemq_topic_expired_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance", destination=~".*$name.*"}[$__rate_interval]))',
+      'topk by(instance, activemq_cluster, job) ($k_selector, rate(activemq_topic_expired_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance", destination=~".*$name.*"}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - {{destination}}',
     ),
@@ -454,6 +457,7 @@ local topTopicsByExpiredMessageRatePanel = {
         axisColorMode: 'text',
         axisLabel: '',
         axisPlacement: 'auto',
+        axisShow: false,
         barAlignment: 0,
         drawStyle: 'line',
         fillOpacity: 25,
@@ -512,7 +516,7 @@ local topTopicsByConsumersPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'topk by(instance, activemq_cluster) (5, activemq_topic_consumer_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance", destination=~".*$name.*"})',
+      'topk by(instance, activemq_cluster, job) (5, activemq_topic_consumer_count{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance", destination=~".*$name.*"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - {{destination}}',
     ),
@@ -554,14 +558,14 @@ local topTopicsByConsumersPanel = {
     showUnfilled: true,
     valueMode: 'color',
   },
-  pluginVersion: '10.2.0-59981',
+  pluginVersion: '10.2.0-60139',
 };
 
 local topTopicsByAverageMessageSizePanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'topk by(instance, activemq_cluster) (5, activemq_topic_average_message_size{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance", destination=~".*$name.*"})',
+      'topk by(instance, activemq_cluster, job) (5, activemq_topic_average_message_size{job=~"$job", activemq_cluster=~"$activemq_cluster", instance=~"$instance", destination=~".*$name.*"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - {{destination}}',
     ),
@@ -579,6 +583,7 @@ local topTopicsByAverageMessageSizePanel = {
         axisColorMode: 'text',
         axisLabel: '',
         axisPlacement: 'auto',
+        axisShow: false,
         axisSoftMin: 0,
         barAlignment: 0,
         drawStyle: 'line',
@@ -684,7 +689,6 @@ local topicSummaryPanel = {
         steps: [
           {
             color: 'green',
-            value: null,
           },
         ],
       },
@@ -752,7 +756,7 @@ local topicSummaryPanel = {
     },
     showHeader: true,
   },
-  pluginVersion: '10.2.0-59981',
+  pluginVersion: '10.2.0-60139',
   transformations: [
     {
       id: 'joinByField',
@@ -832,9 +836,20 @@ local topicSummaryPanel = {
             sort=0
           ),
           template.new(
+            'cluster',
+            promDatasource,
+            'label_values(activemq_memory_usage_ratio{job=~"$job"},cluster)',
+            label='Cluster',
+            refresh=2,
+            includeAll=true,
+            multi=true,
+            allValues='',
+            sort=0
+          ),
+          template.new(
             'activemq_cluster',
             promDatasource,
-            'label_values(activemq_memory_usage_ratio{job=~"$job"},activemq_cluster)',
+            'label_values(activemq_memory_usage_ratio{job=~"$job", cluster=~"$cluster"},activemq_cluster)',
             label='ActiveMQ cluster',
             refresh=2,
             includeAll=true,
@@ -877,6 +892,13 @@ local topicSummaryPanel = {
           ),
         ]
       )
+      .addLink(grafana.link.dashboards(
+        asDropdown=false,
+        title='Other Apache ActiveMQ dashboards',
+        includeVars=true,
+        keepTime=true,
+        tags=($._config.dashboardTags),
+      ))
       .addPanels(
         [
           numberOfTopicsPanel { gridPos: { h: 4, w: 6, x: 0, y: 0 } },

--- a/apache-activemq-mixin/dashboards/apache-activemq-topic-overview.libsonnet
+++ b/apache-activemq-mixin/dashboards/apache-activemq-topic-overview.libsonnet
@@ -16,7 +16,7 @@ local numberOfTopicsPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'count by(instance, activemq_cluster, job) (activemq_topic_queue_size{' + matcher + ', instance=~"$instance"})',
+      'count by(instance, activemq_cluster, job) (activemq_topic_queue_size{' + matcher + ', instance=~"$instance", destination!~"ActiveMQ.Advisory.*"})',
       datasource=promDatasource,
       legendFormat='{{instance}}',
     ),
@@ -64,7 +64,7 @@ local producerCountPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(instance, activemq_cluster, job) (activemq_topic_producer_count{' + matcher + ', instance=~"$instance"})',
+      'sum by(instance, activemq_cluster, job) (activemq_topic_producer_count{' + matcher + ', instance=~"$instance", destination!~"ActiveMQ.Advisory.*"})',
       datasource=promDatasource,
       legendFormat='{{instance}}',
     ),
@@ -112,7 +112,7 @@ local consumerCountPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(instance, activemq_cluster, job) (activemq_topic_consumer_count{' + matcher + ', instance=~"$instance"})',
+      'sum by(instance, activemq_cluster, job) (activemq_topic_consumer_count{' + matcher + ', instance=~"$instance", destination!~"ActiveMQ.Advisory.*"})',
       datasource=promDatasource,
       legendFormat='{{instance}}',
     ),
@@ -160,7 +160,7 @@ local averageConsumersPerTopicPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'avg by (instance, activemq_cluster, job) (activemq_topic_consumer_count{' + matcher + ', instance=~"$instance"})',
+      'avg by (instance, activemq_cluster, job) (activemq_topic_consumer_count{' + matcher + ', instance=~"$instance", destination!~"ActiveMQ.Advisory.*"})',
       datasource=promDatasource,
       legendFormat='{{instance}}',
     ),
@@ -208,7 +208,7 @@ local topTopicsByEnqueueRatePanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'topk by(instance, activemq_cluster, job) ($k_selector, rate(activemq_topic_enqueue_count{' + matcher + ', instance=~"$instance", destination=~".*$name.*"}[$__rate_interval]))',
+      'topk by(instance, activemq_cluster, job) ($k_selector, rate(activemq_topic_enqueue_count{' + matcher + ', instance=~"$instance", destination!~"ActiveMQ.Advisory.*", destination=~".*$name.*"}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - {{destination}}',
     ),
@@ -285,7 +285,7 @@ local topTopicsByDequeueRatePanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'topk by(instance, activemq_cluster, job) ($k_selector, rate(activemq_topic_dequeue_count{' + matcher + ', instance=~"$instance", destination=~".*$name.*"}[$__rate_interval]))',
+      'topk by(instance, activemq_cluster, job) ($k_selector, rate(activemq_topic_dequeue_count{' + matcher + ', instance=~"$instance", destination!~"ActiveMQ.Advisory.*", destination=~".*$name.*"}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - {{destination}}',
     ),
@@ -362,7 +362,7 @@ local topTopicsByAverageEnqueueTimePanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'topk by(instance, activemq_cluster, job) ($k_selector, activemq_topic_average_enqueue_time{' + matcher + ', instance=~"$instance", destination=~".*$name.*"})',
+      'topk by(instance, activemq_cluster, job) ($k_selector, activemq_topic_average_enqueue_time{' + matcher + ', instance=~"$instance", destination!~"ActiveMQ.Advisory.*", destination=~".*$name.*"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - {{destination}}',
     ),
@@ -439,7 +439,7 @@ local topTopicsByExpiredMessageRatePanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'topk by(instance, activemq_cluster, job) ($k_selector, rate(activemq_topic_expired_count{' + matcher + ', instance=~"$instance", destination=~".*$name.*"}[$__rate_interval]))',
+      'topk by(instance, activemq_cluster, job) ($k_selector, rate(activemq_topic_expired_count{' + matcher + ', instance=~"$instance", destination!~"ActiveMQ.Advisory.*", destination=~".*$name.*"}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - {{destination}}',
     ),
@@ -516,7 +516,7 @@ local topTopicsByConsumersPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'topk by(instance, activemq_cluster, job) (5, activemq_topic_consumer_count{' + matcher + ', instance=~"$instance", destination=~".*$name.*"})',
+      'topk by(instance, activemq_cluster, job) (5, activemq_topic_consumer_count{' + matcher + ', instance=~"$instance", destination!~"ActiveMQ.Advisory.*", destination=~".*$name.*"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - {{destination}}',
     ),
@@ -565,7 +565,7 @@ local topTopicsByAverageMessageSizePanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'topk by(instance, activemq_cluster, job) (5, activemq_topic_average_message_size{' + matcher + ', instance=~"$instance", destination=~".*$name.*"})',
+      'topk by(instance, activemq_cluster, job) (5, activemq_topic_average_message_size{' + matcher + ', instance=~"$instance", destination!~"ActiveMQ.Advisory.*", destination=~".*$name.*"})',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}} - {{destination}}',
     ),
@@ -644,25 +644,25 @@ local topicSummaryPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'rate(activemq_topic_enqueue_count{' + matcher + ', instance=~"$instance", destination=~".*$name.*"}[$__rate_interval])',
+      'rate(activemq_topic_enqueue_count{' + matcher + ', instance=~"$instance", destination!~"ActiveMQ.Advisory.*", destination=~".*$name.*"}[$__rate_interval])',
       datasource=promDatasource,
       legendFormat='{{instance}}',
       format='table',
     ),
     prometheus.target(
-      'rate(activemq_topic_dequeue_count{' + matcher + ', instance=~"$instance", destination=~".*$name.*"}[$__rate_interval])',
+      'rate(activemq_topic_dequeue_count{' + matcher + ', instance=~"$instance", destination!~"ActiveMQ.Advisory.*", destination=~".*$name.*"}[$__rate_interval])',
       datasource=promDatasource,
       legendFormat='{{instance}}',
       format='table',
     ),
     prometheus.target(
-      'activemq_topic_average_enqueue_time{' + matcher + ', instance=~"$instance", destination=~".*$name.*"}',
+      'activemq_topic_average_enqueue_time{' + matcher + ', instance=~"$instance", destination!~"ActiveMQ.Advisory.*", destination=~".*$name.*"}',
       datasource=promDatasource,
       legendFormat='{{instance}}',
       format='table',
     ),
     prometheus.target(
-      'activemq_topic_average_message_size{' + matcher + ', instance=~"$instance", destination=~".*$name.*"}',
+      'activemq_topic_average_message_size{' + matcher + ', instance=~"$instance", destination!~"ActiveMQ.Advisory.*", destination=~".*$name.*"}',
       datasource=promDatasource,
       legendFormat='{{instance}}',
       format='table',
@@ -871,27 +871,19 @@ local getMatcher(cfg) = '%(activemqSelector)s, activemq_cluster=~"$activemq_clus
             allValues='',
             sort=0
           ),
-          template.new(
+          template.custom(
             'k_selector',
-            promDatasource,
-            '2,4,6,8,10',
+            query='2,4,6,8,10',
+            current='4',
             label='Top topic count',
-            refresh=0,
+            refresh='never',
             includeAll=false,
             multi=false,
             allValues='',
-            sort=0
           ),
-          template.new(
+          template.text(
             'name',
-            promDatasource,
-            '',
             label='Topic by name',
-            refresh=0,
-            includeAll=false,
-            multi=false,
-            allValues='',
-            sort=0
           ),
         ]
       )

--- a/apache-activemq-mixin/dashboards/apache-activemq-topic-overview.libsonnet
+++ b/apache-activemq-mixin/dashboards/apache-activemq-topic-overview.libsonnet
@@ -1,0 +1,699 @@
+local g = (import 'grafana-builder/grafana.libsonnet');
+local grafana = (import 'grafonnet/grafana.libsonnet');
+local dashboard = grafana.dashboard;
+local template = grafana.template;
+local prometheus = grafana.prometheus;
+
+local dashboardUid = 'apache-activemq-topic-overview';
+
+local promDatasourceName = 'prometheus_datasource';
+
+local promDatasource = {
+  uid: '${%s}' % promDatasourceName,
+};
+
+local numberOfTopicsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'count by(instance) (activemq_topic_queue_size{instance=~"$instance", job=~"$job"})',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+    ),
+  ],
+  type: 'stat',
+  title: 'Number of topics',
+  description: 'Number of topics connected with the broker instance.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    colorMode: 'value',
+    graphMode: 'none',
+    justifyMode: 'auto',
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    textMode: 'auto',
+  },
+  pluginVersion: '10.2.0-59542pre',
+};
+
+local producerCountPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by(instance) (activemq_topic_producer_count{job=~"$job", instance=~"$instance"})',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+    ),
+  ],
+  type: 'stat',
+  title: 'Producer count',
+  description: 'The number of producers attached to topic destinations.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    colorMode: 'value',
+    graphMode: 'none',
+    justifyMode: 'auto',
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    textMode: 'auto',
+  },
+  pluginVersion: '10.2.0-59542pre',
+};
+
+local consumerCountPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by(instance) (activemq_topic_consumer_count{instance=~"$instance", job=~"$job"})',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+    ),
+  ],
+  type: 'stat',
+  title: 'Consumer count',
+  description: 'The number of consumers subscribed to topic destinations.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    colorMode: 'value',
+    graphMode: 'none',
+    justifyMode: 'auto',
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    textMode: 'auto',
+  },
+  pluginVersion: '10.2.0-59542pre',
+};
+
+local averageConsumersPerTopicPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'avg by (instance) (activemq_topic_consumer_count{job=~"$job", instance=~"$instance"})',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+    ),
+  ],
+  type: 'stat',
+  title: 'Average consumers per topic',
+  description: 'Average number of consumers per topic.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    colorMode: 'value',
+    graphMode: 'none',
+    justifyMode: 'auto',
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    textMode: 'auto',
+  },
+  pluginVersion: '10.2.0-59542pre',
+};
+
+local topTopicsByEnqueueRatePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'topk by(instance) (5, rate(activemq_topic_enqueue_count{job=~"$job", instance=~"$instance"}[$__rate_interval]))',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - {{destination}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Top topics by enqueue rate',
+  description: 'The rate messages are sent to the top k topic destinations.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 25,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'mps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local topTopicsByDequeueRatePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'topk by(instance) (5, rate(activemq_topic_dequeue_count{job=~"$job", instance=~"$instance"}[$__rate_interval]))',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - {{destination}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Top topics by dequeue rate',
+  description: 'The rate messages have been acknowledged (and removed) from the top k topic destinations',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 25,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'mps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local topTopicsByAverageEnqueueTimePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'topk by(instance) (5, activemq_topic_average_enqueue_time{job=~"$job", instance=~"$instance"})',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - {{destination}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Top topics by average enqueue time',
+  description: 'Average time a message was held on top k topic destinations.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 25,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'ms',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local topTopicsByExpiredMessageRatePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'topk by(instance) (5, rate(activemq_topic_expired_count{job=~"$job", instance=~"$instance"}[$__rate_interval]))',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - {{destination}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Top topics by expired message rate',
+  description: 'The rate messages have expired on the top k topic destinations.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 25,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'mps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local topTopicsByConsumersPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'topk by(instance) (5, activemq_topic_consumer_count{job=~"$job", instance=~"$instance"})',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - {{destination}}',
+    ),
+  ],
+  type: 'bargauge',
+  title: 'Top topics by consumers',
+  description: 'The number of consumers subscribed to the most active/used topics.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    displayMode: 'gradient',
+    minVizHeight: 10,
+    minVizWidth: 0,
+    orientation: 'horizontal',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    showUnfilled: true,
+    valueMode: 'color',
+  },
+  pluginVersion: '10.2.0-59542pre',
+};
+
+local topTopicsByAverageMessageSizePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'topk by(instance) (5, activemq_topic_average_message_size{job=~"$job", instance=~"$instance"})',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - {{destination}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Top topics by average message size',
+  description: 'Average message size on topic destinations.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        axisSoftMin: 0,
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 25,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      min: 0,
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'decbytes',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+{
+  grafanaDashboards+:: {
+    'apache-activemq-topic-overview.json':
+      dashboard.new(
+        'Apache ActiveMQ topic overview',
+        time_from='%s' % $._config.dashboardPeriod,
+        tags=($._config.dashboardTags),
+        timezone='%s' % $._config.dashboardTimezone,
+        refresh='%s' % $._config.dashboardRefresh,
+        description='',
+        uid=dashboardUid,
+      )
+
+      .addTemplates(
+        [
+          template.datasource(
+            promDatasourceName,
+            'prometheus',
+            null,
+            label='Data Source',
+            refresh='load'
+          ),
+          template.new(
+            'job',
+            promDatasource,
+            'label_values(activemq_topic_producer_count,job)',
+            label='Job',
+            refresh=2,
+            includeAll=true,
+            multi=true,
+            allValues='',
+            sort=0
+          ),
+          template.new(
+            'instance',
+            promDatasource,
+            'label_values(activemq_topic_producer_count{job=~"$job"},instance)',
+            label='Instance',
+            refresh=2,
+            includeAll=true,
+            multi=true,
+            allValues='',
+            sort=0
+          ),
+        ]
+      )
+      .addPanels(
+        [
+          numberOfTopicsPanel { gridPos: { h: 4, w: 6, x: 0, y: 0 } },
+          producerCountPanel { gridPos: { h: 4, w: 6, x: 6, y: 0 } },
+          consumerCountPanel { gridPos: { h: 4, w: 6, x: 12, y: 0 } },
+          averageConsumersPerTopicPanel { gridPos: { h: 4, w: 6, x: 18, y: 0 } },
+          topTopicsByEnqueueRatePanel { gridPos: { h: 8, w: 12, x: 0, y: 4 } },
+          topTopicsByDequeueRatePanel { gridPos: { h: 8, w: 12, x: 12, y: 4 } },
+          topTopicsByAverageEnqueueTimePanel { gridPos: { h: 8, w: 12, x: 0, y: 12 } },
+          topTopicsByExpiredMessageRatePanel { gridPos: { h: 8, w: 12, x: 12, y: 12 } },
+          topTopicsByConsumersPanel { gridPos: { h: 8, w: 12, x: 0, y: 20 } },
+          topTopicsByAverageMessageSizePanel { gridPos: { h: 8, w: 12, x: 12, y: 20 } },
+        ]
+      ),
+  },
+}

--- a/apache-activemq-mixin/dashboards/dashboards.libsonnet
+++ b/apache-activemq-mixin/dashboards/dashboards.libsonnet
@@ -1,0 +1,4 @@
+(import 'apache-activemq-cluster-overview.libsonnet') +
+(import 'apache-activemq-instance-overview.libsonnet') +
+(import 'apache-activemq-queue-overview.libsonnet') +
+(import 'apache-activemq-topic-overview.libsonnet')

--- a/apache-activemq-mixin/dashboards/dashboards.libsonnet
+++ b/apache-activemq-mixin/dashboards/dashboards.libsonnet
@@ -1,4 +1,5 @@
 (import 'apache-activemq-cluster-overview.libsonnet') +
 (import 'apache-activemq-instance-overview.libsonnet') +
 (import 'apache-activemq-queue-overview.libsonnet') +
-(import 'apache-activemq-topic-overview.libsonnet')
+(import 'apache-activemq-topic-overview.libsonnet') +
+(import 'apache-activemq-logs-overview.libsonnet')

--- a/apache-activemq-mixin/jsonnetfile.json
+++ b/apache-activemq-mixin/jsonnetfile.json
@@ -1,0 +1,24 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/grafonnet-lib.git",
+          "subdir": "grafonnet"
+        }
+      },
+      "version": "master"
+    },
+		{
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": "logs-lib"
+        }
+      },
+      "version": "master"
+    }
+  ],
+  "legacyImports": true
+}

--- a/apache-activemq-mixin/jsonnetfile.json
+++ b/apache-activemq-mixin/jsonnetfile.json
@@ -10,6 +10,15 @@
       },
       "version": "master"
     },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/grafonnet.git",
+          "subdir": "gen/grafonnet-latest"
+        }
+      },
+      "version": "main"
+    },
 		{
       "source": {
         "git": {

--- a/apache-activemq-mixin/mixin.libsonnet
+++ b/apache-activemq-mixin/mixin.libsonnet
@@ -1,0 +1,4 @@
+(import 'dashboards/dashboards.libsonnet') +
+(import 'alerts/alerts.libsonnet') +
+(import 'config.libsonnet') +
+(import 'dashboards/addlogs.libsonnet')

--- a/apache-activemq-mixin/mixin.libsonnet
+++ b/apache-activemq-mixin/mixin.libsonnet
@@ -1,4 +1,3 @@
 (import 'dashboards/dashboards.libsonnet') +
 (import 'alerts/alerts.libsonnet') +
-(import 'config.libsonnet') +
-(import 'dashboards/apache-activemq-logs-overview.libsonnet')
+(import 'config.libsonnet')

--- a/apache-activemq-mixin/mixin.libsonnet
+++ b/apache-activemq-mixin/mixin.libsonnet
@@ -1,4 +1,4 @@
 (import 'dashboards/dashboards.libsonnet') +
 (import 'alerts/alerts.libsonnet') +
 (import 'config.libsonnet') +
-(import 'dashboards/addlogs.libsonnet')
+(import 'dashboards/apache-activemq-logs-overview.libsonnet')


### PR DESCRIPTION
Note for reviewers: the default data source for logs "alert-state-history" is incorrect, you must switch to "grafanacloud-keithschmitty-logs" to see the logs.

Dashboards include 
- Apache ActiveMQ cluster overview
- Apache ActiveMQ instance overview
- Apache ActiveMQ queue overview
- Apache ActiveMQ topic overview
- Apache ActiveMQ logs overview

Alerts include
- ApacheActiveMQHighTopicMemoryUsage
- ApacheActiveMQHighQueueMemoryUsage
- ApacheActiveMQHighStoreMemoryUsage
- ApacheActiveMQHighTemporaryMemoryUsage
<img width="3301" alt="apache_activemq_cluster_overview" src="https://github.com/grafana/jsonnet-libs/assets/38274348/b3ea0848-de3d-4c02-b43d-2ac1ffd508bb">
<img width="3292" alt="apache_activemq_instance_overview_1" src="https://github.com/grafana/jsonnet-libs/assets/38274348/6fac5c54-cb94-4eba-a174-749d8905061b">
<img width="3292" alt="apache_activemq_instance-overview_2" src="https://github.com/grafana/jsonnet-libs/assets/38274348/9190f537-1faa-41bc-ba8c-46930f00a8c6">
<img width="3299" alt="apache_activemq_queue_overview" src="https://github.com/grafana/jsonnet-libs/assets/38274348/7f57379f-03b1-4704-b261-9bfc2ef7e5aa">
<img width="3299" alt="apache_activemq_topic_overview" src="https://github.com/grafana/jsonnet-libs/assets/38274348/4a8d333a-c200-484e-a3fa-090495c27bcf">
<img width="3322" alt="apache_activemq_logs_overview" src="https://github.com/grafana/jsonnet-libs/assets/38274348/d83dd1d6-ae0f-48c6-968b-e576f592ad61">

