### PR TITLE
Add refresh onTime for logslib

### DIFF
--- a/logs-lib/logs/variables.libsonnet
+++ b/logs-lib/logs/variables.libsonnet
@@ -22,6 +22,7 @@ function(
           customAllValue='.*'
         )
         + var.query.selectionOptions.withMulti()
+        + var.query.refresh.onTime()
         + var.query.withSort(
           i=1,
           type='alphabetical',


### PR DESCRIPTION
This should fix linting errors, (also more consistent behavior)
```
[template-on-time-change-reload-rule] 'Aerospike logs': Dashboard 'Aerospike logs' templated datasource variable named 'job', should be set to be refreshed 'On Time Range Change (value 2)', is currently '0'
[template-on-time-change-reload-rule] 'Aerospike logs': Dashboard 'Aerospike logs' templated datasource variable named 'aerospike_cluster', should be set to be refreshed 'On Time Range Change (value 2)', is currently '0'
[template-on-time-change-reload-rule] 'Aerospike logs': Dashboard 'Aerospike logs' templated datasource variable named 'instance', should be set to be refreshed 'On Time Range Change (value 2)', is currently '0'
```