### PR TITLE
Fix: PgBouncer Database Selector

### DIFF
--- a/pgbouncer-mixin/variables.libsonnet
+++ b/pgbouncer-mixin/variables.libsonnet
@@ -67,8 +67,8 @@ local utils = commonlib.utils;
       // Use on dashboards where only single entity can be selected, like drill-down dashboards
       singleInstance:
         [root.datasources.prometheus]
-        + variablesFromLabels(groupLabels, instanceLabels, filteringSelector, multiInstance=false)
-        + variablesFromLabels(groupLabels, ['database'], filteringSelector),
+        + variablesFromLabels(groupLabels, pureInstanceLabels, filteringSelector, multiInstance=false)
+        + variablesFromLabels([], ['database'], filteringSelector),
       queriesSelector:
         '%s,%s' % [
           utils.labelsToPromQLSelector(groupLabels + instanceLabels),

--- a/pgbouncer-mixin/variables.libsonnet
+++ b/pgbouncer-mixin/variables.libsonnet
@@ -67,7 +67,8 @@ local utils = commonlib.utils;
       // Use on dashboards where only single entity can be selected, like drill-down dashboards
       singleInstance:
         [root.datasources.prometheus]
-        + variablesFromLabels(groupLabels, instanceLabels, filteringSelector, multiInstance=false),
+        + variablesFromLabels(groupLabels, instanceLabels, filteringSelector, multiInstance=false)
+        + variablesFromLabels(groupLabels, ['database'], filteringSelector),
       queriesSelector:
         '%s,%s' % [
           utils.labelsToPromQLSelector(groupLabels + instanceLabels),


### PR DESCRIPTION
Allows PgBouncer overview dashboard to keep singleInstance while allowing multiple databases