### PR TITLE
Fix Apache Solr selector metric

### DIFF
--- a/apache-solr-mixin/dashboards/apache-solr-query-performance.libsonnet
+++ b/apache-solr-mixin/dashboards/apache-solr-query-performance.libsonnet
@@ -1539,7 +1539,7 @@ local getMatcher(cfg) = '%(solrSelector)s, solr_cluster=~"$solr_cluster", base_u
           template.new(
             'cluster',
             promDatasource,
-            'label_values(cassandra_cache_size{%(multiclusterSelector)s}, cluster)' % $._config,
+            'label_values(solr_metrics_core_errors_total{%(multiclusterSelector)s}, cluster)' % $._config,
             label='Cluster',
             refresh=2,
             includeAll=true,

--- a/apache-solr-mixin/dashboards/apache-solr-resource-monitoring.libsonnet
+++ b/apache-solr-mixin/dashboards/apache-solr-resource-monitoring.libsonnet
@@ -1103,7 +1103,7 @@ local getMatcher(cfg) = '%(solrSelector)s, solr_cluster="$solr_cluster", base_ur
           template.new(
             'cluster',
             promDatasource,
-            'label_values(cassandra_cache_size{%(multiclusterSelector)s}, cluster)' % $._config,
+            'label_values(solr_metrics_core_errors_total{%(multiclusterSelector)s}, cluster)' % $._config,
             label='Cluster',
             refresh=2,
             includeAll=true,


### PR DESCRIPTION
This PR corrects a copy-paste error where the Apache Solr `cluster` selector used an incorrect metric on two dashboards.