### PR TITLE
fix: Add increase to Apache Cassandra `HintsStoredOnNode` alert

### DIFF
--- a/apache-cassandra-mixin/alerts/alerts.libsonnet
+++ b/apache-cassandra-mixin/alerts/alerts.libsonnet
@@ -79,7 +79,7 @@
           {
             alert: 'HintsStoredOnNode',
             expr: |||
-              cassandra_storage_totalhints_count > %(alertsWarningHintsStored1m)s
+              increase(cassandra_storage_totalhints_count[5m]) > %(alertsWarningHintsStored1m)s
             ||| % $._config,
             'for': '1m',
             labels: {


### PR DESCRIPTION
This PR fixes a bug with the Apache Cassandra integration where the `HintsStoredOnNode` alert would continuously fire upon being triggered due to the counter metric not resetting.

#### Related Customer Issue
[#9934](https://github.com/grafana/support-escalations/issues/9934)