### PR TITLE
Aggregation labels for cilium mixin

### DIFF
--- a/cilium-enterprise-mixin/config.libsonnet
+++ b/cilium-enterprise-mixin/config.libsonnet
@@ -1,0 +1,5 @@
+{
+  _config+:: {
+    alertAggregationLabels: [],
+  },
+}

--- a/cilium-enterprise-mixin/mixin.libsonnet
+++ b/cilium-enterprise-mixin/mixin.libsonnet
@@ -23,4 +23,5 @@
     'cilium-policy.json': (import 'dashboards/cilium-agent/cilium-policy.json'),
     'cilium-resource-utilization.json': (import 'dashboards/cilium-agent/cilium-resource-utilization.json'),
   },
-}
+} +
+(import 'config.libsonnet')


### PR DESCRIPTION
I've implemented possibility to aggregate `cilium-enterprise-mixin` alerts by arbitrary set of labels. All alerts are aggregated by the same set, the default set is `[]` (which preserves previous behavior).

Are you interrested in such a change?