### PR TITLE
Add Apache HBase mixin

### DIFF
--- a/apache-hbase-mixin/.lint
+++ b/apache-hbase-mixin/.lint
@@ -1,0 +1,17 @@
+exclusions:
+  template-job-rule:
+    reason: "Prometheus datasource variable is being named as prometheus_datasource now while linter expects 'datasource'"
+  panel-datasource-rule:
+    reason: "Loki datasource variable is being named as loki_datasource now while linter expects 'datasource'"
+  template-datasource-rule:
+    reason: "Based on new convention we are using variable names prometheus_datasource and loki_datasource where as linter expects 'datasource'"
+  template-instance-rule:
+    reason: "Based on new convention we are using variable names prometheus_datasource and loki_datasource where as linter expects 'datasource'"
+  target-instance-rule:
+    reason: "The dashboard is a 'cluster' dashboard where the instance refers to nodes, this dashboard focuses only on the cluster view."
+    entries:
+      - dashboard: "Apache HBase cluster overview"
+  panel-title-description-rule:
+    reason: "Not required for logs volume"
+  panel-units-rule:
+    reason: "Logs volume has no unit"

--- a/apache-hbase-mixin/Makefile
+++ b/apache-hbase-mixin/Makefile
@@ -1,0 +1,34 @@
+JSONNET_FMT := jsonnetfmt -n 2 --max-blank-lines 1 --string-style s --comment-style s
+
+.PHONY: all
+all: build dashboards_out prometheus_alerts.yaml
+
+vendor: jsonnetfile.json
+	jb install
+
+.PHONY: build
+build: vendor
+
+.PHONY: fmt
+fmt:
+	find . -name 'vendor' -prune -o -name '*.libsonnet' -print -o -name '*.jsonnet' -print | \
+		xargs -n 1 -- $(JSONNET_FMT) -i
+
+.PHONY: lint
+lint: build
+	find . -name 'vendor' -prune -o -name '*.libsonnet' -print -o -name '*.jsonnet' -print | \
+		while read f; do \
+			$(JSONNET_FMT) "$$f" | diff -u "$$f" -; \
+		done
+	mixtool lint mixin.libsonnet
+
+dashboards_out: mixin.libsonnet config.libsonnet $(wildcard dashboards/*)
+	@mkdir -p dashboards_out
+	mixtool generate dashboards mixin.libsonnet -d dashboards_out
+
+prometheus_alerts.yaml: mixin.libsonnet alerts/*.libsonnet
+	mixtool generate alerts mixin.libsonnet -a prometheus_alerts.yaml
+
+.PHONY: clean
+clean:
+	rm -rf dashboards_out prometheus_alerts.yaml

--- a/apache-hbase-mixin/README.md
+++ b/apache-hbase-mixin/README.md
@@ -10,12 +10,12 @@ The Apache HBase mixin contains the following dashboards:
 
 and the following alerts:
 
-- ApacheHBaseHighHeapMemUsage
-- ApacheHBaseHighNonHeapMemUsage
-- ApacheHBaseDeadRegionServer
-- ApacheHBaseOldRegionsInTransition
-- ApacheHBaseHighMasterAuthFailureRate
-- ApacheHBaseHighRSAuthFailureRate
+- HBaseHighHeapMemUsage
+- HBaseHighNonHeapMemUsage
+- HBaseDeadRegionServer
+- HBaseOldRegionsInTransition
+- HBaseHighMasterAuthFailureRate
+- HBaseHighRSAuthFailureRate
 
 ## Apache HBase overview
 The Apache HBase cluster overview dashboard provides details on integration status/alerts, current RegionServers, JVM memory usage, cluster connections, master queue performance, and transitioning regions.

--- a/apache-hbase-mixin/README.md
+++ b/apache-hbase-mixin/README.md
@@ -54,8 +54,8 @@ scrape_configs:
       - targets: [localhost]
         labels:
           job: integrations/apache-hbase
+          hbase_cluster: "<your-cluster-name>"
           instance: "<your-instance-name>"
-          apache_hbase_cluster: "<your-cluster-name>"
           __path__: {hbase-home}/logs/*.log
     pipeline_stages:
         - multiline:
@@ -64,7 +64,7 @@ scrape_configs:
             expression: '\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2},\d{3} (?P<level>\w+)  \[(?P<context>.*)\] (?P<message>(?s:.*))$'
         - labels:
             level:
-            context:
+            logger:
 ```
 
 ## Alerts overview

--- a/apache-hbase-mixin/README.md
+++ b/apache-hbase-mixin/README.md
@@ -1,0 +1,122 @@
+# Apache HBase mixin
+
+The Apache HBase mixin is a set of configurable Grafana dashboards and alerts.
+
+The Apache HBase mixin contains the following dashboards:
+
+- Apache HBase cluster overview
+- Apache HBase RegionServer overview
+- Apache HBase logs
+
+and the following alerts:
+
+- ApacheHBaseHighHeapMemUsage
+- ApacheHBaseHighNonHeapMemUsage
+- ApacheHBaseDeadRegionServer
+- ApacheHBaseOldRegionsInTransition
+- ApacheHBaseHighMasterAuthFailureRate
+- ApacheHBaseHighRSAuthFailureRate
+
+## Apache HBase overview
+The Apache HBase cluster overview dashboard provides details on integration status/alerts, current RegionServers, JVM memory usage, cluster connections, master queue performance, and transitioning regions.
+
+![First screenshot of the Apache HBase cluster overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-hbase/screenshots/apache_hbase_cluster_overview_1.png)
+![Second screenshot of the Apache HBase cluster overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-hbase/screenshots/apache_hbase_cluster_overview_2.png)
+
+## Apache HBase RegionServer overview
+The Apache HBase RegionServer overview dashboard provides details on data regions, storage, connections, and request handling performance for a RegionServer node.
+
+![First screenshot of the Apache HBase RegionServer overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-hbase/screenshots/apache_hbase_region_server_overview_1.png)
+![Second screenshot of the Apache HBase RegionServer overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-hbase/screenshots/apache_hbase_region_server_overview_2.png)
+
+
+## Apache HBase logs
+The Apache HBase logs dashboard provides details on incoming system logs.
+
+![First screenshot of the Apache HBase logs dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/apache-hbase/screenshots/apache_hbase_logs_1.png)
+
+Apache HBase system logs are enabled by default in the `config.libsonnet` and can be removed by setting `enableLokiLogs` to `false`. Then run `make` again to regenerate the dashboard:
+
+```
+{
+  _config+:: {
+    enableLokiLogs: false,
+  },
+}
+```
+
+In order for the selectors to properly work for system logs ingested into your logs datasource, please also include the matching `instance`, `job`, and `apache_hbase_cluster` labels onto the [scrape_configs](https://grafana.com/docs/loki/latest/clients/promtail/configuration/#scrape_configs) as to match the labels for ingested metrics.
+
+```yaml
+scrape_configs:
+  - job_name: integrations/apache-hbase
+    static_configs:
+      - targets: [localhost]
+        labels:
+          job: integrations/apache-hbase
+          instance: "<your-instance-name>"
+          apache_hbase_cluster: "<your-cluster-name>"
+          __path__: {hbase-home}/logs/*.log
+    pipeline_stages:
+        - multiline:
+            firstline: '\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2},\d{3}'
+        - regex:
+            expression: '\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2},\d{3} (?P<level>\w+)  \[(?P<context>.*)\] (?P<message>(?s:.*))$'
+        - labels:
+            level:
+            context:
+```
+
+## Alerts overview
+
+- ApacheHBaseHighHeapMemUsage: There is a limited amount of heap memory available to the JVM.
+- ApacheHBaseHighNonHeapMemUsage: There is a limited amount of non-heap memory available to the JVM.
+- ApacheHBaseDeadRegionServer: One or more RegionServer(s) has become unresponsive.
+- ApacheHBaseOldRegionsInTransition: RegionServers are in transition for longer than expected.
+- ApacheHBaseHighMasterAuthFailureRate: A high percentage of authentication attempts to the master are failing.
+- ApacheHBaseHighRSAuthFailureRate: A high percentage of authentication attempts to a RegionServer are failing.
+
+Default thresholds can be configured in `config.libsonnet`.
+
+```js
+{
+  _config+:: {
+    alertsHighHeapMemUsage: 80        // percentage
+    alertsHighNonHeapMemUsage: 80     // percentage
+    alertsDeadRegionServer: 0         // count
+    alertsOldRegionsInTransition: 50  // percentage
+    alertsHighMasterAuthFailRate: 35  // percentage
+    alertsHighRSAuthFailRate: 35      // percentage
+  },
+}
+```
+
+## Install tools
+
+```bash
+go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@latest
+go install github.com/monitoring-mixins/mixtool/cmd/mixtool@latest
+```
+
+For linting and formatting, you would also need `jsonnetfmt` installed. If you
+have a working Go development environment, it's easiest to run the following:
+
+```bash
+go install github.com/google/go-jsonnet/cmd/jsonnetfmt@latest
+```
+
+The files in `dashboards_out` need to be imported
+into your Grafana server. The exact details will be depending on your environment.
+
+`prometheus_alerts.yaml` needs to be imported into Prometheus.
+
+## Generate dashboards and alerts
+
+Edit `config.libsonnet` if required and then build JSON dashboard files for Grafana:
+
+```bash
+make
+```
+
+For more advanced uses of mixins, see
+https://github.com/monitoring-mixins/docs.

--- a/apache-hbase-mixin/alerts/alerts.libsonnet
+++ b/apache-hbase-mixin/alerts/alerts.libsonnet
@@ -1,0 +1,113 @@
+{
+  prometheusAlerts+:: {
+    groups+: [
+      {
+        name: 'apache-hbase-alerts',
+        rules: [
+          {
+            alert: 'HighHeapMemUsage',
+            expr: |||
+              100 * sum without(context, hostname, processname) (jvm_metrics_mem_heap_used_m{job=~"$job", apache_hbase_cluster=~"$apache_hbase_cluster", instance=~"$instance"} / clamp_min(jvm_metrics_mem_heap_committed_m{job=~"$job", apache_hbase_cluster=~"$apache_hbase_cluster", instance=~"$instance"}, 1))  > %(alertsHighHeapMemUsage)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              summary: 'There is a limited amount of heap memory available to the JVM.',
+              description:
+                (
+                  'The heap memory usage for the JVM on instance {{$labels.instance}} in cluster {{$labels.apache_hbase_cluster}} is {{printf "%%.0f" $labels.value}} percent, which is above the threshold of %(alertsHighHeapMemUsage)s'
+                ) % $._config,
+            },
+          },
+          {
+            alert: 'HighNonHeapMemUsage',
+            expr: |||
+              100 * sum without(context, hostname, processname) (jvm_metrics_mem_non_heap_used_m{job=~"$job", apache_hbase_cluster=~"$apache_hbase_cluster", instance=~"$instance"} / clamp_min(jvm_metrics_mem_non_heap_committed_m{job=~"$job", apache_hbase_cluster=~"$apache_hbase_cluster", instance=~"$instance"}, 1))  > %(alertsHighNonHeapMemUsage)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              summary: 'There is a limited amount of non-heap memory available to the JVM.',
+              description:
+                (
+                  'The non-heap memory usage for the JVM on instance {{$labels.instance}} in cluster {{$labels.apache_hbase_cluster}} is {{printf "%%.0f" $labels.value}} percent, which is above the threshold of %(alertsHighNonHeapMemUsage)s'
+                ) % $._config,
+            },
+          },
+          {
+            alert: 'DeadRegionServer',
+            expr: |||
+              server_num_dead_region_servers{job=~"$job", apache_hbase_cluster=~"$apache_hbase_cluster"} > %(alertsDeadRegionServer)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              summary: 'One or more RegionServer(s) has become unresponsive.',
+              description:
+                (
+                  '{{$labels.value}} RegionServer(s) in cluster {{$labels.apache_hbase_cluster}} are unresponsive, which is above the threshold of %(alertsDeadRegionServer)s. The name(s) of the dead RegionServer(s) are {{$labels.deadregionservers}}'
+                ) % $._config,
+            },
+          },
+          {
+            alert: 'OldRegionsInTransition',
+            expr: |||
+              100 * assignment_manager_rit_count_over_threshold{job=~"$job", apache_hbase_cluster=~"$apache_hbase_cluster", instance=~"$instance"} / clamp_min(assignment_manager_rit_count{job=~"$job", apache_hbase_cluster=~"$apache_hbase_cluster", instance=~"$instance"}, 1) > %(alertsOldRegionsInTransition)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              summary: 'RegionServers are in transition for longer than expected.',
+              description:
+                (
+                  '{{printf "%%.0f" $labels.value}} percent of RegionServers in transition in cluster {{$labels.apache_hbase_cluster}} are transitioning for longer than expected, which is above the threshold of %(alertsOldRegionsInTransition)s'
+                ) % $._config,
+            },
+          },
+          {
+            alert: 'HighMasterAuthFailRate',
+            expr: |||
+              100 * rate(master_authentication_failures{job=~"$job", apache_hbase_cluster=~"$apache_hbase_cluster", instance=~"$instance"}[5m]) / (clamp_min(rate(master_authentication_successes{job=~"$job", apache_hbase_cluster=~"$apache_hbase_cluster", instance=~"$instance"}[5m]), 1) + clamp_min(rate(master_authentication_failures{job=~"$job", apache_hbase_cluster=~"$apache_hbase_cluster", instance=~"$instance"}[5m]), 1)) > %(alertsHighMasterAuthFailRate)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              summary: 'A high percentage of authentication attempts to the master are failing.',
+              description:
+                (
+                  '{{printf "%%.0f" $labels.value}} percent of authentication attempts to the master are failing in cluster {{$labels.apache_hbase_cluster}}, which is above the threshold of %(alertsHighMasterAuthFailRate)s'
+                ) % $._config,
+            },
+          },
+          {
+            alert: 'HighRSAuthFailRate',
+            expr: |||
+              100 * rate(region_server_authentication_failures{job=~"$job", apache_hbase_cluster=~"$apache_hbase_cluster", instance=~"$instance"}[5m]) / (clamp_min(rate(region_server_authentication_successes{job=~"$job", apache_hbase_cluster=~"$apache_hbase_cluster", instance=~"$instance"}[5m]), 1) + clamp_min(rate(region_server_authentication_failures{job=~"$job", apache_hbase_cluster=~"$apache_hbase_cluster", instance=~"$instance"}[5m]), 1)) > %(alertsHighRSAuthFailRate)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              summary: 'A high percentage of authentication attempts to a RegionServer are failing.',
+              description:
+                (
+                  '{{printf "%%.0f" $labels.value}} percent of authentication attempts to the RegionServer {{$labels.instance}} are failing in cluster {{$labels.apache_hbase_cluster}}, which is above the threshold of %(alertsHighRSAuthFailRate)s'
+                ) % $._config,
+            },
+          },
+        ],
+      },
+    ],
+  },
+}

--- a/apache-hbase-mixin/alerts/alerts.libsonnet
+++ b/apache-hbase-mixin/alerts/alerts.libsonnet
@@ -68,7 +68,7 @@
               summary: 'RegionServers are in transition for longer than expected.',
               description:
                 (
-                  '{{printf "%%.0f" $labels.value}} percent of RegionServers in transition in cluster {{$labels.hbase_cluster}} are transitioning for longer than expected, which is above the threshold of %(alertsOldRegionsInTransition)s'
+                  '{{printf "%%.0f" $labels.value}} percent of RegionServers in transition in cluster {{$labels.hbase_cluster}} are transitioning for longer than expected, which is above the threshold of %(alertsOldRegionsInTransition)s percent'
                 ) % $._config,
             },
           },

--- a/apache-hbase-mixin/alerts/alerts.libsonnet
+++ b/apache-hbase-mixin/alerts/alerts.libsonnet
@@ -7,7 +7,7 @@
           {
             alert: 'HighHeapMemUsage',
             expr: |||
-              100 * sum without(context, hostname, processname) (jvm_metrics_mem_heap_used_m{job=~"$job", apache_hbase_cluster=~"$apache_hbase_cluster", instance=~"$instance"} / clamp_min(jvm_metrics_mem_heap_committed_m{job=~"$job", apache_hbase_cluster=~"$apache_hbase_cluster", instance=~"$instance"}, 1))  > %(alertsHighHeapMemUsage)s
+              100 * sum without(context, hostname, processname) (jvm_metrics_mem_heap_used_m / clamp_min(jvm_metrics_mem_heap_committed_m, 1))  > %(alertsHighHeapMemUsage)s
             ||| % $._config,
             'for': '5m',
             labels: {
@@ -17,14 +17,14 @@
               summary: 'There is a limited amount of heap memory available to the JVM.',
               description:
                 (
-                  'The heap memory usage for the JVM on instance {{$labels.instance}} in cluster {{$labels.apache_hbase_cluster}} is {{printf "%%.0f" $labels.value}} percent, which is above the threshold of %(alertsHighHeapMemUsage)s'
+                  'The heap memory usage for the JVM on instance {{$labels.instance}} in cluster {{$labels.hbase_cluster}} is {{printf "%%.0f" $labels.value}} percent, which is above the threshold of %(alertsHighHeapMemUsage)s'
                 ) % $._config,
             },
           },
           {
             alert: 'HighNonHeapMemUsage',
             expr: |||
-              100 * sum without(context, hostname, processname) (jvm_metrics_mem_non_heap_used_m{job=~"$job", apache_hbase_cluster=~"$apache_hbase_cluster", instance=~"$instance"} / clamp_min(jvm_metrics_mem_non_heap_committed_m{job=~"$job", apache_hbase_cluster=~"$apache_hbase_cluster", instance=~"$instance"}, 1))  > %(alertsHighNonHeapMemUsage)s
+              100 * sum without(context, hostname, processname) (jvm_metrics_mem_non_heap_used_m / clamp_min(jvm_metrics_mem_non_heap_committed_m, 1))  > %(alertsHighNonHeapMemUsage)s
             ||| % $._config,
             'for': '5m',
             labels: {
@@ -34,14 +34,14 @@
               summary: 'There is a limited amount of non-heap memory available to the JVM.',
               description:
                 (
-                  'The non-heap memory usage for the JVM on instance {{$labels.instance}} in cluster {{$labels.apache_hbase_cluster}} is {{printf "%%.0f" $labels.value}} percent, which is above the threshold of %(alertsHighNonHeapMemUsage)s'
+                  'The non-heap memory usage for the JVM on instance {{$labels.instance}} in cluster {{$labels.hbase_cluster}} is {{printf "%%.0f" $labels.value}} percent, which is above the threshold of %(alertsHighNonHeapMemUsage)s'
                 ) % $._config,
             },
           },
           {
             alert: 'DeadRegionServer',
             expr: |||
-              server_num_dead_region_servers{job=~"$job", apache_hbase_cluster=~"$apache_hbase_cluster"} > %(alertsDeadRegionServer)s
+              server_num_dead_region_servers > %(alertsDeadRegionServer)s
             ||| % $._config,
             'for': '5m',
             labels: {
@@ -51,14 +51,14 @@
               summary: 'One or more RegionServer(s) has become unresponsive.',
               description:
                 (
-                  '{{$labels.value}} RegionServer(s) in cluster {{$labels.apache_hbase_cluster}} are unresponsive, which is above the threshold of %(alertsDeadRegionServer)s. The name(s) of the dead RegionServer(s) are {{$labels.deadregionservers}}'
+                  '{{$labels.value}} RegionServer(s) in cluster {{$labels.hbase_cluster}} are unresponsive, which is above the threshold of %(alertsDeadRegionServer)s. The name(s) of the dead RegionServer(s) are {{$labels.deadregionservers}}'
                 ) % $._config,
             },
           },
           {
             alert: 'OldRegionsInTransition',
             expr: |||
-              100 * assignment_manager_rit_count_over_threshold{job=~"$job", apache_hbase_cluster=~"$apache_hbase_cluster", instance=~"$instance"} / clamp_min(assignment_manager_rit_count{job=~"$job", apache_hbase_cluster=~"$apache_hbase_cluster", instance=~"$instance"}, 1) > %(alertsOldRegionsInTransition)s
+              100 * assignment_manager_rit_count_over_threshold / clamp_min(assignment_manager_rit_count, 1) > %(alertsOldRegionsInTransition)s
             ||| % $._config,
             'for': '5m',
             labels: {
@@ -68,14 +68,14 @@
               summary: 'RegionServers are in transition for longer than expected.',
               description:
                 (
-                  '{{printf "%%.0f" $labels.value}} percent of RegionServers in transition in cluster {{$labels.apache_hbase_cluster}} are transitioning for longer than expected, which is above the threshold of %(alertsOldRegionsInTransition)s'
+                  '{{printf "%%.0f" $labels.value}} percent of RegionServers in transition in cluster {{$labels.hbase_cluster}} are transitioning for longer than expected, which is above the threshold of %(alertsOldRegionsInTransition)s'
                 ) % $._config,
             },
           },
           {
             alert: 'HighMasterAuthFailRate',
             expr: |||
-              100 * rate(master_authentication_failures{job=~"$job", apache_hbase_cluster=~"$apache_hbase_cluster", instance=~"$instance"}[5m]) / (clamp_min(rate(master_authentication_successes{job=~"$job", apache_hbase_cluster=~"$apache_hbase_cluster", instance=~"$instance"}[5m]), 1) + clamp_min(rate(master_authentication_failures{job=~"$job", apache_hbase_cluster=~"$apache_hbase_cluster", instance=~"$instance"}[5m]), 1)) > %(alertsHighMasterAuthFailRate)s
+              100 * rate(master_authentication_failures[5m]) / (clamp_min(rate(master_authentication_successes[5m]), 1) + clamp_min(rate(master_authentication_failures[5m]), 1)) > %(alertsHighMasterAuthFailRate)s
             ||| % $._config,
             'for': '5m',
             labels: {
@@ -85,14 +85,14 @@
               summary: 'A high percentage of authentication attempts to the master are failing.',
               description:
                 (
-                  '{{printf "%%.0f" $labels.value}} percent of authentication attempts to the master are failing in cluster {{$labels.apache_hbase_cluster}}, which is above the threshold of %(alertsHighMasterAuthFailRate)s'
+                  '{{printf "%%.0f" $labels.value}} percent of authentication attempts to the master are failing in cluster {{$labels.hbase_cluster}}, which is above the threshold of %(alertsHighMasterAuthFailRate)s'
                 ) % $._config,
             },
           },
           {
             alert: 'HighRSAuthFailRate',
             expr: |||
-              100 * rate(region_server_authentication_failures{job=~"$job", apache_hbase_cluster=~"$apache_hbase_cluster", instance=~"$instance"}[5m]) / (clamp_min(rate(region_server_authentication_successes{job=~"$job", apache_hbase_cluster=~"$apache_hbase_cluster", instance=~"$instance"}[5m]), 1) + clamp_min(rate(region_server_authentication_failures{job=~"$job", apache_hbase_cluster=~"$apache_hbase_cluster", instance=~"$instance"}[5m]), 1)) > %(alertsHighRSAuthFailRate)s
+              100 * rate(region_server_authentication_failures[5m]) / (clamp_min(rate(region_server_authentication_successes[5m] + clamp_min(rate(region_server_authentication_failures[5m]), 1)))) > %(alertsHighRSAuthFailRate)s
             ||| % $._config,
             'for': '5m',
             labels: {
@@ -102,7 +102,7 @@
               summary: 'A high percentage of authentication attempts to a RegionServer are failing.',
               description:
                 (
-                  '{{printf "%%.0f" $labels.value}} percent of authentication attempts to the RegionServer {{$labels.instance}} are failing in cluster {{$labels.apache_hbase_cluster}}, which is above the threshold of %(alertsHighRSAuthFailRate)s'
+                  '{{printf "%%.0f" $labels.value}} percent of authentication attempts to the RegionServer {{$labels.instance}} are failing in cluster {{$labels.hbase_cluster}}, which is above the threshold of %(alertsHighRSAuthFailRate)s'
                 ) % $._config,
             },
           },

--- a/apache-hbase-mixin/alerts/alerts.libsonnet
+++ b/apache-hbase-mixin/alerts/alerts.libsonnet
@@ -92,7 +92,7 @@
           {
             alert: 'HighRSAuthFailRate',
             expr: |||
-              100 * rate(region_server_authentication_failures[5m]) / (clamp_min(rate(region_server_authentication_successes[5m] + clamp_min(rate(region_server_authentication_failures[5m]), 1)))) > %(alertsHighRSAuthFailRate)s
+              100 * rate(region_server_authentication_failures[5m]) / (clamp_min(rate(region_server_authentication_successes[5m]), 1) + clamp_min(rate(region_server_authentication_failures[5m]), 1)) > %(alertsHighRSAuthFailRate)s
             ||| % $._config,
             'for': '5m',
             labels: {

--- a/apache-hbase-mixin/alerts/alerts.libsonnet
+++ b/apache-hbase-mixin/alerts/alerts.libsonnet
@@ -7,7 +7,7 @@
           {
             alert: 'HBaseHighHeapMemUsage',
             expr: |||
-              100 * sum without(context, hostname, processname) (jvm_metrics_mem_heap_used_m{$._config.filterSelector} / clamp_min(jvm_metrics_mem_heap_committed_m{$._config.filterSelector}, 1))  > %(alertsHighHeapMemUsage)s
+              100 * sum without(context, hostname, processname) (jvm_metrics_mem_heap_used_m{%(filterSelector)s} / clamp_min(jvm_metrics_mem_heap_committed_m{%(filterSelector)s}, 1))  > %(alertsHighHeapMemUsage)s
             ||| % $._config,
             'for': '5m',
             labels: {

--- a/apache-hbase-mixin/alerts/alerts.libsonnet
+++ b/apache-hbase-mixin/alerts/alerts.libsonnet
@@ -17,7 +17,7 @@
               summary: 'There is a limited amount of heap memory available to the JVM.',
               description:
                 (
-                  'The heap memory usage for the JVM on instance {{$labels.instance}} in cluster {{$labels.hbase_cluster}} is {{printf "%%.0f" $labels.value}} percent, which is above the threshold of %(alertsHighHeapMemUsage)s'
+                  'The heap memory usage for the JVM on instance {{$labels.instance}} in cluster {{$labels.hbase_cluster}} is {{printf "%%.0f" $labels.value}} percent, which is above the threshold of %(alertsHighHeapMemUsage)s percent'
                 ) % $._config,
             },
           },
@@ -34,7 +34,7 @@
               summary: 'There is a limited amount of non-heap memory available to the JVM.',
               description:
                 (
-                  'The non-heap memory usage for the JVM on instance {{$labels.instance}} in cluster {{$labels.hbase_cluster}} is {{printf "%%.0f" $labels.value}} percent, which is above the threshold of %(alertsHighNonHeapMemUsage)s'
+                  'The non-heap memory usage for the JVM on instance {{$labels.instance}} in cluster {{$labels.hbase_cluster}} is {{printf "%%.0f" $labels.value}} percent, which is above the threshold of %(alertsHighNonHeapMemUsage)s percent'
                 ) % $._config,
             },
           },
@@ -85,7 +85,7 @@
               summary: 'A high percentage of authentication attempts to the master are failing.',
               description:
                 (
-                  '{{printf "%%.0f" $labels.value}} percent of authentication attempts to the master are failing in cluster {{$labels.hbase_cluster}}, which is above the threshold of %(alertsHighMasterAuthFailRate)s'
+                  '{{printf "%%.0f" $labels.value}} percent of authentication attempts to the master are failing in cluster {{$labels.hbase_cluster}}, which is above the threshold of %(alertsHighMasterAuthFailRate)s percent'
                 ) % $._config,
             },
           },
@@ -102,7 +102,7 @@
               summary: 'A high percentage of authentication attempts to a RegionServer are failing.',
               description:
                 (
-                  '{{printf "%%.0f" $labels.value}} percent of authentication attempts to the RegionServer {{$labels.instance}} are failing in cluster {{$labels.hbase_cluster}}, which is above the threshold of %(alertsHighRSAuthFailRate)s'
+                  '{{printf "%%.0f" $labels.value}} percent of authentication attempts to the RegionServer {{$labels.instance}} are failing in cluster {{$labels.hbase_cluster}}, which is above the threshold of %(alertsHighRSAuthFailRate)s percent'
                 ) % $._config,
             },
           },

--- a/apache-hbase-mixin/alerts/alerts.libsonnet
+++ b/apache-hbase-mixin/alerts/alerts.libsonnet
@@ -5,9 +5,9 @@
         name: 'apache-hbase-alerts',
         rules: [
           {
-            alert: 'HighHeapMemUsage',
+            alert: 'HBaseHighHeapMemUsage',
             expr: |||
-              100 * sum without(context, hostname, processname) (jvm_metrics_mem_heap_used_m / clamp_min(jvm_metrics_mem_heap_committed_m, 1))  > %(alertsHighHeapMemUsage)s
+              100 * sum without(context, hostname, processname) (jvm_metrics_mem_heap_used_m{$._config.filterSelector} / clamp_min(jvm_metrics_mem_heap_committed_m{$._config.filterSelector}, 1))  > %(alertsHighHeapMemUsage)s
             ||| % $._config,
             'for': '5m',
             labels: {
@@ -22,24 +22,7 @@
             },
           },
           {
-            alert: 'HighNonHeapMemUsage',
-            expr: |||
-              100 * sum without(context, hostname, processname) (jvm_metrics_mem_non_heap_used_m / clamp_min(jvm_metrics_mem_non_heap_committed_m, 1))  > %(alertsHighNonHeapMemUsage)s
-            ||| % $._config,
-            'for': '5m',
-            labels: {
-              severity: 'warning',
-            },
-            annotations: {
-              summary: 'There is a limited amount of non-heap memory available to the JVM.',
-              description:
-                (
-                  'The non-heap memory usage for the JVM on instance {{$labels.instance}} in cluster {{$labels.hbase_cluster}} is {{printf "%%.0f" $labels.value}} percent, which is above the threshold of %(alertsHighNonHeapMemUsage)s percent'
-                ) % $._config,
-            },
-          },
-          {
-            alert: 'DeadRegionServer',
+            alert: 'HBaseDeadRegionServer',
             expr: |||
               server_num_dead_region_servers > %(alertsDeadRegionServer)s
             ||| % $._config,
@@ -56,7 +39,7 @@
             },
           },
           {
-            alert: 'OldRegionsInTransition',
+            alert: 'HBaseOldRegionsInTransition',
             expr: |||
               100 * assignment_manager_rit_count_over_threshold / clamp_min(assignment_manager_rit_count, 1) > %(alertsOldRegionsInTransition)s
             ||| % $._config,
@@ -73,7 +56,7 @@
             },
           },
           {
-            alert: 'HighMasterAuthFailRate',
+            alert: 'HBaseHighMasterAuthFailRate',
             expr: |||
               100 * rate(master_authentication_failures[5m]) / (clamp_min(rate(master_authentication_successes[5m]), 1) + clamp_min(rate(master_authentication_failures[5m]), 1)) > %(alertsHighMasterAuthFailRate)s
             ||| % $._config,
@@ -90,7 +73,7 @@
             },
           },
           {
-            alert: 'HighRSAuthFailRate',
+            alert: 'HBaseHighRSAuthFailRate',
             expr: |||
               100 * rate(region_server_authentication_failures[5m]) / (clamp_min(rate(region_server_authentication_successes[5m]), 1) + clamp_min(rate(region_server_authentication_failures[5m]), 1)) > %(alertsHighRSAuthFailRate)s
             ||| % $._config,

--- a/apache-hbase-mixin/config.libsonnet
+++ b/apache-hbase-mixin/config.libsonnet
@@ -1,0 +1,20 @@
+{
+  _config+:: {
+    filterSelector: 'job=~"integrations/apache-hbase"',
+
+    dashboardTags: ['apache-hbase-mixin'],
+    dashboardPeriod: 'now-30m',
+    dashboardTimezone: 'default',
+    dashboardRefresh: '1m',
+
+    // alerts thresholds
+    alertsHighHeapMemUsage: 80,  // percentage
+    alertsHighNonHeapMemUsage: 80,  // percentage
+    alertsDeadRegionServer: 0,  // count
+    alertsOldRegionsInTransition: 50,  // percentage
+    alertsHighMasterAuthFailRate: 35,  // percentage
+    alertsHighRSAuthFailRate: 35,  // percentage
+
+    enableLokiLogs: true,
+  },
+}

--- a/apache-hbase-mixin/dashboards/apache-hbase-cluster-overview.libsonnet
+++ b/apache-hbase-mixin/dashboards/apache-hbase-cluster-overview.libsonnet
@@ -1,0 +1,954 @@
+local g = (import 'grafana-builder/grafana.libsonnet');
+local grafana = (import 'grafonnet/grafana.libsonnet');
+local dashboard = grafana.dashboard;
+local template = grafana.template;
+local prometheus = grafana.prometheus;
+
+local dashboardUid = 'apache-hbase-cluster-overview';
+
+local promDatasourceName = 'prometheus_datasource';
+
+local promDatasource = {
+  uid: '${%s}' % promDatasourceName,
+};
+
+local deadRegionServersPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'server_num_dead_region_servers{job=~"$job", hbase_cluster=~"$hbase_cluster"}',
+      datasource=promDatasource,
+      legendFormat='{{hbase_cluster}}',
+    ),
+  ],
+  type: 'stat',
+  title: 'Dead RegionServers',
+  description: 'Number of RegionServers that are currently dead.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 1,
+          },
+        ],
+      },
+    },
+    overrides: [],
+  },
+  options: {
+    colorMode: 'value',
+    graphMode: 'area',
+    justifyMode: 'auto',
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    textMode: 'value',
+  },
+  pluginVersion: '10.2.0-60853',
+};
+
+local regionserversPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'server_num_region_servers{job=~"$job", hbase_cluster=~"$hbase_cluster"}',
+      datasource=promDatasource,
+      legendFormat='{{hbase_cluster}}',
+      format='table',
+    ),
+  ],
+  type: 'table',
+  title: 'RegionServers',
+  description: 'RegionServers for a cluster.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        align: 'left',
+        cellOptions: {
+          type: 'auto',
+        },
+        inspect: false,
+      },
+      links: [],
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+    },
+    overrides: [
+      {
+        matcher: {
+          id: 'byName',
+          options: 'Instance',
+        },
+        properties: [
+          {
+            id: 'links',
+            value: [
+              {
+                title: '',
+                url: '/d/apache-hbase-regionserver-overview',
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  options: {
+    cellHeight: 'md',
+    footer: {
+      countRows: false,
+      fields: '',
+      reducer: [
+        'sum',
+      ],
+      show: false,
+    },
+    showHeader: true,
+    sortBy: [],
+  },
+  pluginVersion: '10.2.0-60853',
+  transformations: [
+    {
+      id: 'joinByField',
+      options: {
+        byField: 'hostname',
+        mode: 'outer',
+      },
+    },
+    {
+      id: 'organize',
+      options: {
+        excludeByName: {
+          Time: true,
+          'Time 1': true,
+          'Time 2': true,
+          Value: true,
+          'Value #A': true,
+          'Value #B': true,
+          __name__: true,
+          '__name__ 1': true,
+          '__name__ 2': true,
+          clusterid: true,
+          'clusterid 1': true,
+          'clusterid 2': true,
+          context: true,
+          'context 1': true,
+          'context 2': true,
+          hbase_cluster: true,
+          'hbase_cluster 1': true,
+          'hbase_cluster 2': true,
+          instance: false,
+          'instance 1': true,
+          'instance 2': true,
+          isactivemaster: false,
+          'isactivemaster 1': false,
+          'isactivemaster 2': true,
+          job: true,
+          'job 1': true,
+          'job 2': true,
+          liveregionservers: true,
+          'liveregionservers 1': true,
+          'liveregionservers 2': true,
+          servername: false,
+          'servername 1': false,
+          'servername 2': true,
+          zookeeperquorum: true,
+          'zookeeperquorum 1': true,
+          'zookeeperquorum 2': true,
+        },
+        indexByName: {
+          Time: 4,
+          Value: 12,
+          __name__: 5,
+          clusterid: 7,
+          context: 8,
+          hbase_cluster: 6,
+          hostname: 1,
+          instance: 2,
+          isactivemaster: 3,
+          job: 9,
+          liveregionservers: 10,
+          servername: 0,
+          zookeeperquorum: 11,
+        },
+        renameByName: {
+          Time: '',
+          deadregionservers: 'Dead server name',
+          hostname: 'Hostname',
+          instance: 'Instance',
+          isactivemaster: 'Is master',
+          'isactivemaster 1': 'Master',
+          servername: 'Servername',
+          'servername 1': 'Servername',
+        },
+      },
+    },
+  ],
+};
+
+local alertsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'master_num_open_connections{job=~"$job", hbase_cluster=~"$hbase_cluster"}',
+      datasource=promDatasource,
+      legendFormat='{{hbase_cluster}}',
+    ),
+  ],
+  type: 'alertlist',
+  title: 'Alerts',
+  description: 'Panel to report on the status of integration alerts.',
+  options: {
+    alertInstanceLabelFilter: '',
+    alertName: '',
+    dashboardAlerts: false,
+    folder: {
+      title: 'Integration - Apache HBase',
+      uid: 'f3187c03-f385-4f8b-bc97-9ab49f72a147',
+    },
+    groupBy: [],
+    groupMode: 'default',
+    maxItems: 20,
+    sortOrder: 1,
+    stateFilter: {
+      'error': true,
+      firing: true,
+      noData: false,
+      normal: false,
+      pending: true,
+    },
+    viewMode: 'list',
+  },
+};
+
+local jvmMemoryUsagePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'jvm_metrics_mem_non_heap_used_m{job=~"$job", hbase_cluster=~"$hbase_cluster"} / clamp_min(jvm_metrics_mem_non_heap_committed_m{job=~"$job", hbase_cluster=~"$hbase_cluster"}, 1)',
+      datasource=promDatasource,
+      legendFormat='{{hbase_cluster}} - non-heap',
+    ),
+    prometheus.target(
+      'jvm_metrics_mem_heap_used_m{job=~"$job", hbase_cluster=~"$hbase_cluster"} / clamp_min(jvm_metrics_mem_heap_committed_m{job=~"$job", hbase_cluster=~"$hbase_cluster"}, 1)',
+      datasource=promDatasource,
+      legendFormat='{{hbase_cluster}} - heap',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'JVM memory usage',
+  description: 'Memory usage for the JVM.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'continuous-BlYlRd',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        axisShow: false,
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      max: 1,
+      min: 0,
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'percentunit',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local connectionsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'master_num_open_connections{job=~"$job", hbase_cluster=~"$hbase_cluster"}',
+      datasource=promDatasource,
+      legendFormat='{{hbase_cluster}} - master',
+    ),
+    prometheus.target(
+      'region_server_num_open_connections{job=~"$job", hbase_cluster=~"$hbase_cluster"}',
+      datasource=promDatasource,
+      legendFormat='{{hbase_cluster}} - RegionServers',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Connections',
+  description: 'Number of open connections to the cluster.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        axisShow: false,
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local authenticationsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'rate(master_authentication_successes{job=~"$job", hbase_cluster=~"$hbase_cluster"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='{{hbase_cluster}} - master success',
+    ),
+    prometheus.target(
+      'rate(master_authentication_failures{job=~"$job", hbase_cluster=~"$hbase_cluster"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='{{hbase_cluster}} - master failure',
+    ),
+    prometheus.target(
+      'rate(region_server_authentication_successes{job=~"$job", hbase_cluster=~"$hbase_cluster"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='{{hbase_cluster}} - rs success',
+    ),
+    prometheus.target(
+      'rate(region_server_authentication_failures{job=~"$job", hbase_cluster=~"$hbase_cluster"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='{{hbase_cluster}} - rs failure',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Authentications',
+  description: 'Volume of successful and unsuccessful authentications.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        axisShow: false,
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [
+        'min',
+        'mean',
+        'max',
+      ],
+      displayMode: 'table',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local masterQueueSizePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'master_queue_size{job=~"$job", hbase_cluster=~"$hbase_cluster"}',
+      datasource=promDatasource,
+      legendFormat='{{hbase_cluster}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Master queue size',
+  description: 'The size of the queue of requests, operations, and tasks to be processed by the master.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        axisShow: false,
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'decbytes',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local masterQueuedCallsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'master_num_calls_in_general_queue{job=~"$job", hbase_cluster=~"$hbase_cluster"}',
+      datasource=promDatasource,
+      legendFormat='{{hbase_cluster}} - general',
+    ),
+    prometheus.target(
+      'master_num_calls_in_replication_queue{job=~"$job", hbase_cluster=~"$hbase_cluster"}',
+      datasource=promDatasource,
+      legendFormat='{{hbase_cluster}} - replication',
+    ),
+    prometheus.target(
+      'master_num_calls_in_read_queue{job=~"$job", hbase_cluster=~"$hbase_cluster"}',
+      datasource=promDatasource,
+      legendFormat='{{hbase_cluster}} - read',
+    ),
+    prometheus.target(
+      'master_num_calls_in_write_queue{job=~"$job", hbase_cluster=~"$hbase_cluster"}',
+      datasource=promDatasource,
+      legendFormat='{{hbase_cluster}} - write',
+    ),
+    prometheus.target(
+      'master_num_calls_in_scan_queue{job=~"$job", hbase_cluster=~"$hbase_cluster"}',
+      datasource=promDatasource,
+      legendFormat='{{hbase_cluster}} - scan',
+    ),
+    prometheus.target(
+      'master_num_calls_in_priority_queue{job=~"$job", hbase_cluster=~"$hbase_cluster"}',
+      datasource=promDatasource,
+      legendFormat='{{hbase_cluster}} - priority',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Master queued calls',
+  description: 'The number of calls waiting to be processed by the master.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        axisShow: false,
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [
+        'min',
+        'mean',
+        'max',
+      ],
+      displayMode: 'table',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local regionsInTransitionPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'assignment_manager_rit_count{job=~"$job", hbase_cluster=~"$hbase_cluster"}',
+      datasource=promDatasource,
+      legendFormat='{{hbase_cluster}}',
+    ),
+    prometheus.target(
+      'assignment_manager_rit_count_over_threshold{job=~"$job", hbase_cluster=~"$hbase_cluster"}',
+      datasource=promDatasource,
+      legendFormat='{{hbase_cluster}} - old',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Regions in transition',
+  description: 'The number of regions in transition for the cluster.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        axisShow: false,
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local oldestRegionInTransitionPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'assignment_manager_rit_oldest_age{job=~"$job", hbase_cluster=~"$hbase_cluster"}',
+      datasource=promDatasource,
+      legendFormat='{{hbase_cluster}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Oldest region in transition',
+  description: 'The age of the longest region in transition for the master of the cluster.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        axisShow: false,
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'ms',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+{
+  grafanaDashboards+:: {
+    'apache-hbase-cluster-overview.json':
+      dashboard.new(
+        'Apache HBase cluster overview',
+        time_from='%s' % $._config.dashboardPeriod,
+        tags=($._config.dashboardTags),
+        timezone='%s' % $._config.dashboardTimezone,
+        refresh='%s' % $._config.dashboardRefresh,
+        description='',
+        uid=dashboardUid,
+      )
+      .addLink(grafana.link.dashboards(
+        asDropdown=false,
+        title='Other Apache HBase dashboards',
+        includeVars=true,
+        keepTime=true,
+        tags=($._config.dashboardTags),
+      ))
+      .addTemplates(
+        [
+          template.datasource(
+            promDatasourceName,
+            'prometheus',
+            null,
+            label='Data Source',
+            refresh='load'
+          ),
+          template.new(
+            'job',
+            promDatasource,
+            'label_values(master_num_open_connections,job)',
+            label='Job',
+            refresh=2,
+            includeAll=true,
+            multi=true,
+            allValues='',
+            sort=0
+          ),
+          template.new(
+            'hbase_cluster',
+            promDatasource,
+            'label_values(master_num_open_connections{job=~"$job"},hbase_cluster)',
+            label='HBase cluster',
+            refresh=2,
+            includeAll=true,
+            multi=true,
+            allValues='',
+            sort=0
+          ),
+        ]
+      )
+      .addPanels(
+        [
+          deadRegionServersPanel { gridPos: { h: 8, w: 4, x: 0, y: 0 } },
+          regionserversPanel { gridPos: { h: 8, w: 10, x: 4, y: 0 } },
+          alertsPanel { gridPos: { h: 8, w: 10, x: 14, y: 0 } },
+          jvmMemoryUsagePanel { gridPos: { h: 9, w: 24, x: 0, y: 8 } },
+          connectionsPanel { gridPos: { h: 8, w: 12, x: 0, y: 17 } },
+          authenticationsPanel { gridPos: { h: 8, w: 12, x: 12, y: 17 } },
+          masterQueueSizePanel { gridPos: { h: 8, w: 12, x: 0, y: 25 } },
+          masterQueuedCallsPanel { gridPos: { h: 8, w: 12, x: 12, y: 25 } },
+          regionsInTransitionPanel { gridPos: { h: 8, w: 12, x: 0, y: 33 } },
+          oldestRegionInTransitionPanel { gridPos: { h: 8, w: 12, x: 12, y: 33 } },
+        ]
+      ),
+  },
+}

--- a/apache-hbase-mixin/dashboards/apache-hbase-cluster-overview.libsonnet
+++ b/apache-hbase-mixin/dashboards/apache-hbase-cluster-overview.libsonnet
@@ -12,6 +12,7 @@ local promDatasource = {
   uid: '${%s}' % promDatasourceName,
 };
 
+
 local deadRegionServersPanel = {
   datasource: promDatasource,
   targets: [
@@ -61,7 +62,7 @@ local deadRegionServersPanel = {
     },
     textMode: 'value',
   },
-  pluginVersion: '10.2.0-61719',
+  pluginVersion: '10.2.0-62263',
 };
 
 local liveRegionServersPanel = {
@@ -109,7 +110,7 @@ local liveRegionServersPanel = {
     },
     textMode: 'value',
   },
-  pluginVersion: '10.2.0-61719',
+  pluginVersion: '10.2.0-62263',
 };
 
 local regionserversPanel = {
@@ -124,6 +125,7 @@ local regionserversPanel = {
     prometheus.target(
       'server_num_reference_files{job=~"$job", hbase_cluster=~"$hbase_cluster"}',
       datasource=promDatasource,
+      legendFormat='',
       format='table',
     ),
   ],
@@ -203,7 +205,7 @@ local regionserversPanel = {
     showHeader: true,
     sortBy: [],
   },
-  pluginVersion: '10.2.0-61719',
+  pluginVersion: '10.2.0-62263',
   transformations: [
     {
       id: 'merge',
@@ -228,7 +230,7 @@ local regionserversPanel = {
           context: true,
           'context 1': true,
           'context 2': true,
-          hbase_cluster: true,
+          hbase_cluster: false,
           'hbase_cluster 1': true,
           'hbase_cluster 2': true,
           instance: false,
@@ -251,13 +253,13 @@ local regionserversPanel = {
           'zookeeperquorum 2': true,
         },
         indexByName: {
-          Time: 4,
+          Time: 5,
           'Value #A': 12,
           'Value #B': 13,
-          __name__: 5,
+          __name__: 6,
           clusterid: 7,
           context: 8,
-          hbase_cluster: 6,
+          hbase_cluster: 4,
           hostname: 1,
           instance: 2,
           isactivemaster: 3,
@@ -269,6 +271,7 @@ local regionserversPanel = {
         renameByName: {
           Time: '',
           deadregionservers: 'Dead server name',
+          hbase_cluster: 'Cluster',
           hostname: 'Hostname',
           instance: 'Instance',
           'instance 1': '',
@@ -296,8 +299,8 @@ local alertsPanel = {
   title: 'Alerts',
   description: 'Panel to report on the status of integration alerts.',
   options: {
-    alertInstanceLabelFilter: '{job="integrations/apache-hbase"}',
-    alertName: '',
+    alertInstanceLabelFilter: '',
+    alertName: 'HighNonHeapMemUsage',
     dashboardAlerts: false,
     folder: '',
     groupBy: [],
@@ -847,6 +850,7 @@ local regionsInTransitionPanel = {
           mode: 'off',
         },
       },
+      decimals: 0,
       mappings: [],
       thresholds: {
         mode: 'absolute',
@@ -961,6 +965,7 @@ local oldestRegionInTransitionPanel = {
   },
 };
 
+
 {
   grafanaDashboards+:: {
     'apache-hbase-cluster-overview.json':
@@ -1015,17 +1020,17 @@ local oldestRegionInTransitionPanel = {
       )
       .addPanels(
         [
-          deadRegionServersPanel { gridPos: { h: 8, w: 3, x: 0, y: 0 } },
-          liveRegionServersPanel { gridPos: { h: 8, w: 3, x: 3, y: 0 } },
-          regionserversPanel { gridPos: { h: 8, w: 9, x: 6, y: 0 } },
-          alertsPanel { gridPos: { h: 8, w: 9, x: 15, y: 0 } },
-          jvmMemoryUsagePanel { gridPos: { h: 9, w: 24, x: 0, y: 8 } },
-          connectionsPanel { gridPos: { h: 8, w: 12, x: 0, y: 17 } },
-          authenticationsPanel { gridPos: { h: 8, w: 12, x: 12, y: 17 } },
-          masterQueueSizePanel { gridPos: { h: 8, w: 12, x: 0, y: 25 } },
-          masterQueuedCallsPanel { gridPos: { h: 8, w: 12, x: 12, y: 25 } },
-          regionsInTransitionPanel { gridPos: { h: 8, w: 12, x: 0, y: 33 } },
-          oldestRegionInTransitionPanel { gridPos: { h: 8, w: 12, x: 12, y: 33 } },
+          deadRegionServersPanel { gridPos: { h: 8, w: 5, x: 0, y: 0 } },
+          liveRegionServersPanel { gridPos: { h: 8, w: 5, x: 5, y: 0 } },
+          regionserversPanel { gridPos: { h: 8, w: 14, x: 10, y: 0 } },
+          alertsPanel { gridPos: { h: 8, w: 12, x: 0, y: 8 } },
+          jvmMemoryUsagePanel { gridPos: { h: 8, w: 12, x: 12, y: 8 } },
+          connectionsPanel { gridPos: { h: 8, w: 12, x: 0, y: 16 } },
+          authenticationsPanel { gridPos: { h: 8, w: 12, x: 12, y: 16 } },
+          masterQueueSizePanel { gridPos: { h: 8, w: 12, x: 0, y: 24 } },
+          masterQueuedCallsPanel { gridPos: { h: 8, w: 12, x: 12, y: 24 } },
+          regionsInTransitionPanel { gridPos: { h: 8, w: 12, x: 0, y: 32 } },
+          oldestRegionInTransitionPanel { gridPos: { h: 8, w: 12, x: 12, y: 32 } },
         ]
       ),
   },

--- a/apache-hbase-mixin/dashboards/apache-hbase-cluster-overview.libsonnet
+++ b/apache-hbase-mixin/dashboards/apache-hbase-cluster-overview.libsonnet
@@ -393,8 +393,8 @@ local alertsPanel = {
   title: 'Alerts',
   description: 'Panel to report on the status of integration alerts.',
   options: {
-    alertInstanceLabelFilter: '',
-    alertName: 'HighNonHeapMemUsage',
+    alertInstanceLabelFilter: '{job=~"${job:regex}", hbase_cluster=~"${hbase_cluster:regex}", instance=~"${instance:regex}"}',
+    alertName: '',
     dashboardAlerts: false,
     folder: '',
     groupBy: [],

--- a/apache-hbase-mixin/dashboards/apache-hbase-cluster-overview.libsonnet
+++ b/apache-hbase-mixin/dashboards/apache-hbase-cluster-overview.libsonnet
@@ -12,7 +12,6 @@ local promDatasource = {
   uid: '${%s}' % promDatasourceName,
 };
 
-
 local deadRegionServersPanel = {
   datasource: promDatasource,
   targets: [
@@ -297,7 +296,7 @@ local alertsPanel = {
   title: 'Alerts',
   description: 'Panel to report on the status of integration alerts.',
   options: {
-    alertInstanceLabelFilter: '{job=~"integrations/apache-hbase"}',
+    alertInstanceLabelFilter: '{job="integrations/apache-hbase"}',
     alertName: '',
     dashboardAlerts: false,
     folder: '',
@@ -961,7 +960,6 @@ local oldestRegionInTransitionPanel = {
     },
   },
 };
-
 
 {
   grafanaDashboards+:: {

--- a/apache-hbase-mixin/dashboards/apache-hbase-cluster-overview.libsonnet
+++ b/apache-hbase-mixin/dashboards/apache-hbase-cluster-overview.libsonnet
@@ -298,8 +298,8 @@ local alertsPanel = {
   title: 'Alerts',
   description: 'Panel to report on the status of integration alerts.',
   options: {
-    alertInstanceLabelFilter: '',
-    alertName: 'HighNonHeapMemUsage',
+    alertInstanceLabelFilter: '{job=~"${job:regex}", activemq_cluster=~"${activemq_cluster:regex}", instance=~"${instance:regex}"}',
+    alertName: '',
     dashboardAlerts: false,
     folder: '',
     groupBy: [],

--- a/apache-hbase-mixin/dashboards/apache-hbase-cluster-overview.libsonnet
+++ b/apache-hbase-mixin/dashboards/apache-hbase-cluster-overview.libsonnet
@@ -241,7 +241,7 @@ local serversPanel = {
             value: [
               {
                 title: '',
-                url: '/d/apache-hbase-regionserver-overview?from=${__from}&to=${__to}&var-instance=${__data.fields.Instance}',
+                url: '/d/apache-hbase-regionserver-overview?from=${__from}&to=${__to}&var-instance=${__data.fields["RegionServer"]}',
               },
             ],
           },

--- a/apache-hbase-mixin/dashboards/apache-hbase-cluster-overview.libsonnet
+++ b/apache-hbase-mixin/dashboards/apache-hbase-cluster-overview.libsonnet
@@ -12,6 +12,54 @@ local promDatasource = {
   uid: '${%s}' % promDatasourceName,
 };
 
+local liveRegionServersPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'server_num_region_servers{job=~"$job", hbase_cluster=~"$hbase_cluster"}',
+      datasource=promDatasource,
+      legendFormat='{{hbase_cluster}}',
+      format='time_series',
+    ),
+  ],
+  type: 'stat',
+  title: 'Live RegionServers',
+  description: 'Number of RegionServers that are currently live.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+    },
+    overrides: [],
+  },
+  options: {
+    colorMode: 'value',
+    graphMode: 'none',
+    justifyMode: 'auto',
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    textMode: 'value',
+  },
+  pluginVersion: '10.2.0-62263',
+};
+
 local deadRegionServersPanel = {
   datasource: promDatasource,
   targets: [
@@ -41,54 +89,6 @@ local deadRegionServersPanel = {
           {
             color: 'red',
             value: 1,
-          },
-        ],
-      },
-    },
-    overrides: [],
-  },
-  options: {
-    colorMode: 'value',
-    graphMode: 'none',
-    justifyMode: 'auto',
-    orientation: 'auto',
-    reduceOptions: {
-      calcs: [
-        'lastNotNull',
-      ],
-      fields: '',
-      values: false,
-    },
-    textMode: 'value',
-  },
-  pluginVersion: '10.2.0-62263',
-};
-
-local liveRegionServersPanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'server_num_region_servers{job=~"$job", hbase_cluster=~"$hbase_cluster"}',
-      datasource=promDatasource,
-      legendFormat='{{hbase_cluster}}',
-      format='time_series',
-    ),
-  ],
-  type: 'stat',
-  title: 'Live RegionServers',
-  description: 'Number of RegionServers that are currently live.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'thresholds',
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
           },
         ],
       },
@@ -167,7 +167,7 @@ local regionserversPanel = {
             value: [
               {
                 title: '',
-                url: '/d/apache-hbase-regionserver-overview',
+                url: '/d/apache-hbase-regionserver-overview?from=${__from}&to=${__to}&var-instance=${__data.fields.Instance}',
               },
             ],
           },
@@ -286,19 +286,12 @@ local regionserversPanel = {
 
 local alertsPanel = {
   datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'master_num_open_connections{job=~"$job", hbase_cluster=~"$hbase_cluster"}',
-      datasource=promDatasource,
-      legendFormat='{{hbase_cluster}}',
-      format='time_series',
-    ),
-  ],
+  targets: [],
   type: 'alertlist',
   title: 'Alerts',
   description: 'Panel to report on the status of integration alerts.',
   options: {
-    alertInstanceLabelFilter: '{job=~"${job:regex}", activemq_cluster=~"${activemq_cluster:regex}", instance=~"${instance:regex}"}',
+    alertInstanceLabelFilter: '{job=~"${job:regex}", hbase_cluster=~"${hbase_cluster:regex}", instance=~"${instance:regex}"}',
     alertName: '',
     dashboardAlerts: false,
     folder: '',
@@ -317,15 +310,9 @@ local alertsPanel = {
   },
 };
 
-local jvmMemoryUsagePanel = {
+local jvmHeapMemoryUsagePanel = {
   datasource: promDatasource,
   targets: [
-    prometheus.target(
-      'jvm_metrics_mem_non_heap_used_m{job=~"$job", hbase_cluster=~"$hbase_cluster", processname=~"Master"} / clamp_min(jvm_metrics_mem_non_heap_committed_m{job=~"$job", hbase_cluster=~"$hbase_cluster", processname=~"Master"}, 1)',
-      datasource=promDatasource,
-      legendFormat='{{hbase_cluster}} - non-heap',
-      format='time_series',
-    ),
     prometheus.target(
       'jvm_metrics_mem_heap_used_m{job=~"$job", hbase_cluster=~"$hbase_cluster", processname=~"Master"} / clamp_min(jvm_metrics_mem_heap_committed_m{job=~"$job", hbase_cluster=~"$hbase_cluster", processname=~"Master"}, 1)',
       datasource=promDatasource,
@@ -334,8 +321,8 @@ local jvmMemoryUsagePanel = {
     ),
   ],
   type: 'timeseries',
-  title: 'JVM memory usage',
-  description: 'Memory usage for the JVM.',
+  title: 'JVM heap memory usage',
+  description: 'Heap memory usage for the JVM.',
   fieldConfig: {
     defaults: {
       color: {
@@ -463,6 +450,7 @@ local connectionsPanel = {
           mode: 'off',
         },
       },
+      decimals: 0,
       mappings: [],
       thresholds: {
         mode: 'absolute',
@@ -1022,7 +1010,7 @@ local oldestRegionInTransitionPanel = {
           liveRegionServersPanel { gridPos: { h: 8, w: 5, x: 5, y: 0 } },
           regionserversPanel { gridPos: { h: 8, w: 14, x: 10, y: 0 } },
           alertsPanel { gridPos: { h: 8, w: 12, x: 0, y: 8 } },
-          jvmMemoryUsagePanel { gridPos: { h: 8, w: 12, x: 12, y: 8 } },
+          jvmHeapMemoryUsagePanel { gridPos: { h: 8, w: 12, x: 12, y: 8 } },
           connectionsPanel { gridPos: { h: 8, w: 12, x: 0, y: 16 } },
           authenticationsPanel { gridPos: { h: 8, w: 12, x: 12, y: 16 } },
           masterQueueSizePanel { gridPos: { h: 8, w: 12, x: 0, y: 24 } },

--- a/apache-hbase-mixin/dashboards/apache-hbase-cluster-overview.libsonnet
+++ b/apache-hbase-mixin/dashboards/apache-hbase-cluster-overview.libsonnet
@@ -1000,7 +1000,7 @@ local oldestRegionInTransitionPanel = {
             refresh=2,
             includeAll=true,
             multi=true,
-            allValues='',
+            allValues='.+',
             sort=0
           ),
           template.new(

--- a/apache-hbase-mixin/dashboards/apache-hbase-cluster-overview.libsonnet
+++ b/apache-hbase-mixin/dashboards/apache-hbase-cluster-overview.libsonnet
@@ -12,7 +12,6 @@ local promDatasource = {
   uid: '${%s}' % promDatasourceName,
 };
 
-
 local deadRegionServersPanel = {
   datasource: promDatasource,
   targets: [
@@ -964,7 +963,6 @@ local oldestRegionInTransitionPanel = {
     },
   },
 };
-
 
 {
   grafanaDashboards+:: {

--- a/apache-hbase-mixin/dashboards/apache-hbase-logs-overview.libsonnet
+++ b/apache-hbase-mixin/dashboards/apache-hbase-logs-overview.libsonnet
@@ -1,0 +1,32 @@
+local g = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';
+local logsDashboard = import 'github.com/grafana/jsonnet-libs/logs-lib/logs/main.libsonnet';
+{
+  grafanaDashboards+::
+    if $._config.enableLokiLogs then {
+      local apacheHBaseLogs =
+        logsDashboard.new(
+          'Apache HBase logs overview',
+          datasourceName='loki_datasource',
+          datasourceRegex='',
+          filterSelector=$._config.filterSelector,
+          labels=['job', 'hbase_cluster', 'instance', 'context', 'level'],
+          formatParser=null,
+          showLogsVolume=true
+        )
+        {
+          panels+:
+            {
+              logs+:
+                // Apache HBase logs already have timestamp
+                g.panel.logs.options.withShowTime(false),
+            },
+          dashboards+:
+            {
+              logs+: g.dashboard.withLinksMixin($.grafanaDashboards['apache-hbase-cluster-overview.json'].links)
+                     + g.dashboard.withTags($._config.dashboardTags)
+                     + g.dashboard.withRefresh($._config.dashboardRefresh),
+            },
+        },
+      'apache-hbase-logs.json': apacheHBaseLogs.dashboards.logs,
+    } else {},
+}

--- a/apache-hbase-mixin/dashboards/apache-hbase-logs-overview.libsonnet
+++ b/apache-hbase-mixin/dashboards/apache-hbase-logs-overview.libsonnet
@@ -7,9 +7,9 @@ local logsDashboard = import 'github.com/grafana/jsonnet-libs/logs-lib/logs/main
         logsDashboard.new(
           'Apache HBase logs overview',
           datasourceName='loki_datasource',
-          datasourceRegex='(?!grafanacloud.+usage-insights|grafanacloud.+alert-state-history).+',
+          datasourceRegex='',
           filterSelector=$._config.filterSelector,
-          labels=['job', 'hbase_cluster', 'instance', 'context', 'level'],
+          labels=['job', 'hbase_cluster', 'instance', 'logger', 'level'],
           formatParser=null,
           showLogsVolume=true
         )

--- a/apache-hbase-mixin/dashboards/apache-hbase-logs-overview.libsonnet
+++ b/apache-hbase-mixin/dashboards/apache-hbase-logs-overview.libsonnet
@@ -7,7 +7,7 @@ local logsDashboard = import 'github.com/grafana/jsonnet-libs/logs-lib/logs/main
         logsDashboard.new(
           'Apache HBase logs overview',
           datasourceName='loki_datasource',
-          datasourceRegex='',
+          datasourceRegex='(?!grafanacloud.+usage-insights|grafanacloud.+alert-state-history).+',
           filterSelector=$._config.filterSelector,
           labels=['job', 'hbase_cluster', 'instance', 'context', 'level'],
           formatParser=null,

--- a/apache-hbase-mixin/dashboards/apache-hbase-regionserver-overview.libsonnet
+++ b/apache-hbase-mixin/dashboards/apache-hbase-regionserver-overview.libsonnet
@@ -16,7 +16,7 @@ local regionsPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'server_region_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}',
+      'sum by(job, hbase_cluster, instance) (server_region_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{instance}}',
       format='time_series',
@@ -63,14 +63,14 @@ local regionsPanel = {
     },
     textMode: 'auto',
   },
-  pluginVersion: '10.2.0-62263',
+  pluginVersion: '10.3.0-62488',
 };
 
 local storeFilesPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'server_store_file_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}',
+      'sum by(job, hbase_cluster, instance) (server_store_file_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{instance}}',
       format='time_series',
@@ -117,14 +117,14 @@ local storeFilesPanel = {
     },
     textMode: 'auto',
   },
-  pluginVersion: '10.2.0-62263',
+  pluginVersion: '10.3.0-62488',
 };
 
 local storeFileSizePanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'server_store_file_size{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}',
+      'sum by(job, hbase_cluster, instance) (server_store_file_size{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{instance}}',
       format='time_series',
@@ -168,14 +168,14 @@ local storeFileSizePanel = {
     showUnfilled: true,
     valueMode: 'color',
   },
-  pluginVersion: '10.2.0-62263',
+  pluginVersion: '10.3.0-62488',
 };
 
 local rpcConnectionsPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'region_server_num_open_connections{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}',
+      'sum by(job, hbase_cluster, instance) (region_server_num_open_connections{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{instance}}',
       format='time_series',
@@ -217,7 +217,7 @@ local rpcConnectionsPanel = {
     },
     textMode: 'auto',
   },
-  pluginVersion: '10.2.0-62263',
+  pluginVersion: '10.3.0-62488',
 };
 
 local jvmHeapMemoryUsagePanel = {
@@ -390,57 +390,57 @@ local requestsOverviewPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'rate(server_read_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval])',
+      'sum by(job, hbase_cluster, instance) (rate(server_read_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval]))',
       datasource=promDatasource,
-      legendFormat='{{instance}} - read',
+      legendFormat='read',
       format='time_series',
     ),
     prometheus.target(
-      'rate(server_write_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval])',
+      'sum by(job, hbase_cluster, instance) (rate(server_write_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval]))',
       datasource=promDatasource,
-      legendFormat='{{instance}} - write',
+      legendFormat='write',
       format='time_series',
     ),
     prometheus.target(
-      'rate(server_cp_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval])',
+      'sum by(job, hbase_cluster, instance) (rate(server_cp_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval]))',
       datasource=promDatasource,
-      legendFormat='{{instance}} - cp',
+      legendFormat='copy',
       format='time_series',
     ),
     prometheus.target(
-      'rate(server_filtered_read_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval])',
+      'sum by(job, hbase_cluster, instance) (rate(server_filtered_read_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval]))',
       datasource=promDatasource,
-      legendFormat='{{instance}} - filtered read',
+      legendFormat='filtered read',
       format='time_series',
     ),
     prometheus.target(
-      'rate(server_rpc_get_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval])',
+      'sum by(job, hbase_cluster, instance) (rate(server_rpc_get_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval]))',
       datasource=promDatasource,
-      legendFormat='{{instance}} - rpc get',
+      legendFormat='rpc get',
       format='time_series',
     ),
     prometheus.target(
-      'rate(server_rpc_scan_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval])',
+      'sum by(job, hbase_cluster, instance) (rate(server_rpc_scan_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval]))',
       datasource=promDatasource,
-      legendFormat='{{instance}} - rpc scan',
+      legendFormat='rpc scan',
       format='time_series',
     ),
     prometheus.target(
-      'rate(server_rpc_full_scan_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval])',
+      'sum by(job, hbase_cluster, instance) (rate(server_rpc_full_scan_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval]))',
       datasource=promDatasource,
-      legendFormat='{{instance}} - rpc full scan',
+      legendFormat='rpc full scan',
       format='time_series',
     ),
     prometheus.target(
-      'rate(server_rpc_mutate_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval])',
+      'sum by(job, hbase_cluster, instance) (rate(server_rpc_mutate_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval]))',
       datasource=promDatasource,
-      legendFormat='{{instance}} - rpc mutate',
+      legendFormat='rpc mutate',
       format='time_series',
     ),
     prometheus.target(
-      'rate(server_rpc_multi_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval])',
+      'sum by(job, hbase_cluster, instance) (rate(server_rpc_multi_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval]))',
       datasource=promDatasource,
-      legendFormat='{{instance}} - rpc multi',
+      legendFormat='rpc multi',
       format='time_series',
     ),
   ],
@@ -816,39 +816,39 @@ local queuedCallsPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'region_server_num_calls_in_general_queue{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}',
+      'sum by(job, hbase_cluster, instance) (region_server_num_calls_in_general_queue{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"})',
       datasource=promDatasource,
-      legendFormat='{{instance}} - general',
+      legendFormat='general',
       format='time_series',
     ),
     prometheus.target(
-      'region_server_num_calls_in_replication_queue{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}',
+      'sum by(job, hbase_cluster, instance) (region_server_num_calls_in_replication_queue{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"})',
       datasource=promDatasource,
-      legendFormat='{{instance}} - replication',
+      legendFormat='replication',
       format='time_series',
     ),
     prometheus.target(
-      'region_server_num_calls_in_read_queue{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}',
+      'sum by(job, hbase_cluster, instance) (region_server_num_calls_in_read_queue{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"})',
       datasource=promDatasource,
-      legendFormat='{{instance}} - read',
+      legendFormat='read',
       format='time_series',
     ),
     prometheus.target(
-      'region_server_num_calls_in_write_queue{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}',
+      'sum by(job, hbase_cluster, instance) (region_server_num_calls_in_write_queue{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"})',
       datasource=promDatasource,
-      legendFormat='{{instance}} - write',
+      legendFormat='write',
       format='time_series',
     ),
     prometheus.target(
-      'region_server_num_calls_in_scan_queue{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}',
+      'sum by(job, hbase_cluster, instance) (region_server_num_calls_in_scan_queue{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"})',
       datasource=promDatasource,
-      legendFormat='{{instance}} - scan',
+      legendFormat='scan',
       format='time_series',
     ),
     prometheus.target(
-      'region_server_num_calls_in_priority_queue{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}',
+      'sum by(job, hbase_cluster, instance) (region_server_num_calls_in_priority_queue{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"})',
       datasource=promDatasource,
-      legendFormat='{{instance}} - priority',
+      legendFormat='priority',
       format='time_series',
     ),
   ],
@@ -932,33 +932,33 @@ local slowOperationsPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'rate(server_slow_append_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval])',
+      'sum by(job, hbase_cluster, instance) (rate(server_slow_append_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval]))',
       datasource=promDatasource,
-      legendFormat='{{instance}} - append',
+      legendFormat='append',
       format='time_series',
     ),
     prometheus.target(
-      'rate(server_slow_put_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval])',
+      'sum by(job, hbase_cluster, instance) (rate(server_slow_put_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval]))',
       datasource=promDatasource,
-      legendFormat='{{instance}} - put',
+      legendFormat='put',
       format='time_series',
     ),
     prometheus.target(
-      'rate(server_slow_delete_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval])',
+      'sum by(job, hbase_cluster, instance) (rate(server_slow_delete_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval]))',
       datasource=promDatasource,
-      legendFormat='{{instance}} - delete',
+      legendFormat='delete',
       format='time_series',
     ),
     prometheus.target(
-      'rate(server_slow_get_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval])',
+      'sum by(job, hbase_cluster, instance) (rate(server_slow_get_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval]))',
       datasource=promDatasource,
-      legendFormat='{{instance}} - get',
+      legendFormat='get',
       format='time_series',
     ),
     prometheus.target(
-      'rate(server_slow_increment_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval])',
+      'sum by(job, hbase_cluster, instance) (rate(server_slow_increment_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval]))',
       datasource=promDatasource,
-      legendFormat='{{instance}} - increment',
+      legendFormat='increment',
       format='time_series',
     ),
   ],
@@ -1126,15 +1126,15 @@ local authenticationsPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'rate(region_server_authentication_successes{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval])',
+      'sum by(job, hbase_cluster, instance) (rate(region_server_authentication_successes{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval]))',
       datasource=promDatasource,
-      legendFormat='{{instance}} - success',
+      legendFormat='success',
       format='time_series',
     ),
     prometheus.target(
-      'rate(region_server_authentication_failures{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval])',
+      'sum by(job, hbase_cluster, instance) (rate(region_server_authentication_failures{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval]))',
       datasource=promDatasource,
-      legendFormat='{{instance}} - failure',
+      legendFormat='failure',
       format='time_series',
     ),
   ],
@@ -1250,7 +1250,7 @@ local authenticationsPanel = {
             refresh=2,
             includeAll=true,
             multi=true,
-            allValues='.+',
+            allValues='',
             sort=0
           ),
           template.new(
@@ -1279,21 +1279,21 @@ local authenticationsPanel = {
       )
       .addPanels(
         [
-          regionsPanel { gridPos: { h: 8, w: 6, x: 0, y: 0 } },
-          storeFilesPanel { gridPos: { h: 8, w: 6, x: 6, y: 0 } },
-          storeFileSizePanel { gridPos: { h: 8, w: 6, x: 12, y: 0 } },
-          rpcConnectionsPanel { gridPos: { h: 8, w: 6, x: 18, y: 0 } },
-          jvmHeapMemoryUsagePanel { gridPos: { h: 9, w: 24, x: 0, y: 8 } },
-          requestsReceivedPanel { gridPos: { h: 8, w: 16, x: 0, y: 17 } },
-          requestsOverviewPanel { gridPos: { h: 8, w: 8, x: 16, y: 17 } },
-          regionCountPanel { gridPos: { h: 8, w: 12, x: 0, y: 25 } },
-          rpcConnectionCountPanel { gridPos: { h: 8, w: 12, x: 12, y: 25 } },
-          storeFileCountPanel { gridPos: { h: 8, w: 12, x: 0, y: 33 } },
-          storeFileSizePanel { gridPos: { h: 8, w: 12, x: 12, y: 33 } },
-          queuedCallsPanel { gridPos: { h: 8, w: 12, x: 0, y: 41 } },
-          slowOperationsPanel { gridPos: { h: 8, w: 12, x: 12, y: 41 } },
-          cacheHitPercentagePanel { gridPos: { h: 8, w: 12, x: 0, y: 49 } },
-          authenticationsPanel { gridPos: { h: 8, w: 12, x: 12, y: 49 } },
+          regionsPanel { gridPos: { h: 8, w: 3, x: 0, y: 0 } },
+          storeFilesPanel { gridPos: { h: 8, w: 3, x: 3, y: 0 } },
+          storeFileSizePanel { gridPos: { h: 8, w: 3, x: 6, y: 0 } },
+          rpcConnectionsPanel { gridPos: { h: 8, w: 3, x: 9, y: 0 } },
+          jvmHeapMemoryUsagePanel { gridPos: { h: 8, w: 12, x: 12, y: 0 } },
+          requestsReceivedPanel { gridPos: { h: 8, w: 16, x: 0, y: 8 } },
+          requestsOverviewPanel { gridPos: { h: 8, w: 8, x: 16, y: 8 } },
+          regionCountPanel { gridPos: { h: 8, w: 12, x: 0, y: 16 } },
+          rpcConnectionCountPanel { gridPos: { h: 8, w: 12, x: 12, y: 16 } },
+          storeFileCountPanel { gridPos: { h: 8, w: 12, x: 0, y: 24 } },
+          storeFileSizePanel { gridPos: { h: 8, w: 12, x: 12, y: 24 } },
+          queuedCallsPanel { gridPos: { h: 8, w: 12, x: 0, y: 32 } },
+          slowOperationsPanel { gridPos: { h: 8, w: 12, x: 12, y: 32 } },
+          cacheHitPercentagePanel { gridPos: { h: 8, w: 12, x: 0, y: 40 } },
+          authenticationsPanel { gridPos: { h: 8, w: 12, x: 12, y: 40 } },
         ]
       ),
   },

--- a/apache-hbase-mixin/dashboards/apache-hbase-regionserver-overview.libsonnet
+++ b/apache-hbase-mixin/dashboards/apache-hbase-regionserver-overview.libsonnet
@@ -16,7 +16,7 @@ local regionsPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(job, hbase_cluster, instance) (server_region_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"})',
+      'sum by(job, hbase_cluster) (server_region_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{instance}}',
       format='time_series',
@@ -70,7 +70,7 @@ local storeFilesPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(job, hbase_cluster, instance) (server_store_file_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"})',
+      'sum by(job, hbase_cluster) (server_store_file_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{instance}}',
       format='time_series',
@@ -124,7 +124,7 @@ local storeFileSizePanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(job, hbase_cluster, instance) (server_store_file_size{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"})',
+      'sum by(job, hbase_cluster) (server_store_file_size{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{instance}}',
       format='time_series',
@@ -175,7 +175,7 @@ local rpcConnectionsPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(job, hbase_cluster, instance) (region_server_num_open_connections{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"})',
+      'sum by(job, hbase_cluster) (region_server_num_open_connections{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{instance}}',
       format='time_series',
@@ -390,55 +390,55 @@ local requestsOverviewPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(job, hbase_cluster, instance) (rate(server_read_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval]))',
+      'sum by(job, hbase_cluster) (rate(server_read_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='read',
       format='time_series',
     ),
     prometheus.target(
-      'sum by(job, hbase_cluster, instance) (rate(server_write_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval]))',
+      'sum by(job, hbase_cluster) (rate(server_write_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='write',
       format='time_series',
     ),
     prometheus.target(
-      'sum by(job, hbase_cluster, instance) (rate(server_cp_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval]))',
+      'sum by(job, hbase_cluster) (rate(server_cp_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='copy',
       format='time_series',
     ),
     prometheus.target(
-      'sum by(job, hbase_cluster, instance) (rate(server_filtered_read_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval]))',
+      'sum by(job, hbase_cluster) (rate(server_filtered_read_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='filtered read',
       format='time_series',
     ),
     prometheus.target(
-      'sum by(job, hbase_cluster, instance) (rate(server_rpc_get_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval]))',
+      'sum by(job, hbase_cluster) (rate(server_rpc_get_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='rpc get',
       format='time_series',
     ),
     prometheus.target(
-      'sum by(job, hbase_cluster, instance) (rate(server_rpc_scan_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval]))',
+      'sum by(job, hbase_cluster) (rate(server_rpc_scan_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='rpc scan',
       format='time_series',
     ),
     prometheus.target(
-      'sum by(job, hbase_cluster, instance) (rate(server_rpc_full_scan_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval]))',
+      'sum by(job, hbase_cluster) (rate(server_rpc_full_scan_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='rpc full scan',
       format='time_series',
     ),
     prometheus.target(
-      'sum by(job, hbase_cluster, instance) (rate(server_rpc_mutate_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval]))',
+      'sum by(job, hbase_cluster) (rate(server_rpc_mutate_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='rpc mutate',
       format='time_series',
     ),
     prometheus.target(
-      'sum by(job, hbase_cluster, instance) (rate(server_rpc_multi_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval]))',
+      'sum by(job, hbase_cluster) (rate(server_rpc_multi_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='rpc multi',
       format='time_series',
@@ -816,37 +816,37 @@ local queuedCallsPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(job, hbase_cluster, instance) (region_server_num_calls_in_general_queue{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"})',
+      'sum by(job, hbase_cluster) (region_server_num_calls_in_general_queue{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='general',
       format='time_series',
     ),
     prometheus.target(
-      'sum by(job, hbase_cluster, instance) (region_server_num_calls_in_replication_queue{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"})',
+      'sum by(job, hbase_cluster) (region_server_num_calls_in_replication_queue{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='replication',
       format='time_series',
     ),
     prometheus.target(
-      'sum by(job, hbase_cluster, instance) (region_server_num_calls_in_read_queue{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"})',
+      'sum by(job, hbase_cluster) (region_server_num_calls_in_read_queue{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='read',
       format='time_series',
     ),
     prometheus.target(
-      'sum by(job, hbase_cluster, instance) (region_server_num_calls_in_write_queue{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"})',
+      'sum by(job, hbase_cluster) (region_server_num_calls_in_write_queue{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='write',
       format='time_series',
     ),
     prometheus.target(
-      'sum by(job, hbase_cluster, instance) (region_server_num_calls_in_scan_queue{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"})',
+      'sum by(job, hbase_cluster) (region_server_num_calls_in_scan_queue{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='scan',
       format='time_series',
     ),
     prometheus.target(
-      'sum by(job, hbase_cluster, instance) (region_server_num_calls_in_priority_queue{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"})',
+      'sum by(job, hbase_cluster) (region_server_num_calls_in_priority_queue{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='priority',
       format='time_series',
@@ -932,31 +932,31 @@ local slowOperationsPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(job, hbase_cluster, instance) (rate(server_slow_append_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval]))',
+      'sum by(job, hbase_cluster) (rate(server_slow_append_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='append',
       format='time_series',
     ),
     prometheus.target(
-      'sum by(job, hbase_cluster, instance) (rate(server_slow_put_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval]))',
+      'sum by(job, hbase_cluster) (rate(server_slow_put_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='put',
       format='time_series',
     ),
     prometheus.target(
-      'sum by(job, hbase_cluster, instance) (rate(server_slow_delete_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval]))',
+      'sum by(job, hbase_cluster) (rate(server_slow_delete_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='delete',
       format='time_series',
     ),
     prometheus.target(
-      'sum by(job, hbase_cluster, instance) (rate(server_slow_get_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval]))',
+      'sum by(job, hbase_cluster) (rate(server_slow_get_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='get',
       format='time_series',
     ),
     prometheus.target(
-      'sum by(job, hbase_cluster, instance) (rate(server_slow_increment_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval]))',
+      'sum by(job, hbase_cluster) (rate(server_slow_increment_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='increment',
       format='time_series',
@@ -1126,13 +1126,13 @@ local authenticationsPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(job, hbase_cluster, instance) (rate(region_server_authentication_successes{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval]))',
+      'sum by(job, hbase_cluster) (rate(region_server_authentication_successes{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='success',
       format='time_series',
     ),
     prometheus.target(
-      'sum by(job, hbase_cluster, instance) (rate(region_server_authentication_failures{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval]))',
+      'sum by(job, hbase_cluster) (rate(region_server_authentication_failures{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='failure',
       format='time_series',

--- a/apache-hbase-mixin/dashboards/apache-hbase-regionserver-overview.libsonnet
+++ b/apache-hbase-mixin/dashboards/apache-hbase-regionserver-overview.libsonnet
@@ -220,15 +220,9 @@ local rpcConnectionsPanel = {
   pluginVersion: '10.2.0-62263',
 };
 
-local jvmMemoryUsagePanel = {
+local jvmHeapMemoryUsagePanel = {
   datasource: promDatasource,
   targets: [
-    prometheus.target(
-      'jvm_metrics_mem_non_heap_used_m{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance", processname="RegionServer"} / clamp_min(jvm_metrics_mem_non_heap_committed_m{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance", processname="RegionServer"}, 1)',
-      datasource=promDatasource,
-      legendFormat='{{instance}} - non-heap',
-      format='time_series',
-    ),
     prometheus.target(
       'jvm_metrics_mem_heap_used_m{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance", processname="RegionServer"} / clamp_min(jvm_metrics_mem_heap_committed_m{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance", processname="RegionServer"}, 1)',
       datasource=promDatasource,
@@ -237,8 +231,8 @@ local jvmMemoryUsagePanel = {
     ),
   ],
   type: 'timeseries',
-  title: 'JVM memory usage',
-  description: 'Memory usage for the JVM.',
+  title: 'JVM heap memory usage',
+  description: 'Heap memory usage for the JVM.',
   fieldConfig: {
     defaults: {
       color: {
@@ -1273,7 +1267,7 @@ local authenticationsPanel = {
           template.new(
             'instance',
             promDatasource,
-            'label_values(server_region_count{hbase_cluster=~"$hbase_cluster"},instance)',
+            'label_values(server_region_count{job=~"$job", hbase_cluster=~"$hbase_cluster"},instance)',
             label='Instance',
             refresh=2,
             includeAll=true,
@@ -1289,7 +1283,7 @@ local authenticationsPanel = {
           storeFilesPanel { gridPos: { h: 8, w: 6, x: 6, y: 0 } },
           storeFileSizePanel { gridPos: { h: 8, w: 6, x: 12, y: 0 } },
           rpcConnectionsPanel { gridPos: { h: 8, w: 6, x: 18, y: 0 } },
-          jvmMemoryUsagePanel { gridPos: { h: 9, w: 24, x: 0, y: 8 } },
+          jvmHeapMemoryUsagePanel { gridPos: { h: 9, w: 24, x: 0, y: 8 } },
           requestsReceivedPanel { gridPos: { h: 8, w: 16, x: 0, y: 17 } },
           requestsOverviewPanel { gridPos: { h: 8, w: 8, x: 16, y: 17 } },
           regionCountPanel { gridPos: { h: 8, w: 12, x: 0, y: 25 } },

--- a/apache-hbase-mixin/dashboards/apache-hbase-regionserver-overview.libsonnet
+++ b/apache-hbase-mixin/dashboards/apache-hbase-regionserver-overview.libsonnet
@@ -12,7 +12,6 @@ local promDatasource = {
   uid: '${%s}' % promDatasourceName,
 };
 
-
 local regionsPanel = {
   datasource: promDatasource,
   targets: [
@@ -1223,7 +1222,6 @@ local authenticationsPanel = {
     },
   },
 };
-
 
 {
   grafanaDashboards+:: {

--- a/apache-hbase-mixin/dashboards/apache-hbase-regionserver-overview.libsonnet
+++ b/apache-hbase-mixin/dashboards/apache-hbase-regionserver-overview.libsonnet
@@ -12,22 +12,26 @@ local promDatasource = {
   uid: '${%s}' % promDatasourceName,
 };
 
-local regionCountPanel = {
+
+local regionsPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
       'server_region_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}',
       datasource=promDatasource,
+      legendFormat='{{instance}}',
+      format='time_series',
     ),
   ],
   type: 'stat',
-  title: 'Region count',
+  title: 'Regions',
   description: 'The number of regions hosted by the RegionServer.',
   fieldConfig: {
     defaults: {
       color: {
         mode: 'thresholds',
       },
+      decimals: 0,
       mappings: [],
       thresholds: {
         mode: 'absolute',
@@ -35,6 +39,10 @@ local regionCountPanel = {
           {
             color: 'green',
             value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
           },
         ],
       },
@@ -59,22 +67,25 @@ local regionCountPanel = {
   pluginVersion: '10.2.0-61719',
 };
 
-local storeFileCountPanel = {
+local storeFilesPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
       'server_store_file_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}',
       datasource=promDatasource,
+      legendFormat='{{instance}}',
+      format='time_series',
     ),
   ],
   type: 'stat',
-  title: 'Store file count',
+  title: 'Store files',
   description: 'The number of store files on disk currently managed by the RegionServer.',
   fieldConfig: {
     defaults: {
       color: {
         mode: 'thresholds',
       },
+      decimals: 0,
       mappings: [],
       thresholds: {
         mode: 'absolute',
@@ -82,6 +93,10 @@ local storeFileCountPanel = {
           {
             color: 'green',
             value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
           },
         ],
       },
@@ -106,13 +121,14 @@ local storeFileCountPanel = {
   pluginVersion: '10.2.0-61719',
 };
 
-local storeFileSizePanel = {
+local storeFileSizesPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
       'server_store_file_size{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}',
       datasource=promDatasource,
       legendFormat='{{instance}}',
+      format='time_series',
     ),
   ],
   type: 'bargauge',
@@ -124,7 +140,6 @@ local storeFileSizePanel = {
         mode: 'thresholds',
       },
       mappings: [],
-      min: 0,
       thresholds: {
         mode: 'absolute',
         steps: [
@@ -143,7 +158,7 @@ local storeFileSizePanel = {
     minVizHeight: 10,
     minVizWidth: 0,
     namePlacement: 'auto',
-    orientation: 'horizontal',
+    orientation: 'auto',
     reduceOptions: {
       calcs: [
         'lastNotNull',
@@ -163,11 +178,13 @@ local rpcConnectionsPanel = {
     prometheus.target(
       'region_server_num_open_connections{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}',
       datasource=promDatasource,
+      legendFormat='{{instance}}',
+      format='time_series',
     ),
   ],
   type: 'stat',
   title: 'RPC connections',
-  description: 'The number of open connections at the RPC layer.',
+  description: 'The number of open connections to the RegionServer.',
   fieldConfig: {
     defaults: {
       color: {
@@ -211,11 +228,13 @@ local jvmMemoryUsagePanel = {
       'jvm_metrics_mem_non_heap_used_m{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance", processname="RegionServer"} / clamp_min(jvm_metrics_mem_non_heap_committed_m{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance", processname="RegionServer"}, 1)',
       datasource=promDatasource,
       legendFormat='{{instance}} - non-heap',
+      format='time_series',
     ),
     prometheus.target(
       'jvm_metrics_mem_heap_used_m{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance", processname="RegionServer"} / clamp_min(jvm_metrics_mem_heap_committed_m{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance", processname="RegionServer"}, 1)',
       datasource=promDatasource,
       legendFormat='{{instance}} - heap',
+      format='time_series',
     ),
   ],
   type: 'timeseries',
@@ -299,6 +318,7 @@ local requestsReceivedPanel = {
       'rate(server_total_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval])',
       datasource=promDatasource,
       legendFormat='{{instance}}',
+      format='time_series',
     ),
   ],
   type: 'timeseries',
@@ -380,46 +400,55 @@ local requestsOverviewPanel = {
       'rate(server_read_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval])',
       datasource=promDatasource,
       legendFormat='{{instance}} - read',
+      format='time_series',
     ),
     prometheus.target(
       'rate(server_write_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval])',
       datasource=promDatasource,
       legendFormat='{{instance}} - write',
+      format='time_series',
     ),
     prometheus.target(
       'rate(server_cp_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval])',
       datasource=promDatasource,
       legendFormat='{{instance}} - cp',
+      format='time_series',
     ),
     prometheus.target(
       'rate(server_filtered_read_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval])',
       datasource=promDatasource,
       legendFormat='{{instance}} - filtered read',
+      format='time_series',
     ),
     prometheus.target(
       'rate(server_rpc_get_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval])',
       datasource=promDatasource,
       legendFormat='{{instance}} - rpc get',
+      format='time_series',
     ),
     prometheus.target(
       'rate(server_rpc_scan_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval])',
       datasource=promDatasource,
       legendFormat='{{instance}} - rpc scan',
+      format='time_series',
     ),
     prometheus.target(
       'rate(server_rpc_full_scan_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval])',
       datasource=promDatasource,
       legendFormat='{{instance}} - rpc full scan',
+      format='time_series',
     ),
     prometheus.target(
       'rate(server_rpc_mutate_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval])',
       datasource=promDatasource,
       legendFormat='{{instance}} - rpc mutate',
+      format='time_series',
     ),
     prometheus.target(
       'rate(server_rpc_multi_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval])',
       datasource=promDatasource,
       legendFormat='{{instance}} - rpc multi',
+      format='time_series',
     ),
   ],
   type: 'piechart',
@@ -470,6 +499,7 @@ local regionCountPanel = {
       'server_region_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}',
       datasource=promDatasource,
       legendFormat='{{instance}}',
+      format='time_series',
     ),
   ],
   type: 'timeseries',
@@ -519,6 +549,7 @@ local regionCountPanel = {
         steps: [
           {
             color: 'green',
+            value: null,
           },
           {
             color: 'red',
@@ -544,17 +575,18 @@ local regionCountPanel = {
   },
 };
 
-local rpcConnectionsPanel = {
+local rpcConnectionCountPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
       'region_server_num_open_connections{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}',
       datasource=promDatasource,
       legendFormat='{{instance}}',
+      format='time_series',
     ),
   ],
   type: 'timeseries',
-  title: 'RPC connections',
+  title: 'RPC connection count',
   description: 'The number of open connections to the RegionServer.',
   fieldConfig: {
     defaults: {
@@ -599,6 +631,7 @@ local rpcConnectionsPanel = {
         steps: [
           {
             color: 'green',
+            value: null,
           },
           {
             color: 'red',
@@ -631,6 +664,7 @@ local storeFileCountPanel = {
       'server_store_file_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}',
       datasource=promDatasource,
       legendFormat='{{instance}}',
+      format='time_series',
     ),
   ],
   type: 'timeseries',
@@ -680,6 +714,7 @@ local storeFileCountPanel = {
         steps: [
           {
             color: 'green',
+            value: null,
           },
           {
             color: 'red',
@@ -712,6 +747,7 @@ local storeFileSizePanel = {
       'server_store_file_size{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}',
       datasource=promDatasource,
       legendFormat='{{instance}}',
+      format='time_series',
     ),
   ],
   type: 'timeseries',
@@ -760,6 +796,7 @@ local storeFileSizePanel = {
         steps: [
           {
             color: 'green',
+            value: null,
           },
           {
             color: 'red',
@@ -792,31 +829,37 @@ local queuedCallsPanel = {
       'region_server_num_calls_in_general_queue{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}',
       datasource=promDatasource,
       legendFormat='{{instance}} - general',
+      format='time_series',
     ),
     prometheus.target(
       'region_server_num_calls_in_replication_queue{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}',
       datasource=promDatasource,
       legendFormat='{{instance}} - replication',
+      format='time_series',
     ),
     prometheus.target(
       'region_server_num_calls_in_read_queue{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}',
       datasource=promDatasource,
       legendFormat='{{instance}} - read',
+      format='time_series',
     ),
     prometheus.target(
       'region_server_num_calls_in_write_queue{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}',
       datasource=promDatasource,
       legendFormat='{{instance}} - write',
+      format='time_series',
     ),
     prometheus.target(
       'region_server_num_calls_in_scan_queue{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}',
       datasource=promDatasource,
       legendFormat='{{instance}} - scan',
+      format='time_series',
     ),
     prometheus.target(
       'region_server_num_calls_in_priority_queue{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}',
       datasource=promDatasource,
       legendFormat='{{instance}} - priority',
+      format='time_series',
     ),
   ],
   type: 'timeseries',
@@ -865,6 +908,7 @@ local queuedCallsPanel = {
         steps: [
           {
             color: 'green',
+            value: null,
           },
           {
             color: 'red',
@@ -901,26 +945,31 @@ local slowOperationsPanel = {
       'rate(server_slow_append_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval])',
       datasource=promDatasource,
       legendFormat='{{instance}} - append',
+      format='time_series',
     ),
     prometheus.target(
       'rate(server_slow_put_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval])',
       datasource=promDatasource,
       legendFormat='{{instance}} - put',
+      format='time_series',
     ),
     prometheus.target(
       'rate(server_slow_delete_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval])',
       datasource=promDatasource,
       legendFormat='{{instance}} - delete',
+      format='time_series',
     ),
     prometheus.target(
       'rate(server_slow_get_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval])',
       datasource=promDatasource,
       legendFormat='{{instance}} - get',
+      format='time_series',
     ),
     prometheus.target(
       'rate(server_slow_increment_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval])',
       datasource=promDatasource,
       legendFormat='{{instance}} - increment',
+      format='time_series',
     ),
   ],
   type: 'timeseries',
@@ -969,6 +1018,7 @@ local slowOperationsPanel = {
         steps: [
           {
             color: 'green',
+            value: null,
           },
           {
             color: 'red',
@@ -1005,6 +1055,7 @@ local cacheHitPercentagePanel = {
       'server_block_cache_express_hit_percent{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}',
       datasource=promDatasource,
       legendFormat='{{instance}}',
+      format='time_series',
     ),
   ],
   type: 'timeseries',
@@ -1055,6 +1106,7 @@ local cacheHitPercentagePanel = {
         steps: [
           {
             color: 'green',
+            value: null,
           },
           {
             color: 'red',
@@ -1087,11 +1139,13 @@ local authenticationsPanel = {
       'rate(region_server_authentication_successes{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval])',
       datasource=promDatasource,
       legendFormat='{{instance}} - success',
+      format='time_series',
     ),
     prometheus.target(
       'rate(region_server_authentication_failures{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval])',
       datasource=promDatasource,
       legendFormat='{{instance}} - failure',
+      format='time_series',
     ),
   ],
   type: 'timeseries',
@@ -1140,6 +1194,7 @@ local authenticationsPanel = {
         steps: [
           {
             color: 'green',
+            value: null,
           },
           {
             color: 'red',
@@ -1168,6 +1223,7 @@ local authenticationsPanel = {
     },
   },
 };
+
 
 {
   grafanaDashboards+:: {
@@ -1234,15 +1290,15 @@ local authenticationsPanel = {
       )
       .addPanels(
         [
-          regionCountPanel { gridPos: { h: 8, w: 6, x: 0, y: 0 } },
-          storeFileCountPanel { gridPos: { h: 8, w: 6, x: 6, y: 0 } },
-          storeFileSizePanel { gridPos: { h: 8, w: 6, x: 12, y: 0 } },
+          regionsPanel { gridPos: { h: 8, w: 6, x: 0, y: 0 } },
+          storeFilesPanel { gridPos: { h: 8, w: 6, x: 6, y: 0 } },
+          storeFileSizesPanel { gridPos: { h: 8, w: 6, x: 12, y: 0 } },
           rpcConnectionsPanel { gridPos: { h: 8, w: 6, x: 18, y: 0 } },
           jvmMemoryUsagePanel { gridPos: { h: 9, w: 24, x: 0, y: 8 } },
           requestsReceivedPanel { gridPos: { h: 8, w: 16, x: 0, y: 17 } },
           requestsOverviewPanel { gridPos: { h: 8, w: 8, x: 16, y: 17 } },
           regionCountPanel { gridPos: { h: 8, w: 12, x: 0, y: 25 } },
-          rpcConnectionsPanel { gridPos: { h: 8, w: 12, x: 12, y: 25 } },
+          rpcConnectionCountPanel { gridPos: { h: 8, w: 12, x: 12, y: 25 } },
           storeFileCountPanel { gridPos: { h: 8, w: 12, x: 0, y: 33 } },
           storeFileSizePanel { gridPos: { h: 8, w: 12, x: 12, y: 33 } },
           queuedCallsPanel { gridPos: { h: 8, w: 12, x: 0, y: 41 } },

--- a/apache-hbase-mixin/dashboards/apache-hbase-regionserver-overview.libsonnet
+++ b/apache-hbase-mixin/dashboards/apache-hbase-regionserver-overview.libsonnet
@@ -24,7 +24,7 @@ local regionsPanel = {
   ],
   type: 'stat',
   title: 'Regions',
-  description: 'The number of regions hosted by the RegionServer.',
+  description: 'The number of regions hosted by the Region Server.',
   fieldConfig: {
     defaults: {
       color: {
@@ -78,7 +78,7 @@ local storeFilesPanel = {
   ],
   type: 'stat',
   title: 'Store files',
-  description: 'The number of store files on disk currently managed by the RegionServer.',
+  description: 'The number of store files on disk currently managed by the Region Server.',
   fieldConfig: {
     defaults: {
       color: {
@@ -132,7 +132,7 @@ local storeFileSizePanel = {
   ],
   type: 'bargauge',
   title: 'Store file size',
-  description: 'The total size of the store files on disk managed by the RegionServer.',
+  description: 'The total size of the store files on disk managed by the Region Server.',
   fieldConfig: {
     defaults: {
       color: {
@@ -183,7 +183,7 @@ local rpcConnectionsPanel = {
   ],
   type: 'stat',
   title: 'RPC connections',
-  description: 'The number of open connections to the RegionServer.',
+  description: 'The number of open connections to the Region Server.',
   fieldConfig: {
     defaults: {
       color: {
@@ -322,7 +322,7 @@ local requestsReceivedPanel = {
   ],
   type: 'timeseries',
   title: 'Requests received',
-  description: 'The rate of requests received by the RegionServer.',
+  description: 'The rate of requests received by the Region Server.',
   fieldConfig: {
     defaults: {
       color: {
@@ -452,7 +452,7 @@ local requestsOverviewPanel = {
   ],
   type: 'piechart',
   title: 'Requests overview',
-  description: 'Requests received by the RegionServer, broken down by type.',
+  description: 'Requests received by the Region Server, broken down by type.',
   fieldConfig: {
     defaults: {
       color: {
@@ -503,7 +503,7 @@ local regionCountPanel = {
   ],
   type: 'timeseries',
   title: 'Region count',
-  description: 'The number of regions hosted by the RegionServer.',
+  description: 'The number of regions hosted by the Region Server.',
   fieldConfig: {
     defaults: {
       color: {
@@ -586,7 +586,7 @@ local rpcConnectionCountPanel = {
   ],
   type: 'timeseries',
   title: 'RPC connection count',
-  description: 'The number of open connections to the RegionServer.',
+  description: 'The number of open connections to the Region Server.',
   fieldConfig: {
     defaults: {
       color: {
@@ -665,7 +665,7 @@ local storeFileCountPanel = {
   ],
   type: 'timeseries',
   title: 'Store file count',
-  description: 'The number of store files on disk currently managed by the RegionServer.',
+  description: 'The number of store files on disk currently managed by the Region Server.',
   fieldConfig: {
     defaults: {
       color: {
@@ -748,7 +748,7 @@ local storeFileSizePanel = {
   ],
   type: 'timeseries',
   title: 'Store file size',
-  description: 'The total size of the store files on disk managed by the RegionServer.',
+  description: 'The total size of the store files on disk managed by the Region Server.',
   fieldConfig: {
     defaults: {
       color: {
@@ -860,7 +860,7 @@ local queuedCallsPanel = {
   ],
   type: 'timeseries',
   title: 'Queued calls',
-  description: 'The number of calls waiting to be processed by the RegionServer.',
+  description: 'The number of calls waiting to be processed by the Region Server.',
   fieldConfig: {
     defaults: {
       color: {
@@ -1256,7 +1256,7 @@ local authenticationsPanel = {
             refresh=2,
             includeAll=true,
             multi=true,
-            allValues='',
+            allValues='.+',
             sort=0
           ),
           template.new(

--- a/apache-hbase-mixin/dashboards/apache-hbase-regionserver-overview.libsonnet
+++ b/apache-hbase-mixin/dashboards/apache-hbase-regionserver-overview.libsonnet
@@ -12,7 +12,6 @@ local promDatasource = {
   uid: '${%s}' % promDatasourceName,
 };
 
-
 local regionsPanel = {
   datasource: promDatasource,
   targets: [
@@ -1220,7 +1219,6 @@ local authenticationsPanel = {
     },
   },
 };
-
 
 {
   grafanaDashboards+:: {

--- a/apache-hbase-mixin/dashboards/apache-hbase-regionserver-overview.libsonnet
+++ b/apache-hbase-mixin/dashboards/apache-hbase-regionserver-overview.libsonnet
@@ -1219,10 +1219,10 @@ local authenticationsPanel = {
     'apache-hbase-regionserver-overview.json':
       dashboard.new(
         'Apache HBase RegionServer overview',
-        time_from='%s' % $._config.dashboardPeriod,
+        time_from=$._config.dashboardPeriod,
         tags=($._config.dashboardTags),
-        timezone='%s' % $._config.dashboardTimezone,
-        refresh='%s' % $._config.dashboardRefresh,
+        timezone=$._config.dashboardTimezone,
+        refresh=$._config.dashboardRefresh,
         description='',
         uid=dashboardUid,
       )

--- a/apache-hbase-mixin/dashboards/apache-hbase-regionserver-overview.libsonnet
+++ b/apache-hbase-mixin/dashboards/apache-hbase-regionserver-overview.libsonnet
@@ -1,0 +1,1255 @@
+local g = (import 'grafana-builder/grafana.libsonnet');
+local grafana = (import 'grafonnet/grafana.libsonnet');
+local dashboard = grafana.dashboard;
+local template = grafana.template;
+local prometheus = grafana.prometheus;
+
+local dashboardUid = 'apache-hbase-regionserver-overview';
+
+local promDatasourceName = 'prometheus_datasource';
+
+local promDatasource = {
+  uid: '${%s}' % promDatasourceName,
+};
+
+local regionCountPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'server_region_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}',
+      datasource=promDatasource,
+    ),
+  ],
+  type: 'stat',
+  title: 'Region count',
+  description: 'The number of regions hosted by the RegionServer.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    colorMode: 'value',
+    graphMode: 'none',
+    justifyMode: 'auto',
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    textMode: 'auto',
+  },
+  pluginVersion: '10.2.0-61719',
+};
+
+local storeFileCountPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'server_store_file_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}',
+      datasource=promDatasource,
+    ),
+  ],
+  type: 'stat',
+  title: 'Store file count',
+  description: 'The number of store files on disk currently managed by the RegionServer.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    colorMode: 'value',
+    graphMode: 'none',
+    justifyMode: 'auto',
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    textMode: 'auto',
+  },
+  pluginVersion: '10.2.0-61719',
+};
+
+local storeFileSizePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'server_store_file_size{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+    ),
+  ],
+  type: 'bargauge',
+  title: 'Store file size',
+  description: 'The total size of the store files on disk managed by the RegionServer.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [],
+      min: 0,
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'decbytes',
+    },
+    overrides: [],
+  },
+  options: {
+    displayMode: 'gradient',
+    minVizHeight: 10,
+    minVizWidth: 0,
+    namePlacement: 'auto',
+    orientation: 'horizontal',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    showUnfilled: true,
+    valueMode: 'color',
+  },
+  pluginVersion: '10.2.0-61719',
+};
+
+local rpcConnectionsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'region_server_num_open_connections{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}',
+      datasource=promDatasource,
+    ),
+  ],
+  type: 'stat',
+  title: 'RPC connections',
+  description: 'The number of open connections at the RPC layer.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    colorMode: 'value',
+    graphMode: 'none',
+    justifyMode: 'auto',
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    textMode: 'auto',
+  },
+  pluginVersion: '10.2.0-61719',
+};
+
+local jvmMemoryUsagePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'jvm_metrics_mem_non_heap_used_m{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance", processname="RegionServer"} / clamp_min(jvm_metrics_mem_non_heap_committed_m{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance", processname="RegionServer"}, 1)',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - non-heap',
+    ),
+    prometheus.target(
+      'jvm_metrics_mem_heap_used_m{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance", processname="RegionServer"} / clamp_min(jvm_metrics_mem_heap_committed_m{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance", processname="RegionServer"}, 1)',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - heap',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'JVM memory usage',
+  description: 'Memory usage for the JVM.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'continuous-BlYlRd',
+      },
+      custom: {
+        axisBorderShow: false,
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      max: 1,
+      min: 0,
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'percentunit',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local requestsReceivedPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'rate(server_total_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Requests received',
+  description: 'The rate of requests received by the RegionServer.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisBorderShow: false,
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'reqps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local requestsOverviewPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'rate(server_read_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - read',
+    ),
+    prometheus.target(
+      'rate(server_write_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - write',
+    ),
+    prometheus.target(
+      'rate(server_cp_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - cp',
+    ),
+    prometheus.target(
+      'rate(server_filtered_read_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - filtered read',
+    ),
+    prometheus.target(
+      'rate(server_rpc_get_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - rpc get',
+    ),
+    prometheus.target(
+      'rate(server_rpc_scan_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - rpc scan',
+    ),
+    prometheus.target(
+      'rate(server_rpc_full_scan_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - rpc full scan',
+    ),
+    prometheus.target(
+      'rate(server_rpc_mutate_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - rpc mutate',
+    ),
+    prometheus.target(
+      'rate(server_rpc_multi_request_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - rpc multi',
+    ),
+  ],
+  type: 'piechart',
+  title: 'Requests overview',
+  description: 'Requests received by the RegionServer, broken down by type.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+      },
+      mappings: [],
+      unit: 'reqps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      displayMode: 'list',
+      placement: 'right',
+      showLegend: true,
+    },
+    pieType: 'pie',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local regionCountPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'server_region_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Region count',
+  description: 'The number of regions hosted by the RegionServer.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisBorderShow: false,
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      decimals: 0,
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local rpcConnectionsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'region_server_num_open_connections{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'RPC connections',
+  description: 'The number of open connections to the RegionServer.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisBorderShow: false,
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local storeFileCountPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'server_store_file_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Store file count',
+  description: 'The number of store files on disk currently managed by the RegionServer.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisBorderShow: false,
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      decimals: 0,
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local storeFileSizePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'server_store_file_size{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Store file size',
+  description: 'The total size of the store files on disk managed by the RegionServer.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisBorderShow: false,
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'decbytes',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local queuedCallsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'region_server_num_calls_in_general_queue{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - general',
+    ),
+    prometheus.target(
+      'region_server_num_calls_in_replication_queue{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - replication',
+    ),
+    prometheus.target(
+      'region_server_num_calls_in_read_queue{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - read',
+    ),
+    prometheus.target(
+      'region_server_num_calls_in_write_queue{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - write',
+    ),
+    prometheus.target(
+      'region_server_num_calls_in_scan_queue{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - scan',
+    ),
+    prometheus.target(
+      'region_server_num_calls_in_priority_queue{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - priority',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Queued calls',
+  description: 'The number of calls waiting to be processed by the RegionServer.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisBorderShow: false,
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [
+        'min',
+        'mean',
+        'max',
+      ],
+      displayMode: 'table',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local slowOperationsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'rate(server_slow_append_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - append',
+    ),
+    prometheus.target(
+      'rate(server_slow_put_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - put',
+    ),
+    prometheus.target(
+      'rate(server_slow_delete_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - delete',
+    ),
+    prometheus.target(
+      'rate(server_slow_get_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - get',
+    ),
+    prometheus.target(
+      'rate(server_slow_increment_count{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - increment',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Slow operations',
+  description: 'The rate of operations that are slow, as determined by HBase.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisBorderShow: false,
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'ops',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [
+        'min',
+        'mean',
+        'max',
+      ],
+      displayMode: 'table',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local cacheHitPercentagePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'server_block_cache_express_hit_percent{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Cache hit percentage',
+  description: 'The percent of time that requests hit the cache.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisBorderShow: false,
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      max: 100,
+      min: 0,
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'percent',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local authenticationsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'rate(region_server_authentication_successes{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - success',
+    ),
+    prometheus.target(
+      'rate(region_server_authentication_failures{job=~"$job", hbase_cluster=~"$hbase_cluster", instance=~"$instance"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - failure',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Authentications',
+  description: 'The rate of successful and unsuccessful authentications.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisBorderShow: false,
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'reqps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [
+        'min',
+        'mean',
+        'max',
+      ],
+      displayMode: 'table',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+{
+  grafanaDashboards+:: {
+    'apache-hbase-regionserver-overview.json':
+      dashboard.new(
+        'Apache HBase RegionServer overview',
+        time_from='%s' % $._config.dashboardPeriod,
+        tags=($._config.dashboardTags),
+        timezone='%s' % $._config.dashboardTimezone,
+        refresh='%s' % $._config.dashboardRefresh,
+        description='',
+        uid=dashboardUid,
+      )
+      .addLink(grafana.link.dashboards(
+        asDropdown=false,
+        title='Other Apache HBase dashboards',
+        includeVars=true,
+        keepTime=true,
+        tags=($._config.dashboardTags),
+      ))
+      .addTemplates(
+        [
+          template.datasource(
+            promDatasourceName,
+            'prometheus',
+            null,
+            label='Data Source',
+            refresh='load'
+          ),
+          template.new(
+            'job',
+            promDatasource,
+            'label_values(master_num_open_connections,job)',
+            label='Job',
+            refresh=2,
+            includeAll=true,
+            multi=true,
+            allValues='',
+            sort=0
+          ),
+          template.new(
+            'hbase_cluster',
+            promDatasource,
+            'label_values(master_num_open_connections{job=~"$job"},hbase_cluster)',
+            label='Apache HBase cluster',
+            refresh=2,
+            includeAll=true,
+            multi=true,
+            allValues='',
+            sort=0
+          ),
+          template.new(
+            'instance',
+            promDatasource,
+            'label_values(server_region_count{hbase_cluster=~"$hbase_cluster"},instance)',
+            label='Instance',
+            refresh=2,
+            includeAll=true,
+            multi=true,
+            allValues='',
+            sort=0
+          ),
+        ]
+      )
+      .addPanels(
+        [
+          regionCountPanel { gridPos: { h: 8, w: 6, x: 0, y: 0 } },
+          storeFileCountPanel { gridPos: { h: 8, w: 6, x: 6, y: 0 } },
+          storeFileSizePanel { gridPos: { h: 8, w: 6, x: 12, y: 0 } },
+          rpcConnectionsPanel { gridPos: { h: 8, w: 6, x: 18, y: 0 } },
+          jvmMemoryUsagePanel { gridPos: { h: 9, w: 24, x: 0, y: 8 } },
+          requestsReceivedPanel { gridPos: { h: 8, w: 16, x: 0, y: 17 } },
+          requestsOverviewPanel { gridPos: { h: 8, w: 8, x: 16, y: 17 } },
+          regionCountPanel { gridPos: { h: 8, w: 12, x: 0, y: 25 } },
+          rpcConnectionsPanel { gridPos: { h: 8, w: 12, x: 12, y: 25 } },
+          storeFileCountPanel { gridPos: { h: 8, w: 12, x: 0, y: 33 } },
+          storeFileSizePanel { gridPos: { h: 8, w: 12, x: 12, y: 33 } },
+          queuedCallsPanel { gridPos: { h: 8, w: 12, x: 0, y: 41 } },
+          slowOperationsPanel { gridPos: { h: 8, w: 12, x: 12, y: 41 } },
+          cacheHitPercentagePanel { gridPos: { h: 8, w: 12, x: 0, y: 49 } },
+          authenticationsPanel { gridPos: { h: 8, w: 12, x: 12, y: 49 } },
+        ]
+      ),
+  },
+}

--- a/apache-hbase-mixin/dashboards/apache-hbase-regionserver-overview.libsonnet
+++ b/apache-hbase-mixin/dashboards/apache-hbase-regionserver-overview.libsonnet
@@ -12,6 +12,7 @@ local promDatasource = {
   uid: '${%s}' % promDatasourceName,
 };
 
+
 local regionsPanel = {
   datasource: promDatasource,
   targets: [
@@ -63,7 +64,7 @@ local regionsPanel = {
     },
     textMode: 'auto',
   },
-  pluginVersion: '10.2.0-61719',
+  pluginVersion: '10.2.0-62263',
 };
 
 local storeFilesPanel = {
@@ -117,10 +118,10 @@ local storeFilesPanel = {
     },
     textMode: 'auto',
   },
-  pluginVersion: '10.2.0-61719',
+  pluginVersion: '10.2.0-62263',
 };
 
-local storeFileSizesPanel = {
+local storeFileSizePanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
@@ -157,7 +158,7 @@ local storeFileSizesPanel = {
     minVizHeight: 10,
     minVizWidth: 0,
     namePlacement: 'auto',
-    orientation: 'auto',
+    orientation: 'horizontal',
     reduceOptions: {
       calcs: [
         'lastNotNull',
@@ -168,7 +169,7 @@ local storeFileSizesPanel = {
     showUnfilled: true,
     valueMode: 'color',
   },
-  pluginVersion: '10.2.0-61719',
+  pluginVersion: '10.2.0-62263',
 };
 
 local rpcConnectionsPanel = {
@@ -217,7 +218,7 @@ local rpcConnectionsPanel = {
     },
     textMode: 'auto',
   },
-  pluginVersion: '10.2.0-61719',
+  pluginVersion: '10.2.0-62263',
 };
 
 local jvmMemoryUsagePanel = {
@@ -624,6 +625,7 @@ local rpcConnectionCountPanel = {
           mode: 'off',
         },
       },
+      decimals: 0,
       mappings: [],
       thresholds: {
         mode: 'absolute',
@@ -631,10 +633,6 @@ local rpcConnectionCountPanel = {
           {
             color: 'green',
             value: null,
-          },
-          {
-            color: 'red',
-            value: 80,
           },
         ],
       },
@@ -1223,6 +1221,7 @@ local authenticationsPanel = {
   },
 };
 
+
 {
   grafanaDashboards+:: {
     'apache-hbase-regionserver-overview.json':
@@ -1290,7 +1289,7 @@ local authenticationsPanel = {
         [
           regionsPanel { gridPos: { h: 8, w: 6, x: 0, y: 0 } },
           storeFilesPanel { gridPos: { h: 8, w: 6, x: 6, y: 0 } },
-          storeFileSizesPanel { gridPos: { h: 8, w: 6, x: 12, y: 0 } },
+          storeFileSizePanel { gridPos: { h: 8, w: 6, x: 12, y: 0 } },
           rpcConnectionsPanel { gridPos: { h: 8, w: 6, x: 18, y: 0 } },
           jvmMemoryUsagePanel { gridPos: { h: 9, w: 24, x: 0, y: 8 } },
           requestsReceivedPanel { gridPos: { h: 8, w: 16, x: 0, y: 17 } },

--- a/apache-hbase-mixin/dashboards/dashboards.libsonnet
+++ b/apache-hbase-mixin/dashboards/dashboards.libsonnet
@@ -1,0 +1,3 @@
+(import 'apache-hbase-cluster-overview.libsonnet') +
+(import 'apache-hbase-regionserver-overview.libsonnet') +
+(import 'apache-hbase-logs-overview.libsonnet')

--- a/apache-hbase-mixin/jsonnetfile.json
+++ b/apache-hbase-mixin/jsonnetfile.json
@@ -1,0 +1,33 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/grafonnet.git",
+          "subdir": "gen/grafonnet-latest"
+        }
+      },
+      "version": "main"
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/grafonnet-lib.git",
+          "subdir": "grafonnet"
+        }
+      },
+      "version": "master"
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": "logs-lib"
+        }
+      },
+      "version": "master"
+    }
+  ],
+  "legacyImports": true
+}

--- a/apache-hbase-mixin/mixin.libsonnet
+++ b/apache-hbase-mixin/mixin.libsonnet
@@ -1,0 +1,3 @@
+(import 'dashboards/dashboards.libsonnet') +
+(import 'alerts/alerts.libsonnet') +
+(import 'config.libsonnet')


### PR DESCRIPTION
Adds dashboards and alerts for the Apache HBase mixin.

### Note
The vm environment that is currently sending to Grafana cloud is highly unreliable due to Hadoop consuming large amounts of disk space. For a representative image of what these dashboards will look like under load, refer to the time the screenshots were taken.
See also an example of a dead RegionServer at 9:15-9:44am EST on 10/17.

Dashboards:
- Apache HBase cluster overview
- Apache HBase RegionServer overview
- Apache HBase logs overview

Alerts:
- ApacheHBaseHighHeapMemUsage
- ApacheHBaseHighNonHeapMemUsage
- ApacheHBaseDeadRegionServer
- ApacheHBaseOldRegionsInTransition
- ApacheHBaseHighMasterAuthFailureRate
- ApacheHBaseHighRSAuthFailureRate

## Apache HBase cluster overview
<img width="1920" alt="apache_hbase_cluster_overview_1" src="https://github.com/grafana/jsonnet-libs/assets/69878936/e457507b-98aa-45ae-b230-f1b05e77d969">
<img width="1920" alt="apache_hbase_cluster_overview_2" src="https://github.com/grafana/jsonnet-libs/assets/69878936/9431cc8d-f9b0-468c-a963-bbeaf294fab2">


## Apache HBase RegionServer overview
<img width="1920" alt="apache_hbase_regionserver_overview_1" src="https://github.com/grafana/jsonnet-libs/assets/69878936/8d74f093-4a6c-4003-b2ba-4b2c3918c8e4">
<img width="1920" alt="apache_hbase_regionserver_overview_2" src="https://github.com/grafana/jsonnet-libs/assets/69878936/281734da-bf96-4f9d-8ff1-12fe26c29551">
<img width="1920" alt="apache_hbase_regionserver_overview_3" src="https://github.com/grafana/jsonnet-libs/assets/69878936/acb13ae7-b126-4d43-8d2b-64f50ae8c162">


## Apache HBase logs overview
<img width="1920" alt="apache_hbase_logs_overview_1" src="https://github.com/grafana/jsonnet-libs/assets/69878936/8986a517-990a-464a-acdd-5b041b7a7608">

