### PR TITLE
fix: removed pod=~"$pod" filter from CiliumAgentMapOperationFailures alert rule

### DIFF
--- a/cilium-enterprise-mixin/alerts/ciliumAlerts.libsonnet
+++ b/cilium-enterprise-mixin/alerts/ciliumAlerts.libsonnet
@@ -104,7 +104,7 @@
         rules: [
           {
             alert: 'CiliumAgentMapOperationFailures',
-            expr: 'sum(rate(cilium_bpf_map_ops_total{k8s_app="cilium", outcome="fail",pod=~"$pod"}[5m])) by (map_name, pod) > 0',
+            expr: 'sum(rate(cilium_bpf_map_ops_total{k8s_app="cilium", outcome="fail"}[5m])) by (map_name, pod) > 0',
             labels: {
               severity: 'warning',
             },


### PR DESCRIPTION
This PR removes `pod=~"$pod"` filter from `CiliumAgentMapOperationFailures` alert rule in `cilium-enterprise-mixin`.  The filter causes the rule to not match anything as there is no `$pod` pod and I believe it was accidentally copied from similar query in dashboards.