### PR TITLE
Add wildcard option for cluster label (nginx)

### DIFF
--- a/nginx-mixin/mods.libsonnet
+++ b/nginx-mixin/mods.libsonnet
@@ -11,9 +11,9 @@ local config = (import './config.libsonnet');
         list: [
           if i == 1 then
             {
-              allValue: null,
+              allValue: '.*',
               datasource: '$datasource',
-              includeAll: false,
+              includeAll: true,
               label: 'Cluster name',
               multi: false,
               name: 'cluster',


### PR DESCRIPTION
So mixin works if cluster label is not present in logs stream.

Should fix https://github.com/grafana/support-escalations/issues/8716