### PR TITLE
Use freeTarget in windows-lib

### DIFF
--- a/windows-observ-lib/panels.libsonnet
+++ b/windows-observ-lib/panels.libsonnet
@@ -271,13 +271,12 @@ local utils = commonlib.utils;
           |||
         ),
       diskUsage: commonlib.panels.disk.table.usage.new(
-        totalTarget=
-        (t.diskTotal
-         + g.query.prometheus.withFormat('table')
-         + g.query.prometheus.withInstant(true)),
-        usageTarget=t.diskUsage
+        totalTarget=t.diskTotal
                     + g.query.prometheus.withFormat('table')
                     + g.query.prometheus.withInstant(true),
+        freeTarget=t.diskFree
+                   + g.query.prometheus.withFormat('table')
+                   + g.query.prometheus.withInstant(true),
         groupLabel='volume'
       ),
       diskUsagePercent: commonlib.panels.disk.timeSeries.usagePercent.new(

--- a/windows-observ-lib/targets.libsonnet
+++ b/windows-observ-lib/targets.libsonnet
@@ -120,6 +120,12 @@ local lokiQuery = g.query.loki;
         '${' + variables.datasources.prometheus.name + '}',
         '100 - windows_logical_disk_free_bytes{volume="C:", %(queriesSelector)s}/windows_logical_disk_size_bytes{volume="C:", %(queriesSelector)s}*100' % variables
       ),
+    diskFree:
+      prometheusQuery.new(
+        '${' + variables.datasources.prometheus.name + '}',
+        'windows_logical_disk_free_bytes{volume!~"%(ignoreVolumes)s", %(queriesSelector)s}' % variables { ignoreVolumes: config.ignoreVolumes }
+      )
+      + prometheusQuery.withLegendFormat('{{ volume }} available'),
     diskUsage:
       prometheusQuery.new(
         '${' + variables.datasources.prometheus.name + '}',


### PR DESCRIPTION
This is first class metric available from windows_exporter, not cumbersome substraction of two metrics we had in usedTarget. 
Depends on #1090 merged first.