### PR TITLE
Apache Cassandra: fix regex selector

### DIFF
--- a/apache-cassandra-mixin/dashboards/cassandra-keyspaces.libsonnet
+++ b/apache-cassandra-mixin/dashboards/cassandra-keyspaces.libsonnet
@@ -856,7 +856,7 @@ local getMatcher(cfg) = '%(cassandraSelector)s, instance=~"$instance", keyspace=
             template.new(
               'instance',
               promDatasource,
-              'label_values(cassandra_up_endpoint_count{%(cassandraSelector)s, cassandra_cluster="$cassandra_cluster"' % $._config +
+              'label_values(cassandra_up_endpoint_count{%(cassandraSelector)s, cassandra_cluster=~"$cassandra_cluster"' % $._config +
               if $._config.enableDatacenterLabel then ', datacenter=~"$datacenter"' else '' + if $._config.enableRackLabel then
                 ', rack=~"$rack"' else '' + '}, instance)',
               label='Instance',
@@ -869,8 +869,8 @@ local getMatcher(cfg) = '%(cassandraSelector)s, instance=~"$instance", keyspace=
             template.new(
               'keyspace',
               promDatasource,
-              'label_values(cassandra_keyspace_caspreparelatency_seconds{%(cassandraSelector)s, cassandra_cluster="$cassandra_cluster",' % $._config +
-              'instance="$instance"}, keyspace)',
+              'label_values(cassandra_keyspace_caspreparelatency_seconds{%(cassandraSelector)s, cassandra_cluster=~"$cassandra_cluster",' % $._config +
+              'instance=~"$instance"}, keyspace)',
               label='Keyspace',
               refresh=1,
               includeAll=true,

--- a/apache-cassandra-mixin/dashboards/cassandra-nodes.libsonnet
+++ b/apache-cassandra-mixin/dashboards/cassandra-nodes.libsonnet
@@ -1418,7 +1418,7 @@ local getMatcher(cfg) = '%(cassandraSelector)s, cassandra_cluster=~"$cassandra_c
             template.new(
               'instance',
               promDatasource,
-              'label_values(cassandra_cache_size{%(cassandraSelector)s, cassandra_cluster="$cassandra_cluster"' % $._config +
+              'label_values(cassandra_cache_size{%(cassandraSelector)s, cassandra_cluster=~"$cassandra_cluster"' % $._config +
               if $._config.enableDatacenterLabel then ', datacenter=~"$datacenter"' else '' + if $._config.enableRackLabel then
                 ', rack=~"$rack"' else '' + '}, instance)',
               label='Instance',


### PR DESCRIPTION
The keyspace dashboard was not loading metrics because the keyspace variable `=` was used instead of `=~` . With this correction, the keyspace dashboard displays metrics on load as expected.
 
![Screenshot 2023-09-21 at 3 19 53 PM](https://github.com/grafana/jsonnet-libs/assets/13648435/52c8969a-ced3-4421-9cdf-00d5a73bb8d0)
