### PR TITLE
Mixin updates: update loki logs regex filter

### DIFF
--- a/helloworld-observ-lib/variables.libsonnet
+++ b/helloworld-observ-lib/variables.libsonnet
@@ -43,7 +43,7 @@ local utils = commonlib.utils;
         loki:
           var.datasource.new('loki_datasource', 'loki')
           + var.datasource.generalOptions.withLabel('Loki data source')
-          + var.datasource.withRegex('')
+          + var.datasource.withRegex('(?!grafanacloud.+usage-insights|grafanacloud.+alert-state-history).+')
           // hide by default (used for annotations)
           + var.datasource.generalOptions.showOnDashboard.withNothing(),
       },

--- a/istio-2-mixin/variables.libsonnet
+++ b/istio-2-mixin/variables.libsonnet
@@ -70,7 +70,7 @@ local utils = commonlib.utils;
         loki:
           var.datasource.new('loki_datasource', 'loki')
           + var.datasource.generalOptions.withLabel('Loki data source')
-          + var.datasource.withRegex('')
+          + var.datasource.withRegex('(?!grafanacloud.+usage-insights|grafanacloud.+alert-state-history).+')
           // hide by default (used for annotations)
           + var.datasource.generalOptions.showOnDashboard.withNothing(),
       },

--- a/openldap-mixin/variables.libsonnet
+++ b/openldap-mixin/variables.libsonnet
@@ -43,7 +43,7 @@ local utils = commonlib.utils;
         loki:
           var.datasource.new('loki_datasource', 'loki')
           + var.datasource.generalOptions.withLabel('Loki data source')
-          + var.datasource.withRegex('')
+          + var.datasource.withRegex('(?!grafanacloud.+usage-insights|grafanacloud.+alert-state-history).+')
           // hide by default (used for annotations)
           + var.datasource.generalOptions.showOnDashboard.withNothing(),
       },

--- a/pgbouncer-mixin/variables.libsonnet
+++ b/pgbouncer-mixin/variables.libsonnet
@@ -53,7 +53,7 @@ local utils = commonlib.utils;
         loki:
           var.datasource.new('loki_datasource', 'loki')
           + var.datasource.generalOptions.withLabel('Loki data source')
-          + var.datasource.withRegex('')
+          + var.datasource.withRegex('(?!grafanacloud.+usage-insights|grafanacloud.+alert-state-history).+')
           // hide by default (used for annotations)
           + var.datasource.generalOptions.showOnDashboard.withNothing(),
       },

--- a/windows-observ-lib/variables.libsonnet
+++ b/windows-observ-lib/variables.libsonnet
@@ -48,7 +48,7 @@ local utils = commonlib.utils {
          loki:
            var.datasource.new('loki_datasource', 'loki')
            + var.datasource.generalOptions.withLabel('Loki data source')
-           + var.datasource.withRegex('')
+           + var.datasource.withRegex('(?!grafanacloud.+usage-insights|grafanacloud.+alert-state-history).+')
            + var.datasource.generalOptions.showOnDashboard.withNothing(),
        },
        // Use on dashboards where multiple entities can be selected, like fleet dashboards


### PR DESCRIPTION
This PR updates the regex to filter out the usage-insights and alert-state-history from the selectors. A couple were missed beforehand that uses the newest mixin format include:
```+ var.datasource.withRegex('(?!grafanacloud.+usage-insights|grafanacloud.+alert-state-history).+')```
This follows the pattern like in [openstack](https://github.com/grafana/jsonnet-libs/blob/master/openstack-mixin/variables.libsonnet#L47).