### PR TITLE
Apache Tomcat Mixin: Fixes alerts with more specific queries

### DIFF
--- a/apache-tomcat-mixin/.lint
+++ b/apache-tomcat-mixin/.lint
@@ -10,6 +10,8 @@ exclusions:
       - panel: "Servlet requests"
       - panel: "Sessions"
       - panel: "Threads"
+  panel-datasource-rule:
+    reason: "Loki datasource variable is being named as loki_datasource now while linter expects 'datasource'"
   template-datasource-rule:
     reason: "Based on new convention we are using variable names prometheus_datasource and loki_datasource where as linter expects 'datasource'"
   template-instance-rule:

--- a/apache-tomcat-mixin/alerts/alerts.libsonnet
+++ b/apache-tomcat-mixin/alerts/alerts.libsonnet
@@ -7,7 +7,7 @@
           {
             alert: 'ApacheTomcatAlertsHighCpuUsage',
             expr: |||
-              sum by (job, instance) (jvm_process_cpu_load) > %(ApacheTomcatAlertsCriticalCpuUsage)s
+              sum by (job, instance) (jvm_process_cpu_load{job=~"integrations/tomcat"}) > %(ApacheTomcatAlertsCriticalCpuUsage)s
             ||| % $._config,
             'for': '5m',
             labels: {
@@ -25,7 +25,7 @@
           {
             alert: 'ApacheTomcatAlertsHighMemoryUsage',
             expr: |||
-              sum(jvm_memory_usage_used_bytes) by (job, instance) / sum(jvm_physical_memory_bytes) by (job, instance) * 100 > %(ApacheTomcatAlertsCriticalMemoryUsage)s
+              sum(jvm_memory_usage_used_bytes{job=~"integrations/tomcat"}) by (job, instance) / sum(jvm_physical_memory_bytes{job=~"integrations/tomcat"}) by (job, instance) * 100 > %(ApacheTomcatAlertsCriticalMemoryUsage)s
             ||| % $._config,
             'for': '5m',
             labels: {


### PR DESCRIPTION
# Issues related to
[Issue #9878](https://github.com/grafana/support-escalations/issues/9878)

Adds job filter on generic JVM prometheus CPU and memory metrics for Apache Tomcat alert queries. This will cause these alerts to not accidentally get triggered if any other technologies are importing these metrics as well.