### PR TITLE
Adds InfluxDB Mixin

### DIFF
--- a/influxdb-mixin/.lint
+++ b/influxdb-mixin/.lint
@@ -1,0 +1,21 @@
+exclusions:
+  template-job-rule:
+    reason: "Prometheus datasource variable is being named as prometheus_datasource now while linter expects 'datasource'"
+  panel-datasource-rule:
+    reason: "Loki datasource variable is being named as loki_datasource now while linter expects 'datasource'"
+  template-datasource-rule:
+    reason: "Based on new convention we are using variable names prometheus_datasource and loki_datasource where as linter expects 'datasource'"
+  template-instance-rule:
+    reason: "Based on new convention we are using variable names prometheus_datasource and loki_datasource where as linter expects 'datasource'"
+  target-instance-rule:
+    reason: "The dashboard is a 'cluster' dashboard where the instance refers to nodes, this dashboard focuses only on the cluster view."
+    entries:
+      - dashboard: "InfluxDB cluster overview"
+  target-promql-rule:
+    reason: "Linter does not support selector variable value as a scalar in top-k PromQL queries."
+  template-label-promql-rule:
+    reason: "Defining a selector for the value of top-k requires a predefined label that the linter considers invalid."
+  panel-title-description-rule:
+    reason: "Not required for logs volume"
+  panel-units-rule:
+    reason: "Logs volume has no unit"

--- a/influxdb-mixin/Makefile
+++ b/influxdb-mixin/Makefile
@@ -1,0 +1,34 @@
+JSONNET_FMT := jsonnetfmt -n 2 --max-blank-lines 1 --string-style s --comment-style s
+
+.PHONY: all
+all: build dashboards_out prometheus_alerts.yaml
+
+vendor: jsonnetfile.json
+	jb install
+
+.PHONY: build
+build: vendor
+
+.PHONY: fmt
+fmt:
+	find . -name 'vendor' -prune -o -name '*.libsonnet' -print -o -name '*.jsonnet' -print | \
+		xargs -n 1 -- $(JSONNET_FMT) -i
+
+.PHONY: lint
+lint: build
+	find . -name 'vendor' -prune -o -name '*.libsonnet' -print -o -name '*.jsonnet' -print | \
+		while read f; do \
+			$(JSONNET_FMT) "$$f" | diff -u "$$f" -; \
+		done
+	mixtool lint mixin.libsonnet
+
+dashboards_out: mixin.libsonnet config.libsonnet $(wildcard dashboards/*)
+	@mkdir -p dashboards_out
+	mixtool generate dashboards mixin.libsonnet -d dashboards_out
+
+prometheus_alerts.yaml: mixin.libsonnet alerts/*.libsonnet
+	mixtool generate alerts mixin.libsonnet -a prometheus_alerts.yaml
+
+.PHONY: clean
+clean:
+	rm -rf dashboards_out prometheus_alerts.yaml

--- a/influxdb-mixin/README.md
+++ b/influxdb-mixin/README.md
@@ -1,0 +1,128 @@
+# InfluxDB mixin
+
+The InfluxDB mixin is a set of configurable Grafana dashboards and alerts.
+
+The InfluxDB mixin contains the following dashboards:
+
+- InfluxDB cluster overview
+- InfluxDB instance overview
+- InfluxDB logs overview
+
+and the following alerts:
+
+- InfluxDBWarningTaskSchedulerHighFailureRate
+- InfluxDBCriticalTaskSchedulerHighFailureRate
+- InfluxDBHighBusyWorkerPercentage
+- InfluxDBHighHeapMemoryUsage
+- InfluxDBHighAverageAPIRequestLatency
+- InfluxDBSlowAverageIQLExecutionTime
+
+## InfluxDB cluster overview
+
+The InfluxDB cluster overview dashboard provides details on performance of the cluster and highlights top instances. The dashboard covers all available aspects of InfluxDB performance and integration health, including golang performance, query/request load, and task scheduler activity.
+
+![First screenshot of the InfluxDB cluster overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/influxdb/screenshots/influxdb_cluster_overview_1.png)
+![Second screenshot of the InfluxDB cluster overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/influxdb/screenshots/influxdb_cluster_overview_2.png)
+![Third screenshot of the InfluxDB cluster overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/influxdb/screenshots/influxdb_cluster_overview_3.png)
+
+## InfluxDB instance overview
+
+The InfluxDB instance overview dashboard provides details on one or more instances, including instance configuration stats, golang performance, query/request load, and task scheduler activity.
+
+![First screenshot of the InfluxDB instance overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/influxdb/screenshots/influxdb_instance_overview_1.png)
+![Second screenshot of the InfluxDB instance overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/influxdb/screenshots/influxdb_instance_overview_2.png)
+![Third screenshot of the InfluxDB instance overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/influxdb/screenshots/influxdb_instance_overview_3.png)
+
+
+## InfluxDB logs overview
+
+The InfluxDB logs overview dashboard allows users to view incoming system logs. The dashboards also allows users to filter logs based on level, service, engine, and custom regex.
+
+![First screenshot of the InfluxDB logs dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/influxdb/screenshots/influxdb_logs_overview.png)
+
+InfluxDB system logs are enabled by default in the `config.libsonnet` and can be removed by setting `enableLokiLogs` to `false`. Then run `make` again to regenerate the dashboard:
+
+```
+{
+  _config+:: {
+    enableLokiLogs: false,
+  },
+}
+```
+
+In order for the selectors to properly work for system logs ingested into your logs datasource, please also include the matching `instance`, `job`, and `influxdb_cluster` labels onto the [scrape_configs](https://grafana.com/docs/loki/latest/clients/promtail/configuration/#scrape_configs) as to match the labels for ingested metrics.
+
+```yaml
+scrape_configs:
+  - job_name: integrations/influxdb
+    static_configs:
+      - targets: [localhost]
+        labels:
+          job: integrations/influxdb
+          influxdb_cluster: "<your-cluster-name>"
+          instance: "<your-instance-name>"
+          __path__: /var/log/influxdb/influxdb.log
+    pipeline_stages:
+        - multiline:
+            firstline: 'ts=\d{4}'
+        - regex:
+            expression: 'ts=(\S+) lvl=(?P<level>\w+) msg=.* log_id=(\S+) (service=(?P<service>\S+) ){0,1}(engine=(?P<engine>\S*) ){0,1}.*$'
+        - labels:
+            level:
+            service:
+            engine:
+```
+
+## Alerts overview
+
+- InfluxDBWarningTaskSchedulerHighFailureRate: Automated data processing tasks are failing at a high rate.
+- InfluxDBCriticalTaskSchedulerHighFailureRate: Automated data processing tasks are failing at a high rate.
+- InfluxDBHighBusyWorkerPercentage: There is a high percentage of busy workers.
+- InfluxDBHighHeapMemoryUsage: There is a high amount of heap memory being used.
+- InfluxDBHighAverageAPIRequestLatency: Average API request latency is too high. High latency will negatively affect system performance, degrading data availability and precision.
+- InfluxDBSlowAverageIQLExecutionTime: InfluxQL execution times are too slow. Slow query execution times will negatively affect system performance, degrading data availability and precision.
+
+Default thresholds can be configured in `config.libsonnet`.
+
+```js
+{
+  _config+:: {
+    alertsWarningTaskSchedulerHighFailureRate: 25, // %
+    alertsCriticalTaskSchedulerHighFailureRate: 50,  // %
+    alertsWarningHighBusyWorkerPercentage: 80,  // %
+    alertsWarningHighHeapMemoryUsage: 80,  // %
+    alertsWarningHighAverageAPIRequestLatency: 0.1, // count
+    alertsWarningSlowAverageIQLExecutionTime: 0.1, // count
+  },
+}
+```
+
+## Install tools
+
+```bash
+go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@latest
+go install github.com/monitoring-mixins/mixtool/cmd/mixtool@latest
+```
+
+For linting and formatting, you would also need `jsonnetfmt` installed. If you
+have a working Go development environment, it's easiest to run the following:
+
+```bash
+go install github.com/google/go-jsonnet/cmd/jsonnetfmt@latest
+```
+
+The files in `dashboards_out` need to be imported
+into your Grafana server. The exact details will be depending on your environment.
+
+`prometheus_alerts.yaml` needs to be imported into Prometheus.
+
+## Generate dashboards and alerts
+
+Edit `config.libsonnet` if required and then build JSON dashboard files for Grafana:
+
+```bash
+make
+```
+
+For more advanced uses of mixins, see
+https://github.com/monitoring-mixins/docs.

--- a/influxdb-mixin/README.md
+++ b/influxdb-mixin/README.md
@@ -40,7 +40,7 @@ The InfluxDB logs overview dashboard allows users to view incoming InfluxDB logs
 
 ![First screenshot of the InfluxDB logs dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/influxdb/screenshots/influxdb_logs_overview.png)
 
-InfluxDB system logs are enabled by default in the `config.libsonnet` and can be enabled by setting `enableLokiLogs` to `false`. Then run `make` again to regenerate the dashboard:
+InfluxDB system logs are enabled by default in the `config.libsonnet` and can be disabled by setting `enableLokiLogs` to `false`. Then run `make` again to regenerate the dashboard:
 
 ```
 {
@@ -112,7 +112,7 @@ go install github.com/google/go-jsonnet/cmd/jsonnetfmt@latest
 ```
 
 The files in `dashboards_out` need to be imported
-into your Grafana server. The exact details will be depending on your environment.
+into your Grafana server. The exact details will depend on your environment.
 
 `prometheus_alerts.yaml` needs to be imported into Prometheus.
 

--- a/influxdb-mixin/README.md
+++ b/influxdb-mixin/README.md
@@ -38,7 +38,7 @@ The InfluxDB instance overview dashboard provides details on one or more instanc
 
 The InfluxDB logs overview dashboard allows users to view incoming InfluxDB logs. The dashboard also allows users to filter logs based on level, service, engine, and custom regex.
 
-![First screenshot of the InfluxDB logs dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/influxdb/screenshots/influxdb_logs_overview.png)
+![Screenshot of the InfluxDB logs dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/influxdb/screenshots/influxdb_logs_overview.png)
 
 InfluxDB system logs are enabled by default in the `config.libsonnet` and can be disabled by setting `enableLokiLogs` to `false`. Then run `make` again to regenerate the dashboard:
 

--- a/influxdb-mixin/README.md
+++ b/influxdb-mixin/README.md
@@ -19,7 +19,7 @@ and the following alerts:
 
 ## InfluxDB cluster overview
 
-The InfluxDB cluster overview dashboard provides details on performance of the cluster and highlights top instances. The dashboard covers all available aspects of InfluxDB performance and integration health, including golang performance, query/request load, and task scheduler activity.
+The InfluxDB cluster overview dashboard provides details on the cluster's performance and highlights top instances. The dashboard covers all available aspects of InfluxDB performance and integration health, including Golang performance, query/request load, and task scheduler activity.
 
 ![First screenshot of the InfluxDB cluster overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/influxdb/screenshots/influxdb_cluster_overview_1.png)
 ![Second screenshot of the InfluxDB cluster overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/influxdb/screenshots/influxdb_cluster_overview_2.png)
@@ -27,7 +27,7 @@ The InfluxDB cluster overview dashboard provides details on performance of the c
 
 ## InfluxDB instance overview
 
-The InfluxDB instance overview dashboard provides details on one or more instances, including instance configuration stats, golang performance, query/request load, and task scheduler activity.
+The InfluxDB instance overview dashboard provides details on one or more instances, including instance configuration stats, Golang performance, query/request load, and task scheduler activity.
 
 ![First screenshot of the InfluxDB instance overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/influxdb/screenshots/influxdb_instance_overview_1.png)
 ![Second screenshot of the InfluxDB instance overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/influxdb/screenshots/influxdb_instance_overview_2.png)
@@ -36,11 +36,11 @@ The InfluxDB instance overview dashboard provides details on one or more instanc
 
 ## InfluxDB logs overview
 
-The InfluxDB logs overview dashboard allows users to view incoming system logs. The dashboards also allows users to filter logs based on level, service, engine, and custom regex.
+The InfluxDB logs overview dashboard allows users to view incoming InfluxDB logs. The dashboard also allows users to filter logs based on level, service, engine, and custom regex.
 
 ![First screenshot of the InfluxDB logs dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/influxdb/screenshots/influxdb_logs_overview.png)
 
-InfluxDB system logs are enabled by default in the `config.libsonnet` and can be removed by setting `enableLokiLogs` to `false`. Then run `make` again to regenerate the dashboard:
+InfluxDB system logs are enabled by default in the `config.libsonnet` and can be enabled by setting `enableLokiLogs` to `false`. Then run `make` again to regenerate the dashboard:
 
 ```
 {
@@ -50,7 +50,7 @@ InfluxDB system logs are enabled by default in the `config.libsonnet` and can be
 }
 ```
 
-In order for the selectors to properly work for system logs ingested into your logs datasource, please also include the matching `instance`, `job`, and `influxdb_cluster` labels onto the [scrape_configs](https://grafana.com/docs/loki/latest/clients/promtail/configuration/#scrape_configs) as to match the labels for ingested metrics.
+For the selectors to properly work for InfluxDB logs ingested into your logs datasource, please also include the matching `instance`, `job`, and `influxdb_cluster` labels in the [scrape_configs](https://grafana.com/docs/loki/latest/clients/promtail/configuration/#scrape_configs) to match the labels for ingested metrics.
 
 ```yaml
 scrape_configs:
@@ -76,7 +76,7 @@ scrape_configs:
 ## Alerts overview
 
 - InfluxDBWarningTaskSchedulerHighFailureRate: Automated data processing tasks are failing at a high rate.
-- InfluxDBCriticalTaskSchedulerHighFailureRate: Automated data processing tasks are failing at a high rate.
+- InfluxDBCriticalTaskSchedulerHighFailureRate: Automated data processing tasks are failing at a critical rate.
 - InfluxDBHighBusyWorkerPercentage: There is a high percentage of busy workers.
 - InfluxDBHighHeapMemoryUsage: There is a high amount of heap memory being used.
 - InfluxDBHighAverageAPIRequestLatency: Average API request latency is too high. High latency will negatively affect system performance, degrading data availability and precision.

--- a/influxdb-mixin/alerts/alerts.libsonnet
+++ b/influxdb-mixin/alerts/alerts.libsonnet
@@ -89,7 +89,7 @@
               summary: 'Average API request latency is too high. High latency will negatively affect system performance, degrading data availability and precision.',
               description:
                 (
-                  'The average API request latency for instance {{$labels.instance}} on cluster {{$labels.influxdb_cluster}} is {{ printf "%%.0f" $value }} seconds, which is above the threshold of %(alertsWarningHighAverageAPIRequestLatency)s seconds.'
+                  'The average API request latency for instance {{$labels.instance}} on cluster {{$labels.influxdb_cluster}} is {{ printf "%%.2f" $value }} seconds, which is above the threshold of %(alertsWarningHighAverageAPIRequestLatency)s seconds.'
                 ) % $._config,
             },
           },
@@ -106,7 +106,7 @@
               summary: 'InfluxQL execution times are too slow. Slow query execution times will negatively affect system performance, degrading data availability and precision.',
               description:
                 (
-                  'The average InfluxQL query execution time for instance {{$labels.instance}} on cluster {{$labels.influxdb_cluster}} is {{ printf "%%.0f" $value }} seconds, ' +
+                  'The average InfluxQL query execution time for instance {{$labels.instance}} on cluster {{$labels.influxdb_cluster}} is {{ printf "%%.2f" $value }} seconds, ' +
                   'which is above the threshold of %(alertsWarningSlowAverageIQLExecutionTime)s seconds.'
                 ) % $._config,
             },

--- a/influxdb-mixin/alerts/alerts.libsonnet
+++ b/influxdb-mixin/alerts/alerts.libsonnet
@@ -32,7 +32,7 @@
               severity: 'critical',
             },
             annotations: {
-              summary: 'Automated data processing tasks are failing at a high rate.',
+              summary: 'Automated data processing tasks are failing at a critical rate.',
               description:
                 (
                   'Task scheduler task executions for instance {{$labels.instance}} on cluster {{$labels.influxdb_cluster}} are failing at a rate of {{ printf "%%.0f" $value }} percent, ' +

--- a/influxdb-mixin/alerts/alerts.libsonnet
+++ b/influxdb-mixin/alerts/alerts.libsonnet
@@ -1,0 +1,118 @@
+{
+  prometheusAlerts+:: {
+    groups+: [
+      {
+        name: 'influxdb',
+        rules: [
+          {
+            alert: 'InfluxDBWarningTaskSchedulerHighFailureRate',
+            expr: |||
+              100 * rate(task_scheduler_total_execute_failure[5m])/clamp_min(rate(task_scheduler_total_execution_calls[5m]), 1) >= %(alertsWarningTaskSchedulerHighFailureRate)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              summary: 'Automated data processing tasks are failing at a high rate.',
+              description:
+                (
+                  'Task scheduler task executions for instance {{$labels.instance}} on cluster {{$labels.influxdb_cluster}} are failing at a rate of {{ printf "%%.0f" $value }} percent, ' +
+                  'which is above the threshold of %(alertsWarningTaskSchedulerHighFailureRate)s percent.'
+                ) % $._config,
+            },
+          },
+          {
+            alert: 'InfluxDBCriticalTaskSchedulerHighFailureRate',
+            expr: |||
+              100 * rate(task_scheduler_total_execute_failure[5m])/clamp_min(rate(task_scheduler_total_execution_calls[5m]), 1) >= %(alertsCriticalTaskSchedulerHighFailureRate)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              summary: 'Automated data processing tasks are failing at a high rate.',
+              description:
+                (
+                  'Task scheduler task executions for instance {{$labels.instance}} on cluster {{$labels.influxdb_cluster}} are failing at a rate of {{ printf "%%.0f" $value }} percent, ' +
+                  'which is above the threshold of %(alertsCriticalTaskSchedulerHighFailureRate)s percent.'
+                ) % $._config,
+            },
+          },
+          {
+            alert: 'InfluxDBHighBusyWorkerPercentage',
+            expr: |||
+              task_executor_workers_busy >= %(alertsWarningHighBusyWorkerPercentage)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              summary: 'There is a high percentage of busy workers.',
+              description:
+                (
+                  'The busy worker percentage for instance {{$labels.instance}} on cluster {{$labels.influxdb_cluster}} is {{ printf "%%.0f" $value }} percent, ' +
+                  'which is above the threshold of %(alertsWarningHighBusyWorkerPercentage)s percent.'
+                ) % $._config,
+            },
+          },
+          {
+            alert: 'InfluxDBHighHeapMemoryUsage',
+            expr: |||
+              100 * go_memstats_heap_alloc_bytes/clamp_min((go_memstats_heap_idle_bytes + go_memstats_heap_alloc_bytes), 1) >= %(alertsWarningHighHeapMemoryUsage)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              summary: 'There is a high amount of heap memory being used.',
+              description:
+                (
+                  'The heap memory usage for instance {{$labels.instance}} on cluster {{$labels.influxdb_cluster}} is {{ printf "%%.0f" $value }} percent, ' +
+                  'which is above the threshold of %(alertsWarningHighHeapMemoryUsage)s percent.'
+                ) % $._config,
+            },
+          },
+          {
+            alert: 'InfluxDBHighAverageAPIRequestLatency',
+            expr: |||
+              sum without(handler, method, path, response_code, status, user_agent) (increase(http_api_request_duration_seconds_sum[5m])/clamp_min(increase(http_api_requests_total[5m]), 1)) >= %(alertsWarningHighAverageAPIRequestLatency)s
+            ||| % $._config,
+            'for': '1m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              summary: 'Average API request latency is too high. High latency will negatively affect system performance, degrading data availability and precision.',
+              description:
+                (
+                  'The average API request latency for instance {{$labels.instance}} on cluster {{$labels.influxdb_cluster}} is {{ printf "%%.0f" $value }} seconds, which is above the threshold of %(alertsWarningHighAverageAPIRequestLatency)s seconds.'
+                ) % $._config,
+            },
+          },
+          {
+            alert: 'InfluxDBSlowAverageIQLExecutionTime',
+            expr: |||
+              sum without(result) (increase(influxql_service_executing_duration_seconds_sum[5m])/clamp_min(increase(influxql_service_requests_total[5m]), 1)) >= %(alertsWarningSlowAverageIQLExecutionTime)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              summary: 'InfluxQL execution times are too slow. Slow query execution times will negatively affect system performance, degrading data availability and precision.',
+              description:
+                (
+                  'The average InfluxQL query execution time for instance {{$labels.instance}} on cluster {{$labels.influxdb_cluster}} is {{ printf "%%.0f" $value }} seconds, ' +
+                  'which is above the threshold of %(alertsWarningSlowAverageIQLExecutionTime)s seconds.'
+                ) % $._config,
+            },
+          },
+        ],
+      },
+    ],
+  },
+}

--- a/influxdb-mixin/config.libsonnet
+++ b/influxdb-mixin/config.libsonnet
@@ -1,0 +1,23 @@
+{
+  _config+:: {
+    enableMultiCluster: false,
+    influxdbSelector: if self.enableMultiCluster then 'job=~"$job", cluster=~"$cluster"' else 'job=~"$job"',
+    multiclusterSelector: 'job=~"$job"',
+    filterSelector: 'job=~"integrations/influxdb"',
+
+    dashboardTags: ['influxdb-mixin'],
+    dashboardPeriod: 'now-30m',
+    dashboardTimezone: 'default',
+    dashboardRefresh: '1m',
+
+    // alerts thresholds
+    alertsWarningTaskSchedulerHighFailureRate: 25,  // %
+    alertsCriticalTaskSchedulerHighFailureRate: 50,  // %
+    alertsWarningHighBusyWorkerPercentage: 80,  // %
+    alertsWarningHighHeapMemoryUsage: 80,  // %
+    alertsWarningHighAverageAPIRequestLatency: 0.1,  // count
+    alertsWarningSlowAverageIQLExecutionTime: 0.1,  // count
+
+    enableLokiLogs: true,
+  },
+}

--- a/influxdb-mixin/config.libsonnet
+++ b/influxdb-mixin/config.libsonnet
@@ -15,7 +15,7 @@
     alertsCriticalTaskSchedulerHighFailureRate: 50,  // %
     alertsWarningHighBusyWorkerPercentage: 80,  // %
     alertsWarningHighHeapMemoryUsage: 80,  // %
-    alertsWarningHighAverageAPIRequestLatency: 0.1,  // count
+    alertsWarningHighAverageAPIRequestLatency: 0.3,  // count
     alertsWarningSlowAverageIQLExecutionTime: 0.1,  // count
 
     enableLokiLogs: true,

--- a/influxdb-mixin/dashboards/dashboards.libsonnet
+++ b/influxdb-mixin/dashboards/dashboards.libsonnet
@@ -1,0 +1,3 @@
+(import 'influxdb-cluster-overview.libsonnet') +
+(import 'influxdb-instance-overview.libsonnet') +
+(import 'influxdb-logs-overview.libsonnet')

--- a/influxdb-mixin/dashboards/influxdb-cluster-overview.libsonnet
+++ b/influxdb-mixin/dashboards/influxdb-cluster-overview.libsonnet
@@ -379,7 +379,7 @@ local httpAPIResponseCodesPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(job, influxdb_cluster, response_code) (rate(http_api_requests_total{' + matcher + '}[$__rate_interval]))',
+      'sum by(job, influxdb_cluster, response_code) (rate(http_api_requests_total{' + matcher + '}[$__rate_interval])) > 0',
       datasource=promDatasource,
       legendFormat='{{influxdb_cluster}} - {{response_code}}',
     ),
@@ -429,12 +429,12 @@ local httpOperationsPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(job, influxdb_cluster, status) (rate(http_query_request_count{' + matcher + '}[$__rate_interval]))',
+      'sum by(job, influxdb_cluster, status) (rate(http_query_request_count{' + matcher + '}[$__rate_interval])) > 0',
       datasource=promDatasource,
       legendFormat='{{influxdb_cluster}} - query - {{status}}',
     ),
     prometheus.target(
-      'sum by(job, influxdb_cluster, status) (rate(http_write_request_count{' + matcher + '}[$__rate_interval]))',
+      'sum by(job, influxdb_cluster, status) (rate(http_write_request_count{' + matcher + '}[$__rate_interval])) > 0',
       datasource=promDatasource,
       legendFormat='{{influxdb_cluster}} - write - {{status}}',
     ),

--- a/influxdb-mixin/dashboards/influxdb-cluster-overview.libsonnet
+++ b/influxdb-mixin/dashboards/influxdb-cluster-overview.libsonnet
@@ -1,0 +1,1435 @@
+local g = (import 'grafana-builder/grafana.libsonnet');
+local grafana = (import 'grafonnet/grafana.libsonnet');
+local dashboard = grafana.dashboard;
+local template = grafana.template;
+local prometheus = grafana.prometheus;
+
+local dashboardUid = 'influxdb-cluster-overview';
+
+local promDatasourceName = 'prometheus_datasource';
+
+local promDatasource = {
+  uid: '${%s}' % promDatasourceName,
+};
+
+local alertsPanel(matcher) = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      '',
+      datasource=promDatasource,
+      legendFormat='',
+    ),
+  ],
+  type: 'alertlist',
+  title: 'Alerts',
+  description: 'Panel to report on the status of firing alerts.',
+  options: {
+    alertInstanceLabelFilter: '{job=~"${job:regex}", influxdb_cluster=~"${influxdb_cluster:regex}"}',
+    alertName: '',
+    dashboardAlerts: false,
+    groupBy: [],
+    groupMode: 'default',
+    maxItems: 20,
+    sortOrder: 1,
+    stateFilter: {
+      'error': true,
+      firing: true,
+      noData: false,
+      normal: false,
+      pending: true,
+    },
+    viewMode: 'list',
+  },
+};
+
+local serversPanel(matcher) = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'influxdb_uptime_seconds{' + matcher + '}',
+      datasource=promDatasource,
+      legendFormat='Uptime',
+      format='table',
+    ),
+    prometheus.target(
+      'influxdb_buckets_total{' + matcher + '}',
+      datasource=promDatasource,
+      legendFormat='Buckets',
+      format='table',
+    ),
+    prometheus.target(
+      'influxdb_users_total{' + matcher + '}',
+      datasource=promDatasource,
+      legendFormat='Users',
+      format='table',
+    ),
+    prometheus.target(
+      'influxdb_replications_total{' + matcher + '}',
+      datasource=promDatasource,
+      legendFormat='Replications',
+      format='table',
+    ),
+    prometheus.target(
+      'influxdb_remotes_total{' + matcher + '}',
+      datasource=promDatasource,
+      legendFormat='Remotes',
+      format='table',
+    ),
+    prometheus.target(
+      'influxdb_scrapers_total{' + matcher + '}',
+      datasource=promDatasource,
+      legendFormat='Scrapers',
+      format='table',
+    ),
+    prometheus.target(
+      'influxdb_dashboards_total{' + matcher + '}',
+      datasource=promDatasource,
+      legendFormat='Dashboards',
+      format='table',
+    ),
+  ],
+  type: 'table',
+  title: 'Servers',
+  description: 'Statistics for each instance in the cluster.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      custom: {
+        align: 'left',
+        cellOptions: {
+          type: 'auto',
+        },
+        inspect: false,
+      },
+      links: [],
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+    },
+    overrides: [
+      {
+        matcher: {
+          id: 'byName',
+          options: 'instance',
+        },
+        properties: [
+          {
+            id: 'links',
+            value: [
+              {
+                title: 'Instance overview',
+                url: '/d/influxdb-instance-overview?from=${__from}&to=${__to}&var-instance=${__data.fields["Instance"]}',
+              },
+            ],
+          },
+        ],
+      },
+      {
+        matcher: {
+          id: 'byName',
+          options: 'Uptime',
+        },
+        properties: [
+          {
+            id: 'unit',
+            value: 's',
+          },
+        ],
+      },
+    ],
+  },
+  options: {
+    cellHeight: 'sm',
+    footer: {
+      countRows: false,
+      fields: '',
+      reducer: [
+        'sum',
+      ],
+      show: false,
+    },
+    showHeader: true,
+  },
+  pluginVersion: '10.3.0-63516',
+  transformations: [
+    {
+      id: 'joinByField',
+      options: {
+        byField: 'instance',
+        mode: 'outer',
+      },
+    },
+    {
+      id: 'organize',
+      options: {
+        excludeByName: {
+          Time: true,
+          'Time 2': true,
+          'Time 3': true,
+          'Time 4': true,
+          'Time 5': true,
+          'Time 6': true,
+          'Time 7': true,
+          'Value #B': false,
+          'Value #H': true,
+          __name__: true,
+          '__name__ 1': true,
+          '__name__ 2': true,
+          '__name__ 3': true,
+          '__name__ 4': true,
+          '__name__ 5': true,
+          '__name__ 6': true,
+          '__name__ 7': true,
+          id: true,
+          influxdb_cluster: false,
+          'influxdb_cluster 2': true,
+          'influxdb_cluster 3': true,
+          'influxdb_cluster 4': true,
+          'influxdb_cluster 5': true,
+          'influxdb_cluster 6': true,
+          'influxdb_cluster 7': true,
+          job: true,
+          'job 2': true,
+          'job 3': true,
+          'job 4': true,
+          'job 5': true,
+          'job 6': true,
+          'job 7': true,
+        },
+        indexByName: {},
+        renameByName: {
+          Dashboards: '',
+          'Value #A': 'Uptime',
+          'Value #B': 'Buckets',
+          'Value #C': 'Users',
+          'Value #D': 'Replications',
+          'Value #E': 'Remotes',
+          'Value #F': 'Scrapers',
+          'Value #G': 'Dashboards',
+          influxdb_cluster: 'Cluster',
+          instance: 'Instance',
+        },
+      },
+    },
+  ],
+};
+
+local goRow = {
+  datasource: promDatasource,
+  targets: [],
+  type: 'row',
+  title: 'Go',
+  collapsed: false,
+};
+
+local topInstancesByHeapMemoryUsagePanel(matcher) = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'topk($k, go_memstats_heap_alloc_bytes{' + matcher + '}/clamp_min(go_memstats_heap_idle_bytes{' + matcher + '} + go_memstats_heap_alloc_bytes{' + matcher + '}, 1))',
+      datasource=promDatasource,
+      legendFormat='{{influxdb_cluster}} - {{instance}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Top instances by heap memory usage',
+  description: 'Heap memory usage for the largest instances in the cluster.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'continuous-BlYlRd',
+      },
+      custom: {
+        axisBorderShow: false,
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 20,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      max: 1,
+      min: 0,
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'percentunit',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local topInstancesByGCCPUUsagePanel(matcher) = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'go_memstats_gc_cpu_fraction{' + matcher + '}',
+      datasource=promDatasource,
+      legendFormat='{{influxdb_cluster}} - {{instance}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Top instances by GC CPU usage',
+  description: 'Fraction of CPU time used for garbage collection for the top instances in the cluster.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'continuous-BlYlRd',
+      },
+      custom: {
+        axisBorderShow: false,
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 20,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      max: 100,
+      min: 0,
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'percent',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local queriesAndOperationsRow = {
+  datasource: promDatasource,
+  targets: [],
+  type: 'row',
+  title: 'Queries and operations',
+  collapsed: false,
+};
+
+local topInstancesByHTTPAPIRequestsPanel(matcher) = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'topk($k, sum by(job, influxdb_cluster, instance) (rate(http_api_requests_total{' + matcher + '}[$__rate_interval])))',
+      datasource=promDatasource,
+      legendFormat='{{influxdb_cluster}} - {{instance}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Top instances by HTTP API requests',
+  description: 'HTTP API request rate for the instances with the most traffic in the cluster.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisBorderShow: false,
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 20,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'reqps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local httpAPIRequestDurationPanel(matcher) = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'histogram_quantile(0.95, sum by(le, job, influxdb_cluster) (rate(http_api_request_duration_seconds_bucket{' + matcher + '}[$__rate_interval])))',
+      datasource=promDatasource,
+      legendFormat='{{influxdb_cluster}}',
+    ),
+  ],
+  type: 'histogram',
+  title: 'HTTP API request duration',
+  description: 'Time taken to respond to HTTP API requests for the cluster.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      custom: {
+        fillOpacity: 80,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineWidth: 1,
+      },
+      decimals: 0,
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 's',
+    },
+    overrides: [],
+  },
+  options: {
+    bucketOffset: 0,
+    combine: false,
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+  },
+};
+
+local httpAPIResponseCodesPanel(matcher) = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by(job, influxdb_cluster, response_code) (rate(http_api_requests_total{' + matcher + '}[$__rate_interval]))',
+      datasource=promDatasource,
+      legendFormat='{{influxdb_cluster}} - {{response_code}}',
+    ),
+  ],
+  type: 'piechart',
+  title: 'HTTP API response codes',
+  description: 'Rate of different HTTP response codes for the entire cluster.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+      },
+      mappings: [],
+      unit: 'reqps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      displayMode: 'list',
+      placement: 'right',
+      showLegend: true,
+    },
+    pieType: 'pie',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local httpOperationsPanel(matcher) = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by(job, influxdb_cluster, status) (rate(http_query_request_count{' + matcher + '}[$__rate_interval]))',
+      datasource=promDatasource,
+      legendFormat='{{influxdb_cluster}} - query - {{status}}',
+    ),
+    prometheus.target(
+      'sum by(job, influxdb_cluster, status) (rate(http_write_request_count{' + matcher + '}[$__rate_interval]))',
+      datasource=promDatasource,
+      legendFormat='{{influxdb_cluster}} - write - {{status}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'HTTP operations',
+  description: 'Rate of database operations from HTTP for the cluster.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisBorderShow: false,
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 20,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'ops',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local httpOperationDataPanel(matcher) = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by(job, influxdb_cluster) (rate(http_query_request_bytes{' + matcher + '}[$__rate_interval]))',
+      datasource=promDatasource,
+      legendFormat='{{influxdb_cluster}} - query - request',
+    ),
+    prometheus.target(
+      'sum by(job, influxdb_cluster) (rate(http_query_response_bytes{' + matcher + '}[$__rate_interval]))',
+      datasource=promDatasource,
+      legendFormat='{{influxdb_cluster}} - query - response',
+    ),
+    prometheus.target(
+      'sum by(job, influxdb_cluster) (rate(http_write_request_bytes{' + matcher + '}[$__rate_interval]))',
+      datasource=promDatasource,
+      legendFormat='{{influxdb_cluster}} - write - request',
+    ),
+    prometheus.target(
+      'sum by(job, influxdb_cluster) (rate(http_write_response_bytes{' + matcher + '}[$__rate_interval]))',
+      datasource=promDatasource,
+      legendFormat='{{influxdb_cluster}} - write - response',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'HTTP operation data',
+  description: 'Rate of database HTTP operation data for the cluster.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisBorderShow: false,
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 20,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'Bps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [
+        'min',
+        'mean',
+        'max',
+      ],
+      displayMode: 'table',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local topInstancesByIQLQueryRatePanel(matcher) = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'topk($k, sum by(job, influxdb_cluster, instance) (rate(influxql_service_requests_total{' + matcher + '}[$__rate_interval])))',
+      datasource=promDatasource,
+      legendFormat='{{influxdb_cluster}} - {{instance}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Top instances by IQL query rate',
+  description: 'Rate of InfluxQL queries for the instances with the most traffic in the cluster.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisBorderShow: false,
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 20,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'query/s',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local iqlQueryResponseTimePanel(matcher) = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by(job, influxdb_cluster, result) (increase(influxql_service_executing_duration_seconds_sum{' + matcher + '}[$__interval:]))',
+      datasource=promDatasource,
+      legendFormat='{{influxdb_cluster}} - {{result}}',
+      interval='1m',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'IQL query response time / $__interval',
+  description: 'Response time for recent InfluxQL queries, organized by result.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisBorderShow: false,
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 20,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 's',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local boltdbOperationsPanel(matcher) = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'rate(boltdb_reads_total{' + matcher + '}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='{{influxdb_cluster}} - reads',
+    ),
+    prometheus.target(
+      'rate(boltdb_writes_total{' + matcher + '}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='{{influxdb_cluster}} - writes',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'BoltDB operations',
+  description: 'Rate of reads and writes to the underlying BoltDB storage engine for the entire cluster.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisBorderShow: false,
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 20,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'ops',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local taskSchedulerRow = {
+  datasource: promDatasource,
+  targets: [],
+  type: 'row',
+  title: 'Task scheduler',
+  collapsed: false,
+};
+
+local activeTasksPanel(matcher) = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by(job, influxdb_cluster) (task_scheduler_current_execution{' + matcher + '})',
+      datasource=promDatasource,
+      legendFormat='{{influxdb_cluster}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Active tasks',
+  description: 'Number of tasks currently being executed for the cluster.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisBorderShow: false,
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 20,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local activeWorkersPanel(matcher) = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by(job, influxdb_cluster) (task_executor_total_runs_active{' + matcher + '})',
+      datasource=promDatasource,
+      legendFormat='{{influxdb_cluster}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Active workers',
+  description: 'Number of workers currently running tasks on the cluster.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisBorderShow: false,
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 20,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local executionsPanel(matcher) = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'rate(task_scheduler_total_execution_calls{' + matcher + '}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='{{influxdb_cluster}} - total',
+    ),
+    prometheus.target(
+      'rate(task_scheduler_total_execute_failure{' + matcher + '}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='{{influxdb_cluster}} - failed',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Executions',
+  description: 'Rate of executions and execution failures for the cluster.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisBorderShow: false,
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 20,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'ops',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local schedulesPanel(matcher) = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'rate(task_scheduler_total_schedule_calls{' + matcher + '}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='{{influxdb_cluster}} - total',
+    ),
+    prometheus.target(
+      'rate(task_scheduler_total_schedule_fails{' + matcher + '}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='{{influxdb_cluster}} - failed',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Schedules',
+  description: 'Rate of schedule operations and schedule operation failures for the cluster.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisBorderShow: false,
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 20,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'ops',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local getMatcher(cfg) = '%(influxdbSelector)s, influxdb_cluster=~"$influxdb_cluster"' % cfg;
+
+{
+  grafanaDashboards+:: {
+    'influxdb-cluster-overview.json':
+      dashboard.new(
+        'InfluxDB cluster overview',
+        time_from='%s' % $._config.dashboardPeriod,
+        tags=($._config.dashboardTags),
+        timezone='%s' % $._config.dashboardTimezone,
+        refresh='%s' % $._config.dashboardRefresh,
+        description='',
+        uid=dashboardUid,
+      )
+      .addLink(grafana.link.dashboards(
+        asDropdown=false,
+        title='Other InfluxDB dashboards',
+        includeVars=true,
+        keepTime=true,
+        tags=($._config.dashboardTags),
+      ))
+      .addTemplates(
+        [
+          template.datasource(
+            promDatasourceName,
+            'prometheus',
+            null,
+            label='Data Source',
+            refresh='load'
+          ),
+          template.new(
+            'job',
+            promDatasource,
+            'label_values(influxdb_uptime_seconds,job)',
+            label='Job',
+            refresh=2,
+            includeAll=true,
+            multi=true,
+            allValues='.+',
+            sort=0
+          ),
+          template.new(
+            'cluster',
+            promDatasource,
+            'label_values(influxdb_uptime_seconds{%(multiclusterSelector)s}, cluster)' % $._config,
+            label='Cluster',
+            refresh=2,
+            includeAll=true,
+            multi=true,
+            allValues='.*',
+            hide=if $._config.enableMultiCluster then '' else 'variable',
+            sort=0
+          ),
+          template.new(
+            'influxdb_cluster',
+            promDatasource,
+            'label_values(influxdb_uptime_seconds{%(influxdbSelector)s}, influxdb_cluster)' % $._config,
+            label='InfluxDB cluster',
+            refresh=2,
+            includeAll=true,
+            multi=true,
+            allValues='',
+            sort=0
+          ),
+          template.custom(
+            'k',
+            query='5,10,20,50',
+            current='5',
+            label='Top node count',
+            refresh='never',
+            includeAll=false,
+            multi=false,
+            allValues='',
+          ),
+        ]
+      )
+      .addPanels(
+        [
+          alertsPanel(getMatcher($._config)) { gridPos: { h: 8, w: 7, x: 0, y: 0 } },
+          serversPanel(getMatcher($._config)) { gridPos: { h: 8, w: 17, x: 7, y: 0 } },
+          goRow { gridPos: { h: 1, w: 24, x: 0, y: 8 } },
+          topInstancesByHeapMemoryUsagePanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 0, y: 9 } },
+          topInstancesByGCCPUUsagePanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 12, y: 9 } },
+          queriesAndOperationsRow { gridPos: { h: 1, w: 24, x: 0, y: 17 } },
+          topInstancesByHTTPAPIRequestsPanel(getMatcher($._config)) { gridPos: { h: 8, w: 8, x: 0, y: 18 } },
+          httpAPIRequestDurationPanel(getMatcher($._config)) { gridPos: { h: 8, w: 8, x: 8, y: 18 } },
+          httpAPIResponseCodesPanel(getMatcher($._config)) { gridPos: { h: 8, w: 8, x: 16, y: 18 } },
+          httpOperationsPanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 0, y: 26 } },
+          httpOperationDataPanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 12, y: 26 } },
+          topInstancesByIQLQueryRatePanel(getMatcher($._config)) { gridPos: { h: 8, w: 8, x: 0, y: 34 } },
+          iqlQueryResponseTimePanel(getMatcher($._config)) { gridPos: { h: 8, w: 8, x: 8, y: 34 } },
+          boltdbOperationsPanel(getMatcher($._config)) { gridPos: { h: 8, w: 8, x: 16, y: 34 } },
+          taskSchedulerRow { gridPos: { h: 1, w: 24, x: 0, y: 42 } },
+          activeTasksPanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 0, y: 43 } },
+          activeWorkersPanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 12, y: 43 } },
+          executionsPanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 0, y: 51 } },
+          schedulesPanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 12, y: 51 } },
+        ]
+      ),
+  },
+}

--- a/influxdb-mixin/dashboards/influxdb-cluster-overview.libsonnet
+++ b/influxdb-mixin/dashboards/influxdb-cluster-overview.libsonnet
@@ -205,6 +205,13 @@ local serversPanel(matcher) = {
           'job 5': true,
           'job 6': true,
           'job 7': true,
+          'cluster 7': true,
+          'cluster 2': true,
+          cluster: false,
+          'cluster 3': true,
+          'cluster 4': true,
+          'cluster 5': true,
+          'cluster 6': true,
         },
         indexByName: {},
         renameByName: {
@@ -216,8 +223,9 @@ local serversPanel(matcher) = {
           'Value #E': 'Remotes',
           'Value #F': 'Scrapers',
           'Value #G': 'Dashboards',
-          influxdb_cluster: 'Cluster',
+          influxdb_cluster: 'InfluxDB cluster',
           instance: 'Instance',
+          cluster: 'K8s cluster',
         },
       },
     },
@@ -406,7 +414,7 @@ local topInstancesByHTTPAPIRequestsPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'topk($k, sum by(job, influxdb_cluster, instance) (rate(http_api_requests_total{' + matcher + '}[$__rate_interval])))',
+      'topk($k, sum by(' + matcher + ', instance) (rate(http_api_requests_total{' + matcher + '}[$__rate_interval])))',
       datasource=promDatasource,
       legendFormat='{{influxdb_cluster}} - {{instance}}',
     ),
@@ -487,7 +495,7 @@ local httpAPIRequestDurationPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'histogram_quantile(0.95, sum by(le, job, influxdb_cluster) (rate(http_api_request_duration_seconds_bucket{' + matcher + '}[$__rate_interval])))',
+      'histogram_quantile(0.95, sum by(le, ' + matcher + ') (rate(http_api_request_duration_seconds_bucket{' + matcher + '}[$__rate_interval])))',
       datasource=promDatasource,
       legendFormat='{{influxdb_cluster}}',
     ),
@@ -541,7 +549,7 @@ local httpAPIResponseCodesPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(job, influxdb_cluster, response_code) (rate(http_api_requests_total{' + matcher + '}[$__rate_interval]))',
+      'sum by(' + matcher + ', response_code) (rate(http_api_requests_total{' + matcher + '}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='{{influxdb_cluster}} - {{response_code}}',
     ),
@@ -591,12 +599,12 @@ local httpOperationsPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(job, influxdb_cluster, status) (rate(http_query_request_count{' + matcher + '}[$__rate_interval]))',
+      'sum by(' + matcher + ', status) (rate(http_query_request_count{' + matcher + '}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='{{influxdb_cluster}} - query - {{status}}',
     ),
     prometheus.target(
-      'sum by(job, influxdb_cluster, status) (rate(http_write_request_count{' + matcher + '}[$__rate_interval]))',
+      'sum by(' + matcher + ', status) (rate(http_write_request_count{' + matcher + '}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='{{influxdb_cluster}} - write - {{status}}',
     ),
@@ -673,22 +681,22 @@ local httpOperationDataPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(job, influxdb_cluster) (rate(http_query_request_bytes{' + matcher + '}[$__rate_interval]))',
+      'sum by(' + matcher + ') (rate(http_query_request_bytes{' + matcher + '}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='{{influxdb_cluster}} - query - request',
     ),
     prometheus.target(
-      'sum by(job, influxdb_cluster) (rate(http_query_response_bytes{' + matcher + '}[$__rate_interval]))',
+      'sum by(' + matcher + ') (rate(http_query_response_bytes{' + matcher + '}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='{{influxdb_cluster}} - query - response',
     ),
     prometheus.target(
-      'sum by(job, influxdb_cluster) (rate(http_write_request_bytes{' + matcher + '}[$__rate_interval]))',
+      'sum by(' + matcher + ') (rate(http_write_request_bytes{' + matcher + '}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='{{influxdb_cluster}} - write - request',
     ),
     prometheus.target(
-      'sum by(job, influxdb_cluster) (rate(http_write_response_bytes{' + matcher + '}[$__rate_interval]))',
+      'sum by(' + matcher + ') (rate(http_write_response_bytes{' + matcher + '}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='{{influxdb_cluster}} - write - response',
     ),
@@ -769,7 +777,7 @@ local topInstancesByIQLQueryRatePanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'topk($k, sum by(job, influxdb_cluster, instance) (rate(influxql_service_requests_total{' + matcher + '}[$__rate_interval])))',
+      'topk($k, sum by(' + matcher + ', instance) (rate(influxql_service_requests_total{' + matcher + '}[$__rate_interval])))',
       datasource=promDatasource,
       legendFormat='{{influxdb_cluster}} - {{instance}}',
     ),
@@ -850,7 +858,7 @@ local iqlQueryResponseTimePanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(job, influxdb_cluster, result) (increase(influxql_service_executing_duration_seconds_sum{' + matcher + '}[$__interval:]))',
+      'sum by(' + matcher + ', result) (increase(influxql_service_executing_duration_seconds_sum{' + matcher + '}[$__interval:]))',
       datasource=promDatasource,
       legendFormat='{{influxdb_cluster}} - {{result}}',
       interval='1m',
@@ -1018,7 +1026,7 @@ local activeTasksPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(job, influxdb_cluster) (task_scheduler_current_execution{' + matcher + '})',
+      'sum by(' + matcher + ') (task_scheduler_current_execution{' + matcher + '})',
       datasource=promDatasource,
       legendFormat='{{influxdb_cluster}}',
     ),
@@ -1095,7 +1103,7 @@ local activeWorkersPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(job, influxdb_cluster) (task_executor_total_runs_active{' + matcher + '})',
+      'sum by(' + matcher + ') (task_executor_total_runs_active{' + matcher + '})',
       datasource=promDatasource,
       legendFormat='{{influxdb_cluster}}',
     ),

--- a/influxdb-mixin/dashboards/influxdb-cluster-overview.libsonnet
+++ b/influxdb-mixin/dashboards/influxdb-cluster-overview.libsonnet
@@ -495,7 +495,7 @@ local httpAPIRequestDurationPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'histogram_quantile(0.95, sum by(le, ' + matcher + ') (rate(http_api_request_duration_seconds_bucket{' + matcher + '}[$__rate_interval])))',
+      'histogram_quantile(0.95, sum by(le, job, influxdb_cluster) (rate(http_api_request_duration_seconds_bucket{' + matcher + '}[$__rate_interval])))',
       datasource=promDatasource,
       legendFormat='{{influxdb_cluster}}',
     ),

--- a/influxdb-mixin/dashboards/influxdb-cluster-overview.libsonnet
+++ b/influxdb-mixin/dashboards/influxdb-cluster-overview.libsonnet
@@ -414,7 +414,7 @@ local topInstancesByHTTPAPIRequestsPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'topk($k, sum by(' + matcher + ', instance) (rate(http_api_requests_total{' + matcher + '}[$__rate_interval])))',
+      'topk($k, sum by(job, influxdb_cluster, instance) (rate(http_api_requests_total{' + matcher + '}[$__rate_interval])))',
       datasource=promDatasource,
       legendFormat='{{influxdb_cluster}} - {{instance}}',
     ),
@@ -549,7 +549,7 @@ local httpAPIResponseCodesPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(' + matcher + ', response_code) (rate(http_api_requests_total{' + matcher + '}[$__rate_interval]))',
+      'sum by(job, influxdb_cluster, response_code) (rate(http_api_requests_total{' + matcher + '}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='{{influxdb_cluster}} - {{response_code}}',
     ),
@@ -599,12 +599,12 @@ local httpOperationsPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(' + matcher + ', status) (rate(http_query_request_count{' + matcher + '}[$__rate_interval]))',
+      'sum by(job, influxdb_cluster, status) (rate(http_query_request_count{' + matcher + '}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='{{influxdb_cluster}} - query - {{status}}',
     ),
     prometheus.target(
-      'sum by(' + matcher + ', status) (rate(http_write_request_count{' + matcher + '}[$__rate_interval]))',
+      'sum by(job, influxdb_cluster, status) (rate(http_write_request_count{' + matcher + '}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='{{influxdb_cluster}} - write - {{status}}',
     ),
@@ -681,22 +681,22 @@ local httpOperationDataPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(' + matcher + ') (rate(http_query_request_bytes{' + matcher + '}[$__rate_interval]))',
+      'sum by(job, influxdb_cluster) (rate(http_query_request_bytes{' + matcher + '}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='{{influxdb_cluster}} - query - request',
     ),
     prometheus.target(
-      'sum by(' + matcher + ') (rate(http_query_response_bytes{' + matcher + '}[$__rate_interval]))',
+      'sum by(job, influxdb_cluster) (rate(http_query_response_bytes{' + matcher + '}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='{{influxdb_cluster}} - query - response',
     ),
     prometheus.target(
-      'sum by(' + matcher + ') (rate(http_write_request_bytes{' + matcher + '}[$__rate_interval]))',
+      'sum by(job, influxdb_cluster) (rate(http_write_request_bytes{' + matcher + '}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='{{influxdb_cluster}} - write - request',
     ),
     prometheus.target(
-      'sum by(' + matcher + ') (rate(http_write_response_bytes{' + matcher + '}[$__rate_interval]))',
+      'sum by(job, influxdb_cluster) (rate(http_write_response_bytes{' + matcher + '}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='{{influxdb_cluster}} - write - response',
     ),
@@ -777,7 +777,7 @@ local topInstancesByIQLQueryRatePanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'topk($k, sum by(' + matcher + ', instance) (rate(influxql_service_requests_total{' + matcher + '}[$__rate_interval])))',
+      'topk($k, sum by(job, influxdb_cluster, instance) (rate(influxql_service_requests_total{' + matcher + '}[$__rate_interval])))',
       datasource=promDatasource,
       legendFormat='{{influxdb_cluster}} - {{instance}}',
     ),
@@ -858,7 +858,7 @@ local iqlQueryResponseTimePanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(' + matcher + ', result) (increase(influxql_service_executing_duration_seconds_sum{' + matcher + '}[$__interval:]))',
+      'sum by(job, influxdb_cluster, result) (increase(influxql_service_executing_duration_seconds_sum{' + matcher + '}[$__interval:]))',
       datasource=promDatasource,
       legendFormat='{{influxdb_cluster}} - {{result}}',
       interval='1m',
@@ -1026,7 +1026,7 @@ local activeTasksPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(' + matcher + ') (task_scheduler_current_execution{' + matcher + '})',
+      'sum by(job, influxdb_cluster) (task_scheduler_current_execution{' + matcher + '})',
       datasource=promDatasource,
       legendFormat='{{influxdb_cluster}}',
     ),
@@ -1103,7 +1103,7 @@ local activeWorkersPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(' + matcher + ') (task_executor_total_runs_active{' + matcher + '})',
+      'sum by(job, influxdb_cluster) (task_executor_total_runs_active{' + matcher + '})',
       datasource=promDatasource,
       legendFormat='{{influxdb_cluster}}',
     ),

--- a/influxdb-mixin/dashboards/influxdb-cluster-overview.libsonnet
+++ b/influxdb-mixin/dashboards/influxdb-cluster-overview.libsonnet
@@ -232,176 +232,6 @@ local serversPanel(matcher) = {
   ],
 };
 
-local goRow = {
-  datasource: promDatasource,
-  targets: [],
-  type: 'row',
-  title: 'Go',
-  collapsed: false,
-};
-
-local topInstancesByHeapMemoryUsagePanel(matcher) = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'topk($k, go_memstats_heap_alloc_bytes{' + matcher + '}/clamp_min(go_memstats_heap_idle_bytes{' + matcher + '} + go_memstats_heap_alloc_bytes{' + matcher + '}, 1))',
-      datasource=promDatasource,
-      legendFormat='{{influxdb_cluster}} - {{instance}}',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'Top instances by heap memory usage',
-  description: 'Heap memory usage for the largest instances in the cluster.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'continuous-BlYlRd',
-      },
-      custom: {
-        axisBorderShow: false,
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 20,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        insertNulls: false,
-        lineInterpolation: 'smooth',
-        lineWidth: 2,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'never',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      max: 1,
-      min: 0,
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-        ],
-      },
-      unit: 'percentunit',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'multi',
-      sort: 'desc',
-    },
-  },
-};
-
-local topInstancesByGCCPUUsagePanel(matcher) = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'go_memstats_gc_cpu_fraction{' + matcher + '}',
-      datasource=promDatasource,
-      legendFormat='{{influxdb_cluster}} - {{instance}}',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'Top instances by GC CPU usage',
-  description: 'Fraction of CPU time used for garbage collection for the top instances in the cluster.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'continuous-BlYlRd',
-      },
-      custom: {
-        axisBorderShow: false,
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 20,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        insertNulls: false,
-        lineInterpolation: 'smooth',
-        lineWidth: 2,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'never',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      max: 100,
-      min: 0,
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-          {
-            color: 'red',
-            value: 80,
-          },
-        ],
-      },
-      unit: 'percent',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'multi',
-      sort: 'desc',
-    },
-  },
-};
-
 local queriesAndOperationsRow = {
   datasource: promDatasource,
   targets: [],
@@ -1340,6 +1170,176 @@ local schedulesPanel(matcher) = {
   },
 };
 
+local goRow = {
+  datasource: promDatasource,
+  targets: [],
+  type: 'row',
+  title: 'Go',
+  collapsed: false,
+};
+
+local topInstancesByHeapMemoryUsagePanel(matcher) = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'topk($k, go_memstats_heap_alloc_bytes{' + matcher + '}/clamp_min(go_memstats_heap_idle_bytes{' + matcher + '} + go_memstats_heap_alloc_bytes{' + matcher + '}, 1))',
+      datasource=promDatasource,
+      legendFormat='{{influxdb_cluster}} - {{instance}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Top instances by heap memory usage',
+  description: 'Heap memory usage for the largest instances in the cluster.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'continuous-BlYlRd',
+      },
+      custom: {
+        axisBorderShow: false,
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 20,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      max: 1,
+      min: 0,
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'percentunit',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local topInstancesByGCCPUUsagePanel(matcher) = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'go_memstats_gc_cpu_fraction{' + matcher + '}',
+      datasource=promDatasource,
+      legendFormat='{{influxdb_cluster}} - {{instance}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Top instances by GC CPU usage',
+  description: 'Fraction of CPU time used for garbage collection for the top instances in the cluster.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'continuous-BlYlRd',
+      },
+      custom: {
+        axisBorderShow: false,
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 20,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      max: 100,
+      min: 0,
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'percent',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
 local getMatcher(cfg) = '%(influxdbSelector)s, influxdb_cluster=~"$influxdb_cluster"' % cfg;
 
 {
@@ -1420,9 +1420,6 @@ local getMatcher(cfg) = '%(influxdbSelector)s, influxdb_cluster=~"$influxdb_clus
         [
           alertsPanel(getMatcher($._config)) { gridPos: { h: 8, w: 7, x: 0, y: 0 } },
           serversPanel(getMatcher($._config)) { gridPos: { h: 8, w: 17, x: 7, y: 0 } },
-          goRow { gridPos: { h: 1, w: 24, x: 0, y: 8 } },
-          topInstancesByHeapMemoryUsagePanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 0, y: 9 } },
-          topInstancesByGCCPUUsagePanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 12, y: 9 } },
           queriesAndOperationsRow { gridPos: { h: 1, w: 24, x: 0, y: 17 } },
           topInstancesByHTTPAPIRequestsPanel(getMatcher($._config)) { gridPos: { h: 8, w: 8, x: 0, y: 18 } },
           httpAPIRequestDurationPanel(getMatcher($._config)) { gridPos: { h: 8, w: 8, x: 8, y: 18 } },
@@ -1437,6 +1434,9 @@ local getMatcher(cfg) = '%(influxdbSelector)s, influxdb_cluster=~"$influxdb_clus
           activeWorkersPanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 12, y: 43 } },
           executionsPanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 0, y: 51 } },
           schedulesPanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 12, y: 51 } },
+          goRow { gridPos: { h: 1, w: 24, x: 0, y: 8 } },
+          topInstancesByHeapMemoryUsagePanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 0, y: 9 } },
+          topInstancesByGCCPUUsagePanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 12, y: 9 } },
         ]
       ),
   },

--- a/influxdb-mixin/dashboards/influxdb-cluster-overview.libsonnet
+++ b/influxdb-mixin/dashboards/influxdb-cluster-overview.libsonnet
@@ -828,7 +828,7 @@ local topInstancesByIQLQueryRatePanel(matcher) = {
           },
         ],
       },
-      unit: 'query/s',
+      unit: 'queries/s',
     },
     overrides: [],
   },

--- a/influxdb-mixin/dashboards/influxdb-instance-overview.libsonnet
+++ b/influxdb-mixin/dashboards/influxdb-instance-overview.libsonnet
@@ -404,377 +404,6 @@ local threadsPanel(matcher) = {
   pluginVersion: '10.3.0-63516',
 };
 
-local goRow = {
-  datasource: promDatasource,
-  targets: [],
-  type: 'row',
-  title: 'Go',
-  collapsed: false,
-};
-
-local timeSinceLastGCPanel(matcher) = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'time() - go_memstats_last_gc_time_seconds{' + matcher + ', instance=~"$instance"}',
-      datasource=promDatasource,
-      legendFormat='{{instance}}',
-    ),
-  ],
-  type: 'stat',
-  title: 'Time since last GC',
-  description: 'Amount of time since the last garbage collection cycle.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'thresholds',
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-        ],
-      },
-      unit: 's',
-    },
-    overrides: [],
-  },
-  options: {
-    colorMode: 'value',
-    graphMode: 'none',
-    justifyMode: 'auto',
-    orientation: 'auto',
-    reduceOptions: {
-      calcs: [
-        'lastNotNull',
-      ],
-      fields: '',
-      values: false,
-    },
-    textMode: 'auto',
-    wideLayout: true,
-  },
-  pluginVersion: '10.3.0-63516',
-};
-
-local gcTimePanel(matcher) = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'increase(go_gc_duration_seconds_sum{' + matcher + ', instance=~"$instance"}[$__interval:])',
-      datasource=promDatasource,
-      legendFormat='{{instance}}',
-      interval='1m',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'GC time / $__interval',
-  description: 'Server CPU time spent on garbage collection.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisBorderShow: false,
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 20,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        insertNulls: false,
-        lineInterpolation: 'smooth',
-        lineWidth: 2,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'never',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-        ],
-      },
-      unit: 's',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'multi',
-      sort: 'desc',
-    },
-  },
-};
-
-local gcCPUUsagePanel(matcher) = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'go_memstats_gc_cpu_fraction{' + matcher + ', instance=~"$instance"}',
-      datasource=promDatasource,
-      legendFormat='{{instance}}',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'GC CPU usage',
-  description: 'Percent of server CPU time used for garbage collection.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'continuous-BlYlRd',
-      },
-      custom: {
-        axisBorderShow: false,
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 20,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        insertNulls: false,
-        lineInterpolation: 'smooth',
-        lineWidth: 2,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'never',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      max: 100,
-      min: 0,
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-        ],
-      },
-      unit: 'percent',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'multi',
-      sort: 'desc',
-    },
-  },
-};
-
-local heapMemoryUsagePanel(matcher) = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'go_memstats_heap_alloc_bytes{' + matcher + ', instance=~"$instance"}/clamp_min((go_memstats_heap_idle_bytes{' + matcher + ', instance=~"$instance"} + go_memstats_heap_alloc_bytes{' + matcher + ', instance=~"$instance"}), 1)',
-      datasource=promDatasource,
-      legendFormat='{{instance}}',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'Heap memory usage',
-  description: 'Heap memory usage for the server.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'continuous-BlYlRd',
-      },
-      custom: {
-        axisBorderShow: false,
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 20,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        insertNulls: false,
-        lineInterpolation: 'smooth',
-        lineWidth: 2,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'never',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      mappings: [],
-      max: 1,
-      min: 0,
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-        ],
-      },
-      unit: 'percentunit',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'multi',
-      sort: 'desc',
-    },
-  },
-};
-
-local goThreadsPanel(matcher) = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'go_threads{' + matcher + ', instance=~"$instance"}',
-      datasource=promDatasource,
-      legendFormat='{{instance}}',
-    ),
-  ],
-  type: 'timeseries',
-  title: 'Go threads',
-  description: 'Number of OS threads created for the server.',
-  fieldConfig: {
-    defaults: {
-      color: {
-        mode: 'palette-classic',
-      },
-      custom: {
-        axisBorderShow: false,
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisLabel: '',
-        axisPlacement: 'auto',
-        barAlignment: 0,
-        drawStyle: 'line',
-        fillOpacity: 20,
-        gradientMode: 'none',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false,
-        },
-        insertNulls: false,
-        lineInterpolation: 'smooth',
-        lineWidth: 2,
-        pointSize: 5,
-        scaleDistribution: {
-          type: 'linear',
-        },
-        showPoints: 'never',
-        spanNulls: false,
-        stacking: {
-          group: 'A',
-          mode: 'none',
-        },
-        thresholdsStyle: {
-          mode: 'off',
-        },
-      },
-      decimals: 0,
-      mappings: [],
-      thresholds: {
-        mode: 'absolute',
-        steps: [
-          {
-            color: 'green',
-            value: null,
-          },
-        ],
-      },
-      unit: 'none',
-    },
-    overrides: [],
-  },
-  options: {
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'bottom',
-      showLegend: true,
-    },
-    tooltip: {
-      mode: 'multi',
-      sort: 'desc',
-    },
-  },
-};
-
 local queriesAndOperationsRow = {
   datasource: promDatasource,
   targets: [],
@@ -1768,6 +1397,377 @@ local schedulesPanel(matcher) = {
   },
 };
 
+local goRow = {
+  datasource: promDatasource,
+  targets: [],
+  type: 'row',
+  title: 'Go',
+  collapsed: false,
+};
+
+local timeSinceLastGCPanel(matcher) = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'time() - go_memstats_last_gc_time_seconds{' + matcher + ', instance=~"$instance"}',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+    ),
+  ],
+  type: 'stat',
+  title: 'Time since last GC',
+  description: 'Amount of time since the last garbage collection cycle.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 's',
+    },
+    overrides: [],
+  },
+  options: {
+    colorMode: 'value',
+    graphMode: 'none',
+    justifyMode: 'auto',
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    textMode: 'auto',
+    wideLayout: true,
+  },
+  pluginVersion: '10.3.0-63516',
+};
+
+local gcTimePanel(matcher) = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'increase(go_gc_duration_seconds_sum{' + matcher + ', instance=~"$instance"}[$__interval:])',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+      interval='1m',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'GC time / $__interval',
+  description: 'Server CPU time spent on garbage collection.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisBorderShow: false,
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 20,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 's',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local gcCPUUsagePanel(matcher) = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'go_memstats_gc_cpu_fraction{' + matcher + ', instance=~"$instance"}',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'GC CPU usage',
+  description: 'Percent of server CPU time used for garbage collection.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'continuous-BlYlRd',
+      },
+      custom: {
+        axisBorderShow: false,
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 20,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      max: 100,
+      min: 0,
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'percent',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local heapMemoryUsagePanel(matcher) = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'go_memstats_heap_alloc_bytes{' + matcher + ', instance=~"$instance"}/clamp_min((go_memstats_heap_idle_bytes{' + matcher + ', instance=~"$instance"} + go_memstats_heap_alloc_bytes{' + matcher + ', instance=~"$instance"}), 1)',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Heap memory usage',
+  description: 'Heap memory usage for the server.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'continuous-BlYlRd',
+      },
+      custom: {
+        axisBorderShow: false,
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 20,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      max: 1,
+      min: 0,
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'percentunit',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local goThreadsPanel(matcher) = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'go_threads{' + matcher + ', instance=~"$instance"}',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Go threads',
+  description: 'Number of OS threads created for the server.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisBorderShow: false,
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 20,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      decimals: 0,
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
 local getMatcher(cfg) = '%(influxdbSelector)s, influxdb_cluster=~"$influxdb_cluster", instance=~"$instance"' % cfg;
 
 {
@@ -1855,12 +1855,6 @@ local getMatcher(cfg) = '%(influxdbSelector)s, influxdb_cluster=~"$influxdb_clus
           scrapersPanel(getMatcher($._config)) { gridPos: { h: 8, w: 3, x: 15, y: 0 } },
           dashboardsPanel(getMatcher($._config)) { gridPos: { h: 8, w: 3, x: 18, y: 0 } },
           threadsPanel(getMatcher($._config)) { gridPos: { h: 8, w: 3, x: 21, y: 0 } },
-          goRow { gridPos: { h: 1, w: 24, x: 0, y: 8 } },
-          timeSinceLastGCPanel(getMatcher($._config)) { gridPos: { h: 8, w: 6, x: 0, y: 9 } },
-          gcTimePanel(getMatcher($._config)) { gridPos: { h: 8, w: 9, x: 6, y: 9 } },
-          gcCPUUsagePanel(getMatcher($._config)) { gridPos: { h: 8, w: 9, x: 15, y: 9 } },
-          heapMemoryUsagePanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 0, y: 17 } },
-          goThreadsPanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 12, y: 17 } },
           queriesAndOperationsRow { gridPos: { h: 1, w: 24, x: 0, y: 25 } },
           httpAPIRequestsPanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 0, y: 26 } },
           activeQueriesPanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 12, y: 26 } },
@@ -1875,6 +1869,12 @@ local getMatcher(cfg) = '%(influxdbSelector)s, influxdb_cluster=~"$influxdb_clus
           workerUsagePanel(getMatcher($._config)) { gridPos: { h: 8, w: 8, x: 16, y: 51 } },
           executionsPanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 0, y: 59 } },
           schedulesPanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 12, y: 59 } },
+          goRow { gridPos: { h: 1, w: 24, x: 0, y: 8 } },
+          timeSinceLastGCPanel(getMatcher($._config)) { gridPos: { h: 8, w: 6, x: 0, y: 9 } },
+          gcTimePanel(getMatcher($._config)) { gridPos: { h: 8, w: 9, x: 6, y: 9 } },
+          gcCPUUsagePanel(getMatcher($._config)) { gridPos: { h: 8, w: 9, x: 15, y: 9 } },
+          heapMemoryUsagePanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 0, y: 17 } },
+          goThreadsPanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 12, y: 17 } },
         ]
       ),
   },

--- a/influxdb-mixin/dashboards/influxdb-instance-overview.libsonnet
+++ b/influxdb-mixin/dashboards/influxdb-instance-overview.libsonnet
@@ -65,7 +65,7 @@ local bucketsPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'influxdb_buckets_total{' + matcher + ', instance=~"$instance"}',
+      'sum by(job, influxdb_cluster) (influxdb_buckets_total{' + matcher + ', instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{instance}}',
     ),
@@ -114,7 +114,7 @@ local usersPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'influxdb_users_total{' + matcher + ', instance=~"$instance"}',
+      'sum by(job, influxdb_cluster) (influxdb_users_total{' + matcher + ', instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{instance}}',
     ),
@@ -163,7 +163,7 @@ local replicationsPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'influxdb_replications_total{' + matcher + ', instance=~"$instance"}',
+      'sum by(job, influxdb_cluster) (influxdb_replications_total{' + matcher + ', instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{instance}}',
     ),
@@ -212,7 +212,7 @@ local remotesPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'influxdb_remotes_total{' + matcher + ', instance=~"$instance"}',
+      'sum by(job, influxdb_cluster) (influxdb_remotes_total{' + matcher + ', instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{instance}}',
     ),
@@ -261,7 +261,7 @@ local scrapersPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'influxdb_scrapers_total{' + matcher + ', instance=~"$instance"}',
+      'sum by(job, influxdb_cluster) (influxdb_scrapers_total{' + matcher + ', instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{instance}}',
     ),
@@ -310,7 +310,7 @@ local dashboardsPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'influxdb_dashboards_total{' + matcher + ', instance=~"$instance"}',
+      'sum by(job, influxdb_cluster) (influxdb_dashboards_total{' + matcher + ', instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{instance}}',
     ),
@@ -359,7 +359,7 @@ local threadsPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'go_threads{' + matcher + ', instance=~"$instance"}',
+      'sum by(job, influxdb_cluster) (go_threads{' + matcher + ', instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{instance}}',
     ),
@@ -787,7 +787,7 @@ local httpAPIRequestsPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(' + matcher + ', instance, status) (rate(http_api_requests_total{' + matcher + ', instance=~"$instance"}[$__rate_interval]))',
+      'sum by(job, influxdb_cluster, instance, status) (rate(http_api_requests_total{' + matcher + ', instance=~"$instance"}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='{{instance}} - {{status}}',
     ),
@@ -864,17 +864,17 @@ local activeQueriesPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(' + matcher + ', instance) (qc_compiling_active{' + matcher + ', instance=~"$instance"})',
+      'sum by(job, influxdb_cluster, instance) (qc_compiling_active{' + matcher + ', instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{instance}} - compiling',
     ),
     prometheus.target(
-      'sum by(' + matcher + ', instance) (qc_queueing_active{' + matcher + ', instance=~"$instance"})',
+      'sum by(job, influxdb_cluster, instance) (qc_queueing_active{' + matcher + ', instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{instance}} - queueing',
     ),
     prometheus.target(
-      'sum by(' + matcher + ', instance) (qc_executing_active{' + matcher + ', instance=~"$instance"})',
+      'sum by(job, influxdb_cluster, instance) (qc_executing_active{' + matcher + ', instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{instance}} - executing',
     ),
@@ -952,12 +952,12 @@ local httpOperationsPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(' + matcher + ', instance, status) (rate(http_query_request_count{' + matcher + ', instance=~"$instance"}[$__rate_interval]))',
+      'sum by(job, influxdb_cluster, instance, status) (rate(http_query_request_count{' + matcher + ', instance=~"$instance"}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='{{instance}} - query - {{status}}',
     ),
     prometheus.target(
-      'sum by(' + matcher + ', instance, status) (rate(http_write_request_count{' + matcher + ', instance=~"$instance"}[$__rate_interval]))',
+      'sum by(job, influxdb_cluster, instance, status) (rate(http_write_request_count{' + matcher + ', instance=~"$instance"}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='{{instance}} - write - {{status}}',
     ),
@@ -1034,22 +1034,22 @@ local httpOperationDataPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(' + matcher + ', instance) (rate(http_query_request_bytes{' + matcher + ', instance=~"$instance"}[$__rate_interval]))',
+      'sum by(job, influxdb_cluster, instance) (rate(http_query_request_bytes{' + matcher + ', instance=~"$instance"}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='{{instance}} - query request',
     ),
     prometheus.target(
-      'sum by(' + matcher + ', instance) (rate(http_query_response_bytes{' + matcher + ', instance=~"$instance"}[$__rate_interval]))',
+      'sum by(job, influxdb_cluster, instance) (rate(http_query_response_bytes{' + matcher + ', instance=~"$instance"}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='{{instance}} - query response',
     ),
     prometheus.target(
-      'sum by(' + matcher + ', instance) (rate(http_write_request_bytes{' + matcher + ', instance=~"$instance"}[$__rate_interval]))',
+      'sum by(job, influxdb_cluster, instance) (rate(http_write_request_bytes{' + matcher + ', instance=~"$instance"}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='{{instance}} - write request',
     ),
     prometheus.target(
-      'sum by(' + matcher + ', instance) (rate(http_write_response_bytes{' + matcher + ', instance=~"$instance"}[$__rate_interval]))',
+      'sum by(job, influxdb_cluster, instance) (rate(http_write_response_bytes{' + matcher + ', instance=~"$instance"}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='{{instance}} - write response',
     ),
@@ -1130,7 +1130,7 @@ local iqlQueryRatePanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(' + matcher + ', instance, result) (rate(influxql_service_requests_total{' + matcher + ', instance=~"$instance"}[$__rate_interval]))',
+      'sum by(job, influxdb_cluster, instance, result) (rate(influxql_service_requests_total{' + matcher + ', instance=~"$instance"}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='{{instance}} - {{result}}',
     ),
@@ -1207,7 +1207,7 @@ local iqlQueryResponseTimePanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(' + matcher + ', instance, result) (increase(influxql_service_executing_duration_seconds_sum{' + matcher + ', instance=~"$instance"}[$__interval:]))',
+      'sum by(job, influxdb_cluster, instance, result) (increase(influxql_service_executing_duration_seconds_sum{' + matcher + ', instance=~"$instance"}[$__interval:]))',
       datasource=promDatasource,
       legendFormat='{{instance}} - {{result}}',
       interval='1m',

--- a/influxdb-mixin/dashboards/influxdb-instance-overview.libsonnet
+++ b/influxdb-mixin/dashboards/influxdb-instance-overview.libsonnet
@@ -1,0 +1,1881 @@
+local g = (import 'grafana-builder/grafana.libsonnet');
+local grafana = (import 'grafonnet/grafana.libsonnet');
+local dashboard = grafana.dashboard;
+local template = grafana.template;
+local prometheus = grafana.prometheus;
+
+local dashboardUid = 'influxdb-instance-overview';
+
+local promDatasourceName = 'prometheus_datasource';
+
+local promDatasource = {
+  uid: '${%s}' % promDatasourceName,
+};
+
+local uptimePanel(matcher) = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'influxdb_uptime_seconds{' + matcher + ', instance=~"$instance"}',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+    ),
+  ],
+  type: 'stat',
+  title: 'Uptime',
+  description: 'Time that the InfluxDB process has been running.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 's',
+    },
+    overrides: [],
+  },
+  options: {
+    colorMode: 'value',
+    graphMode: 'none',
+    justifyMode: 'auto',
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    textMode: 'auto',
+    wideLayout: true,
+  },
+  pluginVersion: '10.3.0-63516',
+};
+
+local bucketsPanel(matcher) = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'influxdb_buckets_total{' + matcher + ', instance=~"$instance"}',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+    ),
+  ],
+  type: 'stat',
+  title: 'Buckets',
+  description: 'Number of buckets on the server.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    colorMode: 'value',
+    graphMode: 'none',
+    justifyMode: 'auto',
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    textMode: 'auto',
+    wideLayout: true,
+  },
+  pluginVersion: '10.3.0-63516',
+};
+
+local usersPanel(matcher) = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'influxdb_users_total{' + matcher + ', instance=~"$instance"}',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+    ),
+  ],
+  type: 'stat',
+  title: 'Users',
+  description: 'Total number of users for the server.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    colorMode: 'value',
+    graphMode: 'none',
+    justifyMode: 'auto',
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    textMode: 'auto',
+    wideLayout: true,
+  },
+  pluginVersion: '10.3.0-63516',
+};
+
+local replicationsPanel(matcher) = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'influxdb_replications_total{' + matcher + ', instance=~"$instance"}',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+    ),
+  ],
+  type: 'stat',
+  title: 'Replications',
+  description: 'Number of replication configurations on the server.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    colorMode: 'value',
+    graphMode: 'none',
+    justifyMode: 'auto',
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    textMode: 'auto',
+    wideLayout: true,
+  },
+  pluginVersion: '10.3.0-63516',
+};
+
+local remotesPanel(matcher) = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'influxdb_remotes_total{' + matcher + ', instance=~"$instance"}',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+    ),
+  ],
+  type: 'stat',
+  title: 'Remotes',
+  description: 'Number of remote connections configured on the server.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    colorMode: 'value',
+    graphMode: 'none',
+    justifyMode: 'auto',
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    textMode: 'auto',
+    wideLayout: true,
+  },
+  pluginVersion: '10.3.0-63516',
+};
+
+local scrapersPanel(matcher) = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'influxdb_scrapers_total{' + matcher + ', instance=~"$instance"}',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+    ),
+  ],
+  type: 'stat',
+  title: 'Scrapers',
+  description: 'Number of scrapers on the server.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    colorMode: 'value',
+    graphMode: 'none',
+    justifyMode: 'auto',
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    textMode: 'auto',
+    wideLayout: true,
+  },
+  pluginVersion: '10.3.0-63516',
+};
+
+local dashboardsPanel(matcher) = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'influxdb_dashboards_total{' + matcher + ', instance=~"$instance"}',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+    ),
+  ],
+  type: 'stat',
+  title: 'Dashboards',
+  description: 'Number of dashboards on the server.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    colorMode: 'value',
+    graphMode: 'none',
+    justifyMode: 'auto',
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    textMode: 'auto',
+    wideLayout: true,
+  },
+  pluginVersion: '10.3.0-63516',
+};
+
+local threadsPanel(matcher) = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'go_threads{' + matcher + ', instance=~"$instance"}',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+    ),
+  ],
+  type: 'stat',
+  title: 'Threads',
+  description: 'Number of threads currently active on the server.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    colorMode: 'value',
+    graphMode: 'none',
+    justifyMode: 'auto',
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    textMode: 'auto',
+    wideLayout: true,
+  },
+  pluginVersion: '10.3.0-63516',
+};
+
+local goRow = {
+  datasource: promDatasource,
+  targets: [],
+  type: 'row',
+  title: 'Go',
+  collapsed: false,
+};
+
+local timeSinceLastGCPanel(matcher) = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'time() - go_memstats_last_gc_time_seconds{' + matcher + ', instance=~"$instance"}',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+    ),
+  ],
+  type: 'stat',
+  title: 'Time since last GC',
+  description: 'Amount of time since the last garbage collection cycle.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 's',
+    },
+    overrides: [],
+  },
+  options: {
+    colorMode: 'value',
+    graphMode: 'none',
+    justifyMode: 'auto',
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
+    },
+    textMode: 'auto',
+    wideLayout: true,
+  },
+  pluginVersion: '10.3.0-63516',
+};
+
+local gcTimePanel(matcher) = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'increase(go_gc_duration_seconds_sum{' + matcher + ', instance=~"$instance"}[$__interval:])',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+      interval='1m',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'GC time / $__interval',
+  description: 'Server CPU time spent on garbage collection.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisBorderShow: false,
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 20,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 's',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local gcCPUUsagePanel(matcher) = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'go_memstats_gc_cpu_fraction{' + matcher + ', instance=~"$instance"}',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'GC CPU usage',
+  description: 'Percent of server CPU time used for garbage collection.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'continuous-BlYlRd',
+      },
+      custom: {
+        axisBorderShow: false,
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 20,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      max: 100,
+      min: 0,
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'percent',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local heapMemoryUsagePanel(matcher) = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'go_memstats_heap_alloc_bytes{' + matcher + ', instance=~"$instance"}/clamp_min((go_memstats_heap_idle_bytes{' + matcher + ', instance=~"$instance"} + go_memstats_heap_alloc_bytes{' + matcher + ', instance=~"$instance"}), 1)',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Heap memory usage',
+  description: 'Heap memory usage for the server.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'continuous-BlYlRd',
+      },
+      custom: {
+        axisBorderShow: false,
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 20,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      max: 1,
+      min: 0,
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'percentunit',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local goThreadsPanel(matcher) = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'go_threads{' + matcher + ', instance=~"$instance"}',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Go threads',
+  description: 'Number of OS threads created for the server.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisBorderShow: false,
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 20,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      decimals: 0,
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local queriesAndOperationsRow = {
+  datasource: promDatasource,
+  targets: [],
+  type: 'row',
+  title: 'Queries and operations',
+  collapsed: false,
+};
+
+local httpAPIRequestsPanel(matcher) = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by(job, influxdb_cluster, instance, status) (rate(http_api_requests_total{' + matcher + ', instance=~"$instance"}[$__rate_interval]))',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - {{status}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'HTTP API requests',
+  description: 'Rate of HTTP requests to the API, organized by response code.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisBorderShow: false,
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 20,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'reqps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local activeQueriesPanel(matcher) = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by(job, influxdb_cluster, instance) (qc_compiling_active{' + matcher + ', instance=~"$instance"})',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - compiling',
+    ),
+    prometheus.target(
+      'sum by(job, influxdb_cluster, instance) (qc_queueing_active{' + matcher + ', instance=~"$instance"})',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - queueing',
+    ),
+    prometheus.target(
+      'sum by(job, influxdb_cluster, instance) (qc_executing_active{' + matcher + ', instance=~"$instance"})',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - executing',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Active queries',
+  description: 'Number of active queries for the server.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisBorderShow: false,
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 20,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      decimals: 0,
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local httpOperationsPanel(matcher) = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by(job, influxdb_cluster, instance, status) (rate(http_query_request_count{' + matcher + ', instance=~"$instance"}[$__rate_interval]))',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - query - {{status}}',
+    ),
+    prometheus.target(
+      'sum by(job, influxdb_cluster, instance, status) (rate(http_write_request_count{' + matcher + ', instance=~"$instance"}[$__rate_interval]))',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - write - {{status}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'HTTP operations',
+  description: 'Rate of database operations from HTTP for the server.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisBorderShow: false,
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 20,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'ops',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local httpOperationDataPanel(matcher) = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by(job, influxdb_cluster, instance) (rate(http_query_request_bytes{' + matcher + ', instance=~"$instance"}[$__rate_interval]))',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - query request',
+    ),
+    prometheus.target(
+      'sum by(job, influxdb_cluster, instance) (rate(http_query_response_bytes{' + matcher + ', instance=~"$instance"}[$__rate_interval]))',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - query response',
+    ),
+    prometheus.target(
+      'sum by(job, influxdb_cluster, instance) (rate(http_write_request_bytes{' + matcher + ', instance=~"$instance"}[$__rate_interval]))',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - write request',
+    ),
+    prometheus.target(
+      'sum by(job, influxdb_cluster, instance) (rate(http_write_response_bytes{' + matcher + ', instance=~"$instance"}[$__rate_interval]))',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - write response',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'HTTP operation data',
+  description: 'Rate of database HTTP operation data for the server.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisBorderShow: false,
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 20,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'Bps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [
+        'min',
+        'mean',
+        'max',
+      ],
+      displayMode: 'table',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local iqlQueryRatePanel(matcher) = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by(job, influxdb_cluster, instance, result) (rate(influxql_service_requests_total{' + matcher + ', instance=~"$instance"}[$__rate_interval]))',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - {{result}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'IQL query rate',
+  description: 'Rate of InfluxQL queries for the server.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisBorderShow: false,
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 20,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'queries/s',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local iqlQueryResponseTimePanel(matcher) = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'sum by(job, influxdb_cluster, instance, result) (increase(influxql_service_executing_duration_seconds_sum{' + matcher + ', instance=~"$instance"}[$__interval:]))',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - {{result}}',
+      interval='1m',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'IQL query response time / $__interval',
+  description: 'Response time for recent InfluxQL queries, organized by result.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisBorderShow: false,
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 20,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 's',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local boltdbOperationsPanel(matcher) = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'rate(boltdb_reads_total{' + matcher + ', instance=~"$instance"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - reads',
+    ),
+    prometheus.target(
+      'rate(boltdb_writes_total{' + matcher + ', instance=~"$instance"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - writes',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'BoltDB operations',
+  description: 'Rate of reads and writes to the underlying BoltDB storage engine for the server.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisBorderShow: false,
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 20,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'normal',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'ops',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local taskSchedulerRow = {
+  datasource: promDatasource,
+  targets: [],
+  type: 'row',
+  title: 'Task scheduler',
+  collapsed: false,
+};
+
+local activeTasksPanel(matcher) = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'task_scheduler_current_execution{' + matcher + ', instance=~"$instance"}',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Active tasks',
+  description: 'Number of tasks currently being executed for the server.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisBorderShow: false,
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 20,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local activeWorkersPanel(matcher) = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'task_executor_total_runs_active{' + matcher + ', instance=~"$instance"}',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Active workers',
+  description: 'Number of workers currently running tasks on the server.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisBorderShow: false,
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 20,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local workerUsagePanel(matcher) = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'task_executor_workers_busy{' + matcher + ', instance=~"$instance"}',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Worker usage',
+  description: 'Percentage of available workers that are currently busy.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'continuous-BlYlRd',
+      },
+      custom: {
+        axisBorderShow: false,
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 20,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      max: 100,
+      min: 0,
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'percent',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local executionsPanel(matcher) = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'rate(task_scheduler_total_execution_calls{' + matcher + ', instance=~"$instance"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - total',
+    ),
+    prometheus.target(
+      'rate(task_scheduler_total_execute_failure{' + matcher + ', instance=~"$instance"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - failed',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Executions',
+  description: 'Rate of executions and execution failures for the server.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisBorderShow: false,
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 20,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'ops',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local schedulesPanel(matcher) = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'rate(task_scheduler_total_schedule_calls{' + matcher + ', instance=~"$instance"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - total',
+    ),
+    prometheus.target(
+      'rate(task_scheduler_total_schedule_fails{' + matcher + ', instance=~"$instance"}[$__rate_interval])',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - failed',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Schedules',
+  description: 'Rate of schedule operations and schedule operation failures for the server.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisBorderShow: false,
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 20,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'ops',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local getMatcher(cfg) = '%(influxdbSelector)s, influxdb_cluster=~"$influxdb_cluster", instance=~"$instance"' % cfg;
+
+{
+  grafanaDashboards+:: {
+    'influxdb-instance-overview.json':
+      dashboard.new(
+        'InfluxDB instance overview',
+        time_from='%s' % $._config.dashboardPeriod,
+        tags=($._config.dashboardTags),
+        timezone='%s' % $._config.dashboardTimezone,
+        refresh='%s' % $._config.dashboardRefresh,
+        description='',
+        uid=dashboardUid,
+      )
+      .addLink(grafana.link.dashboards(
+        asDropdown=false,
+        title='Other InfluxDB dashboards',
+        includeVars=true,
+        keepTime=true,
+        tags=($._config.dashboardTags),
+      ))
+      .addTemplates(
+        [
+          template.datasource(
+            promDatasourceName,
+            'prometheus',
+            null,
+            label='Data Source',
+            refresh='load'
+          ),
+          template.new(
+            'job',
+            promDatasource,
+            'label_values(influxdb_uptime_seconds,job)',
+            label='Job',
+            refresh=2,
+            includeAll=true,
+            multi=true,
+            allValues='.+',
+            sort=0
+          ),
+          template.new(
+            'cluster',
+            promDatasource,
+            'label_values(influxdb_uptime_seconds{%(multiclusterSelector)s}, cluster)' % $._config,
+            label='Cluster',
+            refresh=2,
+            includeAll=true,
+            multi=true,
+            allValues='.*',
+            hide=if $._config.enableMultiCluster then '' else 'variable',
+            sort=0
+          ),
+          template.new(
+            'influxdb_cluster',
+            promDatasource,
+            'label_values(influxdb_uptime_seconds{%(influxdbSelector)s}, influxdb_cluster)' % $._config,
+            label='InfluxDB cluster',
+            refresh=2,
+            includeAll=true,
+            multi=true,
+            allValues='',
+            sort=0
+          ),
+          template.new(
+            'instance',
+            promDatasource,
+            'label_values(influxdb_uptime_seconds{%(influxdbSelector)s, influxdb_cluster=~"$influxdb_cluster"}, instance)' % $._config,
+            label='Instance',
+            refresh=2,
+            includeAll=true,
+            multi=true,
+            allValues='.+',
+            sort=0
+          ),
+        ]
+      )
+      .addPanels(
+        [
+          uptimePanel(getMatcher($._config)) { gridPos: { h: 8, w: 3, x: 0, y: 0 } },
+          bucketsPanel(getMatcher($._config)) { gridPos: { h: 8, w: 3, x: 3, y: 0 } },
+          usersPanel(getMatcher($._config)) { gridPos: { h: 8, w: 3, x: 6, y: 0 } },
+          replicationsPanel(getMatcher($._config)) { gridPos: { h: 8, w: 3, x: 9, y: 0 } },
+          remotesPanel(getMatcher($._config)) { gridPos: { h: 8, w: 3, x: 12, y: 0 } },
+          scrapersPanel(getMatcher($._config)) { gridPos: { h: 8, w: 3, x: 15, y: 0 } },
+          dashboardsPanel(getMatcher($._config)) { gridPos: { h: 8, w: 3, x: 18, y: 0 } },
+          threadsPanel(getMatcher($._config)) { gridPos: { h: 8, w: 3, x: 21, y: 0 } },
+          goRow { gridPos: { h: 1, w: 24, x: 0, y: 8 } },
+          timeSinceLastGCPanel(getMatcher($._config)) { gridPos: { h: 8, w: 6, x: 0, y: 9 } },
+          gcTimePanel(getMatcher($._config)) { gridPos: { h: 8, w: 9, x: 6, y: 9 } },
+          gcCPUUsagePanel(getMatcher($._config)) { gridPos: { h: 8, w: 9, x: 15, y: 9 } },
+          heapMemoryUsagePanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 0, y: 17 } },
+          goThreadsPanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 12, y: 17 } },
+          queriesAndOperationsRow { gridPos: { h: 1, w: 24, x: 0, y: 25 } },
+          httpAPIRequestsPanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 0, y: 26 } },
+          activeQueriesPanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 12, y: 26 } },
+          httpOperationsPanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 0, y: 34 } },
+          httpOperationDataPanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 12, y: 34 } },
+          iqlQueryRatePanel(getMatcher($._config)) { gridPos: { h: 8, w: 8, x: 0, y: 42 } },
+          iqlQueryResponseTimePanel(getMatcher($._config)) { gridPos: { h: 8, w: 8, x: 8, y: 42 } },
+          boltdbOperationsPanel(getMatcher($._config)) { gridPos: { h: 8, w: 8, x: 16, y: 42 } },
+          taskSchedulerRow { gridPos: { h: 1, w: 24, x: 0, y: 50 } },
+          activeTasksPanel(getMatcher($._config)) { gridPos: { h: 8, w: 8, x: 0, y: 51 } },
+          activeWorkersPanel(getMatcher($._config)) { gridPos: { h: 8, w: 8, x: 8, y: 51 } },
+          workerUsagePanel(getMatcher($._config)) { gridPos: { h: 8, w: 8, x: 16, y: 51 } },
+          executionsPanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 0, y: 59 } },
+          schedulesPanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 12, y: 59 } },
+        ]
+      ),
+  },
+}

--- a/influxdb-mixin/dashboards/influxdb-instance-overview.libsonnet
+++ b/influxdb-mixin/dashboards/influxdb-instance-overview.libsonnet
@@ -581,12 +581,12 @@ local httpOperationsPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(job, influxdb_cluster, instance, status) (rate(http_query_request_count{' + matcher + ', instance=~"$instance"}[$__rate_interval]))',
+      'sum by(job, influxdb_cluster, instance, status) (rate(http_query_request_count{' + matcher + ', instance=~"$instance"}[$__rate_interval])) > 0',
       datasource=promDatasource,
       legendFormat='{{instance}} - query - {{status}}',
     ),
     prometheus.target(
-      'sum by(job, influxdb_cluster, instance, status) (rate(http_write_request_count{' + matcher + ', instance=~"$instance"}[$__rate_interval]))',
+      'sum by(job, influxdb_cluster, instance, status) (rate(http_write_request_count{' + matcher + ', instance=~"$instance"}[$__rate_interval])) > 0',
       datasource=promDatasource,
       legendFormat='{{instance}} - write - {{status}}',
     ),

--- a/influxdb-mixin/dashboards/influxdb-instance-overview.libsonnet
+++ b/influxdb-mixin/dashboards/influxdb-instance-overview.libsonnet
@@ -787,7 +787,7 @@ local httpAPIRequestsPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(job, influxdb_cluster, instance, status) (rate(http_api_requests_total{' + matcher + ', instance=~"$instance"}[$__rate_interval]))',
+      'sum by(' + matcher + ', instance, status) (rate(http_api_requests_total{' + matcher + ', instance=~"$instance"}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='{{instance}} - {{status}}',
     ),
@@ -864,17 +864,17 @@ local activeQueriesPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(job, influxdb_cluster, instance) (qc_compiling_active{' + matcher + ', instance=~"$instance"})',
+      'sum by(' + matcher + ', instance) (qc_compiling_active{' + matcher + ', instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{instance}} - compiling',
     ),
     prometheus.target(
-      'sum by(job, influxdb_cluster, instance) (qc_queueing_active{' + matcher + ', instance=~"$instance"})',
+      'sum by(' + matcher + ', instance) (qc_queueing_active{' + matcher + ', instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{instance}} - queueing',
     ),
     prometheus.target(
-      'sum by(job, influxdb_cluster, instance) (qc_executing_active{' + matcher + ', instance=~"$instance"})',
+      'sum by(' + matcher + ', instance) (qc_executing_active{' + matcher + ', instance=~"$instance"})',
       datasource=promDatasource,
       legendFormat='{{instance}} - executing',
     ),
@@ -952,12 +952,12 @@ local httpOperationsPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(job, influxdb_cluster, instance, status) (rate(http_query_request_count{' + matcher + ', instance=~"$instance"}[$__rate_interval]))',
+      'sum by(' + matcher + ', instance, status) (rate(http_query_request_count{' + matcher + ', instance=~"$instance"}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='{{instance}} - query - {{status}}',
     ),
     prometheus.target(
-      'sum by(job, influxdb_cluster, instance, status) (rate(http_write_request_count{' + matcher + ', instance=~"$instance"}[$__rate_interval]))',
+      'sum by(' + matcher + ', instance, status) (rate(http_write_request_count{' + matcher + ', instance=~"$instance"}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='{{instance}} - write - {{status}}',
     ),
@@ -1034,22 +1034,22 @@ local httpOperationDataPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(job, influxdb_cluster, instance) (rate(http_query_request_bytes{' + matcher + ', instance=~"$instance"}[$__rate_interval]))',
+      'sum by(' + matcher + ', instance) (rate(http_query_request_bytes{' + matcher + ', instance=~"$instance"}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='{{instance}} - query request',
     ),
     prometheus.target(
-      'sum by(job, influxdb_cluster, instance) (rate(http_query_response_bytes{' + matcher + ', instance=~"$instance"}[$__rate_interval]))',
+      'sum by(' + matcher + ', instance) (rate(http_query_response_bytes{' + matcher + ', instance=~"$instance"}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='{{instance}} - query response',
     ),
     prometheus.target(
-      'sum by(job, influxdb_cluster, instance) (rate(http_write_request_bytes{' + matcher + ', instance=~"$instance"}[$__rate_interval]))',
+      'sum by(' + matcher + ', instance) (rate(http_write_request_bytes{' + matcher + ', instance=~"$instance"}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='{{instance}} - write request',
     ),
     prometheus.target(
-      'sum by(job, influxdb_cluster, instance) (rate(http_write_response_bytes{' + matcher + ', instance=~"$instance"}[$__rate_interval]))',
+      'sum by(' + matcher + ', instance) (rate(http_write_response_bytes{' + matcher + ', instance=~"$instance"}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='{{instance}} - write response',
     ),
@@ -1130,7 +1130,7 @@ local iqlQueryRatePanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(job, influxdb_cluster, instance, result) (rate(influxql_service_requests_total{' + matcher + ', instance=~"$instance"}[$__rate_interval]))',
+      'sum by(' + matcher + ', instance, result) (rate(influxql_service_requests_total{' + matcher + ', instance=~"$instance"}[$__rate_interval]))',
       datasource=promDatasource,
       legendFormat='{{instance}} - {{result}}',
     ),
@@ -1207,7 +1207,7 @@ local iqlQueryResponseTimePanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'sum by(job, influxdb_cluster, instance, result) (increase(influxql_service_executing_duration_seconds_sum{' + matcher + ', instance=~"$instance"}[$__interval:]))',
+      'sum by(' + matcher + ', instance, result) (increase(influxql_service_executing_duration_seconds_sum{' + matcher + ', instance=~"$instance"}[$__interval:]))',
       datasource=promDatasource,
       legendFormat='{{instance}} - {{result}}',
       interval='1m',

--- a/influxdb-mixin/dashboards/influxdb-logs-overview.libsonnet
+++ b/influxdb-mixin/dashboards/influxdb-logs-overview.libsonnet
@@ -1,0 +1,32 @@
+local g = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';
+local logsDashboard = import 'github.com/grafana/jsonnet-libs/logs-lib/logs/main.libsonnet';
+{
+  grafanaDashboards+::
+    if $._config.enableLokiLogs then {
+      local influxdbLogs =
+        logsDashboard.new(
+          'InfluxDB logs overview',
+          datasourceName='loki_datasource',
+          datasourceRegex='',
+          filterSelector=$._config.filterSelector,
+          labels=['job', 'influxdb_cluster', 'instance', 'level', 'service', 'engine'],
+          formatParser=null,
+          showLogsVolume=true
+        )
+        {
+          panels+:
+            {
+              logs+:
+                // InfluxDB logs already have timestamp
+                g.panel.logs.options.withShowTime(false),
+            },
+          dashboards+:
+            {
+              logs+: g.dashboard.withLinksMixin($.grafanaDashboards['influxdb-cluster-overview.json'].links)
+                     + g.dashboard.withTags($._config.dashboardTags)
+                     + g.dashboard.withRefresh($._config.dashboardRefresh),
+            },
+        },
+      'influxdb-logs.json': influxdbLogs.dashboards.logs,
+    } else {},
+}

--- a/influxdb-mixin/jsonnetfile.json
+++ b/influxdb-mixin/jsonnetfile.json
@@ -1,0 +1,34 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/grafonnet-lib.git",
+          "subdir": "grafonnet"
+        }
+      },
+      "version": "master"
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/grafonnet.git",
+          "subdir": "gen/grafonnet-latest"
+        }
+      },
+      "version": "main"
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": "logs-lib"
+        }
+      },
+      "version": "master"
+    }
+  ],
+  "legacyImports": true
+}
+

--- a/influxdb-mixin/mixin.libsonnet
+++ b/influxdb-mixin/mixin.libsonnet
@@ -1,0 +1,3 @@
+(import 'dashboards/dashboards.libsonnet') +
+(import 'alerts/alerts.libsonnet') +
+(import 'config.libsonnet')


### PR DESCRIPTION
Adds dashboards and alerts for the InfluxDB mixin.

Dashboards:
- InfluxDB cluster overview
- InfluxDB instance overview
- InfluxDB logs overview

Alerts:
- InfluxDBWarningTaskSchedulerHighFailureRate
- InfluxDBCriticalTaskSchedulerHighFailureRate
- InfluxDBHighBusyWorkerPercentage
- InfluxDBHighHeapMemoryUsage
- InfluxDBHighAverageAPIRequestLatency
- InfluxDBSlowAverageIQLExecutionTime


## InfluxDB cluster overview
<img width="1919" alt="influxdb_cluster_overview_1" src="https://github.com/grafana/jsonnet-libs/assets/69878936/e2f0d16f-1256-4f5f-98d5-4bb593f31f1d">
<img width="1920" alt="influxdb_cluster_overview_2" src="https://github.com/grafana/jsonnet-libs/assets/69878936/48ed6694-e186-4f46-94d0-010327d2fa91">
<img width="1919" alt="influxdb_cluster_overview_3" src="https://github.com/grafana/jsonnet-libs/assets/69878936/8f4638ca-214b-43e9-b3e7-619cea5e1e62">


## InfluxDB instance overview
<img width="1920" alt="influxdb_instance_overview_1" src="https://github.com/grafana/jsonnet-libs/assets/69878936/9f7a9a49-b807-4670-903d-fe79612ba228">
<img width="1920" alt="influxdb_instance_overview_2" src="https://github.com/grafana/jsonnet-libs/assets/69878936/ad5c8aba-943c-439c-8641-48e58a5bd0e9">
<img width="1919" alt="influxdb_instance_overview_3" src="https://github.com/grafana/jsonnet-libs/assets/69878936/8947b302-b48a-419d-8ef1-25e1db76bdcf">


## InfluxDB logs overview
<img width="1920" alt="influxdb_logs_overview" src="https://github.com/grafana/jsonnet-libs/assets/69878936/cb662253-0005-4758-ba47-b99bb0d115dd">
