### PR TITLE
grafana-builder: rename template variable "Data Source" to "Data source"

### DIFF
--- a/grafana-builder/grafana.libsonnet
+++ b/grafana-builder/grafana.libsonnet
@@ -109,7 +109,7 @@
             value: datasource,
           },
           hide: 0,
-          label: 'Data Source',
+          label: 'Data source',
           name: 'datasource',
           options: [],
           query: 'prometheus',


### PR DESCRIPTION
an internal linter is complaining about this