### PR TITLE
Fix: typo in label_values for model_name label

### DIFF
--- a/tensorflow-mixin/dashboards/tensorflow-overview.libsonnet
+++ b/tensorflow-mixin/dashboards/tensorflow-overview.libsonnet
@@ -709,7 +709,7 @@ local getMatcher(cfg) = '%(tensorflowSelector)s, instance=~"$instance"' % cfg;
           template.new(
             'model_name',
             promDatasource,
-            'label_values(:tensorflow:serving:request_count{%(tensorflowSelector)s}}, model_name)' % $._config,
+            'label_values(:tensorflow:serving:request_count{%(tensorflowSelector)s}, model_name)' % $._config,
             label='Model name',
             refresh='time',
             includeAll=true,


### PR DESCRIPTION
### Description
This PR is a small fix to address a broken filter for the `model_name` label for Tensorflow Serving

### Changes
* [fixed typo in label_values for model_name](https://github.com/grafana/jsonnet-libs/commit/de62bc5951e8fb86ea8cf0987c3d384b23ea37f2)