### PR TITLE
Add patch_alerts function

### DIFF
--- a/grafana-cloud-integration-utils/jsonnetfile.json
+++ b/grafana-cloud-integration-utils/jsonnetfile.json
@@ -18,6 +18,15 @@
         }
       },
       "version": "main"
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/jsonnet-libs/xtd.git",
+          "subdir": ""
+        }
+      },
+      "version": "master"
     }
   ],
   "legacyImports": true

--- a/grafana-cloud-integration-utils/util.libsonnet
+++ b/grafana-cloud-integration-utils/util.libsonnet
@@ -1,6 +1,7 @@
 local g = import 'grafonnet-latest/main.libsonnet';
 local grafana = (import 'grafonnet/grafana.libsonnet');
 local statusPanels = import 'status-panels-lib/status-panels/main.libsonnet';
+local xtd = import 'xtd/main.libsonnet';
 
 local debug(obj) =
   std.trace(std.toString(obj), obj);
@@ -139,6 +140,69 @@ local integration_version_panel(version, statusPanelDataSource, height, width, x
         ],
       },
     },
+
+
+  // This function can be used to patch alert rules:
+  // prometheusAlerts format (as in mixin):
+  // {
+  //   groups: [
+  //     {
+  //       name: 'abc',
+  //       rules: [
+  //         {
+  //           alert: 'Alert1',
+  //           expr: 'up==0',
+  //           labels: {
+  //             severity: "warning"
+  //           }
+  //         },
+  //         {
+  //           alert: 'Alert2',
+  //           expr: 'up!=0',
+  //           labels: {
+  //             severity: "warning"
+  //           }
+  //         },
+  //       ]
+  //     }
+  //   ]
+  // }
+  // patch format:
+  // {
+  //   Alert1+: {
+  //     labels+: {
+  //       new_label: 'abc',
+  //       asserts_severity: super.severity,
+  //     }
+  //   },
+  //   Alert2+: {
+  //     labels+: {
+  //       new_label: 'zyx',
+  //     }
+  //   }
+  // }
+  patch_alerts(prometheusAlerts, group_name, alert_rules_patch)::
+    local patch_rules(rules, patch) =
+      std.objectValues(
+        {
+          [o.key]: o.value[0]
+          for o
+          in
+            std.objectKeysValues(xtd.aggregate.byKey(rules, 'alert'))
+        }
+        + patch
+      );
+
+    [
+      if group.name == group_name then
+        {
+          name: group_name,
+          rules: patch_rules(group.rules, alert_rules_patch),
+        }
+      else group
+      for group in prometheusAlerts.groups
+    ],
+
   prepare_dashboards(dashboards, tags, folderName, ignoreDashboards=[], refresh='30s', timeFrom='now-30m'):: {
     [k]: {
       dashboard: $.decorate_dashboard(dashboards[k], tags, refresh, timeFrom),


### PR DESCRIPTION
```
// This function can be used to patch alert rules:
  // prometheusAlerts format (as in mixin):
  // {
  //   groups: [
  //     {
  //       name: 'abc',
  //       rules: [
  //         {
  //           alert: 'Alert1',
  //           expr: 'up==0',
  //           labels: {
  //             severity: "warning"
  //           }
  //         },
  //         {
  //           alert: 'Alert2',
  //           expr: 'up!=0',
  //           labels: {
  //             severity: "warning"
  //           }
  //         },
  //       ]
  //     }
  //   ]
  // }
  // patch format:
  // {
  //   Alert1+: {
  //     labels+: {
  //       new_label: 'abc',
  //       asserts_severity: super.severity,
  //     }
  //   },
  //   Alert2+: {
  //     labels+: {
  //       new_label: 'zyx',
  //     }
  //   }
  // }
```


For example this code can produce:
```
local assertsAlertsMixin = {
    ClickHouseRejectedInserts+: {
      labels+: {
        // asserts_severity: super.severity,
        asserts_alert_category: 'failure',
        asserts_entity_type: 'ServiceInstance',
      },
    },
    ClickHouseReplicasInReadOnly+: {
      labels+: {
        // asserts_severity: super.severity,
        asserts_alert_category: 'failure',
        asserts_entity_type: 'ServiceInstance',
      },
    },
    ClickHouseReplicationQueueBackingUp+: {
      labels+: {
        // asserts_severity: super.severity,
        asserts_alert_category: 'failure',
        asserts_entity_type: 'ServiceInstance',
      },
    },
    ClickHouseZookeeperSessions+: {
      labels+: {
        // asserts_severity: super.severity,
        asserts_alert_category: 'failure',
        asserts_entity_type: 'ServiceInstance',
      },
    },
  },


prometheusAlerts+: (
    util.patch_alerts(mixin.prometheusAlerts, 'ClickHouseAlerts', assertsAlertsMixin))
```


```
jsonnet -J vendor mixin.libsonnet 
{
   "prometheusAlerts": [
      {
         "name": "ClickHouseAlerts",
         "rules": [
            {
               "alert": "ClickHouseRejectedInserts",
               "annotations": {
                  "description": "ClickHouse inserts are being rejected on {{ $labels.instance }} as items are being inserted faster than ClickHouse is able to merge them.",
                  "summary": "ClickHouse has too many rejected inserts."
               },
               "expr": "ClickHouseProfileEvents_RejectedInserts > 1",
               "for": "5m",
               "labels": {
                  "asserts_alert_category": "failure",
                  "asserts_entity_type": "ServiceInstance",
                  "severity": "critical"
               }
            },
            {
               "alert": "ClickHouseReplicasInReadOnly",
               "annotations": {
                  "description": "ClickHouse has replicas in a read only state on {{ $labels.instance }} after losing connection to Zookeeper or at startup.\n",
                  "summary": "ClickHouse has too many replicas in read only state."
               },
               "expr": "ClickHouseMetrics_ReadonlyReplica > 0",
               "for": "5m",
               "labels": {
                  "asserts_alert_category": "failure",
                  "asserts_entity_type": "ServiceInstance",
                  "severity": "critical"
               }
            },
            {
               "alert": "ClickHouseReplicationQueueBackingUp",
               "annotations": {
                  "description": "ClickHouse replication tasks are processing slower than expected on {{ $labels.instance }} causing replication queue size to back up at {{ $value }} exceeding the threshold value of 99.\n",
                  "summary": "ClickHouse replica max queue size backing up."
               },
               "expr": "ClickHouseAsyncMetrics_ReplicasMaxQueueSize > 99\n",
               "for": "5m",
               "labels": {
                  "asserts_alert_category": "failure",
                  "asserts_entity_type": "ServiceInstance",
                  "severity": "warning"
               }
            },
            {
               "alert": "ClickHouseZookeeperSessions",
               "annotations": {
                  "description": "ClickHouse has more than one connection to a Zookeeper on {{ $labels.instance }} which can lead to bugs due to stale reads in Zookeepers consistency model.\n",
                  "summary": "ClickHouse has too many Zookeeper sessions."
               },
               "expr": "ClickHouseMetrics_ZooKeeperSession > 1",
               "for": "5m",
               "labels": {
                  "asserts_alert_category": "failure",
                  "asserts_entity_type": "ServiceInstance",
                  "severity": "critical"
               }
            }
         ]
      }
   ]
}

```