### PR TITLE
Clickhouse: update selectors

### DIFF
--- a/clickhouse-mixin/config.libsonnet
+++ b/clickhouse-mixin/config.libsonnet
@@ -13,7 +13,7 @@
     // for alerts
     alertsReplicasMaxQueueSize: '99',
 
-    filterSelector: 'job=~"clickhouse"',
+    filterSelector: 'job=~".*/clickhouse.*"',
 
     enableLokiLogs: true,
   },

--- a/clickhouse-mixin/dashboards/addlogs.libsonnet
+++ b/clickhouse-mixin/dashboards/addlogs.libsonnet
@@ -25,7 +25,10 @@ local logsDashboard = import 'logs-lib/logs/main.libsonnet';
               {
                 logs+:
                   // copy links from another dashboard
-                  g.dashboard.withLinksMixin($.grafanaDashboards['clickhouse-overview.json'].links),
+                  g.dashboard.withLinksMixin($.grafanaDashboards['clickhouse-overview.json'].links)
+                  + g.dashboard.withUid('clickhouse-logs-overview')
+                  + g.dashboard.withTags($._config.dashboardTags)
+                  + g.dashboard.withRefresh($._config.dashboardRefresh),
               },
           },
         'clickhouse-logs.json': clickhouseLogs.dashboards.logs,

--- a/clickhouse-mixin/dashboards/clickhouse-latency.libsonnet
+++ b/clickhouse-mixin/dashboards/clickhouse-latency.libsonnet
@@ -472,7 +472,7 @@ local zooKeeperWaitTimePanel(matcher) =
             query='label_values(ClickHouseProfileEvents_DiskReadElapsedMicroseconds{job=~"$job"}, instance)',
             current='',
             refresh=2,
-            includeAll=false,
+            includeAll=true,
             sort=1
           ),
           template.new(

--- a/clickhouse-mixin/dashboards/clickhouse-overview.libsonnet
+++ b/clickhouse-mixin/dashboards/clickhouse-overview.libsonnet
@@ -811,7 +811,7 @@ local errorLogsPanel(cfg) =
               query='label_values(ClickHouseProfileEvents_Query{job=~"$job"}, instance)',
               current='',
               refresh=2,
-              includeAll=false,
+              includeAll=true,
               sort=1
             ),
             template.new(

--- a/clickhouse-mixin/dashboards/clickhouse-replica.libsonnet
+++ b/clickhouse-mixin/dashboards/clickhouse-replica.libsonnet
@@ -653,7 +653,7 @@ local zooKeeperRequestsPanel(matcher) =
             query='label_values(ClickHouseMetrics_InterserverConnection{job=~"$job"}, instance)',
             current='',
             refresh=2,
-            includeAll=false,
+            includeAll=true,
             sort=1
           ),
           template.new(


### PR DESCRIPTION
This pr updates the following selectors:
- The filter selector was hardcoded as `clickhouse` before while the k3d env has `sample-app/clickhouse` or `integration/clickhouse` and could easily be extended to many more options. So anything with before or after using .* is used.
- The logs dashboard had no links available from other dashboards, so added logs links where added
- Instance selector now includes all so a specific cluster - instance combination does not have to be selected for

![Screenshot 2023-10-30 at 2 26 33 PM](https://github.com/grafana/jsonnet-libs/assets/13648435/84608293-b9c9-4115-905d-c50a6cbba79d)
