### PR TITLE
Revert caddy changes

### DIFF
--- a/caddy-mixin/dashboards/caddy-overview.jsonnet
+++ b/caddy-mixin/dashboards/caddy-overview.jsonnet
@@ -714,7 +714,7 @@
         datasource: {
           uid: '$datasource',
         },
-        definition: "label_values(caddy_http_requests_total{job=~\"$job\"}, instance)",
+        definition: 'label_values(caddy_http_requests_total{job=~"$job"}, instance)',
         hide: 0,
         includeAll: true,
         label: 'Instance',
@@ -723,7 +723,7 @@
         options: [],
         query: {
           qryType: 1,
-          query: "label_values(caddy_http_requests_total{job=~\"$job\"}, instance)",
+          query: 'label_values(caddy_http_requests_total{job=~"$job"}, instance)',
           refId: 'PrometheusVariableQueryEditor-VariableQuery',
         },
         refresh: 2,

--- a/caddy-mixin/dashboards/caddy-overview.jsonnet
+++ b/caddy-mixin/dashboards/caddy-overview.jsonnet
@@ -1,5 +1,5 @@
 {
-  local matcher = 'job=~"$job", server=~"$service", instance=~"$instance"',
+  local matcher = 'job=~"$job", instance=~"$instance"',
   annotations: {
     list: [
       {
@@ -714,39 +714,7 @@
         datasource: {
           uid: '$datasource',
         },
-        definition: "label_values(caddy_http_requests_total{job=~\"'$job'\"} server)",
-        hide: 0,
-        includeAll: true,
-        label: 'service',
-        multi: true,
-        name: 'service',
-        options: [],
-        query: {
-          qryType: 1,
-          query: "label_values(caddy_http_requests_total{job=~\"'$job'\"}, server)",
-          refId: 'PrometheusVariableQueryEditor-VariableQuery',
-        },
-        refresh: 2,
-        regex: '',
-        skipUrlSync: false,
-        sort: 1,
-        tagValuesQuery: '',
-        tags: [],
-        tagsQuery: '',
-        type: 'query',
-        useTags: false,
-      },
-      {
-        allValue: '.+',
-        current: {
-          selected: false,
-          text: 'All',
-          value: '$__all',
-        },
-        datasource: {
-          uid: '$datasource',
-        },
-        definition: "label_values(caddy_http_requests_total{job=~\"'$job'\", server=~\"$service\"}, instance)",
+        definition: "label_values(caddy_http_requests_total{job=~\"$job\"}, instance)",
         hide: 0,
         includeAll: true,
         label: 'Instance',
@@ -755,7 +723,7 @@
         options: [],
         query: {
           qryType: 1,
-          query: "label_values(caddy_http_requests_total{job=~\"'$job'\", server=~\"$service\"}, instance)",
+          query: "label_values(caddy_http_requests_total{job=~\"$job\"}, instance)",
           refId: 'PrometheusVariableQueryEditor-VariableQuery',
         },
         refresh: 2,


### PR DESCRIPTION
Reverts service selector (https://github.com/grafana/jsonnet-libs/pull/1176) . Not required anymore for asserts.