### PR TITLE
Istio 2 Mixin: Fixes xDS push latency query

### DIFF
--- a/istio-2-mixin/targets.libsonnet
+++ b/istio-2-mixin/targets.libsonnet
@@ -281,6 +281,7 @@ local lokiQuery = g.query.loki;
       )
       + prometheusQuery.withLegendFormat('{{cluster}}')
       + panel.histogram.queryOptions.withInterval('1m')
+      + prometheusQuery.withInstant(true)
       + prometheusQuery.withFormat('heatmap'),
     galleyValidationsPassed:
       prometheusQuery.new(


### PR DESCRIPTION
Fixes the target for the xDS push latency panel as it was displaying too many counts.
## Before
<img width="837" alt="image" src="https://github.com/grafana/jsonnet-libs/assets/12396806/0f8e8d8d-8c5a-497e-ace0-a24589e19b61">

## After
<img width="843" alt="image" src="https://github.com/grafana/jsonnet-libs/assets/12396806/dc4253f2-a871-4fa7-9f8c-34e85e5722f0">
