### PR TITLE
Cassandra mixin: remove filename when multicluster is enabled

### DIFF
--- a/apache-cassandra-mixin/dashboards/cassandra-nodes.libsonnet
+++ b/apache-cassandra-mixin/dashboards/cassandra-nodes.libsonnet
@@ -1312,18 +1312,13 @@ local crossnodeLatencyPanel(matcher) = {
   },
 };
 
-local getMatcher(cfg) = '%(cassandraSelector)s, cassandra_cluster=~"$cassandra_cluster", instance=~"$instance"' % cfg +
-                        if cfg.enableDatacenterLabel then ', datacenter=~"$datacenter"' else '' + if cfg.enableRackLabel then ', rack=~"$rack"' else '';
-
-local getApplyFilename(cfg) = if cfg.enableMultiCluster then '{' + getMatcher(cfg) + '} |= ``' else '{filename="/var/log/cassandra/system.log", ' + getMatcher(cfg) + '} |= ``';
-
-local systemLogsPanel(cfg, matcher) = {
+local systemLogsPanel(matcher) = {
   datasource: lokiDatasource,
   targets: [
     {
       datasource: lokiDatasource,
       editorMode: 'code',
-      expr: getApplyFilename(cfg),
+      expr: '{' + matcher + '} |= ``',
       queryType: 'range',
       refId: 'A',
     },
@@ -1342,6 +1337,9 @@ local systemLogsPanel(cfg, matcher) = {
     wrapLogMessage: false,
   },
 };
+
+local getMatcher(cfg) = '%(cassandraSelector)s, cassandra_cluster=~"$cassandra_cluster", instance=~"$instance"' % cfg +
+                        if cfg.enableDatacenterLabel then ', datacenter=~"$datacenter"' else '' + if cfg.enableRackLabel then ', rack=~"$rack"' else '';
 
 {
   grafanaDashboards+:: {
@@ -1481,7 +1479,7 @@ local systemLogsPanel(cfg, matcher) = {
             crossnodeLatencyPanel(getMatcher($._config)) { gridPos: { h: 6, w: 8, x: 16, y: 30 } },
           ],
           if $._config.enableLokiLogs then [
-            systemLogsPanel($._config, getMatcher($._config)) { gridPos: { h: 6, w: 24, x: 0, y: 36 } },
+            systemLogsPanel(getMatcher($._config)) { gridPos: { h: 6, w: 24, x: 0, y: 36 } },
           ] else [],
         ])
       ),


### PR DESCRIPTION
This pr remove filename all together. This is needed to see logs in the k8s plugin
