### PR TITLE
Gitlab: update multi select instance panel & have multicluster to be false

### DIFF
--- a/gitlab-mixin/config.libsonnet
+++ b/gitlab-mixin/config.libsonnet
@@ -1,6 +1,6 @@
 {
   _config+:: {
-    enableMultiCluster: true,
+    enableMultiCluster: false,
     gitlabSelector: if self.enableMultiCluster then 'job=~"$job", instance=~"$instance", cluster=~"$cluster"' else 'job=~"$job", instance=~"$instance"',
 
     dashboardTags: ['gitlab-mixin'],

--- a/gitlab-mixin/dashboards/gitlab-overview.libsonnet
+++ b/gitlab-mixin/dashboards/gitlab-overview.libsonnet
@@ -679,7 +679,11 @@ local buildTraceOperationsPanel(matcher) = {
             promDatasource,
             'label_values(gitlab_rails_boot_time_seconds{job=~"$job"}, instance)',
             label='Instance',
-            refresh='time'
+            refresh='time',
+            includeAll=true,
+            multi=true,
+            allValues='.+',
+            sort=1
           ),
           template.new(
             'cluster',


### PR DESCRIPTION
- update multi select instance panel. This is needed because only one instance can be selected at once, which makes it awkward when selecting different cluster selectors because you also have to adjust the instance selector to currently.
- multicluster is set to false 