### PR TITLE
Fix units in mongodb

### DIFF
--- a/mongodb-mixin/dashboards/MongoDB_Instance.json
+++ b/mongodb-mixin/dashboards/MongoDB_Instance.json
@@ -1447,7 +1447,7 @@
               }
             ]
           },
-          "unit": "percentunit"
+          "unit": "short"
         },
         "overrides": []
       },


### PR DESCRIPTION
This panel based on rate of counters not any ratio. So using percentunit produces scale of 0-10000%