### PR TITLE
Clickhouse: Fix latency display charts

### DIFF
--- a/clickhouse-mixin/dashboards/clickhouse-latency.libsonnet
+++ b/clickhouse-mixin/dashboards/clickhouse-latency.libsonnet
@@ -176,7 +176,7 @@ local diskWriteLatencyPanel(matcher) =
     type: 'timeseries',
   };
 
-local networkTransmitLatencyPanel(matcher) =
+local networkTransmitLatencyInboundPanel(matcher) =
   {
     datasource: promDatasource,
     description: 'Latency of inbound network traffic',
@@ -259,7 +259,7 @@ local networkTransmitLatencyPanel(matcher) =
     type: 'timeseries',
   };
 
-local networkTransmitLatencyPanel(matcher) =
+local networkTransmitLatencyOutboundPanel(matcher) =
   {
     datasource: promDatasource,
     description: 'Latency of outbound network traffic',
@@ -497,8 +497,8 @@ local zooKeeperWaitTimePanel(matcher) =
           ],
           //next row
           [
-            networkTransmitLatencyPanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 0, y: 8 } },
-            networkTransmitLatencyPanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 12, y: 8 } },
+            networkTransmitLatencyInboundPanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 0, y: 8 } },
+            networkTransmitLatencyOutboundPanel(getMatcher($._config)) { gridPos: { h: 8, w: 12, x: 12, y: 8 } },
           ],
           //next row
           [


### PR DESCRIPTION
Duplicate displays of one of the panels was being shown. I renamed them and it looks like it works as expected. This resolves #1170 

![Screenshot 2024-04-25 at 6 02 30 AM](https://github.com/grafana/jsonnet-libs/assets/13648435/8ba45a30-cb74-43dc-b4c3-0b81c7d049ba)
