### PR TITLE
Clickhouse: Remove total queries

### DIFF
--- a/clickhouse-mixin/dashboards/clickhouse-overview.libsonnet
+++ b/clickhouse-mixin/dashboards/clickhouse-overview.libsonnet
@@ -84,14 +84,6 @@ local successfulQueriesPanel(matcher) =
       {
         datasource: promDatasource,
         editorMode: 'builder',
-        expr: 'rate(ClickHouseProfileEvents_Query{' + matcher + '}[$__rate_interval])',
-        legendFormat: '{{ instance }} - query',
-        range: true,
-        refId: 'A',
-      },
-      {
-        datasource: promDatasource,
-        editorMode: 'builder',
         expr: 'rate(ClickHouseProfileEvents_SelectQuery{' + matcher + '}[$__rate_interval])',
         hide: false,
         legendFormat: '{{ instance }} - select query',
@@ -191,14 +183,6 @@ local failedQueriesPanel(matcher) =
       },
     },
     targets: [
-      {
-        datasource: promDatasource,
-        editorMode: 'builder',
-        expr: 'rate(ClickHouseProfileEvents_FailedQuery{' + matcher + '}[$__rate_interval])',
-        legendFormat: '{{ instance }} - failed query',
-        range: true,
-        refId: 'A',
-      },
       {
         datasource: promDatasource,
         editorMode: 'builder',


### PR DESCRIPTION
Removes the total queries as suggested in the issue #1202 
Updated view:
![Screenshot 2024-04-25 at 5 46 33 AM](https://github.com/grafana/jsonnet-libs/assets/13648435/317b47dc-ac59-4b23-b75a-7ab6fbe8a8ec)
