### PR TITLE
Envoy-mixin: Set grafanaDashboardFolder as hidden field

### DIFF
--- a/envoy-mixin/mixin.libsonnet
+++ b/envoy-mixin/mixin.libsonnet
@@ -1,4 +1,4 @@
 {
-  grafanaDashboardFolder: 'Envoy',
+  grafanaDashboardFolder:: 'Envoy',
 } +
 (import 'dashboards.libsonnet')


### PR DESCRIPTION
Set grafanaDashboardFolder as hidden field, so it works well with grizzly hidden fields mode:

```
 % grr apply mixin.libsonnet
INFO[0000] Applying 2 resources                         
DashboardFolder.Envoy added
Dashboard.54d07750e539f2dcd48d30784c928931 added
```

https://grafana.github.io/grizzly/hidden-elements/
