### PR TITLE
Istio 2 Mixin: Removed CPU alerts

### DIFF
--- a/istio-2-mixin/README.md
+++ b/istio-2-mixin/README.md
@@ -10,8 +10,6 @@ The Istio mixin contains the following dashboards:
 
 and the following alerts:
 
-- IstioHighCPUUsageWarning
-- IstioHighCPUUsageCritical
 - IstioHighRequestLatencyWarning
 - IstioGalleyValidationFailuresWarning
 - IstioListenerConfigConflictsCritical
@@ -216,8 +214,6 @@ For the selectors to properly work with the Istio logs ingested into your logs d
 ```
 
 ## Alerts overview
-- IstioHighCPUUsageWarning: High vCPU usage can indicate that the k8s environment is underprovisioned.
-- IstioHighCPUUsageCritical: High vCPU usage can indicate that the k8s environment is underprovisioned.
 - IstioHighRequestLatencyWarning: High request latency between pods can indicate that there are performance issues within the k8s environment.
 - IstioGalleyValidationFailuresWarning: Istio Galley is reporting failures for a number of configurations.
 - IstioListenerConfigConflictsCritical: Istio Pilot is seeing a number of inbound and or outbound listener conflicts by envoy proxies.
@@ -232,8 +228,6 @@ Default thresholds can be configured in `config.libsonnet`.
 {
     _configs+:: {
       // alerts thresholds
-      alertsWarningHighCPUUsage: 70,  //%
-      alertsCriticalHighCPUUsage: 90, //%
       alertsWarningHighRequestLatency: 4000,
       alertsWarningGalleyValidationFailures: 0,
       alertsCriticalListenerConfigConflicts: 0,

--- a/istio-2-mixin/alerts.libsonnet
+++ b/istio-2-mixin/alerts.libsonnet
@@ -11,38 +11,6 @@
         name: 'istio-alerts-' + this.config.uid,
         rules: [
           {
-            alert: 'IstioHighCPUUsageWarning',
-            expr: |||
-              100 * (sum without (instance, pod) (rate(process_cpu_seconds_total{%(filteringSelector)s, pod=~"istiod.*"}[5m])) + sum without (instance, pod) (rate(istio_agent_process_cpu_seconds_total{%(filteringSelector)s}[5m]))) > %(alertsWarningHighCPUUsage)s
-            ||| % this.config,
-            'for': '5m',
-            labels: {
-              severity: 'warning',
-            },
-            annotations: {
-              summary: 'High vCPU usage can indicate that the k8s environment is underprovisioned.',
-              description: |||
-                Istio cluster {{$labels.cluster}} has had vCPU usage of {{ printf "%%.0f" $value }}%% over the last 5 minutes, which is above the threshold of %(alertsWarningHighCPUUsage)s.
-              ||| % this.config,
-            },
-          },
-          {
-            alert: 'IstioHighCPUUsageCritical',
-            expr: |||
-              100 * (sum without (instance, pod) (rate(process_cpu_seconds_total{%(filteringSelector)s, pod=~"istiod.*"}[5m])) + sum without (instance, pod) (rate(istio_agent_process_cpu_seconds_total{%(filteringSelector)s}[5m]))) > %(alertsCriticalHighCPUUsage)s
-            ||| % this.config,
-            'for': '5m',
-            labels: {
-              severity: 'critical',
-            },
-            annotations: {
-              summary: 'High vCPU usage can indicate that the k8s environment is underprovisioned.',
-              description: |||
-                Istio cluster {{$labels.cluster}} has had vCPU usage of {{ printf "%%.0f" $value }}%% over the last 5 minutes, which is above the threshold of %(alertsCriticalHighCPUUsage)s.
-              ||| % this.config,
-            },
-          },
-          {
             alert: 'IstioHighRequestLatencyWarning',
             expr: |||
               sum without(connection_security_policy, destination_app, destination_canonical_revision, destination_service_name, destination_cluster, destination_principal, destination_service, destination_service_namespace, destination_version, destination_workload, destination_workload_namespace, grpc_response_status, instance, pod, reporter, request_protocol, response_code, response_flags, source_app, source_canonical_revision, source_cluster, source_principal, source_version, source_workload, source_workload_namespace) (increase(istio_request_duration_milliseconds_sum{%(filteringSelector)s, %(reporterSourceFilter)s}[5m]))

--- a/istio-2-mixin/config.libsonnet
+++ b/istio-2-mixin/config.libsonnet
@@ -14,8 +14,6 @@
   dashboardRefresh: '1m',
 
   // Alert thresholds
-  alertsWarningHighCPUUsage: 70,  //%
-  alertsCriticalHighCPUUsage: 90,  //%
   alertsWarningHighRequestLatency: 4000,
   alertsWarningGalleyValidationFailures: 0,
   alertsCriticalListenerConfigConflicts: 0,


### PR DESCRIPTION
vCPU alerts were based on Istio only containers, and therefore would likely never reach high usage levels and would end up just confusing users.