### PR TITLE
Cassandra Mixin: Fixes alerts with more specific queries

### DIFF
--- a/apache-cassandra-mixin/.lint
+++ b/apache-cassandra-mixin/.lint
@@ -17,6 +17,8 @@ exclusions:
       - panel: "Keyspaces count"
       - panel: "Repair jobs started"
       - panel: "Repair jobs completed"
+  panel-datasource-rule:
+    reason: "Loki datasource variable is being named as loki_datasource now while linter expects 'datasource'"
   template-datasource-rule:
     reason: "Based on new convention we are using variable names prometheus_datasource and loki_datasource where as linter expects 'datasource'"
   template-instance-rule:

--- a/apache-cassandra-mixin/alerts/alerts.libsonnet
+++ b/apache-cassandra-mixin/alerts/alerts.libsonnet
@@ -115,7 +115,7 @@
           {
             alert: 'HighCpuUsage',
             expr: |||
-              jvm_process_cpu_load * 100 > %(alertsCriticalHighCpuUsage5m)s
+              jvm_process_cpu_load{job=~"integrations/apache-cassandra"} * 100 > %(alertsCriticalHighCpuUsage5m)s
             ||| % $._config,
             'for': '5m',
             labels: {
@@ -133,7 +133,7 @@
           {
             alert: 'HighMemoryUsage',
             expr: |||
-              sum(jvm_memory_usage_used_bytes{area="Heap"}) / sum(jvm_physical_memory_size) * 100 > %(alertsCriticalHighMemoryUsage5m)s
+              sum(jvm_memory_usage_used_bytes{job=~"integrations/apache-cassandra", area="Heap"}) / sum(jvm_physical_memory_size{job=~"integrations/apache-cassandra"}) * 100 > %(alertsCriticalHighMemoryUsage5m)s
             ||| % $._config,
             'for': '5m',
             labels: {


### PR DESCRIPTION
# Issues related to
[Issue #9878](https://github.com/grafana/support-escalations/issues/9878)

Adds job filter on generic JVM prometheus CPU and memory metrics for Apache Cassandra alert queries. This will cause these alerts to not accidentally get triggered if any other technologies are importing these metrics as well.