### PR TITLE
Add wildcard allValue option to mixin cluster label

### DIFF
--- a/memcached-mixin/dashboards.libsonnet
+++ b/memcached-mixin/dashboards.libsonnet
@@ -7,7 +7,7 @@ local g = (import 'grafana-builder/grafana.libsonnet');
         g.dashboard('Memcached Overview') +
         { uid: '124d5222454213f748dbfaf69b77ec48' }
       )
-      .addMultiTemplate('cluster', 'memcached_commands_total', $._config.clusterLabel)
+      .addMultiTemplate('cluster', 'memcached_commands_total', $._config.clusterLabel, allValue='.*')
       .addMultiTemplate('job', 'memcached_commands_total{' + $._config.clusterLabel + '=~"$cluster"}', 'job')
       .addMultiTemplate('instance', 'memcached_commands_total{' + $._config.clusterLabel + '=~"$cluster",job=~"$job"}', 'instance')
       .addRow(


### PR DESCRIPTION
To make sure mixin(and cloud integraiton) returns data even if 'cluster' label is not used.

Ref: 
https://community.grafana.com/t/memcached-integration-0-0-5-dashboards-appear-to-require-cluster-label/111479