### PR TITLE
Adds Logs dashboard to Velero

### DIFF
--- a/velero-2-mixin/links.libsonnet
+++ b/velero-2-mixin/links.libsonnet
@@ -6,5 +6,13 @@ local g = import './g.libsonnet';
       veleroClusterOverview:
         link.link.new('Velero cluster overview', '/d/' + this.grafana.dashboards.clusterOverview.uid)
         + link.link.options.withKeepTime(true),
-    },
+    }
+    +
+    if this.config.enableLokiLogs then
+      {
+        logs:
+          link.link.new('Velero logs', '/d/' + this.grafana.dashboards.logs.uid)
+          + link.link.options.withKeepTime(true),
+      }
+    else {},
 }


### PR DESCRIPTION
This adds the Logs dashboard to the Velero Mixin: here is the [link](https://keithschmitty.grafana.net/d/velero-logs/velero-logs?from=now-1h&to=now&orgId=1&refresh=1m)