### PR TITLE
Fix threshold in generic.ts.threshold

### DIFF
--- a/common-lib/common/panels/generic/timeSeries/threshold.libsonnet
+++ b/common-lib/common/panels/generic/timeSeries/threshold.libsonnet
@@ -18,7 +18,7 @@ local fieldConfig = g.panel.timeSeries.fieldConfig;
     + timeSeries.standardOptions.color.withMode('fixed')
     + timeSeries.standardOptions.color.withFixedColor('light-orange'),
   stylizeByRegexp(regexp):
-    timeSeries.standardOptions.withOverrides(
+    timeSeries.standardOptions.withOverridesMixin(
       fieldOverride.byRegexp.new(regexp)
       + fieldOverride.byRegexp.withPropertiesFromOptions(this.stylize())
     ),


### PR DESCRIPTION
Using with*Mixin ensures that other unrelayed overrides are not deleted.