### PR TITLE
Add styles to requests panels

### DIFF
--- a/common-lib/README.md
+++ b/common-lib/README.md
@@ -32,7 +32,7 @@ local commonlib = import 'github.com/grafana/jsonnet-libs/common-lib/common/main
 local cpuPanel = oldPanel + commonlib.panels.cpu.timeSeries.utilization.stylize();
 ```
 
-See [windows-observ-lib](../windows-observ-lib/README.md) or [helloworld-observ-lib](../helloworld-observ-lib/README.md)for full example.
+See [windows-observ-lib](../windows-observ-lib/README.md) or [helloworld-observ-lib](../helloworld-observ-lib/README.md) for full example.
 
 ### Signals
 

--- a/common-lib/common/panels.libsonnet
+++ b/common-lib/common/panels.libsonnet
@@ -33,4 +33,8 @@ local g = import './g.libsonnet';
   hardware: {
     timeSeries: import './panels/hardware/timeSeries/main.libsonnet',
   },
+  requests: {
+    timeSeries: import './panels/requests/timeSeries/main.libsonnet',
+    stat: import './panels/requests/stat/main.libsonnet',
+  }
 }

--- a/common-lib/common/panels.libsonnet
+++ b/common-lib/common/panels.libsonnet
@@ -36,5 +36,5 @@ local g = import './g.libsonnet';
   requests: {
     timeSeries: import './panels/requests/timeSeries/main.libsonnet',
     stat: import './panels/requests/stat/main.libsonnet',
-  }
+  },
 }

--- a/common-lib/common/panels/generic/stat/base.libsonnet
+++ b/common-lib/common/panels/generic/stat/base.libsonnet
@@ -8,5 +8,7 @@ base {
     + super.new(targets, description),
 
   stylize(allLayers=true):
-    (if allLayers then super.stylize() else {}),
+    (if allLayers then super.stylize() else {})
+    + stat.standardOptions.color.withMode('fixed')
+    + stat.standardOptions.color.withFixedColor('text'),
 }

--- a/common-lib/common/panels/requests/stat/base.libsonnet
+++ b/common-lib/common/panels/requests/stat/base.libsonnet
@@ -1,0 +1,7 @@
+local g = import '../../../g.libsonnet';
+local stat = g.panel.stat;
+local base = import '../../generic/stat/base.libsonnet';
+
+base {
+
+}

--- a/common-lib/common/panels/requests/stat/duration.libsonnet
+++ b/common-lib/common/panels/requests/stat/duration.libsonnet
@@ -10,7 +10,7 @@ base {
   stylize(allLayers=true):
     (if allLayers then super.stylize() else {})
     + stat.standardOptions.color.withMode('fixed')
-    + stat.standardOptions.color.withFixedColor('blue')
+    + stat.standardOptions.color.withFixedColor('light-blue')
     + stat.standardOptions.withUnit('s')
     + stat.options.withGraphMode('none'),
 }

--- a/common-lib/common/panels/requests/stat/duration.libsonnet
+++ b/common-lib/common/panels/requests/stat/duration.libsonnet
@@ -1,0 +1,16 @@
+local g = import '../../../g.libsonnet';
+local generic = import '../../generic/stat/main.libsonnet';
+local base = import './base.libsonnet';
+local stat = g.panel.stat;
+base {
+  new(title='Response time', targets, description='Response time.'):
+    super.new(title, targets, description)
+    + self.stylize(),
+
+  stylize(allLayers=true):
+    (if allLayers then super.stylize() else {})
+    + stat.standardOptions.color.withMode('fixed')
+    + stat.standardOptions.color.withFixedColor('blue')
+    + stat.standardOptions.withUnit('s')
+    + stat.options.withGraphMode('none'),
+}

--- a/common-lib/common/panels/requests/stat/errors.libsonnet
+++ b/common-lib/common/panels/requests/stat/errors.libsonnet
@@ -1,0 +1,17 @@
+local g = import '../../../g.libsonnet';
+local generic = import '../../generic/stat/main.libsonnet';
+local base = import './base.libsonnet';
+local stat = g.panel.stat;
+// Uptime panel. expects duration in seconds as input
+base {
+  new(title='Errors', targets, description='Rate of errors.'):
+    super.new(title, targets, description)
+    + self.stylize(),
+
+  stylize(allLayers=true):
+    (if allLayers then super.stylize() else {})
+    + stat.standardOptions.color.withMode('fixed')
+    + stat.standardOptions.color.withFixedColor('light-red')
+    + stat.standardOptions.withNoValue('No errors')
+    + stat.options.withGraphMode('none'),
+}

--- a/common-lib/common/panels/requests/stat/errors.libsonnet
+++ b/common-lib/common/panels/requests/stat/errors.libsonnet
@@ -2,7 +2,7 @@ local g = import '../../../g.libsonnet';
 local generic = import '../../generic/stat/main.libsonnet';
 local base = import './base.libsonnet';
 local stat = g.panel.stat;
-// Uptime panel. expects duration in seconds as input
+
 base {
   new(title='Errors', targets, description='Rate of errors.'):
     super.new(title, targets, description)

--- a/common-lib/common/panels/requests/stat/main.libsonnet
+++ b/common-lib/common/panels/requests/stat/main.libsonnet
@@ -1,0 +1,5 @@
+{
+  rate: import './rate.libsonnet',
+  duration: import './duration.libsonnet',
+  errors: import './errors.libsonnet',
+}

--- a/common-lib/common/panels/requests/stat/rate.libsonnet
+++ b/common-lib/common/panels/requests/stat/rate.libsonnet
@@ -1,0 +1,16 @@
+local g = import '../../../g.libsonnet';
+local generic = import '../../generic/stat/main.libsonnet';
+local base = import './base.libsonnet';
+local stat = g.panel.stat;
+// Uptime panel. expects duration in seconds as input
+base {
+  new(title='Rate', targets, description='Rate of requests.'):
+    super.new(title, targets, description)
+    + self.stylize(),
+
+  stylize(allLayers=true):
+    (if allLayers then super.stylize() else {})
+    + stat.standardOptions.color.withMode('fixed')
+    + stat.standardOptions.color.withFixedColor('light-purple')
+    + stat.options.withGraphMode('none'),
+}

--- a/common-lib/common/panels/requests/stat/rate.libsonnet
+++ b/common-lib/common/panels/requests/stat/rate.libsonnet
@@ -2,7 +2,7 @@ local g = import '../../../g.libsonnet';
 local generic = import '../../generic/stat/main.libsonnet';
 local base = import './base.libsonnet';
 local stat = g.panel.stat;
-// Uptime panel. expects duration in seconds as input
+
 base {
   new(title='Rate', targets, description='Rate of requests.'):
     super.new(title, targets, description)

--- a/common-lib/common/panels/requests/timeSeries/base.libsonnet
+++ b/common-lib/common/panels/requests/timeSeries/base.libsonnet
@@ -1,0 +1,6 @@
+local g = import '../../../g.libsonnet';
+local base = import '../../generic/timeSeries/base.libsonnet';
+
+base {
+
+}

--- a/common-lib/common/panels/requests/timeSeries/duration.libsonnet
+++ b/common-lib/common/panels/requests/timeSeries/duration.libsonnet
@@ -16,5 +16,5 @@ base {
     (if allLayers then super.stylize() else {})
     + g.panel.timeSeries.standardOptions.color.withMode('fixed')
     + g.panel.timeSeries.standardOptions.color.withFixedColor('blue')
-    + g.panel.timeSeries.standardOptions.withUnit('s')
+    + g.panel.timeSeries.standardOptions.withUnit('s'),
 }

--- a/common-lib/common/panels/requests/timeSeries/duration.libsonnet
+++ b/common-lib/common/panels/requests/timeSeries/duration.libsonnet
@@ -1,0 +1,20 @@
+local g = import '../../../g.libsonnet';
+local generic = import '../../generic/timeSeries/main.libsonnet';
+local base = import './base.libsonnet';
+base {
+  new(
+    title='Response time',
+    targets,
+    description=|||
+      Response time.
+    |||
+  ):
+    super.new(title, targets, description)
+    + self.stylize(),
+
+  stylize(allLayers=true):
+    (if allLayers then super.stylize() else {})
+    + g.panel.timeSeries.standardOptions.color.withMode('fixed')
+    + g.panel.timeSeries.standardOptions.color.withFixedColor('blue')
+    + g.panel.timeSeries.standardOptions.withUnit('s')
+}

--- a/common-lib/common/panels/requests/timeSeries/errors.libsonnet
+++ b/common-lib/common/panels/requests/timeSeries/errors.libsonnet
@@ -1,0 +1,24 @@
+local g = import '../../../g.libsonnet';
+local base = import './base.libsonnet';
+base {
+  new(
+    title='Errors',
+    targets,
+    description='Request errors.'
+  ):
+    super.new(title, targets, description)
+    + self.stylize(),
+
+  stylize(allLayers=true):
+    local timeSeries = g.panel.timeSeries;
+    local fieldOverride = g.panel.timeSeries.fieldOverride;
+
+    (if allLayers then super.stylize() else {})
+    + timeSeries.fieldConfig.defaults.custom.withDrawStyle('bars')
+    + timeSeries.queryOptions.withMaxDataPoints(100)
+    + timeSeries.fieldConfig.defaults.custom.withFillOpacity(100)
+    + timeSeries.fieldConfig.defaults.custom.withStacking({ mode: 'normal' })
+    + timeSeries.standardOptions.color.withMode('fixed')
+    + timeSeries.standardOptions.color.withFixedColor('light-red')
+    + timeSeries.standardOptions.withNoValue('No errors'),
+}

--- a/common-lib/common/panels/requests/timeSeries/main.libsonnet
+++ b/common-lib/common/panels/requests/timeSeries/main.libsonnet
@@ -1,0 +1,6 @@
+{
+  base: import './base.libsonnet',
+  rate: import './rate.libsonnet',
+  errors: import './errors.libsonnet',
+  duration: import './duration.libsonnet',
+}

--- a/common-lib/common/panels/requests/timeSeries/rate.libsonnet
+++ b/common-lib/common/panels/requests/timeSeries/rate.libsonnet
@@ -1,0 +1,24 @@
+local g = import '../../../g.libsonnet';
+local generic = import '../../generic/timeSeries/main.libsonnet';
+local base = import './base.libsonnet';
+base {
+  new(
+    title='Load / $__interval',
+    targets,
+    description=|||
+      Requests rate per $__interval
+    |||,
+
+  ):
+    super.new(title, targets, description)
+    + self.stylize(),
+
+  stylize(allLayers=true):
+    (if allLayers then super.stylize() else {})
+    + g.panel.timeSeries.fieldConfig.defaults.custom.withDrawStyle('bars')
+    + g.panel.timeSeries.queryOptions.withMaxDataPoints(100)
+    + g.panel.timeSeries.fieldConfig.defaults.custom.withFillOpacity(100)
+    + g.panel.timeSeries.fieldConfig.defaults.custom.withStacking({ mode: 'normal' })
+    + g.panel.timeSeries.standardOptions.color.withMode('fixed')
+    + g.panel.timeSeries.standardOptions.color.withFixedColor('light-purple'),
+}

--- a/common-lib/common/panels/system/stat/uptime.libsonnet
+++ b/common-lib/common/panels/system/stat/uptime.libsonnet
@@ -17,6 +17,7 @@ base {
     (if allLayers then super.stylize() else {})
     + stat.standardOptions.withDecimals(1)
     + stat.standardOptions.withUnit('dtdurations')
+    + stat.standardOptions.color.withMode('thresholds')
     + stat.options.withColorMode('value')
     + stat.options.withGraphMode('none')
     + stat.standardOptions.thresholds.withMode('absolute')


### PR DESCRIPTION
This adds RED panels' styles to commonlib
Styles for rate/duration/errors:
![image](https://github.com/grafana/jsonnet-libs/assets/14870891/57feb211-4b86-41b1-a958-b410952e2198)
