### PR TITLE
Update jb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ install-ci-deps:
 	go install github.com/google/go-jsonnet/cmd/jsonnetfmt@v0.20.0
 	go install github.com/google/go-jsonnet/cmd/jsonnet-lint@v0.20.0
 	go install github.com/monitoring-mixins/mixtool/cmd/mixtool@a9e78b0942a4186162bf170efde7b4b3167d31a4
-	go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@v0.4.0
+	go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@v0.5.1
 
 fmt:
 	@find . -name '*.libsonnet' -print -o -name '*.jsonnet' -print | \


### PR DESCRIPTION
To fix errors when jsonnetfile points to branch names with '/' sep:
That leads to an error in tests:
 'jb: error: failed to install packages: downloading: failed to create tmp dir: mkdirtemp jsonnetpkg-github.com-grafana-jsonnet-libs-windows-observ-lib-vzhuravlev/jl-windows-new: pattern contains path separator'