### PR TITLE
Add withQueriesYaml() method to postgres-exporter

### DIFF
--- a/postgres-exporter/main.libsonnet
+++ b/postgres-exporter/main.libsonnet
@@ -79,4 +79,20 @@ local k = import 'ksonnet-util/kausal.libsonnet';
         ),
       ]),
   },
+
+  withQueriesYaml(content):: {
+    container+:
+      k.core.v1.container.withVolumeMounts([
+        k.core.v1.volumeMount.new(
+          'queries-yaml',
+          '/etc/pg_exporter/queries.yaml',
+        ),
+      ])
+      + k.core.v1.configMap.new('queries-yaml', {
+        'queries.yaml': content,
+      })
+      + k.core.v1.container.withEnvMixin([
+        envVar.new('PG_EXPORTER_EXTEND_QUERY_PATH', '/etc/pg_exporter/queries.yaml'),
+      ]),
+  },
 }

--- a/postgres-exporter/main.libsonnet
+++ b/postgres-exporter/main.libsonnet
@@ -6,6 +6,8 @@ local k = import 'ksonnet-util/kausal.libsonnet';
     data_source_uri='$(HOSTNAME):$(PORT)/postgres',
     data_source_name='',
     ssl=true,
+    // Note that upgrading to an image version greater than 0.12.1
+    // will break dependencies using `withQueriesYaml`.
     image='quay.io/prometheuscommunity/postgres-exporter:v0.10.0',
   ):: {
     local this = self,
@@ -80,6 +82,8 @@ local k = import 'ksonnet-util/kausal.libsonnet';
       ]),
   },
 
+  // Upgrading to an image version greater than 0.12.1
+  // will break this function.
   withQueriesYaml(content):: {
     container+:
       k.core.v1.container.withVolumeMounts([


### PR DESCRIPTION
## Ticket

https://github.com/grafana/k6-cloud/issues/2154

We need this file to use `PG_EXPORTER_EXTEND_QUERY_PATH`.

## Related PRs

https://github.com/grafana/deployment_tools/pull/133721