### PR TITLE
Allow dashboards to show gRPC codes as labels

### DIFF
--- a/grafana-builder/grafana.libsonnet
+++ b/grafana-builder/grafana.libsonnet
@@ -430,6 +430,7 @@
       '3xx': '#6ED0E0',
       '4xx': '#EF843C',
       '5xx': '#E24D42',
+      OK: '#7EB26D',
       success: '#7EB26D',
       'error': '#E24D42',
       cancel: '#A9A9A9',
@@ -441,7 +442,7 @@
             sum by (status) (
               label_replace(label_replace(rate(%s[$__rate_interval]),
               "status", "${1}xx", "%s", "([0-9]).."),
-              "status", "${1}", "%s", "([a-z]+)"))
+              "status", "${1}", "%s", "([a-zA-Z]+)"))
           ||| % [selector, statusLabelName, statusLabelName],
         format: 'time_series',
         intervalFactor: 2,


### PR DESCRIPTION
This PR updates all dashboards to allow reporting gRPC codes as `status_code`s. In order to achieve this, the pattern for recognizing valid status codes has been changed from `[a-z]+` to `[a-zA-Z]+`, since gRPC status codes contain upper cases letters too, e.g., `OK`, `FailedPrecondition`, `Canceled`, etc.

**Note**: The biggest change introduced by this PR is that if a component starts producing responses with gRPC codes only, successful `status_code` labels of the corresponding server and gRPC client request duration metrics will change from respectively `success` and `2xx` to `OK`.