### PR TITLE
time: add `parse_rfc3339` function

### DIFF
--- a/time/date.jsonnet
+++ b/time/date.jsonnet
@@ -34,8 +34,52 @@ local months_seconds(year, month) = std.foldl(
 // days_seconds returns the number of seconds in all days up to day-1.
 local days_seconds(day) = (day - 1) * 24 * 3600;
 
+// is_numeric returns a bool indicating whether the input string is numeric
+local is_numeric(input) = std.length(input) > 0 && std.length(std.prune([
+  if std.codepoint('0') > std.codepoint(char) || std.codepoint(char) > std.codepoint('9') then char
+  for char in std.stringChars(input)
+])) == 0;
+
+// parse_date_or_time parses input which has part_names separated by sep.
+local parse_date_or_time(input, sep, part_names) = (
+  local parts = std.split(input, sep);
+  assert std.length(parts) == std.length(part_names) : 'expected %(expected)d parts separated by %(sep)s in %(format)s formatted input "%(input)s", but got %(got)d' % {
+    expected: std.length(part_names),
+    sep: sep,
+    format: std.join(sep, part_names),
+    input: input,
+    got: std.length(parts),
+  };
+
+  {
+    [part_names[i]]:
+      // Fail with meaningful message if not numeric, otherwise it will be a hell to debug.
+      assert is_numeric(parts[i]) : '%(part_name)%s part "%(part)s" of %(format)s of input "%(input)s" is not numeric' % {
+        part_name: part_names[i],
+        part: parts[i],
+        format: std.join(sep, part_names),
+        input: input,
+      };
+      std.parseInt(parts[i])
+    for i in std.range(0, std.length(parts) - 1)
+  }
+);
+
 {
-  // date_to_unix_timestamp transforms a date into a unix timestamp.
+  // to_unix_timestamp transforms a date into a unix timestamp.
   to_unix_timestamp(year, month, day, hour, minute, second)::
     years_seconds(year) + months_seconds(year, month) + days_seconds(day) + hour * 3600 + minute * 60 + second,
+
+  // parse_rfc3339 parses an RFC3339 timestamp in UTC (ending in 'Z') with date and time separated by 'T', like '2006-01-02T15:04:05Z'
+  // The returned object has "year", "month", "day", "hour", "minute" and "second" keys, as well as a to_unix_timestamp method that returns the unix timestamp of the parsed date.
+  parse_rfc3339(input)::
+    assert std.endsWith(input, 'Z') : 'the provided RFC3339 "%s" should end with "Z"' % input;
+    local datetime = std.split(std.substr(input, 0, std.length(input) - 1), 'T');
+    assert std.length(datetime) == 2 : 'the provided RFC3339 timestamp "%s" does not have date and time parts separated by the character "T"' % input;
+
+    local date = parse_date_or_time(datetime[0], '-', ['year', 'month', 'day']);
+    local time = parse_date_or_time(datetime[1], ':', ['hour', 'minute', 'second']);
+    date + time + {
+      to_unix_timestamp():: $.to_unix_timestamp(self.year, self.month, self.day, self.hour, self.minute, self.second),
+    },
 }

--- a/time/date_test.jsonnet
+++ b/time/date_test.jsonnet
@@ -4,28 +4,45 @@ local test = import 'github.com/yugui/jsonnetunit/jsonnetunit/test.libsonnet';
 // Run this test suite by running:
 // jsonnet -J vendor date_test.jsonnet
 test.suite({
-  'test 1970-01-01 00:00:00 (zero)': {
+  // to_unix_timestamp test cases
+  'test to_unix_timestamp 1970-01-01 00:00:00 (zero)': {
     actual: date.to_unix_timestamp(1970, 1, 1, 0, 0, 0),
     expect: 0,
   },
-  'test 1970-01-02 00:00:00 (one day)': {
+  'test to_unix_timestamp 1970-01-02 00:00:00 (one day)': {
     actual: date.to_unix_timestamp(1970, 1, 2, 0, 0, 0),
     expect: 86400,
   },
-  'test 1971-01-01 00:00:00 (one year)': {
+  'test to_unix_timestamp 1971-01-01 00:00:00 (one year)': {
     actual: date.to_unix_timestamp(1971, 1, 1, 0, 0, 0),
     expect: 365 * 24 * 3600,
   },
-  'test 1972-03-01 00:00:00 (month of leap year)': {
+  'test to_unix_timestamp 1972-03-01 00:00:00 (month of leap year)': {
     actual: date.to_unix_timestamp(1972, 3, 1, 0, 0, 0),
     expect: 2 * 365 * 24 * 3600 + 31 * 24 * 3600 + 29 * 24 * 3600,
   },
-  'test 1974-01-01 00:00:00 (incl leap year)': {
+  'test to_unix_timestamp 1974-01-01 00:00:00 (incl leap year)': {
     actual: date.to_unix_timestamp(1974, 1, 1, 0, 0, 0),
     expect: (4 * 365 + 1) * 24 * 3600,
   },
-  'test 2020-01-02 03:04:05 (full date)': {
+  'test to_unix_timestamp 2020-01-02 03:04:05 (full date)': {
     actual: date.to_unix_timestamp(2020, 1, 2, 3, 4, 5),
+    expect: 1577934245,
+  },
+
+  // parse_rfc3339 test cases
+  'test parse_rfc3339 1970-01-01T00:00:00': {
+    actual: date.parse_rfc3339('1970-01-01T00:00:00Z'),
+    expect: { year: 1970, month: 1, day: 1, hour: 0, minute: 0, second: 0 },
+  },
+  'test parse_rfc3339 2020-01-02 03:04:05': {
+    actual: date.parse_rfc3339('2020-01-02T03:04:05Z'),
+    expect: { year: 2020, month: 1, day: 2, hour: 3, minute: 4, second: 5 },
+  },
+
+  // parse_rfc3339(...).to_unix_timestamp() test cases
+  'test parse_rfc3339("2020-01-02T03:04:05Z").to_unix_timestamp()': {
+    actual: date.parse_rfc3339('2020-01-02T03:04:05Z').to_unix_timestamp(),
     expect: 1577934245,
   },
 })

--- a/time/date_test.jsonnet
+++ b/time/date_test.jsonnet
@@ -31,11 +31,11 @@ test.suite({
   },
 
   // parse_rfc3339 test cases
-  'test parse_rfc3339 1970-01-01T00:00:00': {
+  'test parse_rfc3339 1970-01-01T00:00:00Z': {
     actual: date.parse_rfc3339('1970-01-01T00:00:00Z'),
     expect: { year: 1970, month: 1, day: 1, hour: 0, minute: 0, second: 0 },
   },
-  'test parse_rfc3339 2020-01-02 03:04:05': {
+  'test parse_rfc3339 2020-01-02T03:04:05Z': {
     actual: date.parse_rfc3339('2020-01-02T03:04:05Z'),
     expect: { year: 2020, month: 1, day: 2, hour: 3, minute: 4, second: 5 },
   },


### PR DESCRIPTION
Parsing RFC3339 timestamps can be useful sometimes.

I manually tested the wrong formats, I don't know how to keep tests for that (as the entire jsonnet fails).