### PR TITLE
Clickhouse: Update log selector

### DIFF
--- a/clickhouse-mixin/config.libsonnet
+++ b/clickhouse-mixin/config.libsonnet
@@ -1,14 +1,14 @@
 {
   _config+:: {
-    enableMultiCluster: false,
+    enableMultiCluster: true,
     clickhouseSelector: if self.enableMultiCluster then 'job=~"$job", instance=~"$instance", cluster=~"$cluster"' else 'job=~"$job", instance=~"$instance"',
 
     dashboardTags: ['clickhouse-mixin'],
     dashboardPeriod: 'now-30m',
     dashboardTimezone: 'default',
     dashboardRefresh: '1m',
-    logExpression: if self.enableMultiCluster then '{job=~"$job", instance=~"$instance", cluster=~"$cluster"}'
-    else '{job=~"$job", instance=~"$instance"}',
+    logLabels: if self.enableMultiCluster then ['job', 'instance', 'cluster','level']
+    else ['job', 'instance', 'level'],
 
     // for alerts
     alertsReplicasMaxQueueSize: '99',

--- a/clickhouse-mixin/config.libsonnet
+++ b/clickhouse-mixin/config.libsonnet
@@ -1,6 +1,6 @@
 {
   _config+:: {
-    enableMultiCluster: true,
+    enableMultiCluster: false,
     clickhouseSelector: if self.enableMultiCluster then 'job=~"$job", instance=~"$instance", cluster=~"$cluster"' else 'job=~"$job", instance=~"$instance"',
 
     dashboardTags: ['clickhouse-mixin'],

--- a/clickhouse-mixin/config.libsonnet
+++ b/clickhouse-mixin/config.libsonnet
@@ -7,7 +7,7 @@
     dashboardPeriod: 'now-30m',
     dashboardTimezone: 'default',
     dashboardRefresh: '1m',
-    logLabels: if self.enableMultiCluster then ['job', 'instance', 'cluster','level']
+    logLabels: if self.enableMultiCluster then ['job', 'instance', 'cluster', 'level']
     else ['job', 'instance', 'level'],
 
     // for alerts

--- a/clickhouse-mixin/dashboards/addlogs.libsonnet
+++ b/clickhouse-mixin/dashboards/addlogs.libsonnet
@@ -10,7 +10,7 @@ local logsDashboard = import 'logs-lib/logs/main.libsonnet';
             datasourceName='loki_datasource',
             datasourceRegex='',
             filterSelector=$._config.filterSelector,
-            labels=['job', 'instance', 'level'],
+            labels=$._config.logLabels,
             formatParser=null,
             showLogsVolume=true
           )

--- a/clickhouse-mixin/dashboards/clickhouse-overview.libsonnet
+++ b/clickhouse-mixin/dashboards/clickhouse-overview.libsonnet
@@ -5,7 +5,6 @@ local template = grafana.template;
 local dashboardUid = 'clickhouse-overview';
 local promDatasourceName = 'prometheus_datasource';
 local getMatcher(cfg) = '%(clickhouseSelector)s' % cfg;
-local logExpr(cfg) = '%(logExpr)s' % cfg;
 
 local promDatasource = {
   uid: '${%s}' % promDatasourceName,
@@ -709,39 +708,6 @@ local networkTransmittedPanel(matcher) =
     type: 'timeseries',
   };
 
-local errorLogsPanel(cfg) =
-  {
-    datasource: {
-      type: 'loki',
-      uid: '${loki_datasource}',
-    },
-    description: 'Recent logs from the error log file',
-    options: {
-      dedupStrategy: 'none',
-      enableLogDetails: true,
-      prettifyLogMessage: false,
-      showCommonLabels: false,
-      showLabels: false,
-      showTime: false,
-      sortOrder: 'Descending',
-      wrapLogMessage: false,
-    },
-    targets: [
-      {
-        datasource: {
-          type: 'loki',
-          uid: '${loki_datasource}',
-        },
-        editorMode: 'builder',
-        expr: logExpr(cfg.logExpression),
-        legendFormat: '{{ instance }}',
-        queryType: 'range',
-        refId: 'A',
-      },
-    ],
-    title: 'Error logs',
-    type: 'logs',
-  };
 {
   grafanaDashboards+:: {
 


### PR DESCRIPTION
This pr removes the old dashboard relics and adds in the log label selector for the new dashboard. Resolves #1169 

![Screenshot 2024-04-25 at 6 33 56 AM](https://github.com/grafana/jsonnet-libs/assets/13648435/2c28b0c5-892f-40e9-b87f-21436bea5da7)
