### PR TITLE
modify withRunbookURL to allow internal annotation

### DIFF
--- a/mixin-utils/utils.libsonnet
+++ b/mixin-utils/utils.libsonnet
@@ -117,12 +117,13 @@ local g = import 'grafana-builder/grafana.libsonnet';
   // withRunbookURL - Add/Override the runbook_url annotations for all alerts inside a list of rule groups.
   // - url_format: an URL format for the runbook, the alert name will be substituted in the URL.
   // - groups: the list of rule groups containing alerts.
-  withRunbookURL(url_format, groups, internal=false)::
+  // - annotation_key: the key to use for the annotation whose value will be the formatted runbook URL.
+  withRunbookURL(url_format, groups, annotation_key='runbook_url')::
     local update_rule(rule) =
       if std.objectHas(rule, 'alert')
       then rule {
         annotations+: {
-          [if !internal then 'runbook_url' else 'internal_runbook_url']: url_format % rule.alert,
+          [annotation_key]: url_format % rule.alert,
         },
       }
       else rule;

--- a/mixin-utils/utils.libsonnet
+++ b/mixin-utils/utils.libsonnet
@@ -127,7 +127,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
       }
       else rule;
     [
-      group+ {
+      group {
         rules: [
           update_rule(alert)
           for alert in group.rules

--- a/mixin-utils/utils.libsonnet
+++ b/mixin-utils/utils.libsonnet
@@ -117,17 +117,17 @@ local g = import 'grafana-builder/grafana.libsonnet';
   // withRunbookURL - Add/Override the runbook_url annotations for all alerts inside a list of rule groups.
   // - url_format: an URL format for the runbook, the alert name will be substituted in the URL.
   // - groups: the list of rule groups containing alerts.
-  withRunbookURL(url_format, groups)::
+  withRunbookURL(url_format, groups, internal=false)::
     local update_rule(rule) =
       if std.objectHas(rule, 'alert')
       then rule {
         annotations+: {
-          runbook_url: url_format % rule.alert,
+          [if !internal then 'runbook_url' else 'internal_runbook_url']: url_format % rule.alert,
         },
       }
       else rule;
     [
-      group {
+      group+ {
         rules: [
           update_rule(alert)
           for alert in group.rules


### PR DESCRIPTION
see https://github.com/grafana/deployment_tools/pull/118284

this PR allows a user of the `withRunbookURL` function to indicate that the `internal_runbook_url` annotation should be used instead of the `runbook_url` annotation.