### PR TITLE
Keep datasource in next level dashboard + "Filter by cluster/job" fix

### DIFF
--- a/windows-observ-lib/panels.libsonnet
+++ b/windows-observ-lib/panels.libsonnet
@@ -78,7 +78,7 @@ local utils = commonlib.utils;
             {
               targetBlank: false,
               title: 'Drill down to ${__field.name} ${__value.text}',
-              url: 'd/%s?var-%s=${__data.fields.%s}&${__url_time_range}' % [this.grafana.dashboards.overview.uid, instanceLabel, instanceLabel],
+              url: 'd/%s?var-%s=${__data.fields.%s}&${__url_time_range}&${datasource:queryparam}' % [this.grafana.dashboards.overview.uid, instanceLabel, instanceLabel],
             },
           ]),
           fieldOverride.byRegexp.new(std.join('|', std.map(utils.toSentenceCase, this.config.groupLabels)))
@@ -87,7 +87,7 @@ local utils = commonlib.utils;
             {
               targetBlank: false,
               title: 'Filter by ${__field.name}',
-              url: 'd/%s?var-${__field.name}=${__value.text}&${__url_time_range}' % [this.grafana.dashboards.fleet.uid],
+              url: 'd/%s?var-${__field.name}=${__value.text}&${__url_time_range}&${datasource:queryparam}' % [this.grafana.dashboards.fleet.uid],
             },
           ]),
           fieldOverride.byName.new('Cores')


### PR DESCRIPTION
Hello team,

In the Fleet view for Windows and Linux (Linux is in another repo so I will fix it in another PR), we have 1 broken filter and 1 "sometimes" broken link.

Go to a Linux or Windows fleet overview and click on cluster or job in the table. It will break because the datasource is empty in the link.
Now select a non-default datasource, click on an instance. The next level dashboard is empty because the datasource is not part of the URL and so you end up on the default Prometheus which doesn't have your instance.

Simple fix: I added the datasource at the end of those URL.