### PR TITLE
Support recording and switching between naive and classic latency histograms

### DIFF
--- a/grafana-builder/grafana.libsonnet
+++ b/grafana-builder/grafana.libsonnet
@@ -526,22 +526,6 @@ local utils = import 'mixin-utils/utils.libsonnet';
               label_replace(label_replace(%(metricQuery)s,
               "status", "${1}xx", "%(label)s", "([0-9]).."),
               "status", "${1}", "%(label)s", "([a-zA-Z]+)"))
-              < ($latency_metrics * -Inf)
-          ||| % {
-            metricQuery: utils.nativeClassicHistogramCountRate(metricName, selector).native,
-            label: statusLabelName,
-          },
-        format: 'time_series',
-        legendFormat: '{{status}}',
-        refId: 'A',
-      },
-      {
-        expr:
-          |||
-            sum by (status) (
-              label_replace(label_replace(%(metricQuery)s,
-              "status", "${1}xx", "%(label)s", "([0-9]).."),
-              "status", "${1}", "%(label)s", "([a-zA-Z]+)"))
               < ($latency_metrics * +Inf)
           ||| % {
             metricQuery: utils.nativeClassicHistogramCountRate(metricName, selector).classic,
@@ -550,6 +534,22 @@ local utils = import 'mixin-utils/utils.libsonnet';
         format: 'time_series',
         legendFormat: '{{status}}',
         refId: 'A_classic',
+      },
+      {
+        expr:
+          |||
+            sum by (status) (
+              label_replace(label_replace(%(metricQuery)s,
+              "status", "${1}xx", "%(label)s", "([0-9]).."),
+              "status", "${1}", "%(label)s", "([a-zA-Z]+)"))
+              < ($latency_metrics * -Inf)
+          ||| % {
+            metricQuery: utils.nativeClassicHistogramCountRate(metricName, selector).native,
+            label: statusLabelName,
+          },
+        format: 'time_series',
+        legendFormat: '{{status}}',
+        refId: 'A',
       },
     ],
   } + $.stack,

--- a/grafana-builder/grafana.libsonnet
+++ b/grafana-builder/grafana.libsonnet
@@ -488,7 +488,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
 
   // Assumes that the metricName is for a histogram (as opposed to qpsPanel above)
   // Assumes that there is a dashboard variable named latency_metrics, values are -1 (native) or 1 (classic)
-  qpsPanelNativeHistogram(title, metricName, selector, statusLabelName='status_code'):: $.timeseriesPanel(title) {
+  qpsPanelNativeHistogram(metricName, selector, statusLabelName='status_code'):: {
     fieldConfig+: {
       defaults+: {
         custom+: {
@@ -580,7 +580,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
   },
 
   // Assumes that there is a dashboard variable named latency_metrics, values are -1 (native) or 1 (classic)
-  latencyPanelNativeHistogram(title, metricName, selector, multiplier='1e3'):: $.timeseriesPanel(title) {
+  latencyPanelNativeHistogram(metricName, selector, multiplier='1e3'):: {
     nullPointMode: 'null as zero',
     fieldConfig+: {
       defaults+: {

--- a/grafana-builder/grafana.libsonnet
+++ b/grafana-builder/grafana.libsonnet
@@ -531,13 +531,13 @@ local utils = import 'mixin-utils/utils.libsonnet';
     },
     targets: [
       {
-        expr: utils.showClassicHistogramQuery(utils.nativeClassicHistogramCountRate(metricName, selector)),
+        expr: utils.showClassicHistogramQuery(sumByStatus(utils.nativeClassicHistogramCountRate(metricName, selector))),
         format: 'time_series',
         legendFormat: '{{status}}',
         refId: 'A_classic',
       },
       {
-        expr: utils.showNativeHistogramQuery(utils.nativeClassicHistogramCountRate(metricName, selector)),
+        expr: utils.showNativeHistogramQuery(sumByStatus(utils.nativeClassicHistogramCountRate(metricName, selector))),
         format: 'time_series',
         legendFormat: '{{status}}',
         refId: 'A',

--- a/mixin-utils/utils.libsonnet
+++ b/mixin-utils/utils.libsonnet
@@ -3,80 +3,109 @@ local g = import 'grafana-builder/grafana.libsonnet';
 {
   // The classicNativeHistogramQuantile function is used to calculate histogram quantiles from native histograms or classic histograms.
   // Metric name should be provided without _bucket suffix.
-  nativeClassicHistogramQuantile(percentile, metric, selector, sum_by=[], rate_interval='$__rate_interval', multiplier='')::
+  // If from_recording is true, the function will assume :sum_rate metric suffix and no rate needed.
+  nativeClassicHistogramQuantile(percentile, metric, selector, sum_by=[], rate_interval='$__rate_interval', multiplier='', from_recording=false)::
     local classicSumBy = if std.length(sum_by) > 0 then ' by (%(lbls)s) ' % { lbls: std.join(',', ['le'] + sum_by) } else ' by (le) ';
     local nativeSumBy = if std.length(sum_by) > 0 then ' by (%(lbls)s) ' % { lbls: std.join(',', sum_by) } else ' ';
     local multiplierStr = if multiplier == '' then '' else ' * %s' % multiplier;
+    local rateOpen = if from_recording then '' else 'rate(';
+    local rateClose = if from_recording then '' else '[%s]),' % rate_interval;
     {
-      classic: 'histogram_quantile(%(percentile)s, sum%(classicSumBy)s(rate(%(metric)s_bucket{%(selector)s}[%(rateInterval)s])))%(multiplierStr)s' % {
+      classic: 'histogram_quantile(%(percentile)s, sum%(classicSumBy)s(%(rateOpen)s%(metric)s_bucket%(suffix)s{%(selector)s}%(rateClose)s))%(multiplierStr)s' % {
         classicSumBy: classicSumBy,
         metric: metric,
         multiplierStr: multiplierStr,
         percentile: percentile,
         rateInterval: rate_interval,
+        rateOpen: rateOpen,
+        rateClose: rateClose,
         selector: selector,
+        suffix: if from_recording then ':sum_rate' else '',
       },
-      native: 'histogram_quantile(%(percentile)s, sum%(nativeSumBy)s(rate(%(metric)s{%(selector)s}[%(rateInterval)s])))%(multiplierStr)s' % {
+      native: 'histogram_quantile(%(percentile)s, sum%(nativeSumBy)s(%(rateOpen)s%(metric)s%(suffix)s{%(selector)s}%(rateClose)s))%(multiplierStr)s' % {
         metric: metric,
         multiplierStr: multiplierStr,
         nativeSumBy: nativeSumBy,
         percentile: percentile,
         rateInterval: rate_interval,
+        rateOpen: rateOpen,
+        rateClose: rateClose,
         selector: selector,
+        suffix: if from_recording then ':sum_rate' else '',
       },
     },
 
   // The classicNativeHistogramSumRate function is used to calculate the histogram sum of rate from native histograms or classic histograms.
   // Metric name should be provided without _sum suffix.
-  nativeClassicHistogramSumRate(metric, selector, rate_interval='$__rate_interval')::
+  // If from_recording is true, the function will assume :sum_rate metric suffix and no rate needed.
+  nativeClassicHistogramSumRate(metric, selector, rate_interval='$__rate_interval', from_recording=false)::
+    local rateOpen = if from_recording then '' else 'rate(';
+    local rateClose = if from_recording then '' else '[%s]),' % rate_interval;
     {
-      classic: 'rate(%(metric)s_sum{%(selector)s}[%(rateInterval)s])' % {
+      classic: '%(rateOpen)s%(metric)s_sum%(suffix)s{%(selector)s}%(rateClose)s' % {
         metric: metric,
         rateInterval: rate_interval,
+        rateOpen: rateOpen,
+        rateClose: rateClose,
         selector: selector,
+        suffix: if from_recording then ':sum_rate' else '',
       },
-      native: 'histogram_sum(rate(%(metric)s{%(selector)s}[%(rateInterval)s]))' % {
+      native: 'histogram_sum(%(rateOpen)s%(metric)s%(suffix)s{%(selector)s}%(rateClose)s)' % {
         metric: metric,
         rateInterval: rate_interval,
+        rateOpen: rateOpen,
+        rateClose: rateClose,
         selector: selector,
+        suffix: if from_recording then ':sum_rate' else '',
       },
     },
 
 
   // The classicNativeHistogramCountRate function is used to calculate the histogram count of rate from native histograms or classic histograms.
   // Metric name should be provided without _count suffix.
-  nativeClassicHistogramCountRate(metric, selector, rate_interval='$__rate_interval')::
+  // If from_recording is true, the function will assume :sum_rate metric suffix and no rate needed.
+  nativeClassicHistogramCountRate(metric, selector, rate_interval='$__rate_interval', from_recording=false)::
+    local rateOpen = if from_recording then '' else 'rate(';
+    local rateClose = if from_recording then '' else '[%s]),' % rate_interval;
     {
-      classic: 'rate(%(metric)s_count{%(selector)s}[%(rateInterval)s])' % {
+      classic: '%(rateOpen)s%(metric)s_count%(suffix)s{%(selector)s}%(rateClose)s' % {
         metric: metric,
         rateInterval: rate_interval,
+        rateOpen: rateOpen,
+        rateClose: rateClose,
         selector: selector,
+        suffix: if from_recording then ':sum_rate' else '',
       },
-      native: 'histogram_count(rate(%(metric)s{%(selector)s}[%(rateInterval)s]))' % {
+      native: 'histogram_count(%(rateOpen)s%(metric)s%(suffix)s{%(selector)s}%(rateClose)s)' % {
         metric: metric,
         rateInterval: rate_interval,
+        rateOpen: rateOpen,
+        rateClose: rateClose,
         selector: selector,
+        suffix: if from_recording then ':sum_rate' else '',
       },
     },
 
   // TODO(krajorama) Switch to histogram_avg function for native histograms later.
-  nativeClassicHistogramAverageRate(metric, selector, rate_interval='$__rate_interval', multiplier='')::
+  // nativeClassicHistogramAverageRate function is used to calculate the histogram average rate from native histograms or classic histograms.
+  // If from_recording is true, the function will assume :sum_rate metric suffix and no rate needed.
+  nativeClassicHistogramAverageRate(metric, selector, rate_interval='$__rate_interval', multiplier='', from_recording=false)::
     local multiplierStr = if multiplier == '' then '' else '%s * ' % multiplier;
     {
       classic: |||
         %(multiplier)ssum(%(sumMetricQuery)s) /
         sum(%(countMetricQuery)s)
       ||| % {
-        sumMetricQuery: $.nativeClassicHistogramSumRate(metric, selector, rate_interval).classic,
-        countMetricQuery: $.nativeClassicHistogramCountRate(metric, selector, rate_interval).classic,
+        sumMetricQuery: $.nativeClassicHistogramSumRate(metric, selector, rate_interval, from_recording).classic,
+        countMetricQuery: $.nativeClassicHistogramCountRate(metric, selector, rate_interval, from_recording).classic,
         multiplier: multiplierStr,
       },
       native: |||
         %(multiplier)ssum(%(sumMetricQuery)s) /
         sum(%(countMetricQuery)s)
       ||| % {
-        sumMetricQuery: $.nativeClassicHistogramSumRate(metric, selector, rate_interval).native,
-        countMetricQuery: $.nativeClassicHistogramCountRate(metric, selector, rate_interval).native,
+        sumMetricQuery: $.nativeClassicHistogramSumRate(metric, selector, rate_interval, from_recording).native,
+        countMetricQuery: $.nativeClassicHistogramCountRate(metric, selector, rate_interval, from_recording).native,
         multiplier: multiplierStr,
       },
     },
@@ -204,6 +233,63 @@ local g = import 'grafana-builder/grafana.libsonnet';
     // but not in the selector.
     noop(label):: { label: label, op: 'nop' },
   },
+
+  // latencyRecordingRulePanelNativeHistogram - build a latency panel for a recording rule.
+  // - metric: the base metric name (middle part of recording rule name)
+  // - selectors: list of selectors which will be added to first part of
+  //   recording rule name, and to the query selector itself.
+  // - extra_selectors (optional): list of selectors which will be added to the
+  //   query selector, but not to the beginnig of the recording rule name.
+  //   Useful for external labels.
+  // - multiplier (optional): assumes results are in seconds, will multiply
+  //   by 1e3 to get ms.  Can be turned off.
+  // - sum_by (optional): additional labels to use in the sum by clause, will also be used in the legend
+  latencyRecordingRulePanelNativeHistogram(metric, selectors, extra_selectors=[], multiplier='1e3', sum_by=[])::
+    local labels = std.join('_', [matcher.label for matcher in selectors]);
+    local metricStr = '%(labels)s:%(metric)s' % { labels: labels, metric: metric };
+    local selectorStr = $.toPrometheusSelector(selectors + extra_selectors);
+    {
+      nullPointMode: 'null as zero',
+      yaxes: g.yaxes('ms'),
+      targets: [
+        {
+          expr: $.showClassicHistogramQuery($.nativeClassicHistogramQuantile('0.99', metricStr, selectorStr, sum_by=sum_by, multiplier=multiplier, from_recording=true)),
+          format: 'time_series',
+          legendFormat: '%(legend)s99th percentile' % legend,
+          refId: 'A_classic',
+        },
+        {
+          expr: $.showNativeHistogramQuery($.nativeClassicHistogramQuantile('0.99', metricStr, selectorStr, sum_by=sum_by, multiplier=multiplier, from_recording=true)),
+          format: 'time_series',
+          legendFormat: '%(legend)s99th percentile' % legend,
+          refId: 'A_native',
+        },
+        {
+          expr: $.showClassicHistogramQuery($.nativeClassicHistogramQuantile('0.50', metricStr, selectorStr, sum_by=sum_by, multiplier=multiplier, from_recording=true)),
+          format: 'time_series',
+          legendFormat: '%(legend)s50th percentile' % legend,
+          refId: 'B_classic',
+        },
+        {
+          expr: $.showNativeHistogramQuery($.nativeClassicHistogramQuantile('0.50', metricStr, selectorStr, sum_by=sum_by, multiplier=multiplier, from_recording=true)),
+          format: 'time_series',
+          legendFormat: '%(legend)s50th percentile' % legend,
+          refId: 'B_native',
+        },
+        {
+          expr: $.showClassicHistogramQuery($.nativeClassicHistogramAverageRate(metricStr, selectorStr, multiplier=multiplier, from_recording=true)),
+          format: 'time_series',
+          legendFormat: '%(legend)sAverage' % legend,
+          refId: 'C_classic',
+        },
+        {
+          expr: $.showNativeHistogramQuery($.nativeClassicHistogramAverageRate(metricStr, selectorStr, multiplier=multiplier, from_recording=true)),
+          format: 'time_series',
+          legendFormat: '%(legend)sAverage' % legend,
+          refId: 'C_native',
+        },
+      ],
+    },
 
   toPrometheusSelector(selector)::
     local pairs = [

--- a/mixin-utils/utils.libsonnet
+++ b/mixin-utils/utils.libsonnet
@@ -110,6 +110,22 @@ local g = import 'grafana-builder/grafana.libsonnet';
       },
     },
 
+  nativeClassicSumBy(query, sum_by=[], multiplier='')::
+    local sumBy = if std.length(sum_by) > 0 then ' by (%(lbls)s) ' % { lbls: std.join(',', sum_by) } else ' ';
+    local multiplierStr = if multiplier == '' then '' else ' * %s' % multiplier;
+    {
+      classic: 'sum%(sumBy)s(%(query)s)%(multiplierStr)s' % {
+        multiplierStr: multiplierStr,
+        query: query.classic,
+        sumBy: sumBy,
+      },
+      native: 'sum%(sumBy)s(%(query)s)%(multiplierStr)s' % {
+        multiplierStr: multiplierStr,
+        query: query.native,
+        sumBy: sumBy,
+      },
+    },
+
   // showClassicHistogramQuery wraps a query defined as map {classic: q, native: q}, and compares the classic query
   // to dashboard variable which should take -1 or +1 as values in order to hide or show the classic query.
   showClassicHistogramQuery(query, dashboard_variable='latency_metrics'):: '%s < ($%s * +Inf)' % [query.classic, dashboard_variable],

--- a/mixin-utils/utils.libsonnet
+++ b/mixin-utils/utils.libsonnet
@@ -1,6 +1,93 @@
 local g = import 'grafana-builder/grafana.libsonnet';
 
 {
+  // The classicNativeHistogramQuantile function is used to calculate histogram quantiles from native histograms or classic histograms.
+  // Metric name should be provided without _bucket suffix.
+  nativeClassicHistogramQuantile(percentile, metric, selector, sum_by=[], rate_interval='$__rate_interval', multiplier='')::
+    local classicSumBy = if std.length(sum_by) > 0 then ' by (%(lbls)s) ' % { lbls: std.join(',', ['le'] + sum_by) } else ' by (le) ';
+    local nativeSumBy = if std.length(sum_by) > 0 then ' by (%(lbls)s) ' % { lbls: std.join(',', sum_by) } else ' ';
+    local multiplierStr = if multiplier == '' then '' else ' * %s' % multiplier;
+    {
+      classic: 'histogram_quantile(%(percentile)s, sum%(classicSumBy)s(rate(%(metric)s_bucket{%(selector)s}[%(rateInterval)s])))%(multiplierStr)s' % {
+        classicSumBy: classicSumBy,
+        metric: metric,
+        multiplierStr: multiplierStr,
+        percentile: percentile,
+        rateInterval: rate_interval,
+        selector: selector,
+      },
+      native: 'histogram_quantile(%(percentile)s, sum%(nativeSumBy)s(rate(%(metric)s{%(selector)s}[%(rateInterval)s])))%(multiplierStr)s' % {
+        metric: metric,
+        multiplierStr: multiplierStr,
+        nativeSumBy: nativeSumBy,
+        percentile: percentile,
+        rateInterval: rate_interval,
+        selector: selector,
+      },
+    },
+
+  // The classicNativeHistogramSumRate function is used to calculate the histogram sum of rate from native histograms or classic histograms.
+  // Metric name should be provided without _sum suffix.
+  nativeClassicHistogramSumRate(metric, selector, rate_interval='$__rate_interval')::
+    {
+      classic: 'rate(%(metric)s_sum{%(selector)s}[%(rateInterval)s])' % {
+        metric: metric,
+        rateInterval: rate_interval,
+        selector: selector,
+      },
+      native: 'histogram_sum(rate(%(metric)s{%(selector)s}[%(rateInterval)s]))' % {
+        metric: metric,
+        rateInterval: rate_interval,
+        selector: selector,
+      },
+    },
+
+
+  // The classicNativeHistogramCountRate function is used to calculate the histogram count of rate from native histograms or classic histograms.
+  // Metric name should be provided without _count suffix.
+  nativeClassicHistogramCountRate(metric, selector, rate_interval='$__rate_interval')::
+    {
+      classic: 'rate(%(metric)s_count{%(selector)s}[%(rateInterval)s])' % {
+        metric: metric,
+        rateInterval: rate_interval,
+        selector: selector,
+      },
+      native: 'histogram_count(rate(%(metric)s{%(selector)s}[%(rateInterval)s]))' % {
+        metric: metric,
+        rateInterval: rate_interval,
+        selector: selector,
+      },
+    },
+
+  // TODO(krajorama) Switch to histogram_avg function for native histograms later.
+  nativeClassicHistogramAverageRate(metric, selector, rate_interval='$__rate_interval', multiplier='')::
+    local multiplierStr = if multiplier == '' then '' else '%s * ' % multiplier;
+    {
+      classic: |||
+        %(multiplier)ssum(%(sumMetricQuery)s) /
+        sum(%(countMetricQuery)s)
+      ||| % {
+        sumMetricQuery: $.nativeClassicHistogramSumRate(metric, selector, rate_interval).classic,
+        countMetricQuery: $.nativeClassicHistogramCountRate(metric, selector, rate_interval).classic,
+        multiplier: multiplierStr,
+      },
+      native: |||
+        %(multiplier)ssum(%(sumMetricQuery)s) /
+        sum(%(countMetricQuery)s)
+      ||| % {
+        sumMetricQuery: $.nativeClassicHistogramSumRate(metric, selector, rate_interval).native,
+        countMetricQuery: $.nativeClassicHistogramCountRate(metric, selector, rate_interval).native,
+        multiplier: multiplierStr,
+      },
+    },
+
+  // showClassicHistogramQuery wraps a query defined as map {classic: q, native: q}, and compares the classic query
+  // to dashboard variable which should take -1 or +1 as values in order to hide or show the classic query.
+  showClassicHistogramQuery(query, dashboard_variable='latency_metrics'):: '%s < ($%s * +Inf)' % [query.classic, dashboard_variable],
+  // showNativeHistogramQuery wraps a query defined as map {classic: q, native: q}, and compares the native query
+  // to dashboard variable which should take -1 or +1 as values in order to show or hide the native query.
+  showNativeHistogramQuery(query, dashboard_variable='latency_metrics'):: '%s < ($%s * -Inf)' % [query.native, dashboard_variable],
+
   histogramRules(metric, labels, interval='1m', record_native=false)::
     local vars = {
       metric: metric,

--- a/mixin-utils/utils.libsonnet
+++ b/mixin-utils/utils.libsonnet
@@ -246,6 +246,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
   // - sum_by (optional): additional labels to use in the sum by clause, will also be used in the legend
   latencyRecordingRulePanelNativeHistogram(metric, selectors, extra_selectors=[], multiplier='1e3', sum_by=[])::
     local labels = std.join('_', [matcher.label for matcher in selectors]);
+    local legend = std.join('', ['{{ %(lb)s }} ' % lb for lb in sum_by]);
     local metricStr = '%(labels)s:%(metric)s' % { labels: labels, metric: metric };
     local selectorStr = $.toPrometheusSelector(selectors + extra_selectors);
     {

--- a/mixin-utils/utils.libsonnet
+++ b/mixin-utils/utils.libsonnet
@@ -248,7 +248,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
     local labels = std.join('_', [matcher.label for matcher in selectors]);
     local legend = std.join('', ['{{ %(lb)s }} ' % lb for lb in sum_by]);
     local metricStr = '%(labels)s:%(metric)s' % { labels: labels, metric: metric };
-    local selectorStr = $.toPrometheusSelector(selectors + extra_selectors);
+    local selectorStr = $.toPrometheusSelectorNaked(selectors + extra_selectors);
     {
       nullPointMode: 'null as zero',
       yaxes: g.yaxes('ms'),
@@ -292,12 +292,14 @@ local g = import 'grafana-builder/grafana.libsonnet';
       ],
     },
 
-  toPrometheusSelector(selector)::
+  toPrometheusSelectorNaked(selector)::
     local pairs = [
       '%(label)s%(op)s"%(value)s"' % matcher
       for matcher in std.filter(function(matcher) matcher.op != 'nop', selector)
     ];
-    '{%s}' % std.join(', ', pairs),
+    '%s' % std.join(', ', pairs),
+
+  toPrometheusSelector(selector):: '{%s}' % $.toPrometheusSelectorNaked(selector),
 
   // withRunbookURL - Add/Override the runbook_url annotations for all alerts inside a list of rule groups.
   // - url_format: an URL format for the runbook, the alert name will be substituted in the URL.

--- a/mixin-utils/utils.libsonnet
+++ b/mixin-utils/utils.libsonnet
@@ -9,7 +9,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
     local nativeSumBy = if std.length(sum_by) > 0 then ' by (%(lbls)s) ' % { lbls: std.join(',', sum_by) } else ' ';
     local multiplierStr = if multiplier == '' then '' else ' * %s' % multiplier;
     local rateOpen = if from_recording then '' else 'rate(';
-    local rateClose = if from_recording then '' else '[%s]),' % rate_interval;
+    local rateClose = if from_recording then '' else '[%s])' % rate_interval;
     {
       classic: 'histogram_quantile(%(percentile)s, sum%(classicSumBy)s(%(rateOpen)s%(metric)s_bucket%(suffix)s{%(selector)s}%(rateClose)s))%(multiplierStr)s' % {
         classicSumBy: classicSumBy,
@@ -40,7 +40,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
   // If from_recording is true, the function will assume :sum_rate metric suffix and no rate needed.
   nativeClassicHistogramSumRate(metric, selector, rate_interval='$__rate_interval', from_recording=false)::
     local rateOpen = if from_recording then '' else 'rate(';
-    local rateClose = if from_recording then '' else '[%s]),' % rate_interval;
+    local rateClose = if from_recording then '' else '[%s])' % rate_interval;
     {
       classic: '%(rateOpen)s%(metric)s_sum%(suffix)s{%(selector)s}%(rateClose)s' % {
         metric: metric,
@@ -66,7 +66,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
   // If from_recording is true, the function will assume :sum_rate metric suffix and no rate needed.
   nativeClassicHistogramCountRate(metric, selector, rate_interval='$__rate_interval', from_recording=false)::
     local rateOpen = if from_recording then '' else 'rate(';
-    local rateClose = if from_recording then '' else '[%s]),' % rate_interval;
+    local rateClose = if from_recording then '' else '[%s])' % rate_interval;
     {
       classic: '%(rateOpen)s%(metric)s_count%(suffix)s{%(selector)s}%(rateClose)s' % {
         metric: metric,


### PR DESCRIPTION
Support migration of latency histograms by allowing the user to chose between which one to show: native or classic ?

Also add plumbing for recording related native histogram series.