### PR TITLE
Update Grafana agent down alert

### DIFF
--- a/grafana-agent-mixin/alerts/alerts.libsonnet
+++ b/grafana-agent-mixin/alerts/alerts.libsonnet
@@ -10,6 +10,11 @@
               up{
                 job="integrations/agent",
               } == 0
+              or absent(
+                up{
+                  job="integrations/agent",
+                }
+              )
             |||,
             'for': '5m',
             annotations: {


### PR DESCRIPTION
Fixes: https://github.com/grafana/support-escalations/issues/10404

The alert does not fire if the `up` metric is not scraped which can happen if the agent goes down.