### PR TITLE
CODEOWNERS grooming

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,5 +4,11 @@
 /consul*/ @grafana/mimir-maintainers @grafana/loki-team
 /etcd-operator/ @grafana/mimir-maintainers
 /memcached*/ @grafana/mimir-maintainers @grafana/loki-team
-/prometheus-ksonnet/ @grafana/mimir-maintainers @grafana/cloud-platform
+/prometheus-ksonnet/ @grafana/mimir-maintainers
 /enterprise-metrics/ @grafana/backend-enterprise
+/*-mixin/ @grafana/cloud-integrations
+/common-lib/ @grafana/cloud-integrations
+/grafana-cloud-integration-utils/ @grafana/cloud-integrations
+/logs-lib/ @grafana/cloud-integrations
+/status-panels-lib/ @grafana/cloud-integrations
+/windows-observe-lib/ @grafana/cloud-integrations


### PR DESCRIPTION
Add @grafana/cloud-integrations as owners of all mixins and a few shared libraries.

Remove deprecated @grafana/cloud-platform, not sure if there is a good substitute team for this?

Additionally, I added write permissions to the repo explicitly for @grafana/mimir-maintainers @grafana/loki-team to satisfy the static checking on the CODEOWNERS file. In reality they already had permission due to other group membership.

FYI @zzehring.