### PR TITLE
Fix: Add cluster label template to OracleDB dashboard

### DIFF
--- a/oracledb-mixin/dashboards/overview.libsonnet
+++ b/oracledb-mixin/dashboards/overview.libsonnet
@@ -1099,6 +1099,18 @@ local tablespaceSizePanel(matcher) = {
                 sort=1
               ),
               template.new(
+                'cluster',
+                promDatasource,
+                'label_values(oracledb_up, cluster)' % $._config,
+                label='Cluster',
+                refresh=2,
+                includeAll=true,
+                multi=true,
+                allValues='.*',
+                hide=if $._config.enableMultiCluster then '' else 'variable',
+                sort=0
+              ),
+              template.new(
                 name='instance',
                 label='Instance',
                 datasource='$prometheus_datasource',


### PR DESCRIPTION
### Description
This PR adds the `cluster` label template to the overview dashboard. Missed adding this initially. 

### Changes
* [add cluster label template to dashboard](https://github.com/grafana/jsonnet-libs/commit/a5e08a2461bf5efc79bb41c48353a19d94cf215e)