### PR TITLE
Windows observ lib update

### DIFF
--- a/windows-observ-lib/dashboards.libsonnet
+++ b/windows-observ-lib/dashboards.libsonnet
@@ -27,7 +27,7 @@ local logslib = import 'github.com/grafana/jsonnet-libs/logs-lib/logs/main.libso
               panels.memotyUsageTopKPercent { gridPos+: { w: 24 } },
               panels.diskIOutilPercentTopK { gridPos+: { w: 12 } },
               panels.diskUsagePercentTopK { gridPos+: { w: 12 } },
-              panels.networkErrorsAndDroppedPerSec { gridPos+: { w: 24 } },
+              panels.networkErrorsAndDroppedPerSecTopK { gridPos+: { w: 24 } },
             ], 12, 7
           )
         )
@@ -57,7 +57,7 @@ local logslib = import 'github.com/grafana/jsonnet-libs/logs-lib/logs/main.libso
                       panels.diskUsage { gridPos+: { w: 12, h: 8 } },
                       g.panel.row.new('Network'),
                       panels.networkUsagePerSec { gridPos+: { w: 12, h: 8 } },
-                      panels.networkErrorsPerSec { gridPos+: { w: 12, h: 8 } },
+                      panels.networkErrorsAndDroppedPerSec { gridPos+: { w: 12, h: 8 } },
                     ], 6, 2
                   )
                 )
@@ -92,7 +92,7 @@ local logslib = import 'github.com/grafana/jsonnet-libs/logs-lib/logs/main.libso
                g.util.grid.wrapPanels(
                  [
                    g.panel.row.new('Disk'),
-                   panels.diskUsagePercent,
+                   panels.diskFreeTs,
                    panels.diskUsage,
                    panels.diskIOBytesPerSec,
                    panels.diskIOps,


### PR DESCRIPTION
[Update windows observ lib](https://github.com/grafana/jsonnet-libs/pull/1102/commits/8b60668c0857ac45a711f8a8357d07f69754c388)

- Rename CPU count -> Cores in fleet table
- Change filesystem space available TS graph to bytes (same as linux)
- Add networkErrorsAndDroppedPerSec(use in overview) and networkErrorsAndDroppedPerSecTopK(use in fleet dashboard) panels for errs and drops together
- Add fleet table footer (same as linux)
- Draw errors and dropped network packets (top 25) panel with points (looks better as data is sparse).