### PR TITLE
Get rid of `std.native("parseYaml")`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@ JSONNET_FMT := jsonnetfmt -n 2 --max-blank-lines 2 --string-style s --comment-st
 SHELL := /bin/bash
 
 install-ci-deps:
-	go install github.com/google/go-jsonnet/cmd/jsonnet@v0.18.0
-	go install github.com/google/go-jsonnet/cmd/jsonnetfmt@v0.18.0
-	go install github.com/google/go-jsonnet/cmd/jsonnet-lint@v0.18.0
+	go install github.com/google/go-jsonnet/cmd/jsonnet@v0.20.0
+	go install github.com/google/go-jsonnet/cmd/jsonnetfmt@v0.20.0
+	go install github.com/google/go-jsonnet/cmd/jsonnet-lint@v0.20.0
 	go install github.com/monitoring-mixins/mixtool/cmd/mixtool@a9e78b0942a4186162bf170efde7b4b3167d31a4
 	go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@v0.4.0
 

--- a/argocd-mixin/mixin.libsonnet
+++ b/argocd-mixin/mixin.libsonnet
@@ -6,7 +6,7 @@
   // Helper function to ensure that we don't override other rules, by forcing
   // the patching of the groups list, and not the overall rules object.
   local importRules(rules) = {
-    groups+: std.native('parseYaml')(rules)[0].groups,
+    groups+: std.parseYaml(rules).groups,
   },
 
   prometheusAlerts+:

--- a/asterisk-mixin/mixin.libsonnet
+++ b/asterisk-mixin/mixin.libsonnet
@@ -7,7 +7,7 @@
   // Helper function to ensure that we don't override other rules, by forcing
   // the patching of the groups list, and not the overall rules object.
   local importRules(rules) = {
-    groups+: std.native('parseYaml')(rules)[0].groups,
+    groups+: std.parseYaml(rules).groups,
   },
 
   prometheusAlerts+:

--- a/ceph-mixin/mixin.libsonnet
+++ b/ceph-mixin/mixin.libsonnet
@@ -6,7 +6,7 @@
   // Helper function to ensure that we don't override other rules, by forcing
   // the patching of the groups list, and not the overall rules object.
   local importRules(rules) = {
-    groups+: std.native('parseYaml')(rules)[0].groups,
+    groups+: std.parseYaml(rules).groups,
   },
 
   prometheusAlerts+:

--- a/cert-manager/main.libsonnet
+++ b/cert-manager/main.libsonnet
@@ -92,7 +92,7 @@ local helm = tanka.helm.new(std.thisFile);
 
   crds:
     if $._config.custom_crds
-    then std.native('parseYaml')(importstr 'files/00-crds.yaml')
+    then std.parseYaml(importstr 'files/00-crds.yaml')
     else {},
 } + {
   local _containers = super.labeled.deployment_cert_manager.spec.template.spec.containers,

--- a/cilium-enterprise-mixin/mixin.libsonnet
+++ b/cilium-enterprise-mixin/mixin.libsonnet
@@ -23,10 +23,4 @@
     'cilium-policy.json': (import 'dashboards/cilium-agent/cilium-policy.json'),
     'cilium-resource-utilization.json': (import 'dashboards/cilium-agent/cilium-resource-utilization.json'),
   },
-
-  // Helper function to ensure that we don't override other rules, by forcing
-  // the patching of the groups list, and not the overall rules object.
-  local importRules(rules) = {
-    groups+: std.native('parseYaml')(rules)[0].groups,
-  },
 }

--- a/confluent-kafka-mixin/mixin.libsonnet
+++ b/confluent-kafka-mixin/mixin.libsonnet
@@ -2,10 +2,4 @@
   grafanaDashboards: {
     'confluent-kafka-overview.json': (import 'dashboards/confluent-kafka-overview.json'),
   },
-
-  // Helper function to ensure that we don't override other rules, by forcing
-  // the patching of the groups list, and not the overall rules object.
-  local importRules(rules) = {
-    groups+: std.native('parseYaml')(rules)[0].groups,
-  },
 }

--- a/harbor-mixin/mixin.libsonnet
+++ b/harbor-mixin/mixin.libsonnet
@@ -6,7 +6,7 @@
   // Helper function to ensure that we don't override other rules, by forcing
   // the patching of the groups list, and not the overall rules object.
   local importRules(rules) = {
-    groups+: std.native('parseYaml')(rules)[0].groups,
+    groups+: std.parseYaml(rules).groups,
   },
 
   prometheusAlerts+:

--- a/istio-mixin/mixin.libsonnet
+++ b/istio-mixin/mixin.libsonnet
@@ -7,7 +7,7 @@
   // Helper function to ensure that we don't override other rules, by forcing
   // the patching of the groups list, and not the overall rules object.
   local importRules(rules) = {
-    groups+: std.native('parseYaml')(rules)[0].groups,
+    groups+: std.parseYaml(rules).groups,
   },
 
   prometheusAlerts+:

--- a/jira-mixin/mixin.libsonnet
+++ b/jira-mixin/mixin.libsonnet
@@ -6,7 +6,7 @@
   // Helper function to ensure that we don't override other rules, by forcing
   // the patching of the groups list, and not the overall rules object.
   local importRules(rules) = {
-    groups+: std.native('parseYaml')(rules)[0].groups,
+    groups+: std.parseYaml(rules).groups,
   },
 
   prometheusAlerts+: importRules(importstr 'alerts/general.yaml'),

--- a/kafka-mixin/mixin.libsonnet
+++ b/kafka-mixin/mixin.libsonnet
@@ -12,7 +12,7 @@
   // Helper function to ensure that we don't override other rules, by forcing
   // the patching of the groups list, and not the overall rules object.
   local importRules(rules) = {
-    groups+: std.native('parseYaml')(rules)[0].groups,
+    groups+: std.parseYaml(rules).groups,
   },
 
   prometheusAlerts+:

--- a/kubescape-mixin/mixin.libsonnet
+++ b/kubescape-mixin/mixin.libsonnet
@@ -6,7 +6,7 @@
   // Helper function to ensure that we don't override other rules, by forcing
   // the patching of the groups list, and not the overall rules object.
   local importRules(rules) = {
-    groups+: std.native('parseYaml')(rules)[0].groups,
+    groups+: std.parseYaml(rules).groups,
   },
 
   prometheusAlerts+:

--- a/mongodb-mixin/mixin.libsonnet
+++ b/mongodb-mixin/mixin.libsonnet
@@ -8,7 +8,7 @@
   // Helper function to ensure that we don't override other rules, by forcing
   // the patching of the groups list, and not the overall rules object.
   local importRules(rules) = {
-    groups+: std.native('parseYaml')(rules)[0].groups,
+    groups+: std.parseYaml(rules).groups,
   },
 
   prometheusAlerts+:

--- a/nodejs-mixin/mixin.libsonnet
+++ b/nodejs-mixin/mixin.libsonnet
@@ -6,7 +6,7 @@
   // Helper function to ensure that we don't override other rules, by forcing
   // the patching of the groups list, and not the overall rules object.
   local importRules(rules) = {
-    groups+: std.native('parseYaml')(rules)[0].groups,
+    groups+: std.parseYaml(rules).groups,
   },
 
   prometheusAlerts+: importRules(importstr 'alerts/alerts.yaml'),

--- a/rabbitmq-mixin/mixin.libsonnet
+++ b/rabbitmq-mixin/mixin.libsonnet
@@ -7,7 +7,7 @@
   // Helper function to ensure that we don't override other rules, by forcing
   // the patching of the groups list, and not the overall rules object.
   local importRules(rules) = {
-    groups+: std.native('parseYaml')(rules)[0].groups,
+    groups+: std.parseYaml(rules).groups,
   },
 
   prometheusAlerts+:

--- a/spark-mixin/mixin.libsonnet
+++ b/spark-mixin/mixin.libsonnet
@@ -2,10 +2,4 @@
   grafanaDashboards: {
     'spark-metrics.json': (import 'dashboards/spark-metrics.json'),
   },
-
-  // Helper function to ensure that we don't override other rules, by forcing
-  // the patching of the groups list, and not the overall rules object.
-  local importRules(rules) = {
-    groups+: std.native('parseYaml')(rules)[0].groups,
-  },
 }

--- a/velero-mixin/mixin.libsonnet
+++ b/velero-mixin/mixin.libsonnet
@@ -6,7 +6,7 @@
   // Helper function to ensure that we don't override other rules, by forcing
   // the patching of the groups list, and not the overall rules object.
   local importRules(rules) = {
-    groups+: std.native('parseYaml')(rules)[0].groups,
+    groups+: std.parseYaml(rules).groups,
   },
 
   prometheusAlerts+:

--- a/wso2-enterprise-integrator-mixin/mixin.libsonnet
+++ b/wso2-enterprise-integrator-mixin/mixin.libsonnet
@@ -6,11 +6,4 @@
     'Inbound_Endpoint_Metrics.json': (import 'dashboards/Inbound_Endpoint_Metrics.json'),
     'Proxy_Service_Metrics.json': (import 'dashboards/Proxy_Service_Metrics.json'),
   },
-
-  // Helper function to ensure that we don't override other rules, by forcing
-  // the patching of the groups list, and not the overall rules object.
-  local importRules(rules) = {
-    groups+: std.native('parseYaml')(rules)[0].groups,
-  },
-
 }

--- a/wso2-streaming-integrator-mixin/mixin.libsonnet
+++ b/wso2-streaming-integrator-mixin/mixin.libsonnet
@@ -12,8 +12,4 @@
     'StreamingIntegrator_apps.json': (import 'dashboards/StreamingIntegrator_apps.json'),
     'StreamingIntegrator_overall.json': (import 'dashboards/StreamingIntegrator_overall.json'),
   },
-  local importRules(rules) = {
-    groups+: std.native('parseYaml')(rules)[0].groups,
-  },
-
 }


### PR DESCRIPTION
This is in the jsonnet std lib now. 
I also updated the go-jsonnet versions in the makefile to match the version in mixtool