### PR TITLE
feat: Enable Couchbase k8s logging

### DIFF
--- a/couchbase-mixin/dashboards/couchbase-node-overview.libsonnet
+++ b/couchbase-mixin/dashboards/couchbase-node-overview.libsonnet
@@ -990,7 +990,7 @@ local errorLogsPanel(matcher) = {
     {
       datasource: lokiDatasource,
       editorMode: 'code',
-      expr: '{' + matcher + '} |~ `error|couchbase.log.error`',
+      expr: '{' + matcher + '} |~ `ns_server:error|couchbase.log.error`',
       queryType: 'range',
       refId: 'A',
     },

--- a/couchbase-mixin/dashboards/couchbase-node-overview.libsonnet
+++ b/couchbase-mixin/dashboards/couchbase-node-overview.libsonnet
@@ -990,7 +990,7 @@ local errorLogsPanel(matcher) = {
     {
       datasource: lokiDatasource,
       editorMode: 'code',
-      expr: '{' + matcher + '} |~ `(ns_server:error)`',
+      expr: '{' + matcher + '} |~ `error|couchbase.log.error`',
       queryType: 'range',
       refId: 'A',
     },
@@ -1016,7 +1016,7 @@ local couchbaseLogsPanel(matcher) = {
     {
       datasource: lokiDatasource,
       editorMode: 'code',
-      expr: '{' + matcher + '} |~ `(couchdb:(info|error))`',
+      expr: '{' + matcher + '} |~ `couchdb`',
       queryType: 'range',
       refId: 'A',
     },


### PR DESCRIPTION
This PR modifies the regex on the Couchbase log panels to capture logs for both k8s and non-k8s deployments.