### PR TITLE
Update MongoDB Atlas mixin: fix allValue for selectors

### DIFF
--- a/mongodb-atlas-mixin/dashboards/mongodb-atlas-cluster-overview.libsonnet
+++ b/mongodb-atlas-mixin/dashboards/mongodb-atlas-cluster-overview.libsonnet
@@ -2105,7 +2105,7 @@ local databaseWaitsAcquiringLockPanel = {
             refresh=2,
             includeAll=true,
             multi=true,
-            allValues='',
+            allValues='.+',
             sort=0
           ),
           template.new(
@@ -2116,7 +2116,7 @@ local databaseWaitsAcquiringLockPanel = {
             refresh=2,
             includeAll=true,
             multi=true,
-            allValues='',
+            allValues='.+',
             sort=0
           ),
         ]

--- a/mongodb-atlas-mixin/dashboards/mongodb-atlas-elections-overview.libsonnet
+++ b/mongodb-atlas-mixin/dashboards/mongodb-atlas-elections-overview.libsonnet
@@ -858,7 +858,7 @@ local averageCatchupOperationsPanel = {
             refresh=2,
             includeAll=true,
             multi=true,
-            allValues='',
+            allValues='.+',
             sort=0
           ),
           template.new(
@@ -869,7 +869,7 @@ local averageCatchupOperationsPanel = {
             refresh=2,
             includeAll=true,
             multi=true,
-            allValues='',
+            allValues='.+',
             sort=0
           ),
           template.new(
@@ -880,7 +880,7 @@ local averageCatchupOperationsPanel = {
             refresh=2,
             includeAll=true,
             multi=true,
-            allValues='',
+            allValues='.+',
             sort=0
           ),
           template.new(
@@ -891,7 +891,7 @@ local averageCatchupOperationsPanel = {
             refresh=2,
             includeAll=true,
             multi=true,
-            allValues='',
+            allValues='.+',
             sort=0
           ),
         ]

--- a/mongodb-atlas-mixin/dashboards/mongodb-atlas-operations-overview.libsonnet
+++ b/mongodb-atlas-mixin/dashboards/mongodb-atlas-operations-overview.libsonnet
@@ -1272,7 +1272,7 @@ local collectionWaitTimePanel = {
             refresh=2,
             includeAll=true,
             multi=true,
-            allValues='',
+            allValues='.+',
             sort=0
           ),
           template.new(
@@ -1283,7 +1283,7 @@ local collectionWaitTimePanel = {
             refresh=2,
             includeAll=true,
             multi=true,
-            allValues='',
+            allValues='.+',
             sort=0
           ),
           template.new(
@@ -1294,7 +1294,7 @@ local collectionWaitTimePanel = {
             refresh=2,
             includeAll=true,
             multi=true,
-            allValues='',
+            allValues='.+',
             sort=0
           ),
           template.new(
@@ -1305,7 +1305,7 @@ local collectionWaitTimePanel = {
             refresh=2,
             includeAll=true,
             multi=true,
-            allValues='',
+            allValues='.+',
             sort=0
           ),
         ]

--- a/mongodb-atlas-mixin/dashboards/mongodb-atlas-performance-overview.libsonnet
+++ b/mongodb-atlas-mixin/dashboards/mongodb-atlas-performance-overview.libsonnet
@@ -773,7 +773,7 @@ local hardwareIOWaitTimePanel = {
             refresh=2,
             includeAll=true,
             multi=true,
-            allValues='',
+            allValues='.+',
             sort=0
           ),
           template.new(
@@ -784,7 +784,7 @@ local hardwareIOWaitTimePanel = {
             refresh=2,
             includeAll=true,
             multi=true,
-            allValues='',
+            allValues='.+',
             sort=0
           ),
           template.new(
@@ -795,7 +795,7 @@ local hardwareIOWaitTimePanel = {
             refresh=2,
             includeAll=true,
             multi=true,
-            allValues='',
+            allValues='.+',
             sort=0
           ),
           template.new(
@@ -806,7 +806,7 @@ local hardwareIOWaitTimePanel = {
             refresh=2,
             includeAll=true,
             multi=true,
-            allValues='',
+            allValues='.+',
             sort=0
           ),
         ]

--- a/mongodb-atlas-mixin/dashboards/mongodb-atlas-sharding-overview.libsonnet
+++ b/mongodb-atlas-mixin/dashboards/mongodb-atlas-sharding-overview.libsonnet
@@ -1268,7 +1268,7 @@ local unshardedPanel = {
               refresh=2,
               includeAll=true,
               multi=true,
-              allValues='',
+              allValues='.+',
               sort=0
             ),
             template.new(
@@ -1279,7 +1279,7 @@ local unshardedPanel = {
               refresh=2,
               includeAll=true,
               multi=true,
-              allValues='',
+              allValues='.+',
               sort=0
             ),
             template.new(
@@ -1290,7 +1290,7 @@ local unshardedPanel = {
               refresh=2,
               includeAll=true,
               multi=true,
-              allValues='',
+              allValues='.+',
               sort=0
             ),
             template.new(
@@ -1301,7 +1301,7 @@ local unshardedPanel = {
               refresh=2,
               includeAll=true,
               multi=true,
-              allValues='',
+              allValues='.+',
               sort=0
             ),
           ]


### PR DESCRIPTION
quick fix to set `allValue = '.+'` for all variable selectors