### PR TITLE
Add Apache Solr mixin

### DIFF
--- a/apache-solr/.lint
+++ b/apache-solr/.lint
@@ -1,0 +1,46 @@
+exclusions:
+  template-job-rule:
+    reason: "Prometheus datasource variable is being named as prometheus_datasource now while linter expects 'datasource'"
+  panel-datasource-rule:
+    reason: "Loki datasource variable is being named as loki_datasource now while linter expects 'datasource'"
+  template-datasource-rule:
+    reason: "Based on new convention we are using variable names prometheus_datasource and loki_datasource where as linter expects 'datasource'"
+  template-instance-rule:
+    reason: "Based on new convention we are using variable names prometheus_datasource and loki_datasource where as linter expects 'datasource'"
+  target-promql-rule:
+    reason: "Linter does not support selector variable value as a scalar in top-k PromQL queries."
+  template-label-promql-rule:
+    reason: "Defining a selector for the value of top-k requires a predefined label that the linter considers invalid."
+  panel-title-description-rule:
+    reason: "Not required for logs volume"
+  panel-units-rule:
+    reason: "Custom units are used for better user experience in these panels"
+    entries:
+    - panel: "Logs volume"
+    - panel: "Live nodes"
+    - panel: "Zookeeper status"
+    - panel: "Zookeeper ensemble size"
+    - panel: "Shard status"
+    - panel: "Replica status"
+    - panel: "Top update handlers by core / $__interval"
+    - panel: "Top core errors by core / $__interval"
+    - panel: "Top node errors by node / $__interval"
+    - panel: "Update handlers / $__interval"
+    - panel: "Cache evictions / $__interval"
+    - panel: "Core timeouts / $__interval"
+    - panel: "Node timeouts / $__interval"
+    - panel: "Query error rate"
+    - panel: "Query client errors"
+    - panel: "Connections"
+    - panel: "Threads / $__interval"
+    - panel: "Garbage collections / $__interval"
+    - panel: "File descriptors"
+    - panel: "Requests  / $__interval"
+    - panel: "Responses  / $__interval"
+    - panel: "Dispatches  / $__interval"
+  target-instance-rule:
+    reason: "base_url is used instead of instance because of how cluster metrics are returned."
+    entires:
+      - dashboard: "Apache Solr cluster overview"
+      - dashboard: "Apache Solr query performance overview"
+      - dashboard: "Apache Solr resource monitoring overview"

--- a/apache-solr/Makefile
+++ b/apache-solr/Makefile
@@ -1,0 +1,34 @@
+JSONNET_FMT := jsonnetfmt -n 2 --max-blank-lines 1 --string-style s --comment-style s
+
+.PHONY: all
+all: build dashboards_out prometheus_alerts.yaml
+
+vendor: jsonnetfile.json
+	jb install
+
+.PHONY: build
+build: vendor
+
+.PHONY: fmt
+fmt:
+	find . -name 'vendor' -prune -o -name '*.libsonnet' -print -o -name '*.jsonnet' -print | \
+		xargs -n 1 -- $(JSONNET_FMT) -i
+
+.PHONY: lint
+lint: build
+	find . -name 'vendor' -prune -o -name '*.libsonnet' -print -o -name '*.jsonnet' -print | \
+		while read f; do \
+			$(JSONNET_FMT) "$$f" | diff -u "$$f" -; \
+		done
+	mixtool lint mixin.libsonnet
+
+dashboards_out: mixin.libsonnet config.libsonnet $(wildcard dashboards/*)
+	@mkdir -p dashboards_out
+	mixtool generate dashboards mixin.libsonnet -d dashboards_out
+
+prometheus_alerts.yaml: mixin.libsonnet alerts/*.libsonnet
+	mixtool generate alerts mixin.libsonnet -a prometheus_alerts.yaml
+
+.PHONY: clean
+clean:
+	rm -rf dashboards_out prometheus_alerts.yaml

--- a/apache-solr/README.md
+++ b/apache-solr/README.md
@@ -1,0 +1,133 @@
+# Apache Solr Mixin
+
+Apache Solr mixin is a set of configurable Grafana dashboards and alerts.
+
+The Apache Solr mixin contains the following dashboards:
+
+- Apache Solr cluster overview
+- Apache Solr query performance overview
+- Apache Solr resource monitoring overview
+- Apache Solr Logs overview
+
+and the following alerts:
+
+- ApacheSolrZookeeperChangeInEnsembleSize
+- ApacheSolrHighCPUUsageCritical
+- ApacheSolrHighCPUUsageWarning
+- ApacheSolrHighHeapMemoryUsageCritical
+- ApacheSolrHighHeapMemoryUsageWarning
+- ApacheSolrLowCacheHitRatio
+- ApacheSolrHighCoreErrors
+- ApacheSolrHighDocumentIndexing
+
+## Apache Solr Cluster Overview
+
+The Apache Solr cluster overview dashboard provides details on cluster, shard, replica and Zookeeper health as well as top core and error metrics.
+
+![Apache Solr Cluster Overview Dashboard 1](https://storage.googleapis.com/grafanalabs-integration-assets/apache-solr/screenshots/apache-solr-cluster-1.png)
+![Apache Solr Cluster Overview Dashboard 2](https://storage.googleapis.com/grafanalabs-integration-assets/apache-solr/screenshots/apache-solr-cluster-2.png)
+
+## Apache Solr Query Performance Overview
+
+The Apache Solr query performance overview dashboard provides details on various query load and latency, update handlers, cache, timeout and error metrics.
+
+![Apache Solr Query Performance Overview Dashboard 1](https://storage.googleapis.com/grafanalabs-integration-assets/apache-solr/screenshots/apache-solr-query-performance-1.png)
+![Apache Solr Query Performance Overview Dashboard 2](https://storage.googleapis.com/grafanalabs-integration-assets/apache-solr/screenshots/apache-solr-query-performance-2.png)
+
+## Apache Solr Resource Monitoring Overview
+
+The Apache Solr resource monitoring overview dashboard provides details on connection, threads, core fs usage, JVM and Jetty metrics.
+
+![Apache Solr Resource Monitoring Overview Dashboard 1](https://storage.googleapis.com/grafanalabs-integration-assets/apache-solr/screenshots/apache-solr-resource-monitoring-1.png)
+![Apache Solr Resource Monitoring Overview Dashboard 2](https://storage.googleapis.com/grafanalabs-integration-assets/apache-solr/screenshots/apache-solr-resource-monitoring-2.png)
+
+## Apache Solr Logs Overview
+
+The Apache Solr logs overview dashboard provides details on slow requests, garbage collection, and error logs. [Promtail and Loki needs to be installed](https://grafana.com/docs/loki/latest/installation/) and provisioned for logs with your Grafana instance. The default Apache Solr error log path is `/var/solr/logs/solr.log` for each instance on Linux.
+
+Apache Solr logs are enabled by default in the `config.libsonnet` and can be removed by setting `enableLokiLogs` to `false`. Then run `make` again to regenerate the dashboard:
+
+```
+{
+  _config+:: {
+    enableLokiLogs: false,
+  },
+}
+```
+
+In order for the selectors to properly work for system logs ingested into your logs datasource, please also include the matching `job` and `solr_cluster` labels onto the [scrape_configs](https://grafana.com/docs/loki/latest/clients/promtail/configuration/#scrape_configs) as to match the labels for ingested metrics.
+
+```yaml
+scrape_configs:
+  - job_name: integrations/apache-solr
+    static_configs:
+      - targets: [localhost]
+        labels:
+          job: integrations/apache-solr
+          instance: '<your-instance-name>'
+          solr_cluster: '<your-cluster-name>'
+          __path__: /var/log/logs/*.log
+```
+
+![Apache Solr Logs Overview Dashboard 1](https://storage.googleapis.com/grafanalabs-integration-assets/apache-solr/screenshots/apache-solr-logs-overview.png)
+
+## Alerts Overview
+
+
+| Alert                                   | Summary                                                                                                             |
+|-----------------------------------------|---------------------------------------------------------------------------------------------------------------------|
+| ApacheSolrZookeeperChangeInEnsembleSize | Changes in the ZooKeeper ensemble size can affect the stability and performance of the cluster.                     |
+| ApacheSolrHighCPUUsageCritical          | High CPU load can indicate that Solr nodes are under heavy load, potentially impacting performance.                 |
+| ApacheSolrHighCPUUsageWarning           | High CPU load can indicate that Solr nodes are under heavy load, potentially impacting performance.                 |
+| ApacheSolrHighHeapMemoryUsageCritical   | High heap memory usage can lead to garbage collection issues, out-of-memory errors, and overall system instability. |
+| ApacheSolrHighHeapMemoryUsageWarning    | High heap memory usage can lead to garbage collection issues, out-of-memory errors, and overall system instability. |
+| ApacheSolrLowCacheHitRatio              | Low cache hit ratios can lead to increased disk I/O and slower query response times.                                |
+| ApacheSolrHighCoreErrors                | A spike in core errors can indicate serious issues at the core level, affecting data integrity and availability.    |
+| ApacheSolrHighDocumentIndexing          | A sudden spike in document indexing could indicate unintended or malicious bulk updates.                            |
+
+Default thresholds can be configured in `config.libsonnet`
+
+```js
+{
+  _config+:: {
+    alertsCriticalCPUUsage: 85,
+    alertsWarningCPUUsage: 75,
+    alertsWarningMemoryUsage: 85,
+    alertsCriticalMemoryUsage: 75,
+    alertsWarningCacheUsage: 75,
+    alertsWarningCoreErrors: 15,
+    alertsWarningDocumentIndexing: 30,
+  },
+}
+```
+
+## Install Tools
+
+```bash
+go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@latest
+go install github.com/monitoring-mixins/mixtool/cmd/mixtool@latest
+# or in brew: brew install go-jsonnet
+```
+
+For linting and formatting, you would also need `mixtool` and `jsonnetfmt` installed. If you
+have a working Go development environment, it's easiest to run the following:
+
+```bash
+go install github.com/google/go-jsonnet/cmd/jsonnetfmt@latest
+```
+
+The files in `dashboards_out` need to be imported
+into your Grafana server. The exact details will be depending on your environment.
+
+`prometheus_alerts.yaml` needs to be imported into Prometheus.
+
+## Generate Dashboards And Alerts
+
+Edit `config.libsonnet` if required and then build JSON dashboard files for Grafana:
+
+```bash
+make
+```
+
+For more advanced uses of mixins, see
+https://github.com/monitoring-mixins/docs.

--- a/apache-solr/alerts/alerts.libsonnet
+++ b/apache-solr/alerts/alerts.libsonnet
@@ -1,0 +1,142 @@
+{
+  prometheusAlerts+:: {
+    groups+: [
+      {
+        name: 'apache-solr',
+        rules: [
+          {
+            alert: 'ApacheSolrZookeeperChangeInEnsembleSize',
+            expr: |||
+              'changes(solr_zookeeper_ensemble_size[5m]) > 0'
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              summary: 'Changes in the ZooKeeper ensemble size can affect the stability and performance of the cluster.',
+              description:
+                (
+                  'Zookeeper host {{$labels.zk_host}} has had an ensemble change of {{ printf "%%.0f" $value }} over the last 5 minutes'
+                ) % $._config,
+            },
+          },
+          {
+            alert: 'ApacheSolrHighCPUUsageCritical',
+            expr: |||
+              '100 * sum without (base_url, item) (avg_over_time(solr_metrics_jvm_os_cpu_load{item="systemCpuLoad"}[5m])) > %(alertsCriticalCPUUsage)s'
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              summary: 'High CPU load can indicate that Solr nodes are under heavy load, potentially impacting performance.',
+              description:
+                (
+                  '{{$labels.instance}} on cluster {{$labels.solr_cluster}} has had a system CPU load of {{ printf "%%.0f" $value }}%%, which is above the threshold of %(alertsCriticalCPUUsage)s.'
+                ) % $._config,
+            },
+          },
+          {
+            alert: 'ApacheSolrHighCPUUsageWarning',
+            expr: |||
+              '100 * sum without (base_url, item) (avg_over_time(solr_metrics_jvm_os_cpu_load{item="systemCpuLoad"}[5m])) > %(alertsWarningCPUUsage)s'
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              summary: 'High CPU load can indicate that Solr nodes are under heavy load, potentially impacting performance.',
+              description:
+                (
+                  '{{$labels.instance}} on cluster {{$labels.solr_cluster}} has had a system CPU load of {{ printf "%%.0f" $value }}%%, which is above the threshold of %(alertsWarningCPUUsage)s.'
+                ) % $._config,
+            },
+          },
+          {
+            alert: 'ApacheSolrHighHeapMemoryUsageCritical',
+            expr: |||
+              '100 * sum without(item, base_url)(solr_metrics_jvm_memory_heap_bytes{item="used"}) / clamp_min(sum without(item, base_url)(solr_metrics_jvm_memory_heap_bytes{item="max"}), 1) > %(alertsCriticalMemoryUsage)s'
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              summary: 'High heap memory usage can lead to garbage collection issues, out-of-memory errors, and overall system instability.',
+              description: |||
+                {{$labels.instance}} on cluster {{$labels.solr_cluster}} has had high memory usage of {{ printf "%%.0f" $value }}%%, which is above the thresold of %(alertsCriticalMemoryUsage)s.
+              ||| % $._config,
+            },
+          },
+          {
+            alert: 'ApacheSolrHighHeapMemoryUsageWarning',
+            expr: |||
+              '100 * sum without(item, base_url)(solr_metrics_jvm_memory_heap_bytes{item="used"}) / clamp_min(sum without(item, base_url)(solr_metrics_jvm_memory_heap_bytes{item="max"}), 1) > %(alertsWarningMemoryUsage)s'
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              summary: 'High heap memory usage can lead to garbage collection issues, out-of-memory errors, and overall system instability.',
+              description: |||
+                {{$labels.instance}} on cluster {{$labels.solr_cluster}} has had high memory usage of {{ printf "%%.0f" $value }}%%, which is above the thresold of %(alertsWarningMemoryUsage)s.
+              ||| % $._config,
+            },
+          },
+          {
+            alert: 'ApacheSolrLowCacheHitRatio',
+            expr: |||
+              '100 * sum without(base_url, category, collection, item, replica, shard) (solr_metrics_core_searcher_cache_ratio{item="hitratio", type=~"documentCache|filterCache|queryResultCache"}[10m]) < %(alertsWarningCacheUsage)s'
+            ||| % $._config,
+            'for': '10m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              summary: 'Low cache hit ratios can lead to increased disk I/O and slower query response times.',
+              description: |||
+                {{$labels.instance}} on cluster {{$labels.solr_cluster}} has had a low cache hit ratio of {{ printf "%%.0f" $value }}%% on core {{$labels.core}} of type {{$labels.type}}, which is under the threshold of %(alertsWarningCacheUsage)s.
+              ||| % $._config,
+            },
+          },
+          {
+            alert: 'ApacheSolrHighCoreErrors',
+            expr: |||
+              '100 * sum without(base_url, category, collection, handler, replica, shard) (increase(solr_metrics_core_errors_total[10m]) / clamp_min(avg_over_time(solr_metrics_core_errors_total[10m]), 1)) > %(alertsWarningCoreErrors)s'
+            ||| % $._config,
+            'for': '10m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              summary: 'A spike in core errors can indicate serious issues at the core level, affecting data integrity and availability.',
+              description: |||
+                {{$labels.instance}} on cluster {{$labels.solr_cluster}} has had a high amount of core errors {{ printf "%%.0f" $value }}%% on core {{$labels.core}}, which is above the threshold of %(alertsWarningCoreErrors)s.
+              ||| % $._config,
+            },
+          },
+          {
+            alert: 'ApacheSolrHighDocumentIndexing',
+            expr: |||
+              '100 * sum without(base_url, category, collection, handler, replica, shard) (increase(solr_metrics_core_update_handler_adds_total[15m]) / clamp_min(avg_over_time(solr_metrics_core_update_handler_adds_total[15m]), 1)) > %(alertsWarningDocumentIndexing)s'
+            ||| % $._config,
+            'for': '15m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              summary: 'A sudden spike in document indexing could indicate unintended or malicious bulk updates.',
+              description: |||
+                {{$labels.instance}} on cluster {{$labels.solr_cluster}} has had a high document indexing value of {{ printf "%%.0f" $value }}%% on core {{$labels.core}}, which is above the threshold of %(alertsWarningDocumentIndexing)s.
+              ||| % $._config,
+            },
+          },
+        ],
+      },
+    ],
+  },
+}

--- a/apache-solr/config.libsonnet
+++ b/apache-solr/config.libsonnet
@@ -1,0 +1,24 @@
+{
+  _config+:: {
+    enableMultiCluster: false,
+    solrSelector: if self.enableMultiCluster then 'job=~"$job", cluster=~"$cluster"' else 'job=~"$job"',
+    multiclusterSelector: 'job=~"$job"',
+    filterSelector: 'job=~"integrations/apache-solr"',
+
+    dashboardTags: ['apache-solr-mixin'],
+    dashboardPeriod: 'now-30m',
+    dashboardTimezone: 'default',
+    dashboardRefresh: '1m',
+
+    // alerts thresholds
+    alertsCriticalCPUUsage: 85,
+    alertsWarningCPUUsage: 75,
+    alertsWarningMemoryUsage: 85,
+    alertsCriticalMemoryUsage: 75,
+    alertsWarningCacheUsage: 75,
+    alertsWarningCoreErrors: 15,
+    alertsWarningDocumentIndexing: 30,
+
+    enableLokiLogs: true,
+  },
+}

--- a/apache-solr/dashboards/apache-solr-cluster-overview.libsonnet
+++ b/apache-solr/dashboards/apache-solr-cluster-overview.libsonnet
@@ -1,0 +1,1712 @@
+local grafana = (import 'grafonnet/grafana.libsonnet');
+local dashboard = grafana.dashboard;
+local template = grafana.template;
+local prometheus = grafana.prometheus;
+
+local dashboardUid = 'apache-solr-cluster-overview';
+
+local promDatasourceName = 'prometheus_datasource';
+
+local promDatasource = {
+  uid: '${%s}' % promDatasourceName,
+};
+
+
+local liveNodesPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'solr_collections_live_nodes{job=~"$job", instance=~"$instance", solr_cluster=~"$solr_cluster"}',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - {{zk_host}}',
+      instant=true,
+      format='table',
+    ),
+  ],
+  type: 'barchart',
+  title: 'Live nodes',
+  description: 'Number of live nodes in the Solr cluster.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds',
+      },
+      custom: {
+        axisBorderShow: false,
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisGridShow: false,
+        axisLabel: '',
+        axisPlacement: 'auto',
+        fillOpacity: 30,
+        gradientMode: 'opacity',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false
+        },
+        lineWidth: 2,
+        scaleDistribution: {
+          type: 'linear'
+        },
+        thresholdsStyle: {
+          mode: 'off'
+        }
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null
+          }
+        ]
+      },
+      unit: '',
+    },
+    overrides: []
+  },
+  options: {
+    barRadius: 0,
+    barWidth: 0.97,
+    colorByField: 'instance',
+    fullHighlight: false,
+    groupWidth: 0.7,
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'right',
+      showLegend: true,
+      width: 0
+    },
+    orientation: 'horizontal',
+    showValue: 'auto',
+    stacking: 'none',
+    tooltip: {
+      mode: 'single',
+      sort: 'none'
+    },
+    xField: 'instance',
+    xTickLabelRotation: 0,
+    xTickLabelSpacing: 0
+  },
+  pluginVersion: '9.4.3',
+};
+
+local zookeeperStatusPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'solr_zookeeper_status{job=~"$job", instance=~"$instance", solr_cluster=~"$solr_cluster"}',
+      datasource=promDatasource,
+      intervalFactor=2,
+      instant=true,
+      legendFormat='{{instance}} - {{zk_host}}',
+      format='table',
+    ),
+  ],
+  type: 'table',
+  title: 'Zookeeper status',
+  description: 'Status of ZooKeeper, integral for cluster coordination.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'fixed',
+      },
+      custom: {
+        align: 'left',
+        cellOptions: {
+          type: 'color-text',
+        },
+        inspect: false,
+      },
+      mappings: [
+        {
+          options: {
+            '0': {
+              color: 'red',
+              index: 1,
+              text: 'Unavailable',
+            },
+            '1': {
+              color: 'green',
+              index: 0,
+              text: 'Available',
+            },
+          },
+          type: 'value',
+        },
+      ],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [
+      {
+        matcher: {
+          id: 'byName',
+          options: 'Time',
+        },
+        properties: [
+          {
+            id: 'custom.hidden',
+            value: true,
+          },
+        ],
+      },
+      {
+        matcher: {
+          id: 'byName',
+          options: 'job',
+        },
+        properties: [
+          {
+            id: 'custom.hidden',
+            value: true,
+          },
+        ],
+      },
+      {
+        matcher: {
+          id: 'byName',
+          options: '__name__',
+        },
+        properties: [
+          {
+            id: 'custom.hidden',
+            value: true,
+          },
+        ],
+      },
+      {
+        matcher: {
+          id: 'byName',
+          options: 'status',
+        },
+        properties: [
+          {
+            id: 'custom.hidden',
+            value: true,
+          },
+        ],
+      },
+      {
+        matcher: {
+          id: 'byName',
+          options: 'solr_cluster',
+        },
+        properties: [
+          {
+            id: 'displayName',
+            value: 'Solr cluster',
+          },
+        ],
+      },
+      {
+        matcher: {
+          id: 'byName',
+          options: 'zk_host',
+        },
+        properties: [
+          {
+            id: 'displayName',
+            value: 'Zookeeper host',
+          },
+        ],
+      },
+      {
+        matcher: {
+          id: 'byName',
+          options: 'Value',
+        },
+        properties: [
+          {
+            id: 'displayName',
+            value: 'Status',
+          },
+        ],
+      },
+    ],
+  },
+  options: {
+    cellHeight: 'sm',
+    footer: {
+      countRows: false,
+      fields: [],
+      reducer: [
+        'sum',
+      ],
+      show: false,
+    },
+    showHeader: true,
+  },
+  pluginVersion: '9.4.3',
+};
+
+local zookeeperEnsembleSizePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'solr_zookeeper_ensemble_size{job=~"$job", instance=~"$instance", solr_cluster=~"$solr_cluster"}',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - {{zk_host}}',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Zookeeper ensemble size',
+  description: 'Size of the ZooKeeper ensemble.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: '',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local alertsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      '',
+      datasource=promDatasource,
+      legendFormat='',
+    ),
+  ],
+  type: 'alertlist',
+  title: 'Alerts',
+  description: 'Panel to report on the status of firing alerts.',
+  options: {
+    alertInstanceLabelFilter: '{job=~"$job", instance="$instance", solr_cluster=~"$solr_cluster"}',
+    alertName: '',
+    dashboardAlerts: false,
+    groupBy: [],
+    groupMode: 'default',
+    maxItems: 20,
+    sortOrder: 1,
+    stateFilter: {
+      'error': true,
+      firing: true,
+      noData: false,
+      normal: false,
+      pending: true,
+    },
+    viewMode: 'list',
+  },
+};
+
+local shardStatePanel = {
+  datasource: {
+    type: 'prometheus',
+    uid: '${prometheus_datasource}'
+  },
+  description: 'Percent of running shards in the cluster.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds'
+      },
+      mappings: [],
+      max: 100,
+      min: 0,
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'red',
+            value: null
+          },
+          {
+            color: 'yellow',
+            value: 80
+          },
+          {
+            color: 'green',
+            value: 95
+          }
+        ]
+      },
+      unit: 'percent'
+    },
+    overrides: []
+  },
+  options: {
+    colorMode: 'value',
+    graphMode: 'none',
+    justifyMode: 'auto',
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull'
+      ],
+      fields: '',
+      values: false
+    },
+    textMode: 'value',
+    wideLayout: true
+  },
+  pluginVersion: '9.4.3',
+  targets: [
+    {
+      disableTextWrap: false,
+      expr: '100 * sum(solr_collections_shard_state{job=~"$job", instance=~"$instance", solr_cluster=~"$solr_cluster"})  / count(solr_collections_shard_state{job=~"$job", instance=~"$instance", solr_cluster=~"$solr_cluster"})',
+      fullMetaSearch: false,
+      includeNullMetadata: true,
+      instant: false,
+      legendFormat: '__auto',
+      range: true,
+      useBackend: false
+    }
+  ],
+  title: 'Shard state',
+  type: 'stat',
+};
+
+local shardStatusPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'solr_collections_shard_state{job=~"$job", instance=~"$instance", solr_cluster=~"$solr_cluster"}',
+      datasource=promDatasource,
+      intervalFactor=2,
+      instant=true,
+      legendFormat='{{auto}}',
+      format='table',
+    ),
+  ],
+  type: 'table',
+  title: 'Shard status',
+  description: 'Shows the state of various shards in the cluster.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'fixed',
+      },
+      custom: {
+        align: 'left',
+        cellOptions: {
+          type: 'color-text',
+        },
+        inspect: false,
+      },
+      mappings: [
+        {
+          options: {
+            '0': {
+              color: 'red',
+              index: 1,
+              text: 'Unavailable',
+            },
+            '1': {
+              color: 'green',
+              index: 0,
+              text: 'Available',
+            },
+          },
+          type: 'value',
+        },
+      ],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [
+      {
+        matcher: {
+          id: 'byName',
+          options: 'Time',
+        },
+        properties: [
+          {
+            id: 'custom.hidden',
+            value: true,
+          },
+        ],
+      },
+      {
+        matcher: {
+          id: 'byName',
+          options: 'job',
+        },
+        properties: [
+          {
+            id: 'custom.hidden',
+            value: true,
+          },
+        ],
+      },
+      {
+        matcher: {
+          id: 'byName',
+          options: '__name__',
+        },
+        properties: [
+          {
+            id: 'custom.hidden',
+            value: true,
+          },
+        ],
+      },
+      {
+        matcher: {
+          id: 'byName',
+          options: 'solr_cluster',
+        },
+        properties: [
+          {
+            id: 'custom.hidden',
+            value: true,
+          },
+        ],
+      },
+      {
+        matcher: {
+          id: 'byName',
+          options: 'zk_host',
+        },
+        properties: [
+          {
+            id: 'custom.hidden',
+            value: true,
+          },
+        ],
+      },
+      {
+        matcher: {
+          id: 'byName',
+          options: 'Value',
+        },
+        properties: [
+          {
+            id: 'displayName',
+            value: 'Status',
+          },
+        ],
+      },
+      {
+        matcher: {
+          id: 'byName',
+          options: 'instance',
+        },
+        properties: [
+          {
+            id: 'displayName',
+            value: 'Instance',
+          },
+        ],
+      },
+      {
+        matcher: {
+          id: 'byName',
+          options: 'shard',
+        },
+        properties: [
+          {
+            id: 'displayName',
+            value: 'Shard',
+          },
+        ],
+      },
+      {
+        matcher: {
+          id: 'byName',
+          options: 'collection',
+        },
+        properties: [
+          {
+            id: 'displayName',
+            value: 'Collection',
+          },
+        ],
+      },
+    ],
+  },
+  options: {
+    cellHeight: 'sm',
+    footer: {
+      countRows: false,
+      fields: [],
+      reducer: [
+        'sum',
+      ],
+      show: false,
+    },
+    showHeader: true,
+  },
+  pluginVersion: '9.4.3',
+};
+
+local replicaStatePanel = {
+  datasource: {
+    type: 'prometheus',
+    uid: '${prometheus_datasource}'
+  },
+  description: 'Shows the total percent of running shards in the cluster.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'thresholds'
+      },
+      mappings: [],
+      max: 100,
+      min: 0,
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'red',
+            value: null
+          },
+          {
+            color: 'yellow',
+            value: 80
+          },
+          {
+            color: 'green',
+            value: 95
+          }
+        ]
+      },
+      unit: 'percent'
+    },
+    overrides: []
+  },
+  options: {
+    colorMode: 'value',
+    graphMode: 'none',
+    justifyMode: 'auto',
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull'
+      ],
+      fields: '',
+      values: false
+    },
+    textMode: 'value',
+    wideLayout: true
+  },
+  pluginVersion: '9.4.3',
+  targets: [
+    {
+      disableTextWrap: false,
+      expr: '100 * sum(solr_collections_shard_state{job=~"$job", instance=~"$instance", solr_cluster=~"$solr_cluster"})  / count(solr_collections_shard_state{job=~"$job", instance=~"$instance", solr_cluster=~"$solr_cluster"})',
+      fullMetaSearch: false,
+      includeNullMetadata: true,
+      instant: false,
+      legendFormat: '__auto',
+      range: true,
+      useBackend: false
+    }
+  ],
+  title: 'Shard state',
+  type: 'stat',
+};
+
+local replicaStatusPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'solr_collections_replica_state{job=~"$job", instance=~"$instance", solr_cluster=~"$solr_cluster"}',
+      datasource=promDatasource,
+      legendFormat='{{auto}}',
+      instant=true,
+      intervalFactor=2,
+      format='table',
+    ),
+  ],
+  type: 'table',
+  title: 'Replica status',
+  description: 'State of replicas within a Solr collection.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'fixed',
+      },
+      custom: {
+        align: 'left',
+        cellOptions: {
+          type: 'color-text',
+        },
+        inspect: false,
+      },
+      mappings: [
+        {
+          options: {
+            '0': {
+              color: 'red',
+              index: 1,
+              text: 'Unavailable',
+            },
+            '1': {
+              color: 'green',
+              index: 0,
+              text: 'Available',
+            },
+          },
+          type: 'value',
+        },
+      ],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [
+      {
+        matcher: {
+          id: 'byName',
+          options: 'Time',
+        },
+        properties: [
+          {
+            id: 'custom.hidden',
+            value: true,
+          },
+        ],
+      },
+      {
+        matcher: {
+          id: 'byName',
+          options: 'job',
+        },
+        properties: [
+          {
+            id: 'custom.hidden',
+            value: true,
+          },
+        ],
+      },
+      {
+        matcher: {
+          id: 'byName',
+          options: '__name__',
+        },
+        properties: [
+          {
+            id: 'custom.hidden',
+            value: true,
+          },
+        ],
+      },
+      {
+        matcher: {
+          id: 'byName',
+          options: 'solr_cluster',
+        },
+        properties: [
+          {
+            id: 'custom.hidden',
+            value: true,
+          },
+        ],
+      },
+      {
+        matcher: {
+          id: 'byName',
+          options: 'collection',
+        },
+        properties: [
+          {
+            id: 'custom.hidden',
+            value: true,
+          },
+        ],
+      },
+      {
+        matcher: {
+          id: 'byName',
+          options: 'shard',
+        },
+        properties: [
+          {
+            id: 'custom.hidden',
+            value: true,
+          },
+        ],
+      },
+      {
+        matcher: {
+          id: 'byName',
+          options: 'replica',
+        },
+        properties: [
+          {
+            id: 'custom.hidden',
+            value: true,
+          },
+        ],
+      },
+      {
+        matcher: {
+          id: 'byName',
+          options: 'base_url',
+        },
+        properties: [
+          {
+            id: 'custom.hidden',
+            value: true,
+          },
+        ],
+      },
+      {
+        matcher: {
+          id: 'byName',
+          options: 'node_name',
+        },
+        properties: [
+          {
+            id: 'custom.hidden',
+            value: true,
+          },
+        ],
+      },
+      {
+        matcher: {
+          id: 'byName',
+          options: 'type',
+        },
+        properties: [
+          {
+            id: 'custom.hidden',
+            value: true,
+          },
+        ],
+      },
+      {
+        matcher: {
+          id: 'byName',
+          options: 'state',
+        },
+        properties: [
+          {
+            id: 'custom.hidden',
+            value: true,
+          },
+        ],
+      },
+      {
+        matcher: {
+          id: 'byName',
+          options: 'zk_host',
+        },
+        properties: [
+          {
+            id: 'custom.hidden',
+            value: true,
+          },
+        ],
+      },
+      {
+        matcher: {
+          id: 'byName',
+          options: 'Value',
+        },
+        properties: [
+          {
+            id: 'displayName',
+            value: 'Status',
+          },
+        ],
+      },
+      {
+        matcher: {
+          id: 'byName',
+          options: 'core',
+        },
+        properties: [
+          {
+            id: 'displayName',
+            value: 'Core',
+          },
+        ],
+      },
+      {
+        matcher: {
+          id: 'byName',
+          options: 'instance',
+        },
+        properties: [
+          {
+            id: 'displayName',
+            value: 'Instance',
+          },
+        ],
+      },
+      {
+        matcher: {
+          id: 'byName',
+          options: 'replica_name',
+        },
+        properties: [
+          {
+            id: 'displayName',
+            value: 'Replica name',
+          },
+        ],
+      },
+    ],
+  },
+  options: {
+    cellHeight: 'sm',
+    footer: {
+      countRows: false,
+      fields: [],
+      reducer: [
+        'sum',
+      ],
+      show: false,
+    },
+    showHeader: true,
+  },
+  pluginVersion: '9.4.3',
+};
+
+local topNodeMetricsRow = {
+  datasource: promDatasource,
+  targets: [],
+  type: 'row',
+  title: 'Top node metrics',
+  collapsed: false,
+};
+
+local topCPULoadByNodePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'topk($k, 100 * solr_metrics_jvm_os_cpu_load{job=~"$job", instance=~"$instance", solr_cluster=~"$solr_cluster", item="systemCpuLoad"})',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - {{base_url}}',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Top CPU load by node',
+  description: 'CPU load caused by the JVM.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      min: 0,
+      max: 100,
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'blue',
+          },
+          {
+            color: 'yellow',
+            value: 90,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'percent',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local topHeapMemoryUsageByNodePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'topk($k, 100 * sum without(item)(solr_metrics_jvm_memory_heap_bytes{item="used"}) / clamp_min(sum without(item)(solr_metrics_jvm_memory_heap_bytes{item="max"}), 1))',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Top heap memory usage by node',
+  description: 'Tracks JVM heap memory usage.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      min: 0,
+      max: 100,
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'blue',
+          },
+          {
+            color: 'yellow',
+            value: 90,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'percent',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local topMeanQueriesByNodePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'topk($k, solr_metrics_core_query_mean_rate{job=~"$job", instance=~"$instance", solr_cluster=~"$solr_cluster", category="QUERY", collection=~"$solr_collection", core=~"$solr_core"})',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - {{collection}} - {{core}} - {{searchHandler}}',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Top mean queries by node',
+  description: 'Average rate of query processing in the cluster.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'ms',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local topUpdateHandlersByNodePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'topk($k, increase(solr_metrics_core_update_handler_adds_total{job=~"$job", instance=~"$instance", solr_cluster=~"$solr_cluster", collection=~"$solr_collection", core=~"$solr_core"}[$__interval:]))',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - {{collection}} - {{core}}',
+      format='time_series',
+      interval='1m',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Top update handlers by node / $__interval',
+  description: 'Total number of document additions in the cluster.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'documents',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local topIndexSizeByNodePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'topk($k, solr_metrics_core_index_size_bytes{job=~"$job", instance=~"$instance", solr_cluster=~"$solr_cluster", collection=~"$solr_collection", core=~"$solr_core"})',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - {{collection}} - {{core}}',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Top index size by node',
+  description: 'Size of the Solr index.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'bytes',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local topCacheHitRatioByNodePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'bottomk($k, 100 * solr_metrics_core_searcher_cache_ratio{job=~"$job", instance=~"$instance", solr_cluster=~"$solr_cluster", collection=~"$solr_collection", core=~"$solr_core", type=~"documentCache|filterCache|queryResultCache"})',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - {{collection}} - {{core}} - {{type}}',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Top cache hit ratio by node',
+  description: 'Cache hit ratio in Solr searchers.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      min: 0,
+      max: 100,
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+          {
+            color: 'yellow',
+            value: 90,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'percent',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local errorsRow = {
+  datasource: promDatasource,
+  targets: [],
+  type: 'row',
+  title: 'Errors',
+  collapsed: false,
+};
+
+local topCoreErrorsByNodePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'topk($k, sum by (job, instance, solr_cluster, collection, core) (increase(solr_metrics_core_errors_total{job=~"$job", instance=~"$instance", solr_cluster=~"$solr_cluster", collection=~"$solr_collection", core=~"$solr_core"}[$__interval:])))',
+      datasource=promDatasource,
+      legendFormat='{{instance}} - {{collection}} - {{core}}',
+      format='time_series',
+      interval='1m',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Top core errors by node / $__interval',
+  description: 'Total errors in Solr cores.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local topNodeErrorsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'topk($k, sum by (job, instance, solr_cluster, collection) (increase(solr_metrics_node_errors_total{job=~"$job", instance=~"$instance", solr_cluster=~"$solr_cluster"}[$__interval:])))',
+      datasource=promDatasource,
+      legendFormat='{{instance}}',
+      format='time_series',
+      interval='1m',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Top node errors / $__interval',
+  description: 'Total number of errors on Solr node.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+{
+  grafanaDashboards+:: {
+    'apache-solr-cluster-overview.json':
+      dashboard.new(
+        'Apache Solr cluster overview',
+        time_from='%s' % $._config.dashboardPeriod,
+        tags=($._config.dashboardTags),
+        timezone='%s' % $._config.dashboardTimezone,
+        refresh='%s' % $._config.dashboardRefresh,
+        description='',
+        uid=dashboardUid,
+      )
+      .addLink(grafana.link.dashboards(
+        asDropdown=false,
+        title='Other Apache Solr dashboards',
+        includeVars=true,
+        keepTime=true,
+        tags=($._config.dashboardTags),
+      ))
+      .addTemplates(
+        [
+          template.datasource(
+            promDatasourceName,
+            'prometheus',
+            null,
+            label='Data Source',
+            refresh='load'
+          ),
+          template.new(
+            'job',
+            promDatasource,
+            'label_values(solr_metrics_core_errors_total,job)',
+            label='Job',
+            refresh=2,
+            includeAll=true,
+            multi=true,
+            allValues='.+',
+            sort=1
+          ),
+          template.new(
+            'instance',
+            promDatasource,
+            'label_values(solr_metrics_core_errors_total{job=~"$job"}, instance)',
+            label='Instance',
+            refresh=2,
+            includeAll=true,
+            multi=true,
+            allValues='.+',
+            sort=1
+          ),
+          template.new(
+            'solr_cluster',
+            promDatasource,
+            'label_values(solr_metrics_core_errors_total{job=~"$job"}, solr_cluster)',
+            label='Solr cluster',
+            refresh=2,
+            includeAll=true,
+            multi=true,
+            allValues='.+',
+            sort=1
+          ),
+          template.custom(
+            'k',
+            query='5,10,20,50',
+            current='5',
+            label='Top node count',
+            refresh='never',
+            includeAll=false,
+            multi=false,
+            allValues='',
+          ),
+          template.new(
+            'solr_collection',
+            promDatasource,
+            'label_values(solr_metrics_core_errors_total{job=~"$job"}, collection)',
+            label='Collection',
+            refresh=2,
+            includeAll=true,
+            multi=true,
+            allValues='.+',
+            sort=1
+          ),
+          template.new(
+            'solr_core',
+            promDatasource,
+            'label_values(solr_metrics_core_errors_total{job=~"$job"}, core)',
+            label='Core',
+            refresh=2,
+            includeAll=true,
+            multi=true,
+            allValues='.+',
+            sort=1
+          ),
+        ]
+      )
+      .addPanels(
+        [
+          liveNodesPanel { gridPos: { h: 6, w: 6, x: 0, y: 0 } },
+          zookeeperStatusPanel { gridPos: { h: 6, w: 6, x: 6, y: 0 } },
+          zookeeperEnsembleSizePanel { gridPos: { h: 6, w: 6, x: 12, y: 0 } },
+          alertsPanel { gridPos: { h: 6, w: 6, x: 18, y: 0 } },
+          shardStatePanel { gridPos: { h: 6, w: 4, x: 0, y: 6 } },
+          shardStatusPanel { gridPos: { h: 6, w: 8, x: 4, y: 6 } },
+          replicaStatePanel { gridPos: { h: 6, w: 4, x: 12, y: 6 } },
+          replicaStatusPanel { gridPos: { h: 6, w: 8, x: 16, y: 6 } },
+          topNodeMetricsRow { gridPos: { h: 1, w: 24, x: 0, y: 12 } },
+          topCPULoadByNodePanel { gridPos: { h: 6, w: 12, x: 0, y: 13 } },
+          topHeapMemoryUsageByNodePanel { gridPos: { h: 6, w: 12, x: 12, y: 13 } },
+          topMeanQueriesByNodePanel { gridPos: { h: 6, w: 12, x: 0, y: 19 } },
+          topUpdateHandlersByNodePanel { gridPos: { h: 6, w: 12, x: 12, y: 19 } },
+          topIndexSizeByNodePanel { gridPos: { h: 6, w: 12, x: 0, y: 25 } },
+          topCacheHitRatioByNodePanel { gridPos: { h: 6, w: 12, x: 12, y: 25 } },
+          errorsRow { gridPos: { h: 1, w: 24, x: 0, y: 31 } },
+          topCoreErrorsByNodePanel { gridPos: { h: 6, w: 12, x: 0, y: 32 } },
+          topNodeErrorsPanel { gridPos: { h: 6, w: 12, x: 12, y: 32 } },
+        ]
+      ),
+  },
+}

--- a/apache-solr/dashboards/apache-solr-cluster-overview.libsonnet
+++ b/apache-solr/dashboards/apache-solr-cluster-overview.libsonnet
@@ -11,98 +11,77 @@ local promDatasource = {
   uid: '${%s}' % promDatasourceName,
 };
 
-
 local liveNodesPanel = {
-  datasource: promDatasource,
-  targets: [
-    prometheus.target(
-      'solr_collections_live_nodes{job=~"$job", instance=~"$instance", solr_cluster=~"$solr_cluster"}',
-      datasource=promDatasource,
-      legendFormat='{{instance}} - {{zk_host}}',
-      instant=true,
-      format='table',
-    ),
-  ],
-  type: 'barchart',
-  title: 'Live nodes',
+  datasource: {
+    type: 'prometheus',
+    uid: '${prometheus_datasource}',
+  },
   description: 'Number of live nodes in the Solr cluster.',
   fieldConfig: {
     defaults: {
       color: {
         mode: 'thresholds',
       },
-      custom: {
-        axisBorderShow: false,
-        axisCenteredZero: false,
-        axisColorMode: 'text',
-        axisGridShow: false,
-        axisLabel: '',
-        axisPlacement: 'auto',
-        fillOpacity: 30,
-        gradientMode: 'opacity',
-        hideFrom: {
-          legend: false,
-          tooltip: false,
-          viz: false
-        },
-        lineWidth: 2,
-        scaleDistribution: {
-          type: 'linear'
-        },
-        thresholdsStyle: {
-          mode: 'off'
-        }
-      },
       mappings: [],
+      min: 0,
       thresholds: {
         mode: 'absolute',
         steps: [
           {
+            color: 'red',
+            value: null,
+          },
+          {
             color: 'green',
-            value: null
-          }
-        ]
+            value: 1,
+          },
+        ],
       },
-      unit: '',
+      unit: 'none',
     },
-    overrides: []
+    overrides: [],
   },
   options: {
-    barRadius: 0,
-    barWidth: 0.97,
-    colorByField: 'instance',
-    fullHighlight: false,
-    groupWidth: 0.7,
-    legend: {
-      calcs: [],
-      displayMode: 'list',
-      placement: 'right',
-      showLegend: true,
-      width: 0
+    colorMode: 'value',
+    graphMode: 'none',
+    justifyMode: 'auto',
+    orientation: 'auto',
+    reduceOptions: {
+      calcs: [
+        'lastNotNull',
+      ],
+      fields: '',
+      values: false,
     },
-    orientation: 'horizontal',
-    showValue: 'auto',
-    stacking: 'none',
-    tooltip: {
-      mode: 'single',
-      sort: 'none'
-    },
-    xField: 'instance',
-    xTickLabelRotation: 0,
-    xTickLabelSpacing: 0
+    textMode: 'value',
+    wideLayout: true,
   },
   pluginVersion: '9.4.3',
+  targets: [
+    {
+      disableTextWrap: false,
+      expr: 'min by (job, solr_cluster) (solr_collections_live_nodes{job=~"$job", solr_cluster=~"$solr_cluster"})',
+      fullMetaSearch: false,
+      includeNullMetadata: true,
+      instant: false,
+      legendFormat: '__auto',
+      range: true,
+      useBackend: false,
+    },
+  ],
+  title: 'Live nodes',
+  type: 'stat',
 };
 
 local zookeeperStatusPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'solr_zookeeper_status{job=~"$job", instance=~"$instance", solr_cluster=~"$solr_cluster"}',
+      'solr_zookeeper_status{job=~"$job", solr_cluster=~"$solr_cluster"}',
       datasource=promDatasource,
       intervalFactor=2,
       instant=true,
-      legendFormat='{{instance}} - {{zk_host}}',
+      legendFormat='{{zk_host}}',
       format='table',
     ),
   ],
@@ -255,9 +234,9 @@ local zookeeperEnsembleSizePanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'solr_zookeeper_ensemble_size{job=~"$job", instance=~"$instance", solr_cluster=~"$solr_cluster"}',
+      'solr_zookeeper_ensemble_size{job=~"$job", solr_cluster=~"$solr_cluster"}',
       datasource=promDatasource,
-      legendFormat='{{instance}} - {{zk_host}}',
+      legendFormat='{{zk_host}}',
       format='time_series',
     ),
   ],
@@ -309,7 +288,7 @@ local zookeeperEnsembleSizePanel = {
           },
         ],
       },
-      unit: '',
+      unit: 'none',
     },
     overrides: [],
   },
@@ -340,7 +319,7 @@ local alertsPanel = {
   title: 'Alerts',
   description: 'Panel to report on the status of firing alerts.',
   options: {
-    alertInstanceLabelFilter: '{job=~"$job", instance="$instance", solr_cluster=~"$solr_cluster"}',
+    alertInstanceLabelFilter: '{job=~"$job", solr_cluster=~"$solr_cluster"}',
     alertName: '',
     dashboardAlerts: false,
     groupBy: [],
@@ -361,13 +340,13 @@ local alertsPanel = {
 local shardStatePanel = {
   datasource: {
     type: 'prometheus',
-    uid: '${prometheus_datasource}'
+    uid: '${prometheus_datasource}',
   },
   description: 'Percent of running shards in the cluster.',
   fieldConfig: {
     defaults: {
       color: {
-        mode: 'thresholds'
+        mode: 'thresholds',
       },
       mappings: [],
       max: 100,
@@ -377,21 +356,21 @@ local shardStatePanel = {
         steps: [
           {
             color: 'red',
-            value: null
+            value: null,
           },
           {
             color: 'yellow',
-            value: 80
+            value: 80,
           },
           {
             color: 'green',
-            value: 95
-          }
-        ]
+            value: 95,
+          },
+        ],
       },
-      unit: 'percent'
+      unit: 'percent',
     },
-    overrides: []
+    overrides: [],
   },
   options: {
     colorMode: 'value',
@@ -400,28 +379,28 @@ local shardStatePanel = {
     orientation: 'auto',
     reduceOptions: {
       calcs: [
-        'lastNotNull'
+        'lastNotNull',
       ],
       fields: '',
-      values: false
+      values: false,
     },
     textMode: 'value',
-    wideLayout: true
+    wideLayout: true,
   },
   pluginVersion: '9.4.3',
   targets: [
     {
       disableTextWrap: false,
-      expr: '100 * sum(solr_collections_shard_state{job=~"$job", instance=~"$instance", solr_cluster=~"$solr_cluster"})  / count(solr_collections_shard_state{job=~"$job", instance=~"$instance", solr_cluster=~"$solr_cluster"})',
+      expr: '100 * sum(solr_collections_shard_state{job=~"$job", solr_cluster=~"$solr_cluster"})  / count(solr_collections_shard_state{job=~"$job", solr_cluster=~"$solr_cluster"})',
       fullMetaSearch: false,
       includeNullMetadata: true,
       instant: false,
       legendFormat: '__auto',
       range: true,
-      useBackend: false
-    }
+      useBackend: false,
+    },
   ],
-  title: 'Shard state',
+  title: 'Running shards',
   type: 'stat',
 };
 
@@ -429,7 +408,7 @@ local shardStatusPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'solr_collections_shard_state{job=~"$job", instance=~"$instance", solr_cluster=~"$solr_cluster"}',
+      'solr_collections_shard_state{job=~"$job", solr_cluster=~"$solr_cluster"}',
       datasource=promDatasource,
       intervalFactor=2,
       instant=true,
@@ -609,13 +588,13 @@ local shardStatusPanel = {
 local replicaStatePanel = {
   datasource: {
     type: 'prometheus',
-    uid: '${prometheus_datasource}'
+    uid: '${prometheus_datasource}',
   },
   description: 'Shows the total percent of running shards in the cluster.',
   fieldConfig: {
     defaults: {
       color: {
-        mode: 'thresholds'
+        mode: 'thresholds',
       },
       mappings: [],
       max: 100,
@@ -625,21 +604,21 @@ local replicaStatePanel = {
         steps: [
           {
             color: 'red',
-            value: null
+            value: null,
           },
           {
             color: 'yellow',
-            value: 80
+            value: 80,
           },
           {
             color: 'green',
-            value: 95
-          }
-        ]
+            value: 95,
+          },
+        ],
       },
-      unit: 'percent'
+      unit: 'percent',
     },
-    overrides: []
+    overrides: [],
   },
   options: {
     colorMode: 'value',
@@ -648,28 +627,28 @@ local replicaStatePanel = {
     orientation: 'auto',
     reduceOptions: {
       calcs: [
-        'lastNotNull'
+        'lastNotNull',
       ],
       fields: '',
-      values: false
+      values: false,
     },
     textMode: 'value',
-    wideLayout: true
+    wideLayout: true,
   },
   pluginVersion: '9.4.3',
   targets: [
     {
       disableTextWrap: false,
-      expr: '100 * sum(solr_collections_shard_state{job=~"$job", instance=~"$instance", solr_cluster=~"$solr_cluster"})  / count(solr_collections_shard_state{job=~"$job", instance=~"$instance", solr_cluster=~"$solr_cluster"})',
+      expr: '100 * sum(solr_collections_replica_state{job=~"$job", solr_cluster=~"$solr_cluster"})  / count(solr_collections_replica_state{job=~"$job", solr_cluster=~"$solr_cluster"})',
       fullMetaSearch: false,
       includeNullMetadata: true,
       instant: false,
       legendFormat: '__auto',
       range: true,
-      useBackend: false
-    }
+      useBackend: false,
+    },
   ],
-  title: 'Shard state',
+  title: 'Running shards',
   type: 'stat',
 };
 
@@ -677,7 +656,7 @@ local replicaStatusPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'solr_collections_replica_state{job=~"$job", instance=~"$instance", solr_cluster=~"$solr_cluster"}',
+      'solr_collections_replica_state{job=~"$job", solr_cluster=~"$solr_cluster"}',
       datasource=promDatasource,
       legendFormat='{{auto}}',
       instant=true,
@@ -942,7 +921,7 @@ local topNodeMetricsRow = {
   datasource: promDatasource,
   targets: [],
   type: 'row',
-  title: 'Top node metrics',
+  title: 'Top core metrics',
   collapsed: false,
 };
 
@@ -950,19 +929,19 @@ local topCPULoadByNodePanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'topk($k, 100 * solr_metrics_jvm_os_cpu_load{job=~"$job", instance=~"$instance", solr_cluster=~"$solr_cluster", item="systemCpuLoad"})',
+      'topk($k, 100 * avg by (job, base_url, solr_cluster) (solr_metrics_jvm_os_cpu_load{job=~"$job", solr_cluster=~"$solr_cluster", item="systemCpuLoad"}))',
       datasource=promDatasource,
-      legendFormat='{{instance}} - {{base_url}}',
+      legendFormat='{{base_url}}',
       format='time_series',
     ),
   ],
   type: 'timeseries',
   title: 'Top CPU load by node',
-  description: 'CPU load caused by the JVM.',
+  description: 'Top CPU load caused by the JVM.',
   fieldConfig: {
     defaults: {
       color: {
-        mode: 'palette-classic',
+        mode: 'continuous-BlYlRd',
       },
       custom: {
         axisCenteredZero: false,
@@ -1035,19 +1014,19 @@ local topHeapMemoryUsageByNodePanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'topk($k, 100 * sum without(item)(solr_metrics_jvm_memory_heap_bytes{item="used"}) / clamp_min(sum without(item)(solr_metrics_jvm_memory_heap_bytes{item="max"}), 1))',
+      'topk($k, 100 * avg by (job, base_url, solr_cluster) (sum without(item)(solr_metrics_jvm_memory_heap_bytes{job=~"$job", solr_cluster=~"$solr_cluster", item="used"}) / clamp_min(sum without(item)(solr_metrics_jvm_memory_heap_bytes{job=~"$job", solr_cluster=~"$solr_cluster", item="max"}), 1)))',
       datasource=promDatasource,
-      legendFormat='{{instance}}',
+      legendFormat='{{base_url}}',
       format='time_series',
     ),
   ],
   type: 'timeseries',
   title: 'Top heap memory usage by node',
-  description: 'Tracks JVM heap memory usage.',
+  description: 'Top JVM heap memory usage.',
   fieldConfig: {
     defaults: {
       color: {
-        mode: 'palette-classic',
+        mode: 'continuous-BlYlRd',
       },
       custom: {
         axisCenteredZero: false,
@@ -1120,15 +1099,15 @@ local topMeanQueriesByNodePanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'topk($k, solr_metrics_core_query_mean_rate{job=~"$job", instance=~"$instance", solr_cluster=~"$solr_cluster", category="QUERY", collection=~"$solr_collection", core=~"$solr_core"})',
+      'topk($k, avg by(job, base_url, solr_cluster, collection, core, searchHandler) (solr_metrics_core_query_mean_rate{job=~"$job", solr_cluster=~"$solr_cluster", category="QUERY", collection=~"$solr_collection", core=~"$solr_core"}))',
       datasource=promDatasource,
-      legendFormat='{{instance}} - {{collection}} - {{core}} - {{searchHandler}}',
+      legendFormat='{{collection}} - {{core}} - {{searchHandler}}',
       format='time_series',
     ),
   ],
   type: 'timeseries',
-  title: 'Top mean queries by node',
-  description: 'Average rate of query processing in the cluster.',
+  title: 'Top mean queries by core',
+  description: 'Top average rate of query processing in the cluster by core.',
   fieldConfig: {
     defaults: {
       color: {
@@ -1174,7 +1153,7 @@ local topMeanQueriesByNodePanel = {
           },
         ],
       },
-      unit: 'ms',
+      unit: 'reqps',
     },
     overrides: [],
   },
@@ -1196,16 +1175,16 @@ local topUpdateHandlersByNodePanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'topk($k, increase(solr_metrics_core_update_handler_adds_total{job=~"$job", instance=~"$instance", solr_cluster=~"$solr_cluster", collection=~"$solr_collection", core=~"$solr_core"}[$__interval:]))',
+      'topk($k, avg by (job, base_url, solr_cluster, collection, core) (increase(solr_metrics_core_update_handler_adds_total{job=~"$job", solr_cluster=~"$solr_cluster", collection=~"$solr_collection", core=~"$solr_core"}[$__interval:])))',
       datasource=promDatasource,
-      legendFormat='{{instance}} - {{collection}} - {{core}}',
+      legendFormat='{{collection}} - {{core}}',
       format='time_series',
       interval='1m',
     ),
   ],
   type: 'timeseries',
-  title: 'Top update handlers by node / $__interval',
-  description: 'Total number of document additions in the cluster.',
+  title: 'Top update handlers by core / $__interval',
+  description: 'Top number of total document additions in the cluster by core.',
   fieldConfig: {
     defaults: {
       color: {
@@ -1273,15 +1252,15 @@ local topIndexSizeByNodePanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'topk($k, solr_metrics_core_index_size_bytes{job=~"$job", instance=~"$instance", solr_cluster=~"$solr_cluster", collection=~"$solr_collection", core=~"$solr_core"})',
+      'topk($k, avg by (job, base_url, solr_cluster, collection, core) (solr_metrics_core_index_size_bytes{job=~"$job", solr_cluster=~"$solr_cluster", collection=~"$solr_collection", core=~"$solr_core"}))',
       datasource=promDatasource,
-      legendFormat='{{instance}} - {{collection}} - {{core}}',
+      legendFormat='{{collection}} - {{core}}',
       format='time_series',
     ),
   ],
   type: 'timeseries',
-  title: 'Top index size by node',
-  description: 'Size of the Solr index.',
+  title: 'Top index size by core',
+  description: 'Top size of the Solr index by core.',
   fieldConfig: {
     defaults: {
       color: {
@@ -1349,15 +1328,15 @@ local topCacheHitRatioByNodePanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'bottomk($k, 100 * solr_metrics_core_searcher_cache_ratio{job=~"$job", instance=~"$instance", solr_cluster=~"$solr_cluster", collection=~"$solr_collection", core=~"$solr_core", type=~"documentCache|filterCache|queryResultCache"})',
+      'bottomk($k, 100 * avg by (job, base_url, solr_cluster, collection, core, type) (solr_metrics_core_searcher_cache_ratio{job=~"$job", solr_cluster=~"$solr_cluster", collection=~"$solr_collection", core=~"$solr_core", type=~"documentCache|filterCache|queryResultCache"}))',
       datasource=promDatasource,
-      legendFormat='{{instance}} - {{collection}} - {{core}} - {{type}}',
+      legendFormat='{{collection}} - {{core}} - {{type}}',
       format='time_series',
     ),
   ],
   type: 'timeseries',
-  title: 'Top cache hit ratio by node',
-  description: 'Cache hit ratio in Solr searchers.',
+  title: 'Top cache hit ratio by core',
+  description: 'Top cache hit ratio in Solr searchers by core.',
   fieldConfig: {
     defaults: {
       color: {
@@ -1442,16 +1421,16 @@ local topCoreErrorsByNodePanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'topk($k, sum by (job, instance, solr_cluster, collection, core) (increase(solr_metrics_core_errors_total{job=~"$job", instance=~"$instance", solr_cluster=~"$solr_cluster", collection=~"$solr_collection", core=~"$solr_core"}[$__interval:])))',
+      'topk($k, avg by (job, solr_cluster, collection, core, baseurl) (increase(solr_metrics_core_errors_total{job=~"$job", solr_cluster=~"$solr_cluster", collection=~"$solr_collection", core=~"$solr_core"}[$__interval:])))',
       datasource=promDatasource,
-      legendFormat='{{instance}} - {{collection}} - {{core}}',
+      legendFormat='{{collection}} - {{core}}',
       format='time_series',
       interval='1m',
     ),
   ],
   type: 'timeseries',
-  title: 'Top core errors by node / $__interval',
-  description: 'Total errors in Solr cores.',
+  title: 'Top core errors by core / $__interval',
+  description: 'Top Solr core errors.',
   fieldConfig: {
     defaults: {
       color: {
@@ -1519,16 +1498,16 @@ local topNodeErrorsPanel = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
-      'topk($k, sum by (job, instance, solr_cluster, collection) (increase(solr_metrics_node_errors_total{job=~"$job", instance=~"$instance", solr_cluster=~"$solr_cluster"}[$__interval:])))',
+      'topk($k, avg by (job, base_url, solr_cluster, collection) (increase(solr_metrics_node_errors_total{job=~"$job", solr_cluster=~"$solr_cluster"}[$__interval:])))',
       datasource=promDatasource,
-      legendFormat='{{instance}}',
+      legendFormat='{{base_url}}',
       format='time_series',
       interval='1m',
     ),
   ],
   type: 'timeseries',
-  title: 'Top node errors / $__interval',
-  description: 'Total number of errors on Solr node.',
+  title: 'Top node errors by node / $__interval',
+  description: 'Top Solr node errors.',
   fieldConfig: {
     defaults: {
       color: {
@@ -1624,17 +1603,6 @@ local topNodeErrorsPanel = {
             promDatasource,
             'label_values(solr_metrics_core_errors_total,job)',
             label='Job',
-            refresh=2,
-            includeAll=true,
-            multi=true,
-            allValues='.+',
-            sort=1
-          ),
-          template.new(
-            'instance',
-            promDatasource,
-            'label_values(solr_metrics_core_errors_total{job=~"$job"}, instance)',
-            label='Instance',
             refresh=2,
             includeAll=true,
             multi=true,

--- a/apache-solr/dashboards/apache-solr-logs-overview.libsonnet
+++ b/apache-solr/dashboards/apache-solr-logs-overview.libsonnet
@@ -1,0 +1,34 @@
+local g = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';
+local logsDashboard = import 'github.com/grafana/jsonnet-libs/logs-lib/logs/main.libsonnet';
+
+{
+  grafanaDashboards+::
+    if $._config.enableLokiLogs then
+      {
+        local apacheSolrLogsPanel =
+          logsDashboard.new(
+            'Apache Solr logs',
+            datasourceName='loki_datasource',
+            datasourceRegex='(?!grafanacloud.+usage-insights|grafanacloud.+alert-state-history).+',
+            filterSelector=$._config.filterSelector,
+            labels=['job', 'instance', 'solr_cluster', 'filename'],
+            formatParser=null,
+            showLogsVolume=true
+          )
+          {
+            panels+:
+              {
+                logs+:
+                  g.panel.logs.options.withShowTime(false),
+              },
+            dashboards+:
+              {
+                logs+: g.dashboard.withLinksMixin($.grafanaDashboards['apache-solr-cluster-overview.json'].links)
+                       + g.dashboard.withUid('apache-solr-logs-overview')
+                       + g.dashboard.withTags($._config.dashboardTags)
+                       + g.dashboard.withRefresh($._config.dashboardRefresh),
+              },
+          },
+        'apache-solr-logs-overview.json': apacheSolrLogsPanel.dashboards.logs,
+      } else {},
+}

--- a/apache-solr/dashboards/apache-solr-query-performance-overview.libsonnet
+++ b/apache-solr/dashboards/apache-solr-query-performance-overview.libsonnet
@@ -1,0 +1,1611 @@
+local grafana = (import 'grafonnet/grafana.libsonnet');
+local dashboard = grafana.dashboard;
+local template = grafana.template;
+local prometheus = grafana.prometheus;
+
+local dashboardUid = 'apache-solr-query-performance-overview';
+
+local promDatasourceName = 'prometheus_datasource';
+
+local promDatasource = {
+  uid: '${%s}' % promDatasourceName,
+};
+
+local updateHandlersPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'avg by(job, base_url, collection, core) (increase(solr_metrics_core_update_handler_adds_total{job=~"$job", base_url=~"$base_url", solr_cluster=~"$solr_cluster", collection=~"$solr_collection", core=~"$solr_core"}[$__interval:]))',
+      datasource=promDatasource,
+      legendFormat='{{collection}} - {{core}}',
+      format='time_series',
+      interval='1m',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Update handlers / $__interval',
+  description: 'Counts the increase in document additions over the specified interval.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'table',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local coreSearchAndRetrievalQueryLoadPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'avg by(searchHandler, job, base_url, collection, core) (solr_metrics_core_query_5minRate{job=~"$job", base_url=~"$base_url", solr_cluster=~"$solr_cluster", searchHandler=~"/select|/query|/get", collection=~"$solr_collection", core=~"$solr_core",})',
+      datasource=promDatasource,
+      legendFormat='{{collection}} - {{core}} - {{searchHandler}}',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Core search and retrieval query load',
+  description: 'Measures the average rate of queries per second over a 5-minute period for core search and retrieval operations.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'reqps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'table',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local coreSearchAndRetrieval95pQueryLatencyPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'avg by(searchHandler, job, base_url, collection, core) (solr_metrics_core_query_p95_ms{job=~"$job", base_url=~"$base_url", solr_cluster=~"$solr_cluster", searchHandler=~"/select|/query|/get", collection=~"$solr_collection", core=~"$solr_core",})',
+      datasource=promDatasource,
+      legendFormat='{{collection}} - {{core}} - {{searchHandler}}',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Core search and retrieval 95p query latency',
+  description: 'Represents the 95th percentile latency for core search and retrieval queries.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'ms',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'table',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+local coreSearchAndRetrieval99pQueryLatencyPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'avg by(searchHandler, job, base_url, collection, core) (solr_metrics_core_query_p99_ms{job=~"$job", base_url=~"$base_url", solr_cluster=~"$solr_cluster", searchHandler=~"/select|/query|/get", collection=~"$solr_collection", core=~"$solr_core",})',
+      datasource=promDatasource,
+      legendFormat='{{collection}} - {{core}} - {{searchHandler}}',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Core search and retrieval 99p query latency',
+  description: 'Represents the 99th percentile latency for core search and retrieval queries, measured in milliseconds.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'ms',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'table',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local coreSearchAndRetrievalLocalQueryLoadPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'avg by(searchHandler, job, base_url, collection, core) (solr_metrics_core_query_local_5minRate{job=~"$job", base_url=~"$base_url", solr_cluster=~"$solr_cluster", searchHandler=~"/select|/query|/get", collection=~"$solr_collection", core=~"$solr_core",})',
+      datasource=promDatasource,
+      legendFormat='{{collection}} - {{core}} - {{searchHandler}}',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Core search and retrieval local query load',
+  description: 'Indicates the average rate of local queries per second over a 5-minute period for core search and retrieval operations.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'reqps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'table',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local coreSearchAndRetrievalLocal95pQueryLatencyPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'avg by(searchHandler, job, base_url, collection, core) (solr_metrics_core_query_local_p95_ms{job=~"$job", base_url=~"$base_url", solr_cluster=~"$solr_cluster", searchHandler=~"/select|/query|/get", collection=~"$solr_collection", core=~"$solr_core",})',
+      datasource=promDatasource,
+      legendFormat='{{collection}} - {{core}} - {{searchHandler}}',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Core search and retrieval local p95 query latency',
+  description: 'Represents the 95th percentile latency for local core search and retrieval queries',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'ms',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'table',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local coreSearchAndRetrievalLocal99pQueryLatencyPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'avg by(searchHandler, job, base_url, collection, core) (solr_metrics_core_query_local_p99_ms{job=~"$job", base_url=~"$base_url", solr_cluster=~"$solr_cluster", searchHandler=~"/select|/query|/get", collection=~"$solr_collection", core=~"$solr_core",})',
+      datasource=promDatasource,
+      legendFormat='{{collection}} - {{core}} - {{searchHandler}}',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Core search and retrieval 99p local query latency',
+  description: 'Represents the 99th percentile latency for local core search and retrieval queries',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'ms',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'table',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local localQueriesRow = {
+  datasource: promDatasource,
+  targets: [],
+  type: 'row',
+  title: 'Local queries',
+  collapsed: false,
+};
+
+local specializedQueryLoadPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'avg by(searchHandler, job, base_url, collection, core) (solr_metrics_core_query_5minRate{job=~"$job", base_url=~"$base_url", solr_cluster=~"$solr_cluster", searchHandler=~"/sql|/export|/stream", collection=~"$solr_collection", core=~"$solr_core",})',
+      datasource=promDatasource,
+      legendFormat='{{collection}} - {{core}} - {{searchHandler}}',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Specialized query load',
+  description: 'Measures the average rate of specialized queries per second over a 5-minute period.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'reqps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'table',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local specialized95pQueryLatencyPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'avg by(searchHandler, job, base_url, collection, core) (solr_metrics_core_query_p95_ms{job=~"$job", base_url=~"$base_url", solr_cluster=~"$solr_cluster", searchHandler=~"/sql|/export|/stream", collection=~"$solr_collection", core=~"$solr_core",})',
+      datasource=promDatasource,
+      legendFormat='{{collection}} - {{core}} - {{searchHandler}}',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Specialized 95p query latency',
+  description: 'Displays the 993ith percentile latency for specialized query types.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'ms',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'table',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local specialized99pQueryLatencyPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'avg by(searchHandler, job, base_url, collection, core) (solr_metrics_core_query_p99_ms{job=~"$job", base_url=~"$base_url", solr_cluster=~"$solr_cluster", searchHandler=~"/sql|/export|/stream", collection=~"$solr_collection", core=~"$solr_core",})',
+      datasource=promDatasource,
+      legendFormat='{{collection}} - {{core}} - {{searchHandler}}',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Specialized 99p query latency',
+  description: 'Displays the 99th percentile latency for specialized query types.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'ms',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'table',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local specializedLocalQueryLoadPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'avg by(searchHandler, job, base_url, collection, core) (solr_metrics_core_query_local_5minRate{job=~"$job", base_url=~"$base_url", solr_cluster=~"$solr_cluster", searchHandler=~"/sql|/export|/stream", collection=~"$solr_collection", core=~"$solr_core",})',
+      datasource=promDatasource,
+      legendFormat='{{collection}} - {{core}} - {{searchHandler}}',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Specialized local query load',
+  description: 'Indicates the average rate of local specialized queries per second over a 5-minute period.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'reqps',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'table',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local specializedLocal95pQueryLatencyPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'avg by(searchHandler, job, base_url, collection, core) (solr_metrics_core_query_local_p95_ms{job=~"$job", base_url=~"$base_url", solr_cluster=~"$solr_cluster", searchHandler=~"/sql|/export|/stream", collection=~"$solr_collection", core=~"$solr_core",})',
+      datasource=promDatasource,
+      legendFormat='{{collection}} - {{core}} - {{searchHandler}}',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Specialized local 95p query latency',
+  description: 'Shows the 95th percentile latency for specialized local queries.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'ms',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'table',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local specializedLocal99pQueryLatencyPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'avg by(searchHandler, job, base_url, collection, core) (solr_metrics_core_query_local_p99_ms{job=~"$job", base_url=~"$base_url", solr_cluster=~"$solr_cluster", searchHandler=~"/sql|/export|/stream", collection=~"$solr_collection", core=~"$solr_core",})',
+      datasource=promDatasource,
+      legendFormat='{{collection}} - {{core}} - {{searchHandler}}',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Specialized local 99p query latency',
+  description: 'Shows the 99th percentile latency for specialized local queries.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'ms',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'table',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local cacheRow = {
+  datasource: promDatasource,
+  targets: [],
+  type: 'row',
+  title: 'Cache metrics',
+  collapsed: false,
+};
+
+local cacheEvictionsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'avg by(type, job, base_url, collection, core) (increase(solr_metrics_core_searcher_cache{job=~"$job", base_url=~"$base_url", solr_cluster=~"$solr_cluster", collection=~"$solr_collection", core=~"$solr_core", type=~"documentCache|filterCache|queryResultCache", item=~"evictions"}[$__interval:]))',
+      datasource=promDatasource,
+      legendFormat='{{collection}} - {{core}} - {{type}}',
+      format='time_series',
+      interval='1m',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Cache evictions / $__interval',
+  description: 'Tracks the number of cache evictions.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'table',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local cacheHitRatioPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'avg by(type, job, base_url, collection, core) (100 * solr_metrics_core_searcher_cache_ratio{job=~"$job", base_url=~"$base_url", solr_cluster=~"$solr_cluster", collection=~"$solr_collection", core=~"$solr_core", type=~"documentCache|filterCache|queryResultCache"})',
+      datasource=promDatasource,
+      legendFormat='{{collection}} - {{core}} - {{type}}',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Cache hit ratio',
+  description: 'The cache hit ratio for various cache activities.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      min: 0,
+      max: 100,
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'percent',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'table',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local timeoutsRow = {
+  datasource: promDatasource,
+  targets: [],
+  type: 'row',
+  title: 'Timeouts',
+  collapsed: false,
+};
+
+local coreTimeoutsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'avg by(job, base_url, collection, core) (increase(solr_metrics_core_timeouts_total{job=~"$job", base_url=~"$base_url", solr_cluster=~"$solr_cluster", collection=~"$solr_collection", core=~"$solr_core"}[$__interval:]))',
+      datasource=promDatasource,
+      legendFormat='{{collection}} - {{core}}',
+      format='time_series',
+      interval='1m',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Core timeouts / $__interval',
+  description: 'Tracks the increase in the number of query timeouts over the specified time interval.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'table',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local nodeTimeoutsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'avg by(job, base_url) (increase(solr_metrics_node_timeouts_total{job=~"$job", base_url=~"$base_url", solr_cluster=~"$solr_cluster"}[$__interval:]))',
+      datasource=promDatasource,
+      legendFormat='{{base_url}}',
+      format='time_series',
+      interval='1m',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Node timeouts / $__interval',
+  description: 'Tracks the increase in node-level query timeouts over the specified interval.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'table',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local errorsRow = {
+  datasource: promDatasource,
+  targets: [],
+  type: 'row',
+  title: 'Errors',
+  collapsed: false,
+};
+
+local queryErrorRatePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'avg by(job, base_url, collection, core) (solr_metrics_core_query_errors_1minRate{job=~"$job", base_url=~"$base_url", solr_cluster=~"$solr_cluster", collection=~"$solr_collection", core=~"$solr_core"})',
+      datasource=promDatasource,
+      legendFormat='{{collection}} - {{core}}',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Query error rate',
+  description: 'Measures the rate of query errors over a 1-minute period.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'errors / min',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'table',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local queryClientErrorsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'avg by(job, base_url, collection, core) (solr_metrics_core_query_client_errors_1minRate{job=~"$job", base_url=~"$base_url", solr_cluster=~"$solr_cluster", collection=~"$solr_collection", core=~"$solr_core"})',
+      datasource=promDatasource,
+      legendFormat='{{collection}} - {{core}}',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Query client errors',
+  description: 'This metric represents the rate of client errors over a 1-minute period.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'errors / min',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'table',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+{
+  grafanaDashboards+:: {
+    'apache-solr-query-performance-overview.json':
+      dashboard.new(
+        'Apache Solr query performance overview',
+        time_from='%s' % $._config.dashboardPeriod,
+        tags=($._config.dashboardTags),
+        timezone='%s' % $._config.dashboardTimezone,
+        refresh='%s' % $._config.dashboardRefresh,
+        description='',
+        uid=dashboardUid,
+      )
+      .addLink(grafana.link.dashboards(
+        asDropdown=false,
+        title='Other Apache Solr dashboards',
+        includeVars=true,
+        keepTime=true,
+        tags=($._config.dashboardTags),
+      ))
+      .addTemplates(
+        [
+          template.datasource(
+            promDatasourceName,
+            'prometheus',
+            null,
+            label='Data Source',
+            refresh='load'
+          ),
+          template.new(
+            'job',
+            promDatasource,
+            'label_values(solr_metrics_core_errors_total,job)',
+            label='Job',
+            refresh=2,
+            includeAll=true,
+            multi=true,
+            allValues='.+',
+            sort=1
+          ),
+          template.new(
+            'base_url',
+            promDatasource,
+            'label_values(solr_metrics_core_errors_total{job=~"$job"}, base_url)',
+            label='Instance',
+            refresh=2,
+            includeAll=true,
+            multi=true,
+            allValues='.+',
+            sort=1
+          ),
+          template.new(
+            'solr_cluster',
+            promDatasource,
+            'label_values(solr_metrics_core_errors_total{job=~"$job"}, solr_cluster)',
+            label='Solr cluster',
+            refresh=2,
+            includeAll=true,
+            multi=true,
+            allValues='.+',
+            sort=1
+          ),
+          template.new(
+            'solr_collection',
+            promDatasource,
+            'label_values(solr_metrics_core_errors_total{job=~"$job"}, collection)',
+            label='Collection',
+            refresh=2,
+            includeAll=true,
+            multi=true,
+            allValues='.+',
+            sort=1
+          ),
+          template.new(
+            'solr_core',
+            promDatasource,
+            'label_values(solr_metrics_core_errors_total{job=~"$job"}, core)',
+            label='Core',
+            refresh=2,
+            includeAll=true,
+            multi=true,
+            allValues='.+',
+            sort=1
+          ),
+        ]
+      )
+      .addPanels(
+        [
+          updateHandlersPanel { gridPos: { h: 6, w: 24, x: 0, y: 0 } },
+          coreSearchAndRetrievalQueryLoadPanel { gridPos: { h: 6, w: 8, x: 0, y: 6 } },
+          coreSearchAndRetrieval95pQueryLatencyPanel { gridPos: { h: 6, w: 8, x: 8, y: 6 } },
+          coreSearchAndRetrieval99pQueryLatencyPanel { gridPos: { h: 6, w: 8, x: 16, y: 6 } },
+          specializedQueryLoadPanel { gridPos: { h: 6, w: 8, x: 0, y: 12 } },
+          specialized95pQueryLatencyPanel { gridPos: { h: 6, w: 8, x: 8, y: 12 } },
+          specialized99pQueryLatencyPanel { gridPos: { h: 6, w: 8, x: 16, y: 12 } },
+          localQueriesRow { gridPos: { h: 1, w: 24, x: 0, y: 18 } },
+          coreSearchAndRetrievalLocalQueryLoadPanel { gridPos: { h: 6, w: 8, x: 0, y: 19 } },
+          coreSearchAndRetrievalLocal95pQueryLatencyPanel { gridPos: { h: 6, w: 8, x: 8, y: 19 } },
+          coreSearchAndRetrievalLocal99pQueryLatencyPanel { gridPos: { h: 6, w: 8, x: 16, y: 19 } },
+          specializedLocalQueryLoadPanel { gridPos: { h: 6, w: 8, x: 0, y: 25 } },
+          specializedLocal95pQueryLatencyPanel { gridPos: { h: 6, w: 8, x: 8, y: 25 } },
+          specializedLocal99pQueryLatencyPanel { gridPos: { h: 6, w: 8, x: 16, y: 25 } },
+          cacheRow { gridPos: { h: 1, w: 24, x: 0, y: 31 } },
+          cacheEvictionsPanel { gridPos: { h: 6, w: 12, x: 0, y: 32 } },
+          cacheHitRatioPanel { gridPos: { h: 6, w: 12, x: 12, y: 32 } },
+          timeoutsRow { gridPos: { h: 1, w: 24, x: 0, y: 38 } },
+          coreTimeoutsPanel { gridPos: { h: 6, w: 12, x: 0, y: 44 } },
+          nodeTimeoutsPanel { gridPos: { h: 6, w: 12, x: 12, y: 44 } },
+          errorsRow { gridPos: { h: 1, w: 24, x: 0, y: 50 } },
+          queryErrorRatePanel { gridPos: { h: 6, w: 12, x: 0, y: 51 } },
+          queryClientErrorsPanel { gridPos: { h: 6, w: 12, x: 12, y: 51 } },
+        ]
+      ),
+  },
+}

--- a/apache-solr/dashboards/apache-solr-resource-monitoring-overview.libsonnet
+++ b/apache-solr/dashboards/apache-solr-resource-monitoring-overview.libsonnet
@@ -1,0 +1,1145 @@
+local grafana = (import 'grafonnet/grafana.libsonnet');
+local dashboard = grafana.dashboard;
+local template = grafana.template;
+local prometheus = grafana.prometheus;
+
+local dashboardUid = 'apache-solr-resource-monitoring-overview';
+
+local promDatasourceName = 'prometheus_datasource';
+
+local promDatasource = {
+  uid: '${%s}' % promDatasourceName,
+};
+
+local connectionsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'avg by (job, solr_cluster, base_url, item) (solr_metrics_node_connections{job=~"$job", base_url=~"$base_url", solr_cluster=~"$solr_cluster"})',
+      datasource=promDatasource,
+      legendFormat='{{base_url}} - {{item}}',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Connections',
+  description: 'Number of connections to the Solr node.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'table',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local threadsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'avg by (job, solr_cluster, base_url) (increase(solr_metrics_node_thread_pool_submitted_total{job=~"$job", base_url=~"$base_url", solr_cluster=~"$solr_cluster", executor="updateOnlyExecutor"}[$__interval:]))',
+      datasource=promDatasource,
+      legendFormat='{{base_url}} - submitted',
+      format='time_series',
+    ),
+    prometheus.target(
+      'avg by (job, solr_cluster, base_url) (increase(solr_metrics_node_thread_pool_completed_total{job=~"$job", base_url=~"$base_url", solr_cluster=~"$solr_cluster", executor="updateOnlyExecutor"}[$__interval:]))',
+      datasource=promDatasource,
+      legendFormat='{{base_url}} - completed',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Threads / $__interval',
+  description: 'Total number of tasks submitted and completed in the thread pool.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'table',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local nodeCoreFSUsagePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'avg by (job, solr_cluster, base_url, item) (solr_metrics_node_core_root_fs_bytes{job=~"$job", base_url=~"$base_url", solr_cluster=~"$solr_cluster"})',
+      datasource=promDatasource,
+      legendFormat='{{base_url}} - {{item}}',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Node core FS usage',
+  description: "Disk space used by Solr node's root file system.",
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'bytes',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'table',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local garbageCollectionsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'avg by (job, solr_cluster, base_url, item) (increase(solr_metrics_jvm_gc_total{job=~"$job", base_url=~"$base_url", solr_cluster=~"$solr_cluster"}[$__interval:]))',
+      datasource=promDatasource,
+      legendFormat='{{base_url}} - {{item}}',
+      format='time_series',
+      interval='1m',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Garbage collections / $__interval',
+  description: 'Counts the total number of garbage collection events.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'table',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local garbageCollectionTimePanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'avg by (job, solr_cluster, base_url, item) (increase(solr_metrics_jvm_gc_seconds_total{job=~"$job", base_url=~"$base_url", solr_cluster=~"$solr_cluster"}[$__interval:]) / clamp_min(increase(solr_metrics_jvm_gc_total{job=~"$job", base_url=~"$base_url", solr_cluster=~"$solr_cluster"}[$__interval:]), 1))',
+      datasource=promDatasource,
+      legendFormat='{{base_url}} - {{item}}',
+      format='time_series',
+      interval='1m',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Garbage collection time / $__interval',
+  description: 'Total time spent in garbage collection.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 's',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'table',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local jvmMetricsRow = {
+  datasource: promDatasource,
+  targets: [],
+  type: 'row',
+  title: 'JVM metrics',
+  collapsed: false,
+};
+
+local cpuAverageLoadPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'avg by (job, solr_cluster, base_url) (100 * solr_metrics_jvm_os_cpu_load{job=~"$job", base_url=~"$base_url", solr_cluster=~"$solr_cluster", item="systemCpuLoad"})',
+      datasource=promDatasource,
+      legendFormat='{{base_url}}',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'CPU load',
+  description: 'CPU load caused by the JVM.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'continuous-BlYlRd',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      min: 0,
+      max: 100,
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+          },
+          {
+            color: 'yellow',
+            value: 90,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+      unit: 'percent',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'table',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local osMemoryPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'avg by (job, solr_cluster, base_url) (solr_metrics_jvm_os_memory_bytes{job=~"$job", base_url=~"$base_url", solr_cluster=~"$solr_cluster", item="freePhysicalMemorySize"})',
+      datasource=promDatasource,
+      legendFormat='{{base_url}} - free physical',
+      format='time_series',
+    ),
+    prometheus.target(
+      'avg by (job, solr_cluster, base_url) (solr_metrics_jvm_os_memory_bytes{job=~"$job", base_url=~"$base_url", solr_cluster=~"$solr_cluster", item="totalPhysicalMemorySize"})',
+      datasource=promDatasource,
+      legendFormat='{{base_url}} - total physical',
+      format='time_series',
+    ),
+    prometheus.target(
+      'avg by (job, solr_cluster, base_url) (solr_metrics_jvm_os_memory_bytes{job=~"$job", base_url=~"$base_url", solr_cluster=~"$solr_cluster", item="committedVirtualMemorySize"})',
+      datasource=promDatasource,
+      legendFormat='{{base_url}} - committed virtual',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'OS memory',
+  description: "The operating system's virtual committed memory, free physical memory and total physical memory usage.",
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'continuous-BlYlRd',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'bytes',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'table',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local numberOfFileDescriptorsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'avg by (job, solr_cluster, base_url, item) (solr_metrics_jvm_os_file_descriptors{job=~"$job", base_url=~"$base_url", solr_cluster=~"$solr_cluster"})',
+      datasource=promDatasource,
+      legendFormat='{{base_url}} - {{item}}',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'File descriptors',
+  description: 'Number of open file descriptors.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'table',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local memoryUsedPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'avg by (job, solr_cluster, base_url) (solr_metrics_jvm_memory_heap_bytes{job=~"$job", base_url=~"$base_url", solr_cluster=~"$solr_cluster", item="used"})',
+      datasource=promDatasource,
+      legendFormat='{{base_url}} - heap',
+      format='time_series',
+    ),
+    prometheus.target(
+      'avg by (job, solr_cluster, base_url) (solr_metrics_jvm_memory_non_heap_bytes{job=~"$job", base_url=~"$base_url", solr_cluster=~"$solr_cluster", item="used"})',
+      datasource=promDatasource,
+      legendFormat='{{base_url}} - non-heap',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Memory used',
+  description: 'The heap and non-heap memory used by the JVM.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'continuous-BlYlRd',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'bytes',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'table',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local memoryCommittedPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'avg by (job, solr_cluster, base_url) (solr_metrics_jvm_memory_heap_bytes{job=~"$job", base_url=~"$base_url", solr_cluster=~"$solr_cluster", item="committed"})',
+      datasource=promDatasource,
+      legendFormat='{{base_url}} - heap',
+      format='time_series',
+    ),
+    prometheus.target(
+      'avg by (job, solr_cluster, base_url) (solr_metrics_jvm_memory_non_heap_bytes{job=~"$job", base_url=~"$base_url", solr_cluster=~"$solr_cluster", item="committed"})',
+      datasource=promDatasource,
+      legendFormat='{{base_url}} - non-heap',
+      format='time_series',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Memory committed',
+  description: 'The heap and non-heap memory committed by the JVM.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'continuous-BlYlRd',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'bytes',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'table',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local jettyMetricsRow = {
+  datasource: promDatasource,
+  targets: [],
+  type: 'row',
+  title: 'Jetty metrics',
+  collapsed: false,
+};
+
+local requestsPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'avg by (job, solr_cluster, base_url, method) (increase(solr_metrics_jetty_requests_total{job=~"$job", base_url=~"$base_url", solr_cluster=~"$solr_cluster"}[$__interval:]))',
+      datasource=promDatasource,
+      legendFormat='{{base_url}} - {{method}}',
+      format='time_series',
+      interval='1m',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Requests  / $__interval',
+  description: 'Total number of requests received by Jetty.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'table',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local responsesPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'avg by (job, solr_cluster, base_url, status) (increase(solr_metrics_jetty_response_total{job=~"$job", base_url=~"$base_url", solr_cluster=~"$solr_cluster"}[$__interval:]))',
+      datasource=promDatasource,
+      legendFormat='{{base_url}} - {{status}}',
+      format='time_series',
+      interval='1m',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Responses  / $__interval',
+  description: 'Total number of responses generated by Jetty.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'table',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+local dispatchesPanel = {
+  datasource: promDatasource,
+  targets: [
+    prometheus.target(
+      'avg by (job, solr_cluster, base_url) (increase(solr_metrics_jetty_dispatches_total{job=~"$job", base_url=~"$base_url", solr_cluster=~"$solr_cluster"}[$__interval:]))',
+      datasource=promDatasource,
+      legendFormat='{{base_url}}',
+      format='time_series',
+      interval='1m',
+    ),
+  ],
+  type: 'timeseries',
+  title: 'Dispatches  / $__interval',
+  description: 'Total count of dispatches handled by Jetty.',
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 30,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        lineInterpolation: 'smooth',
+        lineWidth: 2,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'never',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+        ],
+      },
+      unit: 'none',
+    },
+    overrides: [],
+  },
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'table',
+      placement: 'right',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'multi',
+      sort: 'desc',
+    },
+  },
+};
+
+{
+  grafanaDashboards+:: {
+    'apache-solr-resource-monitoring-overview.json':
+      dashboard.new(
+        'Apache Solr resource monitoring overview',
+        time_from='%s' % $._config.dashboardPeriod,
+        tags=($._config.dashboardTags),
+        timezone='%s' % $._config.dashboardTimezone,
+        refresh='%s' % $._config.dashboardRefresh,
+        description='',
+        uid=dashboardUid,
+      )
+      .addLink(grafana.link.dashboards(
+        asDropdown=false,
+        title='Other Apache Solr dashboards',
+        includeVars=true,
+        keepTime=true,
+        tags=($._config.dashboardTags),
+      ))
+      .addTemplates(
+        [
+          template.datasource(
+            promDatasourceName,
+            'prometheus',
+            null,
+            label='Data Source',
+            refresh='load'
+          ),
+          template.new(
+            'job',
+            promDatasource,
+            'label_values(solr_metrics_core_errors_total,job)',
+            label='Job',
+            refresh=2,
+            includeAll=true,
+            multi=true,
+            allValues='.+',
+            sort=1
+          ),
+          template.new(
+            'base_url',
+            promDatasource,
+            'label_values(solr_metrics_core_errors_total{job=~"$job"}, base_url)',
+            label='Instance',
+            refresh=2,
+            includeAll=true,
+            multi=true,
+            allValues='.+',
+            sort=1
+          ),
+          template.new(
+            'solr_cluster',
+            promDatasource,
+            'label_values(solr_metrics_core_errors_total{job=~"$job"}, solr_cluster)',
+            label='Solr cluster',
+            refresh=2,
+            includeAll=true,
+            multi=true,
+            allValues='.+',
+            sort=1
+          ),
+        ]
+      )
+      .addPanels(
+        [
+          connectionsPanel { gridPos: { h: 6, w: 8, x: 0, y: 0 } },
+          threadsPanel { gridPos: { h: 6, w: 8, x: 8, y: 0 } },
+          nodeCoreFSUsagePanel { gridPos: { h: 6, w: 8, x: 16, y: 0 } },
+          jvmMetricsRow { gridPos: { h: 1, w: 24, x: 0, y: 6 } },
+          garbageCollectionsPanel { gridPos: { h: 6, w: 12, x: 0, y: 7 } },
+          garbageCollectionTimePanel { gridPos: { h: 6, w: 12, x: 12, y: 7 } },
+          cpuAverageLoadPanel { gridPos: { h: 6, w: 8, x: 0, y: 13 } },
+          osMemoryPanel { gridPos: { h: 6, w: 8, x: 8, y: 13 } },
+          numberOfFileDescriptorsPanel { gridPos: { h: 6, w: 8, x: 16, y: 13 } },
+          memoryUsedPanel { gridPos: { h: 6, w: 12, x: 0, y: 19 } },
+          memoryCommittedPanel { gridPos: { h: 6, w: 12, x: 12, y: 19 } },
+          jettyMetricsRow { gridPos: { h: 1, w: 24, x: 0, y: 25 } },
+          requestsPanel { gridPos: { h: 6, w: 8, x: 0, y: 26 } },
+          responsesPanel { gridPos: { h: 6, w: 8, x: 8, y: 26 } },
+          dispatchesPanel { gridPos: { h: 6, w: 8, x: 16, y: 26 } },
+        ]
+      ),
+  },
+}

--- a/apache-solr/dashboards/dashboards.libsonnet
+++ b/apache-solr/dashboards/dashboards.libsonnet
@@ -1,0 +1,4 @@
+(import 'apache-solr-cluster-overview.libsonnet') +
+(import 'apache-solr-query-performance-overview.libsonnet') +
+(import 'apache-solr-resource-monitoring-overview.libsonnet') +
+(import 'apache-solr-logs-overview.libsonnet')

--- a/apache-solr/jsonnetfile.json
+++ b/apache-solr/jsonnetfile.json
@@ -1,0 +1,33 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/grafonnet.git",
+          "subdir": "gen/grafonnet-latest"
+        }
+      },
+      "version": "main"
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/grafonnet-lib.git",
+          "subdir": "grafonnet"
+        }
+      },
+      "version": "master"
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": "logs-lib"
+        }
+      },
+      "version": "master"
+    }
+  ],
+  "legacyImports": true
+}

--- a/apache-solr/mixin.libsonnet
+++ b/apache-solr/mixin.libsonnet
@@ -1,0 +1,3 @@
+(import 'dashboards/dashboards.libsonnet') +
+(import 'alerts/alerts.libsonnet') +
+(import 'config.libsonnet')


### PR DESCRIPTION
- Adds the Apache Solr Mixin

The way this mixin set up is a little unique because of how prometheus metrics are collected. Instead of aggregating on an instance basis, metrics are aggregated by base_url, which is more appropriate, but renamed to instance to follow the common pattern. This is because when prometheus reports back all connected instance with a base_url label. 
Here is an example metric in which some load was put on the the `http://10.142.0.18:8983` instance:
```log
solr_metrics_core_query_local_p75_ms{category="QUERY",searchHandler="/get",core="cluster-collection_shard1_replica_n3",collection="cluster-collection",shard="shard1",replica="replica_n3",base_url="http://10.142.0.17:8983/solr",} 0.0
solr_metrics_core_query_local_p75_ms{category="QUERY",searchHandler="/get",core="cluster-collection_shard2_replica_n4",collection="cluster-collection",shard="shard2",replica="replica_n4",base_url="http://10.142.0.23:8983/solr",} 0.0
solr_metrics_core_query_local_p75_ms{category="QUERY",searchHandler="/get",core="cluster-collection_shard1_replica_n1",collection="cluster-collection",shard="shard1",replica="replica_n1",base_url="http://10.142.0.18:8983/solr",} 2.350878
solr_metrics_core_query_local_p75_ms{category="QUERY",searchHandler="/get",core="cluster-collection_shard2_replica_n6",collection="cluster-collection",shard="shard2",replica="replica_n6",base_url="http://10.142.0.18:8983/solr",} 0.504269
```

### Cluster Overview
![Screenshot 2024-01-02 at 1 27 41 PM](https://github.com/grafana/jsonnet-libs/assets/13648435/f140c839-c308-486c-8767-5a93f4c47f65)
![Screenshot 2024-01-02 at 1 27 47 PM](https://github.com/grafana/jsonnet-libs/assets/13648435/1f7b096c-9d8f-4904-9494-b4469b53e143)
###  Query Performance
![Screenshot 2024-01-02 at 1 37 19 PM](https://github.com/grafana/jsonnet-libs/assets/13648435/71676d31-410b-4ac7-9c86-e7eb11971bd2)
![Screenshot 2024-01-02 at 1 37 26 PM](https://github.com/grafana/jsonnet-libs/assets/13648435/8ac689d3-32d4-4acb-b450-0fe5b5b6a968)


### Resource monitoring
![Screenshot 2024-01-02 at 1 37 37 PM](https://github.com/grafana/jsonnet-libs/assets/13648435/98ef6141-472a-4792-96c8-774e8d61ea96)
![Screenshot 2024-01-02 at 1 37 54 PM](https://github.com/grafana/jsonnet-libs/assets/13648435/fba42f56-3121-4626-9b65-c6e258b27d71)

### Logs
![Screenshot 2024-01-02 at 1 38 36 PM](https://github.com/grafana/jsonnet-libs/assets/13648435/d4d62601-371d-40fd-b1cd-1d71bb4186bb)
