### PR TITLE
Apache ActiveMQ Tweaks

### DIFF
--- a/apache-activemq-mixin/README.md
+++ b/apache-activemq-mixin/README.md
@@ -20,28 +20,27 @@ and the following alerts:
 ## Apache ActiveMQ cluster overview
 
 The Apache ActiveMQ cluster overview provides cluster level statistics showing cluster count, broker count, producer counts, consumer counts, overall memory level usage, and a general look into enqueue/dequeue counts.
-![Screenshot of the Apache ActiveMQ cluster overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/aerospike/screenshots/apache_activemq_cluster_overview.png)
+![Screenshot of the Apache ActiveMQ cluster overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-activemq/screenshots/apache_activemq_cluster_overview.png)
 
 ## Apache ActiveMQ instance overview
 
 The Apache ActiveMQ instance overview provides instance level statistics showing memory levels, producer counts, consumer counts, queue sizes, enqueue/dequeue counts, average enqueue times, expired message counts, jvm garabage collection info, and alerts.
-![First screenshot of the Apache ActiveMQ instance overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/aerospike/screenshots/apache_activemq_instance_overview_1.png)
-![Second screenshot of the Apache ActiveMQ instance overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/aerospike/screenshots/apache_activemq_instance_overview_2.png)
+![First screenshot of the Apache ActiveMQ instance overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-activemq/screenshots/apache_activemq_instance_overview_1.png)
+![Second screenshot of the Apache ActiveMQ instance overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-activemq/screenshots/apache_activemq_instance_overview_2.png)
 
 ## Apache ActiveMQ queue overview
 
 The Apache ActiveMQ queue overview provides queue level statistics showing number of queues, message size, producer counts, consumer counts, enqueue/dequeue rates, average enqueue times, expired message rates, and average size of messages.
-![Screenshot of the Apache ActiveMQ queue overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/aerospike/screenshots/apache_activemq_queue_overview.png)
+![Screenshot of the Apache ActiveMQ queue overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-activemq/screenshots/apache_activemq_queue_overview.png)
 
 ## Apache ActiveMQ queue overview
 
 The Apache ActiveMQ topic overview provides queue level statistics showing number of topics, message size, producer counts, consumer counts, enqueue/dequeue rates, average enqueue times, expired message rates, and average size of messages.
-![Screenshot of the Apache ActiveMQ topic overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/aerospike/screenshots/apache_activemq_topic_overview.png)
+![Screenshot of the Apache ActiveMQ topic overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-activemq/screenshots/apache_activemq_topic_overview.png)
 
 ## Apache ActiveMQ logs overview
 
-The Apache ActiveMQ logs overview provides logs of the ActiveMQ environment that is able to be parsed by severity.
-#![Screenshot of the Apache ActiveMQ logs overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/aerospike/screenshots/apache_activemq_logs_overview.png)
+The Apache ActiveMQ logs overview provides logs of the ActiveMQ environment that is able to be parsed by severity. #![Screenshot of the Apache ActiveMQ logs overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-activemq/screenshots/apache_activemq_logs_overview.png)
 
 ## Alerts Overview
 
@@ -67,11 +66,13 @@ Default thresholds can be configured in `config.libsonnet`.
     alertsHighTemporaryMemoryUsage: 70,  // %
 
     enableLokiLogs: false,
-    filterSelector: 'job=~"integrations/activemq"',
+    filterSelector: 'job=~"integrations/apache-activemq"',
   },
 }
 ```
+
 ## Logs configuration
+
 In order to get logs parsing multiple lines and levels correctly you will need to add the following lines to your grafana-agent.yaml file in the logs section
 
 ```yaml
@@ -84,6 +85,7 @@ pipeline_stages:
         - labels:
             level:
 ```
+
 ## Install tools
 
 ```bash

--- a/apache-activemq-mixin/alerts/alerts.libsonnet
+++ b/apache-activemq-mixin/alerts/alerts.libsonnet
@@ -7,7 +7,7 @@
           {
             alert: 'ApacheActiveMQHighTopicMemoryUsage',
             expr: |||
-              sum (activemq_topic_memory_percent_usage{destination!~"ActiveMQ.Advisory.*"}) > %(alertsHighTopicMemoryUsage)s
+              sum without (destination) (activemq_topic_memory_percent_usage{destination!~"ActiveMQ.Advisory.*"}) > %(alertsHighTopicMemoryUsage)s
             ||| % $._config,
             'for': '5m',
             labels: {
@@ -25,7 +25,7 @@
           {
             alert: 'ApacheActiveMQHighQueueMemoryUsage',
             expr: |||
-              sum (activemq_queue_memory_percent_usage) > %(alertsHighQueueMemoryUsage)s
+              sum without (destination) (activemq_queue_memory_percent_usage) > %(alertsHighQueueMemoryUsage)s
             ||| % $._config,
             'for': '5m',
             labels: {

--- a/apache-activemq-mixin/alerts/alerts.libsonnet
+++ b/apache-activemq-mixin/alerts/alerts.libsonnet
@@ -7,7 +7,7 @@
           {
             alert: 'ApacheActiveMQHighTopicMemoryUsage',
             expr: |||
-              sum without (job) (activemq_topic_memory_percent_usage{destination!~"ActiveMQ.Advisory.*"}) > %(alertsHighTopicMemoryUsage)s
+              sum (activemq_topic_memory_percent_usage{destination!~"ActiveMQ.Advisory.*"}) > %(alertsHighTopicMemoryUsage)s
             ||| % $._config,
             'for': '5m',
             labels: {
@@ -25,7 +25,7 @@
           {
             alert: 'ApacheActiveMQHighQueueMemoryUsage',
             expr: |||
-              sum without (job) (activemq_queue_memory_percent_usage) > %(alertsHighQueueMemoryUsage)s
+              sum (activemq_queue_memory_percent_usage) > %(alertsHighQueueMemoryUsage)s
             ||| % $._config,
             'for': '5m',
             labels: {

--- a/apache-activemq-mixin/config.libsonnet
+++ b/apache-activemq-mixin/config.libsonnet
@@ -18,6 +18,6 @@
     alertsHighTemporaryMemoryUsage: 70,  // %
 
     enableLokiLogs: true,
-    filterSelector: 'job=~"integrations/activemq"',
+    filterSelector: 'job=~"integrations/apache-activemq"',
   },
 }

--- a/apache-activemq-mixin/dashboards/apache-activemq-cluster-overview.libsonnet
+++ b/apache-activemq-mixin/dashboards/apache-activemq-cluster-overview.libsonnet
@@ -70,7 +70,7 @@ local brokerCountPanel(matcher) = {
     ),
   ],
   type: 'stat',
-  title: 'Broker',
+  title: 'Brokers',
   description: 'Number of broker instances across clusters.',
   fieldConfig: {
     defaults: {
@@ -379,6 +379,8 @@ local averageTemporaryMemoryUsagePanel(matcher) = {
         mode: 'thresholds',
       },
       mappings: [],
+      max: 1,
+      min: 0,
       thresholds: {
         mode: 'absolute',
         steps: [
@@ -437,6 +439,8 @@ local averageStoreMemoryUsagePanel(matcher) = {
         mode: 'thresholds',
       },
       mappings: [],
+      max: 1,
+      min: 0,
       thresholds: {
         mode: 'absolute',
         steps: [
@@ -494,6 +498,8 @@ local averageBrokerMemoryUsagePanel(matcher) = {
         mode: 'thresholds',
       },
       mappings: [],
+      max: 1,
+      min: 0,
       thresholds: {
         mode: 'absolute',
         steps: [
@@ -554,7 +560,7 @@ local getMatcher(cfg) = '%(activemqSelector)s, activemq_cluster=~"$activemq_clus
             promDatasourceName,
             'prometheus',
             null,
-            label='Data Source',
+            label='Data source',
             refresh='load'
           ),
           template.new(
@@ -565,7 +571,7 @@ local getMatcher(cfg) = '%(activemqSelector)s, activemq_cluster=~"$activemq_clus
             refresh=2,
             includeAll=true,
             multi=true,
-            allValues='',
+            allValues='.+',
             sort=0
           ),
           template.new(
@@ -576,7 +582,7 @@ local getMatcher(cfg) = '%(activemqSelector)s, activemq_cluster=~"$activemq_clus
             refresh=2,
             includeAll=true,
             multi=true,
-            allValues='',
+            allValues='.*',
             hide=if $._config.enableMultiCluster then '' else 'variable',
             sort=0
           ),
@@ -588,7 +594,7 @@ local getMatcher(cfg) = '%(activemqSelector)s, activemq_cluster=~"$activemq_clus
             refresh=2,
             includeAll=true,
             multi=true,
-            allValues='',
+            allValues='.+',
             sort=0
           ),
         ]

--- a/apache-activemq-mixin/dashboards/apache-activemq-instance-overview.libsonnet
+++ b/apache-activemq-mixin/dashboards/apache-activemq-instance-overview.libsonnet
@@ -839,7 +839,7 @@ local garbageCollectionDurationPanel(matcher) = {
     ),
   ],
   type: 'timeseries',
-  title: 'Garbage collection duration,
+  title: 'Garbage collection duration',
   description: 'The time spent performing recent garbage collections',
   fieldConfig: {
     defaults: {
@@ -991,7 +991,7 @@ local activemqAlertsPanel(matcher) = {
   options: {
     alertName: '',
     dashboardAlerts: false,
-    alertInstanceLabelFilter: '{' + matcher + ', instance=~"${instance:regex}", destination!~"ActiveMQ.Advisory.*"}',
+    alertInstanceLabelFilter: '{' + matcher + ', instance=~"${instance:regex}"}',
     datasource: promDatasource,
     groupBy: [],
     groupMode: 'default',

--- a/apache-activemq-mixin/dashboards/apache-activemq-instance-overview.libsonnet
+++ b/apache-activemq-mixin/dashboards/apache-activemq-instance-overview.libsonnet
@@ -832,15 +832,15 @@ local garbageCollectionDurationPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by (instance, activemq_cluster) (increase(jvm_gc_collection_seconds_count{' + matcher + ', instance=~"$instance"}[$__interval:])) / clamp_min(sum by (instance, activemq_cluster ) (increase(java_lang_g1_young_generation_collectioncount{' + matcher + ', instance=~"$instance"}[$__interval:])), 1)',
+      'jvm_gc_duration_seconds{' + matcher + ', instance=~"$instance"}',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}}',
       interval='1m',
     ),
   ],
   type: 'timeseries',
-  title: 'Garbage collection duration / $__interval',
-  description: 'The average time spent performing recent garbage collections',
+  title: 'Garbage collection duration,
+  description: 'The time spent performing recent garbage collections',
   fieldConfig: {
     defaults: {
       color: {
@@ -909,7 +909,7 @@ local garbageCollectionCountPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'increase(java_lang_g1_young_generation_collectioncount{' + matcher + ', instance=~"$instance"}[$__interval:])',
+      'increase(jvm_gc_collection_count{' + matcher + ', instance=~"$instance", name="G1 Young Generation"}[$__interval:])',
       datasource=promDatasource,
       legendFormat='{{activemq_cluster}} - {{instance}}',
       interval='1m',
@@ -1030,7 +1030,7 @@ local getAlertsMatcher(cfg) = '%(activemqAlertsSelector)s, activemq_cluster=~"${
             promDatasourceName,
             'prometheus',
             null,
-            label='Data Source',
+            label='Data source',
             refresh='load'
           ),
           template.new(
@@ -1041,7 +1041,7 @@ local getAlertsMatcher(cfg) = '%(activemqAlertsSelector)s, activemq_cluster=~"${
             refresh=2,
             includeAll=true,
             multi=true,
-            allValues='',
+            allValues='.+',
             sort=0
           ),
           template.new(
@@ -1052,7 +1052,7 @@ local getAlertsMatcher(cfg) = '%(activemqAlertsSelector)s, activemq_cluster=~"${
             refresh=2,
             includeAll=true,
             multi=true,
-            allValues='',
+            allValues='.*',
             hide=if $._config.enableMultiCluster then '' else 'variable',
             sort=0
           ),
@@ -1064,7 +1064,7 @@ local getAlertsMatcher(cfg) = '%(activemqAlertsSelector)s, activemq_cluster=~"${
             refresh=2,
             includeAll=true,
             multi=true,
-            allValues='',
+            allValues='.+',
             sort=0
           ),
           template.new(
@@ -1075,7 +1075,7 @@ local getAlertsMatcher(cfg) = '%(activemqAlertsSelector)s, activemq_cluster=~"${
             refresh=2,
             includeAll=true,
             multi=true,
-            allValues='',
+            allValues='.+',
             sort=0
           ),
         ]

--- a/apache-activemq-mixin/dashboards/apache-activemq-queue-overview.libsonnet
+++ b/apache-activemq-mixin/dashboards/apache-activemq-queue-overview.libsonnet
@@ -692,6 +692,40 @@ local queueSummaryPanel(matcher) = {
           },
         ],
       },
+      {
+        matcher: {
+          id: 'byName',
+          options: 'ActiveMQ Cluster',
+        },
+        properties: [
+          {
+            id: 'links',
+            value: [
+              {
+                title: 'Cluster link',
+                url: 'd/apache-activemq-cluster-overview?var-activemq_cluster=${__data.fields.activemq_cluster}&${__url_time_range}&var-datasource=${datasource}',
+              },
+            ],
+          },
+        ],
+      },
+      {
+        matcher: {
+          id: 'byName',
+          options: 'Instance',
+        },
+        properties: [
+          {
+            id: 'links',
+            value: [
+              {
+                title: 'Instance link',
+                url: 'd/apache-activemq-instance-overview?var-instance=${__data.fields.instance}&${__url_time_range}&var-datasource=${datasource}',
+              },
+            ],
+          },
+        ],
+      },
     ],
   },
   options: {
@@ -705,12 +739,7 @@ local queueSummaryPanel(matcher) = {
       show: false,
     },
     showHeader: true,
-    sortBy: [
-      {
-        desc: false,
-        displayName: '{activemq_cluster="cluster-a", destination="TEST", instance="localhost:12345", job="integrations/activemq"}',
-      },
-    ],
+    sortBy: [],
   },
   pluginVersion: '10.2.0-60139',
   transformations: [
@@ -785,7 +814,7 @@ local getMatcher(cfg) = '%(activemqSelector)s, activemq_cluster=~"$activemq_clus
             promDatasourceName,
             'prometheus',
             null,
-            label='Data Source',
+            label='Data source',
             refresh='load'
           ),
           template.new(
@@ -796,7 +825,7 @@ local getMatcher(cfg) = '%(activemqSelector)s, activemq_cluster=~"$activemq_clus
             refresh=2,
             includeAll=true,
             multi=true,
-            allValues='',
+            allValues='.+',
             sort=0
           ),
           template.new(
@@ -807,7 +836,7 @@ local getMatcher(cfg) = '%(activemqSelector)s, activemq_cluster=~"$activemq_clus
             refresh=2,
             includeAll=true,
             multi=true,
-            allValues='',
+            allValues='.*',
             hide=if $._config.enableMultiCluster then '' else 'variable',
             sort=0
           ),
@@ -819,7 +848,7 @@ local getMatcher(cfg) = '%(activemqSelector)s, activemq_cluster=~"$activemq_clus
             refresh=2,
             includeAll=true,
             multi=true,
-            allValues='',
+            allValues='.+',
             sort=0
           ),
           template.new(
@@ -830,7 +859,7 @@ local getMatcher(cfg) = '%(activemqSelector)s, activemq_cluster=~"$activemq_clus
             refresh=2,
             includeAll=true,
             multi=true,
-            allValues='',
+            allValues='.+',
             sort=0
           ),
           template.custom(

--- a/apache-activemq-mixin/dashboards/apache-activemq-topic-overview.libsonnet
+++ b/apache-activemq-mixin/dashboards/apache-activemq-topic-overview.libsonnet
@@ -742,6 +742,40 @@ local topicSummaryPanel(matcher) = {
           },
         ],
       },
+      {
+        matcher: {
+          id: 'byName',
+          options: 'ActiveMQ Cluster',
+        },
+        properties: [
+          {
+            id: 'links',
+            value: [
+              {
+                title: 'Cluster link',
+                url: 'd/apache-activemq-cluster-overview?var-activemq_cluster=${__data.fields.activemq_cluster}&${__url_time_range}&var-datasource=${datasource}',
+              },
+            ],
+          },
+        ],
+      },
+      {
+        matcher: {
+          id: 'byName',
+          options: 'Instance',
+        },
+        properties: [
+          {
+            id: 'links',
+            value: [
+              {
+                title: 'Instance link',
+                url: 'd/apache-activemq-instance-overview?var-instance=${__data.fields.instance}&${__url_time_range}&var-datasource=${datasource}',
+              },
+            ],
+          },
+        ],
+      },
     ],
   },
   options: {
@@ -829,7 +863,7 @@ local getMatcher(cfg) = '%(activemqSelector)s, activemq_cluster=~"$activemq_clus
             promDatasourceName,
             'prometheus',
             null,
-            label='Data Source',
+            label='Data source',
             refresh='load'
           ),
           template.new(
@@ -840,7 +874,7 @@ local getMatcher(cfg) = '%(activemqSelector)s, activemq_cluster=~"$activemq_clus
             refresh=2,
             includeAll=true,
             multi=true,
-            allValues='',
+            allValues='.+',
             sort=0
           ),
           template.new(
@@ -851,7 +885,7 @@ local getMatcher(cfg) = '%(activemqSelector)s, activemq_cluster=~"$activemq_clus
             refresh=2,
             includeAll=true,
             multi=true,
-            allValues='',
+            allValues='.*',
             hide=if $._config.enableMultiCluster then '' else 'variable',
             sort=0
           ),
@@ -863,7 +897,7 @@ local getMatcher(cfg) = '%(activemqSelector)s, activemq_cluster=~"$activemq_clus
             refresh=2,
             includeAll=true,
             multi=true,
-            allValues='',
+            allValues='.+',
             sort=0
           ),
           template.new(
@@ -874,7 +908,7 @@ local getMatcher(cfg) = '%(activemqSelector)s, activemq_cluster=~"$activemq_clus
             refresh=2,
             includeAll=true,
             multi=true,
-            allValues='',
+            allValues='.+',
             sort=0
           ),
           template.custom(

--- a/apache-activemq-mixin/jsonnetfile.json
+++ b/apache-activemq-mixin/jsonnetfile.json
@@ -19,7 +19,7 @@
       },
       "version": "main"
     },
-		{
+    {
       "source": {
         "git": {
           "remote": "https://github.com/grafana/jsonnet-libs.git",


### PR DESCRIPTION
- Added Drill down links onto queue and topics summary table.
<img width="1677" alt="image" src="https://github.com/grafana/jsonnet-libs/assets/38274348/90fc6802-a8f5-4492-885c-0366e66f0f6f">

- Simplified JVM queries and made it compatible with sample app
- Altered "Broker" -> "Brokers" on cluster dashboard
- Fixed linting issues caused by having empty allValues='' on template variables
- Added min and max on bar gauges on cluster dashboard to ensure bar gauges grow correctly.
- Got rid of sum without (job) on alerts because job labels are needed on alerts panel.