### PR TITLE
Fix Apache HBase alerts

### DIFF
--- a/apache-hbase-mixin/alerts/alerts.libsonnet
+++ b/apache-hbase-mixin/alerts/alerts.libsonnet
@@ -17,7 +17,7 @@
               summary: 'There is a limited amount of heap memory available to the JVM.',
               description:
                 (
-                  'The heap memory usage for the JVM on instance {{$labels.instance}} in cluster {{$labels.hbase_cluster}} is {{printf "%%.0f" $labels.value}} percent, which is above the threshold of %(alertsHighHeapMemUsage)s percent'
+                  'The heap memory usage for the JVM on instance {{$labels.instance}} in cluster {{$labels.hbase_cluster}} is {{printf "%%.0f" $value}} percent, which is above the threshold of %(alertsHighHeapMemUsage)s percent'
                 ) % $._config,
             },
           },
@@ -34,7 +34,7 @@
               summary: 'One or more RegionServer(s) has become unresponsive.',
               description:
                 (
-                  '{{$labels.value}} RegionServer(s) in cluster {{$labels.hbase_cluster}} are unresponsive, which is above the threshold of %(alertsDeadRegionServer)s. The name(s) of the dead RegionServer(s) are {{$labels.deadregionservers}}'
+                  '{{$value}} RegionServer(s) in cluster {{$labels.hbase_cluster}} are unresponsive, which is above the threshold of %(alertsDeadRegionServer)s. The name(s) of the dead RegionServer(s) are {{$labels.deadregionservers}}'
                 ) % $._config,
             },
           },
@@ -51,7 +51,7 @@
               summary: 'RegionServers are in transition for longer than expected.',
               description:
                 (
-                  '{{printf "%%.0f" $labels.value}} percent of RegionServers in transition in cluster {{$labels.hbase_cluster}} are transitioning for longer than expected, which is above the threshold of %(alertsOldRegionsInTransition)s percent'
+                  '{{printf "%%.0f" $value}} percent of RegionServers in transition in cluster {{$labels.hbase_cluster}} are transitioning for longer than expected, which is above the threshold of %(alertsOldRegionsInTransition)s percent'
                 ) % $._config,
             },
           },
@@ -68,7 +68,7 @@
               summary: 'A high percentage of authentication attempts to the master are failing.',
               description:
                 (
-                  '{{printf "%%.0f" $labels.value}} percent of authentication attempts to the master are failing in cluster {{$labels.hbase_cluster}}, which is above the threshold of %(alertsHighMasterAuthFailRate)s percent'
+                  '{{printf "%%.0f" $value}} percent of authentication attempts to the master are failing in cluster {{$labels.hbase_cluster}}, which is above the threshold of %(alertsHighMasterAuthFailRate)s percent'
                 ) % $._config,
             },
           },
@@ -85,7 +85,7 @@
               summary: 'A high percentage of authentication attempts to a RegionServer are failing.',
               description:
                 (
-                  '{{printf "%%.0f" $labels.value}} percent of authentication attempts to the RegionServer {{$labels.instance}} are failing in cluster {{$labels.hbase_cluster}}, which is above the threshold of %(alertsHighRSAuthFailRate)s percent'
+                  '{{printf "%%.0f" $value}} percent of authentication attempts to the RegionServer {{$labels.instance}} are failing in cluster {{$labels.hbase_cluster}}, which is above the threshold of %(alertsHighRSAuthFailRate)s percent'
                 ) % $._config,
             },
           },

--- a/apache-hbase-mixin/dashboards/apache-hbase-cluster-overview.libsonnet
+++ b/apache-hbase-mixin/dashboards/apache-hbase-cluster-overview.libsonnet
@@ -395,7 +395,7 @@ local alertsPanel = {
   title: 'Alerts',
   description: 'Panel to report on the status of integration alerts.',
   options: {
-    alertInstanceLabelFilter: '{job=~"${job:regex}", hbase_cluster=~"${hbase_cluster:regex}", instance=~"${instance:regex}"}',
+    alertInstanceLabelFilter: '{job=~"${job:regex}", hbase_cluster=~"${hbase_cluster:regex}"}',
     alertName: '',
     dashboardAlerts: false,
     folder: '',


### PR DESCRIPTION
This PR fixes a few minor issues with the alerts for the Apache HBase mixin.
1. Alert panel regex is updated to not include the instance label, which was preventing the panel from showing alerts properly.
2. Alert descriptions are changed to include `$value` rather than `$labels.value`, which was resolving incorrectly.