### PR TITLE
Update CPU modes panel

### DIFF
--- a/common-lib/common/panels/cpu/timeSeries/utilization_by_mode.libsonnet
+++ b/common-lib/common/panels/cpu/timeSeries/utilization_by_mode.libsonnet
@@ -17,6 +17,8 @@ base {
 
     + timeSeries.standardOptions.withUnit('percent')
     + timeSeries.fieldConfig.defaults.custom.withFillOpacity(80)
+    + timeSeries.standardOptions.withMax(100)
+    + timeSeries.standardOptions.withMin(0)
     + timeSeries.fieldConfig.defaults.custom.withStacking({ mode: 'normal' })
     + timeSeries.standardOptions.withOverrides(
       [


### PR DESCRIPTION
Add min=0,max=100 to see what mode is most used:
<img width="652" alt="image" src="https://github.com/grafana/jsonnet-libs/assets/14870891/19ab503e-b4c0-4374-bfd3-38dbb77c58b8">
->
<img width="650" alt="Screenshot 2023-11-28 at 22 49 28" src="https://github.com/grafana/jsonnet-libs/assets/14870891/6c76adcd-e6e8-4318-a7ad-ec70716ddbb0">
