### PR TITLE
Commonlib: add new panels

### DIFF
--- a/common-lib/common/panels.libsonnet
+++ b/common-lib/common/panels.libsonnet
@@ -9,11 +9,13 @@ local g = import './g.libsonnet';
   },
   network: {
     timeSeries: import './panels/network/timeSeries/main.libsonnet',
+    statusHistory: import './panels/network/statusHistory/main.libsonnet',
   },
   system: {
     stat: import './panels/system/stat/main.libsonnet',
     table: import './panels/system/table/main.libsonnet',
     statusHistory: import './panels/system/statusHistory/main.libsonnet',
+    timeSeries: import './panels/system/timeSeries/main.libsonnet',
   },
   cpu: {
     stat: import './panels/cpu/stat/main.libsonnet',

--- a/common-lib/common/panels/cpu/timeSeries/utilization_by_core.libsonnet
+++ b/common-lib/common/panels/cpu/timeSeries/utilization_by_core.libsonnet
@@ -7,7 +7,7 @@ base {
     targets,
     description=|||
       CPU utilization percent by core is a metric that indicates level of central processing unit (CPU) usage in a computer system.
-      It represents the load placed on eaxch CPU core or processors.
+      It represents the load placed on each CPU core or processors.
     |||
   ):
     super.new(title, targets, description)

--- a/common-lib/common/panels/cpu/timeSeries/utilization_by_core.libsonnet
+++ b/common-lib/common/panels/cpu/timeSeries/utilization_by_core.libsonnet
@@ -1,0 +1,20 @@
+local g = import '../../../g.libsonnet';
+local generic = import '../../generic/timeSeries/main.libsonnet';
+local base = import './base.libsonnet';
+base {
+  new(
+    title='CPU usage',
+    targets,
+    description=|||
+      CPU utilization percent by core is a metric that indicates level of central processing unit (CPU) usage in a computer system.
+      It represents the load placed on eaxch CPU core or processors.
+    |||
+  ):
+    super.new(title, targets, description)
+    + self.stylize(),
+
+  stylize(allLayers=true):
+    (if allLayers then super.stylize() else {})
+    + generic.percentage.stylize(allLayers=false)
+    + g.panel.timeSeries.fieldConfig.defaults.custom.withStacking({ mode: 'normal' }),
+}

--- a/common-lib/common/panels/network/statusHistory/base.libsonnet
+++ b/common-lib/common/panels/network/statusHistory/base.libsonnet
@@ -1,0 +1,5 @@
+local g = import '../../../g.libsonnet';
+local base = import '../../generic/statusHistory/base.libsonnet';
+base {
+
+}

--- a/common-lib/common/panels/network/statusHistory/interface_status.libsonnet
+++ b/common-lib/common/panels/network/statusHistory/interface_status.libsonnet
@@ -1,0 +1,29 @@
+local g = import '../../../g.libsonnet';
+local base = import './base.libsonnet';
+local statusHistory = g.panel.statusHistory;
+base {
+  new(title='Interface status', targets, description='Interfaces statuses'):
+    super.new(title, targets, description),
+
+  stylize(allLayers=true):
+    (if allLayers then super.stylize() else {})
+    + statusHistory.standardOptions.color.withMode('fixed')
+    + statusHistory.options.withShowValue('never')
+    + statusHistory.standardOptions.withMappings(
+      {
+        type: 'value',
+        options: {
+          '0': {
+            text: 'Down',
+            color: 'light-red',
+            index: 0,
+          },
+          '1': {
+            text: 'Up',
+            color: 'light-green',
+            index: 1,
+          },
+        },
+      }
+    ),
+}

--- a/common-lib/common/panels/network/statusHistory/main.libsonnet
+++ b/common-lib/common/panels/network/statusHistory/main.libsonnet
@@ -1,0 +1,3 @@
+{
+  interfaceStatus: import './interface_status.libsonnet',
+}

--- a/common-lib/common/panels/network/timeSeries/base.libsonnet
+++ b/common-lib/common/panels/network/timeSeries/base.libsonnet
@@ -16,7 +16,7 @@ base {
 
   withNegateOutPackets(regexp='/transmit|tx|out/'):
     defaults.custom.withAxisLabel('out(-) | in(+)')
-    + defaults.custom.withAxisCenteredZero(true)
+    + defaults.custom.withAxisCenteredZero(false)
     + timeSeries.standardOptions.withOverrides(
       fieldOverride.byRegexp.new(regexp)
       + fieldOverride.byRegexp.withPropertiesFromOptions(

--- a/common-lib/common/panels/system/timeSeries/base.libsonnet
+++ b/common-lib/common/panels/system/timeSeries/base.libsonnet
@@ -1,0 +1,10 @@
+local g = import '../../../g.libsonnet';
+local base = import '../../generic/timeSeries/base.libsonnet';
+local timeSeries = g.panel.timeSeries;
+local fieldOverride = g.panel.timeSeries.fieldOverride;
+local custom = timeSeries.fieldConfig.defaults.custom;
+local defaults = timeSeries.fieldConfig.defaults;
+local options = timeSeries.options;
+base {
+
+}

--- a/common-lib/common/panels/system/timeSeries/load_average.libsonnet
+++ b/common-lib/common/panels/system/timeSeries/load_average.libsonnet
@@ -1,0 +1,41 @@
+local g = import '../../../g.libsonnet';
+local generic = import '../../generic/timeSeries/main.libsonnet';
+local base = import './base.libsonnet';
+base {
+
+  new(
+    title='Load average',
+    loadTargets,
+    cpuCountTarget,
+    description=|||
+      System load average over the previous 1, 5, and 15 minute ranges.
+
+      A measurement of how many processes are waiting for CPU cycles. The maximum number is the number of CPU cores for the node.
+    |||
+  ):
+    // validate inputs
+    std.prune(
+      {
+        checks: [
+          if !(std.objectHas(cpuCountTarget, 'legendFormat')) then error 'cpuCountTarget must have legendFormat"',
+        ],
+      }
+    )
+    +
+    local targets = loadTargets + [cpuCountTarget];
+    super.new(title, targets, description)
+    // call directly threshold styler (not called from super automatically)
+    + self.stylizeCpuCores(cpuCountTarget.legendFormat),
+
+  stylizeCpuCores(cpuCountName):
+    generic.threshold.stylizeByRegexp(cpuCountName),
+
+  stylize(allLayers=true, cpuCountName=null):
+    (if allLayers then super.stylize() else {})
+
+    + g.panel.timeSeries.fieldConfig.defaults.custom.withFillOpacity(0)
+    + g.panel.timeSeries.standardOptions.withMin(0)
+    + g.panel.timeSeries.standardOptions.withUnit('short')
+    // this is only called if cpuCountName provided
+    + (if cpuCountName != null then self.stylizeCpuCores(cpuCountName) else {}),
+}

--- a/common-lib/common/panels/system/timeSeries/main.libsonnet
+++ b/common-lib/common/panels/system/timeSeries/main.libsonnet
@@ -1,0 +1,4 @@
+{
+  base: import './base.libsonnet',
+  loadAverage: import './load_average.libsonnet',
+}


### PR DESCRIPTION
Add new common panels:
- system -> timeSeries -> load average
- network -> statusHistory -> interface status
- cpu -> timeSeries -> cpu load by core

Update:
- network -> timeSeries - base:
change defaults.custom.withAxisCenteredZero to false in order preserve space inside panels when one of the traffic directions are empty.