### PR TITLE
Catchpoint test name dashboard

### DIFF
--- a/catchpoint-mixin/dashboards.libsonnet
+++ b/catchpoint-mixin/dashboards.libsonnet
@@ -71,7 +71,7 @@ local logslib = import 'logs-lib/logs/main.libsonnet';
           )
         )
         // hide link to self
-        + root.applyCommon(vars, uid + '-testname-overview', tags, links { catchpointTestNameOverview+:: {} }, annotations, timezone, refresh, period),
+        + root.applyCommon(vars.testNameVariable, uid + '-testname-overview', tags, links { catchpointTestNameOverview+:: {} }, annotations, timezone, refresh, period),
       nodeNameOverview:
         g.dashboard.new(prefix + ' web performance by node name')
         + g.dashboard.withPanels(

--- a/catchpoint-mixin/dashboards.libsonnet
+++ b/catchpoint-mixin/dashboards.libsonnet
@@ -76,12 +76,31 @@ local logslib = import 'logs-lib/logs/main.libsonnet';
         + g.dashboard.withPanels(
           g.util.grid.wrapPanels(
             [
-
+              panels.pageCompletionTimeNodeName,
+              panels.DNSResolutionNodeName,
+              panels.contentHandlingNodeName { gridPos+: { w: 8 } },
+              panels.clientProcessingNodeName { gridPos+: { w: 8 } },
+              panels.additionalDelayNodeName { gridPos+: { w: 8 } },
+              g.panel.row.new('Response'),
+              panels.responseContentSizeNodeName,
+              panels.totalContentSizeNodeName,
+              g.panel.row.new('Network activity'),
+              panels.networkConnectionsNodeName { gridPos+: { w: 8 } },
+              panels.hostsContactedNodeName { gridPos+: { w: 8 } },
+              panels.cacheAccessNodeName { gridPos+: { w: 8 } },
+              g.panel.row.new('Request'),
+              panels.requestsRatioNodeName,
+              panels.redirectionsNodeName,
+              g.panel.row.new('Content type'),
+              panels.contentTypesLoadedBySizeNodeName,
+              panels.contentLoadedByTypeNodeName,
+              g.panel.row.new('Errors'),
+              panels.errorsNodeName { gridPos+: { w: 24 } },
             ], 12, 6
           )
         )
         // hide link to self
-        + root.applyCommon(vars, uid + '-nodename-overview', tags, links { catchpointNodeNameOverview+:: {} }, annotations, timezone, refresh, period),
+        + root.applyCommon(vars.nodeNameVariable, uid + '-nodename-overview', tags, links { catchpointNodeNameOverview+:: {} }, annotations, timezone, refresh, period),
     },
 
   //Apply common options(uids, tags, annotations etc..) to all dashboards above

--- a/catchpoint-mixin/dashboards.libsonnet
+++ b/catchpoint-mixin/dashboards.libsonnet
@@ -89,13 +89,12 @@ local logslib = import 'logs-lib/logs/main.libsonnet';
               panels.hostsContactedNodeName { gridPos+: { w: 8 } },
               panels.cacheAccessNodeName { gridPos+: { w: 8 } },
               g.panel.row.new('Request'),
-              panels.requestsRatioNodeName,
+              panels.requestSucessRatioNodeName,
               panels.redirectionsNodeName,
-              g.panel.row.new('Content type'),
-              panels.contentTypesLoadedBySizeNodeName,
-              panels.contentLoadedByTypeNodeName,
-              g.panel.row.new('Errors'),
-              panels.errorsNodeName { gridPos+: { w: 24 } },
+              g.panel.row.new('Errors and content types'),
+              panels.errorsNodeName { gridPos+: { w: 8 } },
+              panels.contentTypesLoadedBySizeNodeName { gridPos+: { w: 8 } },
+              panels.contentLoadedByTypeNodeName { gridPos+: { w: 8 } },
             ], 12, 6
           )
         )

--- a/catchpoint-mixin/dashboards.libsonnet
+++ b/catchpoint-mixin/dashboards.libsonnet
@@ -43,7 +43,7 @@ local logslib = import 'logs-lib/logs/main.libsonnet';
         // hide link to self
         + root.applyCommon(vars.overviewVariables, uid + '-overview', tags, links { catchpointOverview+:: {} }, annotations, timezone, refresh, period),
       testNameOverview:
-        g.dashboard.new(prefix + ' web performance by node name')
+        g.dashboard.new(prefix + ' web performance by test name')
         + g.dashboard.withPanels(
           g.util.grid.wrapPanels(
             [
@@ -60,13 +60,12 @@ local logslib = import 'logs-lib/logs/main.libsonnet';
               panels.hostsContacted { gridPos+: { w: 8 } },
               panels.cacheAccess { gridPos+: { w: 8 } },
               g.panel.row.new('Request'),
-              panels.requestsRatio,
+              panels.requestSucessRatio,
               panels.redirections,
-              g.panel.row.new('Content type'),
-              panels.contentTypesLoadedBySize,
-              panels.contentLoadedByType,
-              g.panel.row.new('Errors'),
-              panels.errors { gridPos+: { w: 24 } },
+              g.panel.row.new('Errors and content types'),
+              panels.errors { gridPos+: { w: 8 } },
+              panels.contentTypesLoadedBySize { gridPos+: { w: 8 } },
+              panels.contentLoadedByType { gridPos+: { w: 8 } },
             ], 12, 6
           )
         )

--- a/catchpoint-mixin/dashboards.libsonnet
+++ b/catchpoint-mixin/dashboards.libsonnet
@@ -47,7 +47,26 @@ local logslib = import 'logs-lib/logs/main.libsonnet';
         + g.dashboard.withPanels(
           g.util.grid.wrapPanels(
             [
-
+              panels.pageCompletionTime,
+              panels.DNSResolution,
+              panels.contentHandling { gridPos+: { w: 8 } },
+              panels.clientProcessing { gridPos+: { w: 8 } },
+              panels.additionalDelay { gridPos+: { w: 8 } },
+              g.panel.row.new('Response'),
+              panels.responseContentSize,
+              panels.totalContentSize,
+              g.panel.row.new('Network activity'),
+              panels.networkConnections { gridPos+: { w: 8 } },
+              panels.hostsContacted { gridPos+: { w: 8 } },
+              panels.cacheAccess { gridPos+: { w: 8 } },
+              g.panel.row.new('Request'),
+              panels.requestsRatio,
+              panels.redirections,
+              g.panel.row.new('Content type'),
+              panels.contentTypesLoadedBySize,
+              panels.contentLoadedByType,
+              g.panel.row.new('Errors'),
+              panels.errors { gridPos+: { w: 24 } },
             ], 12, 6
           )
         )

--- a/catchpoint-mixin/links.libsonnet
+++ b/catchpoint-mixin/links.libsonnet
@@ -12,5 +12,5 @@ local g = import './g.libsonnet';
       catchpointNodeNameOverview:
         link.link.new('Catchpoint node name', '/d/' + this.grafana.dashboards.nodeNameOverview.uid)
         + link.link.options.withKeepTime(true),
-    }
+    },
 }

--- a/catchpoint-mixin/main.libsonnet
+++ b/catchpoint-mixin/main.libsonnet
@@ -27,7 +27,7 @@ local variables = import './variables.libsonnet';
     },
 
     prometheus: {
-      alerts: {}, 
+      alerts: {},
       recordingRules: {},
     },
   },

--- a/catchpoint-mixin/panels.libsonnet
+++ b/catchpoint-mixin/panels.libsonnet
@@ -149,11 +149,7 @@ local utils = commonlib.utils;
         commonlib.panels.generic.timeSeries.base.new(
           'Connection and DNS resolution',
           targets=[t.DNSResolution, t.SSLTime, t.connectTime],
-<<<<<<< HEAD
           description='Time taken to establish an SSL handshake, DNS resolution, and connect.'
-=======
-          description='Time taken establish an SSL handshake, DNS resolution and connect.'
->>>>>>> 9dbd01b (added extra selector, changed layout, revamped queries)
         )
         + g.panel.timeSeries.standardOptions.withUnit('ms')
         + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
@@ -180,11 +176,7 @@ local utils = commonlib.utils;
         commonlib.panels.generic.timeSeries.base.new(
           'Additional delays',
           targets=[t.additionalDelay, t.waitTime],
-<<<<<<< HEAD
           description='Additional delays encountered due to redirects, as well as time from successful connection to receiving the first byte.'
-=======
-          description='Additional delays encountered due to redirects as well as time from successful connection to receiving the first byte.'
->>>>>>> 9dbd01b (added extra selector, changed layout, revamped queries)
         )
         + g.panel.timeSeries.standardOptions.withUnit('ms')
         + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),

--- a/catchpoint-mixin/panels.libsonnet
+++ b/catchpoint-mixin/panels.libsonnet
@@ -277,5 +277,141 @@ local utils = commonlib.utils;
           barGauge.standardOptions.threshold.step.withValue(1) + barGauge.thresholdStep.withColor('super-light-red'),
         ]),
 
+      // Web Performance by Node Name Dashboard Panels
+      pageCompletionTimeNodeName:
+        commonlib.panels.generic.timeSeries.base.new(
+          'Page completion time',
+          targets=[t.pageCompletionTimeNodeName],
+          description='Time taken for the browser to fully render the page after all resources are downloaded.'
+        )
+        + g.panel.timeSeries.standardOptions.withUnit('ms')
+        + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
+
+      DNSResolutionNodeName:
+        commonlib.panels.generic.timeSeries.base.new(
+          'Connection and DNS resolution',
+          targets=[t.DNSResolutionNodeName],
+          description='Time taken to establish a connection to the URL and resolve the domain name, which is critical for identifying network connectivity and DNS resolution issues.'
+        )
+        + g.panel.timeSeries.standardOptions.withUnit('ms')
+        + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
+
+      contentHandlingNodeName:
+        commonlib.panels.generic.timeSeries.base.new(
+          'Content handling',
+          targets=[t.contentHandlingLoadNodeName, t.contentHandlingRenderNodeName],
+          description='Time taken to load and render content on the webpage.'
+        )
+        + g.panel.timeSeries.standardOptions.withUnit('ms')
+        + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
+
+      clientProcessingNodeName:
+        commonlib.panels.generic.timeSeries.base.new(
+          'Client processing',
+          targets=[t.clientProcessingNodeName],
+          description='Client processing time, which reflects the time spent on client-side processing, including script execution and rendering.'
+        )
+        + g.panel.timeSeries.standardOptions.withUnit('ms')
+        + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
+
+      additionalDelayNodeName:
+        commonlib.panels.generic.timeSeries.base.new(
+          'Additional delays',
+          targets=[t.additionalDelayNodeName],
+          description='Additional delays encountered due to redirects.'
+        )
+        + g.panel.timeSeries.standardOptions.withUnit('ms')
+        + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
+
+      responseContentSizeNodeName:
+        commonlib.panels.generic.timeSeries.base.new(
+          'Response content size',
+          targets=[t.responseContentSizeNodeName, t.responseHeaderSizeNodeName],
+          description='Size of the HTTP response content in bytes.'
+        )
+        + g.panel.timeSeries.standardOptions.withUnit('decbytes')
+        + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
+
+      totalContentSizeNodeName:
+        commonlib.panels.generic.timeSeries.base.new(
+          'Total content size',
+          targets=[t.totalContentSizeNodeName, t.totalHeaderSizeNodeName],
+          description='Total size of the HTTP response content and headers in bytes.'
+        )
+        + g.panel.timeSeries.standardOptions.withUnit('decbytes')
+        + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
+
+      networkConnectionsNodeName:
+        commonlib.panels.generic.timeSeries.base.new(
+          'Network connections',
+          targets=[t.networkConnectionsNodeName],
+          description='Number of connections made.'
+        )
+        + g.panel.timeSeries.standardOptions.withUnit('conn')
+        + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
+
+      hostsContactedNodeName:
+        commonlib.panels.generic.timeSeries.base.new(
+          'Hosts contacted',
+          targets=[t.hostsContactedNodeName],
+          description='Number of hosts contacted.'
+        )
+        + g.panel.timeSeries.standardOptions.withUnit('hosts')
+        + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
+
+
+      cacheAccessNodeName:
+        commonlib.panels.generic.timeSeries.base.new(
+          'Cache access',
+          targets=[t.cacheAccessNodeName],
+          description='Number of cached elements accessed.'
+        )
+        + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
+
+      requestsRatioNodeName:
+        commonlib.panels.generic.timeSeries.base.new(
+          'Requests success/failure ratio',
+          targets=[t.requestsSuccessRatioNodeName],
+          description='Success ratio of requests made.'
+        )
+        + g.panel.timeSeries.standardOptions.withUnit('percentunit')
+        + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
+
+      redirectionsNodeName:
+        commonlib.panels.generic.timeSeries.base.new(
+          'Redirects',
+          targets=[t.redirectionsNodeName],
+          description='Number of HTTP redirections encountered.'
+        )
+        + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
+
+      contentTypesLoadedBySizeNodeName:
+        pieChart.new(title='Content types loaded by size')
+        + pieChart.queryOptions.withTargets([t.imageLoadedBySizeNodeName, t.htmlLoadedBySizeNodeName, t.cssLoadedBySizeNodeName, t.scriptLoadedBySizeNodeName, t.fontLoadedBySizeNodeName, t.xmlLoadedBySizeNodeName, t.mediaLoadedBySizeNodeName])
+        + pieChart.options.legend.withPlacement('right')
+        + pieChart.options.withTooltipMixin({
+          mode: 'multi',
+          sort: 'desc',
+        })
+        + pieChart.panelOptions.withDescription('Size of content loaded in bytes')
+        + pieChart.standardOptions.withUnit('decbytes'),
+
+      contentLoadedByTypeNodeName:
+        barGauge.new(title='Content loaded by type')
+        + barGauge.queryOptions.withTargets([t.imageLoadedByTypeNodeName, t.htmlLoadedByTypeNodeName, t.cssLoadedByTypeNodeName, t.scriptLoadedByTypeNodeName, t.fontLoadedByTypeNodeName, t.xmlLoadedByTypeNodeName, t.mediaLoadedByTypeNodeName])
+        + barGauge.panelOptions.withDescription('Number of elements loaded.')
+        + barGauge.options.withOrientation('horizontal')
+        + barGauge.standardOptions.thresholds.withSteps([
+          barGauge.thresholdStep.withColor('super-light-green'),
+        ]),
+
+      errorsNodeName:
+        commonlib.panels.generic.timeSeries.base.new(
+          'Errors',
+          targets=[t.errorsNodeName],
+          description='Indicates if any errors occurred.'
+        )
+        + g.panel.timeSeries.standardOptions.withUnit('err')
+        + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
     },
 }

--- a/catchpoint-mixin/panels.libsonnet
+++ b/catchpoint-mixin/panels.libsonnet
@@ -139,7 +139,7 @@ local utils = commonlib.utils;
       pageCompletionTime:
         commonlib.panels.generic.timeSeries.base.new(
           'Page completion time',
-          targets=[t.pageCompletionTime],
+          targets=[t.pageCompletionTime, t.pageTotalLoadTime],
           description='Time taken for the browser to fully render the page after all resources are downloaded.'
         )
         + g.panel.timeSeries.standardOptions.withUnit('ms')
@@ -148,8 +148,8 @@ local utils = commonlib.utils;
       DNSResolution:
         commonlib.panels.generic.timeSeries.base.new(
           'Connection and DNS resolution',
-          targets=[t.DNSResolution],
-          description='Time taken to establish a connection to the URL and resolve the domain name, which is critical for identifying network connectivity and DNS resolution issues.'
+          targets=[t.DNSResolution, t.SSLTime, t.connectTime],
+          description='Time taken establish an SSL handshake, DNS resolution and connect.'
         )
         + g.panel.timeSeries.standardOptions.withUnit('ms')
         + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
@@ -175,8 +175,8 @@ local utils = commonlib.utils;
       additionalDelay:
         commonlib.panels.generic.timeSeries.base.new(
           'Additional delays',
-          targets=[t.additionalDelay],
-          description='Additional delays encountered due to redirects.'
+          targets=[t.additionalDelay, t.waitTime],
+          description='Additional delays encountered due to redirects as well as time from successful connection to receiving the first byte.'
         )
         + g.panel.timeSeries.standardOptions.withUnit('ms')
         + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
@@ -226,10 +226,10 @@ local utils = commonlib.utils;
         )
         + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
 
-      requestsRatio:
+      requestSucessRatio:
         commonlib.panels.generic.timeSeries.base.new(
-          'Requests success/failure ratio',
-          targets=[t.requestsSuccessRatio],
+          'Requests success ratio',
+          targets=[t.requestSuccessRatio],
           description='Success ratio of requests made.'
         )
         + g.panel.timeSeries.standardOptions.withUnit('percentunit')
@@ -263,13 +263,17 @@ local utils = commonlib.utils;
           barGauge.thresholdStep.withColor('super-light-green'),
         ]),
 
+
       errors:
-        commonlib.panels.generic.timeSeries.base.new(
-          'Errors',
-          targets=[t.errors],
-          description='Indicates if any errors occurred.'
-        )
-        + g.panel.timeSeries.standardOptions.withUnit('err')
-        + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
+        barGauge.new(title='Errors')
+        + barGauge.queryOptions.withTargets([t.objectLoadedError, t.DNSError, t.loadError, t.timeoutError, t.connectionError, t.transactionError])
+        + barGauge.panelOptions.withDescription('Indicates various potential errors that are occuring.')
+        + barGauge.options.withOrientation('horizontal')
+        + barGauge.standardOptions.withMax(1)
+        + barGauge.standardOptions.thresholds.withSteps([
+          barGauge.thresholdStep.withColor('super-light-green'),
+          barGauge.standardOptions.threshold.step.withValue(1) + barGauge.thresholdStep.withColor('super-light-red'),
+        ]),
+
     },
 }

--- a/catchpoint-mixin/panels.libsonnet
+++ b/catchpoint-mixin/panels.libsonnet
@@ -7,9 +7,12 @@ local utils = commonlib.utils;
     {
       local t = this.grafana.targets,
       local stat = g.panel.stat,
-      local barGauge = g.panel.barGauge,
       local fieldOverride = g.panel.table.fieldOverride,
       local alertList = g.panel.alertList,
+      local pieChart = g.panel.pieChart,
+      local barGauge = g.panel.barGauge,
+
+      // Catchpoint Overview dashboard Panels
       topAvgLoadTimeTestName:
         commonlib.panels.generic.timeSeries.base.new(
           'Top average total load time by test name',
@@ -131,5 +134,114 @@ local utils = commonlib.utils;
           description='The top number of errors encountered among all test names over the specified interval.'
         )
         + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
+
+
+      // Web Performance by Test Name Dashboard Panels
+      pageCompletionTime:
+        commonlib.panels.generic.timeSeries.base.new(
+          'Page completion time',
+          targets=[t.pageCompletionTime],
+          description=''
+        ),
+
+      DNSResolution:
+        commonlib.panels.generic.timeSeries.base.new(
+          'Connection and DNS resolution',
+          targets=[t.DNSResolution],
+          description=''
+        ),
+      contentHandling:
+        commonlib.panels.generic.timeSeries.base.new(
+          'Content handling',
+          targets=[t.contentHandlingLoad, t.contentHandlingRender],
+          description=''
+        ),
+
+      clientProcessing:
+        commonlib.panels.generic.timeSeries.base.new(
+          'Client processing',
+          targets=[t.clientProcessing],
+          description=''
+        ),
+
+      additionalDelay:
+        commonlib.panels.generic.timeSeries.base.new(
+          'Additional delays',
+          targets=[t.additionalDelay],
+          description=''
+        ),
+
+      responseContentSize:
+        commonlib.panels.generic.timeSeries.base.new(
+          'Response content size',
+          targets=[t.responseContentSize, t.responseHeaderSize],
+          description=''
+        ),
+
+      totalContentSize:
+        commonlib.panels.generic.timeSeries.base.new(
+          'Total content size',
+          targets=[t.totalContentSize, t.totalHeaderSize],
+          description=''
+        ),
+
+      networkConnections:
+        commonlib.panels.generic.timeSeries.base.new(
+          'Network connections',
+          targets=[t.networkConnections],
+          description=''
+        ),
+
+      hostsContacted:
+        commonlib.panels.generic.timeSeries.base.new(
+          'Hosts contacted',
+          targets=[t.hostsContacted],
+          description=''
+        ),
+
+      cacheAccess:
+        commonlib.panels.generic.timeSeries.base.new(
+          'Cache access',
+          targets=[t.cacheAccess],
+          description=''
+        ),
+
+      requestsRatio:
+        commonlib.panels.generic.timeSeries.base.new(
+          'Requests success/failure ratio',
+          targets=[t.requestsSuccessRatio, t.requestsFailureRatio],
+          description=''
+        ),
+
+      redirections:
+        commonlib.panels.generic.timeSeries.base.new(
+          'Redirects',
+          targets=[t.redirections],
+          description=''
+        ),
+
+      contentTypesLoadedBySize:
+        pieChart.new(title='Content types loaded by size')
+        + pieChart.queryOptions.withTargets([t.imageLoadedBySize, t.htmlLoadedBySize, t.cssLoadedBySize, t.scriptLoadedBySize, t.fontLoadedBySize, t.xmlLoadedBySize, t.mediaLoadedBySize])
+        + pieChart.options.legend.withPlacement('right')
+        + pieChart.options.withTooltipMixin({
+          mode: 'multi',
+          sort: 'desc',
+        })
+        + pieChart.panelOptions.withDescription(''),
+
+
+      contentLoadedByType:
+        barGauge.new(title='Content loaded by type')
+        + barGauge.queryOptions.withTargets([t.imageLoadedByType, t.htmlLoadedByType, t.cssLoadedByType, t.scriptLoadedByType, t.fontLoadedByType, t.xmlLoadedByType, t.mediaLoadedByType])
+        + barGauge.panelOptions.withDescription('')
+        + barGauge.options.withOrientation('horizontal'),
+
+      errors:
+        commonlib.panels.generic.timeSeries.base.new(
+          'Errors',
+          targets=[t.errors],
+          description=''
+        ),
     },
 }

--- a/catchpoint-mixin/panels.libsonnet
+++ b/catchpoint-mixin/panels.libsonnet
@@ -264,7 +264,6 @@ local utils = commonlib.utils;
           barGauge.thresholdStep.withColor('super-light-green'),
         ]),
 
-
       errors:
         barGauge.new(title='Errors')
         + barGauge.queryOptions.withTargets([t.objectLoadedError, t.DNSError, t.loadError, t.timeoutError, t.connectionError, t.transactionError])
@@ -358,7 +357,6 @@ local utils = commonlib.utils;
         + g.panel.timeSeries.standardOptions.withUnit('hosts')
         + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
 
-
       cacheAccessNodeName:
         commonlib.panels.generic.timeSeries.base.new(
           'Cache access',
@@ -405,7 +403,6 @@ local utils = commonlib.utils;
         + barGauge.standardOptions.thresholds.withSteps([
           barGauge.thresholdStep.withColor('super-light-green'),
         ]),
-
 
       errorsNodeName:
         barGauge.new(title='Errors')

--- a/catchpoint-mixin/panels.libsonnet
+++ b/catchpoint-mixin/panels.libsonnet
@@ -149,7 +149,7 @@ local utils = commonlib.utils;
         commonlib.panels.generic.timeSeries.base.new(
           'Connection and DNS resolution',
           targets=[t.DNSResolution, t.SSLTime, t.connectTime],
-          description='Time taken establish an SSL handshake, DNS resolution and connect.'
+          description='Time taken to establish an SSL handshake, DNS resolution, and connect.'
         )
         + g.panel.timeSeries.standardOptions.withUnit('ms')
         + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
@@ -176,7 +176,7 @@ local utils = commonlib.utils;
         commonlib.panels.generic.timeSeries.base.new(
           'Additional delays',
           targets=[t.additionalDelay, t.waitTime],
-          description='Additional delays encountered due to redirects as well as time from successful connection to receiving the first byte.'
+          description='Additional delays encountered due to redirects, as well as time from successful connection to receiving the first byte.'
         )
         + g.panel.timeSeries.standardOptions.withUnit('ms')
         + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
@@ -185,7 +185,7 @@ local utils = commonlib.utils;
         commonlib.panels.generic.timeSeries.base.new(
           'Response content size',
           targets=[t.responseContentSize, t.responseHeaderSize],
-          description='Size of the HTTP response content in bytes.'
+          description='Size of the HTTP response content.'
         )
         + g.panel.timeSeries.standardOptions.withUnit('decbytes')
         + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
@@ -194,7 +194,7 @@ local utils = commonlib.utils;
         commonlib.panels.generic.timeSeries.base.new(
           'Total content size',
           targets=[t.totalContentSize, t.totalHeaderSize],
-          description='Total size of the HTTP response content and headers in bytes.'
+          description='Total size of the HTTP response content and headers.'
         )
         + g.panel.timeSeries.standardOptions.withUnit('decbytes')
         + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
@@ -251,7 +251,7 @@ local utils = commonlib.utils;
           mode: 'multi',
           sort: 'desc',
         })
-        + pieChart.panelOptions.withDescription('Size of content loaded in bytes')
+        + pieChart.panelOptions.withDescription('Size of content loaded.')
         + pieChart.standardOptions.withUnit('decbytes'),
 
       contentLoadedByType:

--- a/catchpoint-mixin/panels.libsonnet
+++ b/catchpoint-mixin/panels.libsonnet
@@ -374,6 +374,8 @@ local utils = commonlib.utils;
           description='Success ratio of requests made.'
         )
         + g.panel.timeSeries.standardOptions.withUnit('percentunit')
+        + g.panel.timeSeries.standardOptions.withMax(1)
+        + g.panel.timeSeries.standardOptions.withMin(0)
         + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
 
       redirectionsNodeName:

--- a/catchpoint-mixin/panels.libsonnet
+++ b/catchpoint-mixin/panels.libsonnet
@@ -233,6 +233,8 @@ local utils = commonlib.utils;
           description='Success ratio of requests made.'
         )
         + g.panel.timeSeries.standardOptions.withUnit('percentunit')
+        + g.panel.timeSeries.standardOptions.withMax(1)
+        + g.panel.timeSeries.standardOptions.withMin(0)
         + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
 
       redirections:

--- a/catchpoint-mixin/panels.libsonnet
+++ b/catchpoint-mixin/panels.libsonnet
@@ -135,90 +135,113 @@ local utils = commonlib.utils;
         )
         + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
 
-
       // Web Performance by Test Name Dashboard Panels
       pageCompletionTime:
         commonlib.panels.generic.timeSeries.base.new(
           'Page completion time',
           targets=[t.pageCompletionTime],
-          description=''
-        ),
+          description='Time taken for the browser to fully render the page after all resources are downloaded.'
+        )
+        + g.panel.timeSeries.standardOptions.withUnit('ms')
+        + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
 
       DNSResolution:
         commonlib.panels.generic.timeSeries.base.new(
           'Connection and DNS resolution',
           targets=[t.DNSResolution],
-          description=''
-        ),
+          description='Time taken to establish a connection to the URL and resolve the domain name, which is critical for identifying network connectivity and DNS resolution issues.'
+        )
+        + g.panel.timeSeries.standardOptions.withUnit('ms')
+        + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
+
       contentHandling:
         commonlib.panels.generic.timeSeries.base.new(
           'Content handling',
           targets=[t.contentHandlingLoad, t.contentHandlingRender],
-          description=''
-        ),
+          description='Time taken to load and render content on the webpage.'
+        )
+        + g.panel.timeSeries.standardOptions.withUnit('ms')
+        + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
 
       clientProcessing:
         commonlib.panels.generic.timeSeries.base.new(
           'Client processing',
           targets=[t.clientProcessing],
-          description=''
-        ),
+          description='Client processing time, which reflects the time spent on client-side processing, including script execution and rendering.'
+        )
+        + g.panel.timeSeries.standardOptions.withUnit('ms')
+        + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
 
       additionalDelay:
         commonlib.panels.generic.timeSeries.base.new(
           'Additional delays',
           targets=[t.additionalDelay],
-          description=''
-        ),
+          description='Additional delays encountered due to redirects.'
+        )
+        + g.panel.timeSeries.standardOptions.withUnit('ms')
+        + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
 
       responseContentSize:
         commonlib.panels.generic.timeSeries.base.new(
           'Response content size',
           targets=[t.responseContentSize, t.responseHeaderSize],
-          description=''
-        ),
+          description='Size of the HTTP response content in bytes.'
+        )
+        + g.panel.timeSeries.standardOptions.withUnit('decbytes')
+        + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
 
       totalContentSize:
         commonlib.panels.generic.timeSeries.base.new(
           'Total content size',
           targets=[t.totalContentSize, t.totalHeaderSize],
-          description=''
-        ),
+          description='Total size of the HTTP response content and headers in bytes.'
+        )
+        + g.panel.timeSeries.standardOptions.withUnit('decbytes')
+        + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
 
       networkConnections:
         commonlib.panels.generic.timeSeries.base.new(
           'Network connections',
           targets=[t.networkConnections],
-          description=''
-        ),
+          description='Number of connections made.'
+        )
+        + g.panel.timeSeries.standardOptions.withUnit('conn')
+        + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
 
       hostsContacted:
         commonlib.panels.generic.timeSeries.base.new(
           'Hosts contacted',
           targets=[t.hostsContacted],
-          description=''
-        ),
+          description='Number of hosts contacted.'
+        )
+        + g.panel.timeSeries.standardOptions.withUnit('hosts')
+        + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
+
 
       cacheAccess:
         commonlib.panels.generic.timeSeries.base.new(
           'Cache access',
           targets=[t.cacheAccess],
-          description=''
-        ),
+          description='Number of cached elements accessed.'
+        )
+        + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
 
       requestsRatio:
         commonlib.panels.generic.timeSeries.base.new(
           'Requests success/failure ratio',
-          targets=[t.requestsSuccessRatio, t.requestsFailureRatio],
-          description=''
-        ),
+          targets=[t.requestsSuccessRatio],
+          description='Success ratio of requests made.'
+        )
+        + g.panel.timeSeries.standardOptions.withUnit('percentunit')
+        + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
 
       redirections:
         commonlib.panels.generic.timeSeries.base.new(
           'Redirects',
           targets=[t.redirections],
-          description=''
-        ),
+          description='Number of HTTP redirections encountered.'
+        )
+        + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
 
       contentTypesLoadedBySize:
         pieChart.new(title='Content types loaded by size')
@@ -228,20 +251,25 @@ local utils = commonlib.utils;
           mode: 'multi',
           sort: 'desc',
         })
-        + pieChart.panelOptions.withDescription(''),
-
+        + pieChart.panelOptions.withDescription('Size of content loaded in bytes')
+        + pieChart.standardOptions.withUnit('decbytes'),
 
       contentLoadedByType:
         barGauge.new(title='Content loaded by type')
         + barGauge.queryOptions.withTargets([t.imageLoadedByType, t.htmlLoadedByType, t.cssLoadedByType, t.scriptLoadedByType, t.fontLoadedByType, t.xmlLoadedByType, t.mediaLoadedByType])
-        + barGauge.panelOptions.withDescription('')
-        + barGauge.options.withOrientation('horizontal'),
+        + barGauge.panelOptions.withDescription('Number of elements loaded.')
+        + barGauge.options.withOrientation('horizontal')
+        + barGauge.standardOptions.thresholds.withSteps([
+          barGauge.thresholdStep.withColor('super-light-green'),
+        ]),
 
       errors:
         commonlib.panels.generic.timeSeries.base.new(
           'Errors',
           targets=[t.errors],
-          description=''
-        ),
+          description='Indicates if any errors occurred.'
+        )
+        + g.panel.timeSeries.standardOptions.withUnit('err')
+        + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
     },
 }

--- a/catchpoint-mixin/panels.libsonnet
+++ b/catchpoint-mixin/panels.libsonnet
@@ -149,7 +149,11 @@ local utils = commonlib.utils;
         commonlib.panels.generic.timeSeries.base.new(
           'Connection and DNS resolution',
           targets=[t.DNSResolution, t.SSLTime, t.connectTime],
+<<<<<<< HEAD
           description='Time taken to establish an SSL handshake, DNS resolution, and connect.'
+=======
+          description='Time taken establish an SSL handshake, DNS resolution and connect.'
+>>>>>>> 9dbd01b (added extra selector, changed layout, revamped queries)
         )
         + g.panel.timeSeries.standardOptions.withUnit('ms')
         + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
@@ -176,7 +180,11 @@ local utils = commonlib.utils;
         commonlib.panels.generic.timeSeries.base.new(
           'Additional delays',
           targets=[t.additionalDelay, t.waitTime],
+<<<<<<< HEAD
           description='Additional delays encountered due to redirects, as well as time from successful connection to receiving the first byte.'
+=======
+          description='Additional delays encountered due to redirects as well as time from successful connection to receiving the first byte.'
+>>>>>>> 9dbd01b (added extra selector, changed layout, revamped queries)
         )
         + g.panel.timeSeries.standardOptions.withUnit('ms')
         + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
@@ -216,7 +224,6 @@ local utils = commonlib.utils;
         )
         + g.panel.timeSeries.standardOptions.withUnit('hosts')
         + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
-
 
       cacheAccess:
         commonlib.panels.generic.timeSeries.base.new(
@@ -281,7 +288,7 @@ local utils = commonlib.utils;
       pageCompletionTimeNodeName:
         commonlib.panels.generic.timeSeries.base.new(
           'Page completion time',
-          targets=[t.pageCompletionTimeNodeName],
+          targets=[t.pageCompletionTimeNodeName, t.pageTotalLoadTimeNodeName],
           description='Time taken for the browser to fully render the page after all resources are downloaded.'
         )
         + g.panel.timeSeries.standardOptions.withUnit('ms')
@@ -290,8 +297,8 @@ local utils = commonlib.utils;
       DNSResolutionNodeName:
         commonlib.panels.generic.timeSeries.base.new(
           'Connection and DNS resolution',
-          targets=[t.DNSResolutionNodeName],
-          description='Time taken to establish a connection to the URL and resolve the domain name, which is critical for identifying network connectivity and DNS resolution issues.'
+          targets=[t.DNSResolutionNodeName, t.SSLTimeNodeName, t.connectTimeNodeName],
+          description='Time taken establish an SSL handshake, DNS resolution and connect.'
         )
         + g.panel.timeSeries.standardOptions.withUnit('ms')
         + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
@@ -299,7 +306,7 @@ local utils = commonlib.utils;
       contentHandlingNodeName:
         commonlib.panels.generic.timeSeries.base.new(
           'Content handling',
-          targets=[t.contentHandlingLoadNodeName, t.contentHandlingRenderNodeName],
+          targets=[t.contentHandlingLoad, t.contentHandlingRender],
           description='Time taken to load and render content on the webpage.'
         )
         + g.panel.timeSeries.standardOptions.withUnit('ms')
@@ -317,8 +324,8 @@ local utils = commonlib.utils;
       additionalDelayNodeName:
         commonlib.panels.generic.timeSeries.base.new(
           'Additional delays',
-          targets=[t.additionalDelayNodeName],
-          description='Additional delays encountered due to redirects.'
+          targets=[t.additionalDelayNodeName, t.waitTimeNodeName],
+          description='Additional delays encountered due to redirects as well as time from successful connection to receiving the first byte.'
         )
         + g.panel.timeSeries.standardOptions.withUnit('ms')
         + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
@@ -368,10 +375,10 @@ local utils = commonlib.utils;
         )
         + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
 
-      requestsRatioNodeName:
+      requestSucessRatioNodeName:
         commonlib.panels.generic.timeSeries.base.new(
-          'Requests success/failure ratio',
-          targets=[t.requestsSuccessRatioNodeName],
+          'Requests success ratio',
+          targets=[t.requestSuccessRatioNodeName],
           description='Success ratio of requests made.'
         )
         + g.panel.timeSeries.standardOptions.withUnit('percentunit')
@@ -405,13 +412,16 @@ local utils = commonlib.utils;
           barGauge.thresholdStep.withColor('super-light-green'),
         ]),
 
+
       errorsNodeName:
-        commonlib.panels.generic.timeSeries.base.new(
-          'Errors',
-          targets=[t.errorsNodeName],
-          description='Indicates if any errors occurred.'
-        )
-        + g.panel.timeSeries.standardOptions.withUnit('err')
-        + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
+        barGauge.new(title='Errors')
+        + barGauge.queryOptions.withTargets([t.objectLoadedErrorNodeName, t.DNSErrorNodeName, t.loadErrorNodeName, t.timeoutErrorNodeName, t.connectionErrorNodeName, t.transactionErrorNodeName])
+        + barGauge.panelOptions.withDescription('Indicates various potential errors that are occuring.')
+        + barGauge.options.withOrientation('horizontal')
+        + barGauge.standardOptions.withMax(1)
+        + barGauge.standardOptions.thresholds.withSteps([
+          barGauge.thresholdStep.withColor('super-light-green'),
+          barGauge.standardOptions.threshold.step.withValue(1) + barGauge.thresholdStep.withColor('super-light-red'),
+        ]),
     },
 }

--- a/catchpoint-mixin/targets.libsonnet
+++ b/catchpoint-mixin/targets.libsonnet
@@ -394,5 +394,222 @@ local utils = commonlib.utils {
       )
       + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(nodeNameLabel)),
 
+    // Web performance by node name dashboard
+    pageCompletionTimeNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_document_complete_time{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
+
+    DNSResolutionNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_dns_time{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
+
+    contentHandlingLoadNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_content_load_time{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s - load' % utils.labelsToPanelLegend(testNameLabel)),
+
+    contentHandlingRenderNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_render_start_time{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s - render' % utils.labelsToPanelLegend(testNameLabel)),
+
+    clientProcessingNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_client_time{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
+
+    additionalDelayNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_redirect_time{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
+
+    responseContentSizeNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_response_content_size{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s - content' % utils.labelsToPanelLegend(testNameLabel)),
+
+    responseHeaderSizeNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_response_header_size{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s - header' % utils.labelsToPanelLegend(testNameLabel)),
+
+    totalContentSizeNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_total_content_size{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s - content' % utils.labelsToPanelLegend(testNameLabel)),
+
+    totalHeaderSizeNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_total_header_size{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s - header' % utils.labelsToPanelLegend(testNameLabel)),
+
+    networkConnectionsNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_connections_count{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
+
+    hostsContactedNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_hosts_count{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
+
+    cacheAccessNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_cached_count{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
+
+    requestsSuccessRatioNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        '(avg by (test_name) (catchpoint_requests_count{%(nodeNameSelector)s}) - avg by (test_name) (catchpoint_failed_requests_count{%(nodeNameSelector)s})) / avg by (test_name) (catchpoint_requests_count{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s - success' % utils.labelsToPanelLegend(testNameLabel)),
+
+    requestsFailureRatioNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'avg by (test_name) (catchpoint_failed_requests_count{%(nodeNameSelector)s}) / clamp_min(avg by (test_name) (catchpoint_requests_count{%(nodeNameSelector)s}), 1)' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s - failure' % utils.labelsToPanelLegend(testNameLabel)),
+
+    redirectionsNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_redirections_count{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
+
+    imageLoadedBySizeNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (node_name) (catchpoint_image_content_type{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('image'),
+
+    scriptLoadedBySizeNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (node_name) (catchpoint_script_content_type{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('script'),
+
+    htmlLoadedBySizeNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (node_name) (catchpoint_html_content_type{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('html'),
+
+    cssLoadedBySizeNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (node_name) (catchpoint_css_content_type{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('css'),
+
+    fontLoadedBySizeNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (node_name) (catchpoint_font_content_type{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('font'),
+
+    xmlLoadedBySizeNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (node_name) (catchpoint_xml_content_type{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('xml'),
+
+    mediaLoadedBySizeNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (node_name) (catchpoint_media_content_type{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('media'),
+
+    imageLoadedByTypeNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (node_name) (catchpoint_image_count{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('image'),
+
+    scriptLoadedByTypeNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (node_name) (catchpoint_script_count{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('script'),
+
+    htmlLoadedByTypeNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (node_name) (catchpoint_html_count{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('html'),
+
+    cssLoadedByTypeNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (node_name) (catchpoint_css_count{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('css'),
+
+    fontLoadedByTypeNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (node_name) (catchpoint_font_count{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('font'),
+
+    xmlLoadedByTypeNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (node_name) (catchpoint_xml_count{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('xml'),
+
+    mediaLoadedByTypeNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (node_name) (catchpoint_media_count{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('media'),
+
+    errorsNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_any_error{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
   },
 }

--- a/catchpoint-mixin/targets.libsonnet
+++ b/catchpoint-mixin/targets.libsonnet
@@ -104,116 +104,117 @@ local utils = commonlib.utils {
       )
       + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
 
+
     // Web performance by test name dashboard
     pageCompletionTime:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        '(sum by (test_name) (catchpoint_document_complete_time{%(testNameSelector)s})' % vars
+        'sum by (node_name) (catchpoint_document_complete_time{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
 
     DNSResolution:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        '(sum by (test_name) (catchpoint_dns_time{%(testNameSelector)s})' % vars
+        'sum by (node_name) (catchpoint_dns_time{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
 
     contentHandlingLoad:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        '(sum by (test_name) (catchpoint_content_load_time{%(testNameSelector)s})' % vars
+        'sum by (node_name) (catchpoint_content_load_time{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('%s - load' % utils.labelsToPanelLegend(testNameLabel)),
 
     contentHandlingRender:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        '(sum by (test_name) (catchpoint_render_start_time{%(testNameSelector)s})' % vars
+        'sum by (node_name) (catchpoint_render_start_time{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('%s - render' % utils.labelsToPanelLegend(testNameLabel)),
 
     clientProcessing:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        '(sum by (test_name) (catchpoint_client_time{%(testNameSelector)s})' % vars
+        'sum by (node_name) (catchpoint_client_time{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
 
     additionalDelay:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        '(sum by (test_name) (catchpoint_redirect_time{%(testNameSelector)s})' % vars
+        'sum by (node_name) (catchpoint_redirect_time{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
 
     responseContentSize:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        '(sum by (test_name) (catchpoint_response_content_size{%(testNameSelector)s})' % vars
+        'sum by (node_name) (catchpoint_response_content_size{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('%s - content' % utils.labelsToPanelLegend(testNameLabel)),
 
     responseHeaderSize:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        '(sum by (test_name) (catchpoint_response_header_size{%(testNameSelector)s})' % vars
+        'sum by (node_name) (catchpoint_response_header_size{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('%s - header' % utils.labelsToPanelLegend(testNameLabel)),
 
     totalContentSize:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        '(sum by (test_name) (catchpoint_total_content_size{%(testNameSelector)s})' % vars
+        'sum by (node_name) (catchpoint_total_content_size{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('%s - content' % utils.labelsToPanelLegend(testNameLabel)),
 
     totalHeaderSize:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        '(sum by (test_name) (catchpoint_total_header_size{%(testNameSelector)s})' % vars
+        'sum by (node_name) (catchpoint_total_header_size{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('%s - header' % utils.labelsToPanelLegend(testNameLabel)),
 
     networkConnections:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        '(sum by (test_name) (catchpoint_connections_count{%(testNameSelector)s})' % vars
+        'sum by (node_name) (catchpoint_connections_count{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
 
     hostsContacted:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        '(sum by (test_name) (catchpoint_hosts_count{%(testNameSelector)s})' % vars
+        'sum by (node_name) (catchpoint_hosts_count{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
 
     cacheAccess:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        '(sum by (test_name) (catchpoint_cached_count{%(testNameSelector)s})' % vars
+        'sum by (node_name) (catchpoint_cached_count{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
 
     requestsSuccessRatio:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        '(sum by (test_name) (catchpoint_requests_count{%(testNameSelector)s}) - catchpoint_failed_requests_count{%(testNameSelector)s}) / clamp_min(catchpoint_requests_count{%(testNameSelector)s}, 1)' % vars
+        '(avg by (node_name) (catchpoint_requests_count{%(testNameSelector)s}) - avg by (node_name) (catchpoint_failed_requests_count{%(testNameSelector)s})) / avg by (node_name) (catchpoint_requests_count{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('%s - success' % utils.labelsToPanelLegend(testNameLabel)),
 
     requestsFailureRatio:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'catchpoint_failed_requests_count{%(testNameSelector)s} / clamp_min(catchpoint_requests_count{%(testNameSelector)s}, 1)' % vars
+        'avg by (node_name) (catchpoint_failed_requests_count{%(testNameSelector)s}) / clamp_min(avg by (node_name) (catchpoint_requests_count{%(testNameSelector)s}), 1)' % vars
       )
       + prometheusQuery.withLegendFormat('%s - failure' % utils.labelsToPanelLegend(testNameLabel)),
 
     redirections:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (test_name) (catchpoint_redirections_count{%(testNameSelector)s})' % vars
+        'sum by (node_name) (catchpoint_redirections_count{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
 
@@ -222,106 +223,105 @@ local utils = commonlib.utils {
         '${' + vars.datasources.prometheus.name + '}',
         'sum by (test_name) (catchpoint_image_content_type{%(testNameSelector)s})' % vars
       )
-      + prometheusQuery.withLegendFormat(''),
+      + prometheusQuery.withLegendFormat('image'),
 
     scriptLoadedBySize:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
         'sum by (test_name) (catchpoint_script_content_type{%(testNameSelector)s})' % vars
       )
-      + prometheusQuery.withLegendFormat(''),
+      + prometheusQuery.withLegendFormat('script'),
 
     htmlLoadedBySize:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
         'sum by (test_name) (catchpoint_html_content_type{%(testNameSelector)s})' % vars
       )
-      + prometheusQuery.withLegendFormat(''),
+      + prometheusQuery.withLegendFormat('html'),
 
     cssLoadedBySize:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
         'sum by (test_name) (catchpoint_css_content_type{%(testNameSelector)s})' % vars
       )
-      + prometheusQuery.withLegendFormat(''),
+      + prometheusQuery.withLegendFormat('css'),
 
     fontLoadedBySize:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
         'sum by (test_name) (catchpoint_font_content_type{%(testNameSelector)s})' % vars
       )
-      + prometheusQuery.withLegendFormat(''),
+      + prometheusQuery.withLegendFormat('font'),
 
     xmlLoadedBySize:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
         'sum by (test_name) (catchpoint_xml_content_type{%(testNameSelector)s})' % vars
       )
-      + prometheusQuery.withLegendFormat(''),
+      + prometheusQuery.withLegendFormat('xml'),
 
     mediaLoadedBySize:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
         'sum by (test_name) (catchpoint_media_content_type{%(testNameSelector)s})' % vars
       )
-      + prometheusQuery.withLegendFormat(''),
-
+      + prometheusQuery.withLegendFormat('media'),
 
     imageLoadedByType:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
         'sum by (test_name) (catchpoint_image_count{%(testNameSelector)s})' % vars
       )
-      + prometheusQuery.withLegendFormat(''),
+      + prometheusQuery.withLegendFormat('image'),
 
     scriptLoadedByType:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
         'sum by (test_name) (catchpoint_script_count{%(testNameSelector)s})' % vars
       )
-      + prometheusQuery.withLegendFormat(''),
+      + prometheusQuery.withLegendFormat('script'),
 
     htmlLoadedByType:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
         'sum by (test_name) (catchpoint_html_count{%(testNameSelector)s})' % vars
       )
-      + prometheusQuery.withLegendFormat(''),
+      + prometheusQuery.withLegendFormat('html'),
 
     cssLoadedByType:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
         'sum by (test_name) (catchpoint_css_count{%(testNameSelector)s})' % vars
       )
-      + prometheusQuery.withLegendFormat(''),
+      + prometheusQuery.withLegendFormat('css'),
 
     fontLoadedByType:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
         'sum by (test_name) (catchpoint_font_count{%(testNameSelector)s})' % vars
       )
-      + prometheusQuery.withLegendFormat(''),
+      + prometheusQuery.withLegendFormat('font'),
 
     xmlLoadedByType:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
         'sum by (test_name) (catchpoint_xml_count{%(testNameSelector)s})' % vars
       )
-      + prometheusQuery.withLegendFormat(''),
+      + prometheusQuery.withLegendFormat('xml'),
 
     mediaLoadedByType:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
         'sum by (test_name) (catchpoint_media_count{%(testNameSelector)s})' % vars
       )
-      + prometheusQuery.withLegendFormat(''),
+      + prometheusQuery.withLegendFormat('media'),
 
-    Errors:
+    errors:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (test_name) (catchpoint_any_error{%(testNameSelector)s})' % vars
+        'sum by (node_name) (catchpoint_any_error{%(testNameSelector)s})' % vars
       )
-      + prometheusQuery.withLegendFormat(''),
+      + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
 
   },
 }

--- a/catchpoint-mixin/targets.libsonnet
+++ b/catchpoint-mixin/targets.libsonnet
@@ -111,112 +111,141 @@ local utils = commonlib.utils {
         '${' + vars.datasources.prometheus.name + '}',
         'sum by (node_name) (catchpoint_document_complete_time{%(testNameSelector)s})' % vars
       )
-      + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
+      + prometheusQuery.withLegendFormat('%s - completion' % utils.labelsToPanelLegend(nodeNameLabel)),
+
+    pageTotalLoadTime:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (node_name) (catchpoint_total_time{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s - load' % utils.labelsToPanelLegend(nodeNameLabel)),
 
     DNSResolution:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
         'sum by (node_name) (catchpoint_dns_time{%(testNameSelector)s})' % vars
       )
-      + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
+      + prometheusQuery.withLegendFormat('%s - DNS' % utils.labelsToPanelLegend(nodeNameLabel)),
+
+    SSLTime:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (node_name) (catchpoint_ssl_time{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s - SSL' % utils.labelsToPanelLegend(nodeNameLabel)),
+
+    connectTime:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (node_name) (catchpoint_connect_time{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s - connect' % utils.labelsToPanelLegend(nodeNameLabel)),
 
     contentHandlingLoad:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
         'sum by (node_name) (catchpoint_content_load_time{%(testNameSelector)s})' % vars
       )
-      + prometheusQuery.withLegendFormat('%s - load' % utils.labelsToPanelLegend(testNameLabel)),
+      + prometheusQuery.withLegendFormat('%s - load' % utils.labelsToPanelLegend(nodeNameLabel)),
+
 
     contentHandlingRender:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
         'sum by (node_name) (catchpoint_render_start_time{%(testNameSelector)s})' % vars
       )
-      + prometheusQuery.withLegendFormat('%s - render' % utils.labelsToPanelLegend(testNameLabel)),
+      + prometheusQuery.withLegendFormat('%s - render' % utils.labelsToPanelLegend(nodeNameLabel)),
 
     clientProcessing:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
         'sum by (node_name) (catchpoint_client_time{%(testNameSelector)s})' % vars
       )
-      + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
+      + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(nodeNameLabel)),
 
     additionalDelay:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
         'sum by (node_name) (catchpoint_redirect_time{%(testNameSelector)s})' % vars
       )
-      + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
+      + prometheusQuery.withLegendFormat('%s - redirect' % utils.labelsToPanelLegend(nodeNameLabel)),
+
+    waitTime:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (node_name) (catchpoint_wait_time{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s - wait' % utils.labelsToPanelLegend(nodeNameLabel)),
 
     responseContentSize:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
         'sum by (node_name) (catchpoint_response_content_size{%(testNameSelector)s})' % vars
       )
-      + prometheusQuery.withLegendFormat('%s - content' % utils.labelsToPanelLegend(testNameLabel)),
+      + prometheusQuery.withLegendFormat('%s - content' % utils.labelsToPanelLegend(nodeNameLabel)),
 
     responseHeaderSize:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
         'sum by (node_name) (catchpoint_response_header_size{%(testNameSelector)s})' % vars
       )
-      + prometheusQuery.withLegendFormat('%s - header' % utils.labelsToPanelLegend(testNameLabel)),
+      + prometheusQuery.withLegendFormat('%s - header' % utils.labelsToPanelLegend(nodeNameLabel)),
 
     totalContentSize:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
         'sum by (node_name) (catchpoint_total_content_size{%(testNameSelector)s})' % vars
       )
-      + prometheusQuery.withLegendFormat('%s - content' % utils.labelsToPanelLegend(testNameLabel)),
+      + prometheusQuery.withLegendFormat('%s - content' % utils.labelsToPanelLegend(nodeNameLabel)),
 
     totalHeaderSize:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
         'sum by (node_name) (catchpoint_total_header_size{%(testNameSelector)s})' % vars
       )
-      + prometheusQuery.withLegendFormat('%s - header' % utils.labelsToPanelLegend(testNameLabel)),
+      + prometheusQuery.withLegendFormat('%s - header' % utils.labelsToPanelLegend(nodeNameLabel)),
 
     networkConnections:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
         'sum by (node_name) (catchpoint_connections_count{%(testNameSelector)s})' % vars
       )
-      + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
+      + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(nodeNameLabel)),
 
     hostsContacted:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
         'sum by (node_name) (catchpoint_hosts_count{%(testNameSelector)s})' % vars
       )
-      + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
+      + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(nodeNameLabel)),
 
     cacheAccess:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
         'sum by (node_name) (catchpoint_cached_count{%(testNameSelector)s})' % vars
       )
-      + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
+      + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(nodeNameLabel)),
 
-    requestsSuccessRatio:
+    requestSuccessRatio:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
         '(avg by (node_name) (catchpoint_requests_count{%(testNameSelector)s}) - avg by (node_name) (catchpoint_failed_requests_count{%(testNameSelector)s})) / avg by (node_name) (catchpoint_requests_count{%(testNameSelector)s})' % vars
       )
-      + prometheusQuery.withLegendFormat('%s - success' % utils.labelsToPanelLegend(testNameLabel)),
+      + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(nodeNameLabel)),
 
     requestsFailureRatio:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
         'avg by (node_name) (catchpoint_failed_requests_count{%(testNameSelector)s}) / clamp_min(avg by (node_name) (catchpoint_requests_count{%(testNameSelector)s}), 1)' % vars
       )
-      + prometheusQuery.withLegendFormat('%s - failure' % utils.labelsToPanelLegend(testNameLabel)),
+      + prometheusQuery.withLegendFormat('%s - failure' % utils.labelsToPanelLegend(nodeNameLabel)),
 
     redirections:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
         'sum by (node_name) (catchpoint_redirections_count{%(testNameSelector)s})' % vars
       )
-      + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
+      + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(nodeNameLabel)),
 
     imageLoadedBySize:
       prometheusQuery.new(
@@ -316,12 +345,54 @@ local utils = commonlib.utils {
       )
       + prometheusQuery.withLegendFormat('media'),
 
+    objectLoadedError:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_error_objects_loaded{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('object loaded'),
+
+    DNSError:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_dns_error{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('DNS'),
+
+    loadError:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_load_error{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('load'),
+
+    timeoutError:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_timeout_error{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('timeout'),
+
+    connectionError:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_connection_error{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('connection'),
+
+    transactionError:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_transaction_error{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('transaction'),
+
     errors:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
         'sum by (node_name) (catchpoint_any_error{%(testNameSelector)s})' % vars
       )
-      + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
+      + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(nodeNameLabel)),
 
   },
 }

--- a/catchpoint-mixin/targets.libsonnet
+++ b/catchpoint-mixin/targets.libsonnet
@@ -104,7 +104,6 @@ local utils = commonlib.utils {
       )
       + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
 
-
     // Web performance by test name dashboard
     pageCompletionTime:
       prometheusQuery.new(
@@ -147,7 +146,6 @@ local utils = commonlib.utils {
         'sum by (node_name) (catchpoint_content_load_time{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('%s - load' % utils.labelsToPanelLegend(nodeNameLabel)),
-
 
     contentHandlingRender:
       prometheusQuery.new(
@@ -436,7 +434,6 @@ local utils = commonlib.utils {
         'sum by (test_name) (catchpoint_content_load_time{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('%s - load' % utils.labelsToPanelLegend(testNameLabel)),
-
 
     contentHandlingRenderNodeName:
       prometheusQuery.new(

--- a/catchpoint-mixin/targets.libsonnet
+++ b/catchpoint-mixin/targets.libsonnet
@@ -398,217 +398,288 @@ local utils = commonlib.utils {
     pageCompletionTimeNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (test_name) (catchpoint_document_complete_time{%(nodeNameSelector)s})' % vars
+        'sum by (test_name) (catchpoint_document_complete_time{%(testNameSelector)s})' % vars
       )
-      + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
+      + prometheusQuery.withLegendFormat('%s - completion' % utils.labelsToPanelLegend(testNameLabel)),
+
+    pageTotalLoadTimeNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_total_time{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s - load' % utils.labelsToPanelLegend(testNameLabel)),
 
     DNSResolutionNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (test_name) (catchpoint_dns_time{%(nodeNameSelector)s})' % vars
+        'sum by (test_name) (catchpoint_dns_time{%(testNameSelector)s})' % vars
       )
-      + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
+      + prometheusQuery.withLegendFormat('%s - DNS' % utils.labelsToPanelLegend(testNameLabel)),
+
+    SSLTimeNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_ssl_time{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s - SSL' % utils.labelsToPanelLegend(testNameLabel)),
+
+    connectTimeNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_connect_time{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s - connect' % utils.labelsToPanelLegend(testNameLabel)),
 
     contentHandlingLoadNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (test_name) (catchpoint_content_load_time{%(nodeNameSelector)s})' % vars
+        'sum by (test_name) (catchpoint_content_load_time{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('%s - load' % utils.labelsToPanelLegend(testNameLabel)),
+
 
     contentHandlingRenderNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (test_name) (catchpoint_render_start_time{%(nodeNameSelector)s})' % vars
+        'sum by (test_name) (catchpoint_render_start_time{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('%s - render' % utils.labelsToPanelLegend(testNameLabel)),
 
     clientProcessingNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (test_name) (catchpoint_client_time{%(nodeNameSelector)s})' % vars
+        'sum by (test_name) (catchpoint_client_time{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
 
     additionalDelayNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (test_name) (catchpoint_redirect_time{%(nodeNameSelector)s})' % vars
+        'sum by (test_name) (catchpoint_redirect_time{%(testNameSelector)s})' % vars
       )
-      + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
+      + prometheusQuery.withLegendFormat('%s - redirect' % utils.labelsToPanelLegend(testNameLabel)),
+
+    waitTimeNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_wait_time{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s - wait' % utils.labelsToPanelLegend(testNameLabel)),
 
     responseContentSizeNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (test_name) (catchpoint_response_content_size{%(nodeNameSelector)s})' % vars
+        'sum by (test_name) (catchpoint_response_content_size{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('%s - content' % utils.labelsToPanelLegend(testNameLabel)),
 
     responseHeaderSizeNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (test_name) (catchpoint_response_header_size{%(nodeNameSelector)s})' % vars
+        'sum by (test_name) (catchpoint_response_header_size{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('%s - header' % utils.labelsToPanelLegend(testNameLabel)),
 
     totalContentSizeNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (test_name) (catchpoint_total_content_size{%(nodeNameSelector)s})' % vars
+        'sum by (test_name) (catchpoint_total_content_size{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('%s - content' % utils.labelsToPanelLegend(testNameLabel)),
 
     totalHeaderSizeNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (test_name) (catchpoint_total_header_size{%(nodeNameSelector)s})' % vars
+        'sum by (test_name) (catchpoint_total_header_size{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('%s - header' % utils.labelsToPanelLegend(testNameLabel)),
 
     networkConnectionsNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (test_name) (catchpoint_connections_count{%(nodeNameSelector)s})' % vars
+        'sum by (test_name) (catchpoint_connections_count{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
 
     hostsContactedNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (test_name) (catchpoint_hosts_count{%(nodeNameSelector)s})' % vars
+        'sum by (test_name) (catchpoint_hosts_count{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
 
     cacheAccessNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (test_name) (catchpoint_cached_count{%(nodeNameSelector)s})' % vars
+        'sum by (test_name) (catchpoint_cached_count{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
 
-    requestsSuccessRatioNodeName:
+    requestSuccessRatioNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        '(avg by (test_name) (catchpoint_requests_count{%(nodeNameSelector)s}) - avg by (test_name) (catchpoint_failed_requests_count{%(nodeNameSelector)s})) / avg by (test_name) (catchpoint_requests_count{%(nodeNameSelector)s})' % vars
+        '(avg by (test_name) (catchpoint_requests_count{%(testNameSelector)s}) - avg by (test_name) (catchpoint_failed_requests_count{%(testNameSelector)s})) / avg by (test_name) (catchpoint_requests_count{%(testNameSelector)s})' % vars
       )
-      + prometheusQuery.withLegendFormat('%s - success' % utils.labelsToPanelLegend(testNameLabel)),
+      + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
 
     requestsFailureRatioNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'avg by (test_name) (catchpoint_failed_requests_count{%(nodeNameSelector)s}) / clamp_min(avg by (test_name) (catchpoint_requests_count{%(nodeNameSelector)s}), 1)' % vars
+        'avg by (test_name) (catchpoint_failed_requests_count{%(testNameSelector)s}) / clamp_min(avg by (test_name) (catchpoint_requests_count{%(testNameSelector)s}), 1)' % vars
       )
       + prometheusQuery.withLegendFormat('%s - failure' % utils.labelsToPanelLegend(testNameLabel)),
 
     redirectionsNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (test_name) (catchpoint_redirections_count{%(nodeNameSelector)s})' % vars
+        'sum by (test_name) (catchpoint_redirections_count{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
 
     imageLoadedBySizeNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (node_name) (catchpoint_image_content_type{%(nodeNameSelector)s})' % vars
+        'sum by (node_name) (catchpoint_image_content_type{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('image'),
 
     scriptLoadedBySizeNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (node_name) (catchpoint_script_content_type{%(nodeNameSelector)s})' % vars
+        'sum by (node_name) (catchpoint_script_content_type{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('script'),
 
     htmlLoadedBySizeNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (node_name) (catchpoint_html_content_type{%(nodeNameSelector)s})' % vars
+        'sum by (node_name) (catchpoint_html_content_type{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('html'),
 
     cssLoadedBySizeNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (node_name) (catchpoint_css_content_type{%(nodeNameSelector)s})' % vars
+        'sum by (node_name) (catchpoint_css_content_type{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('css'),
 
     fontLoadedBySizeNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (node_name) (catchpoint_font_content_type{%(nodeNameSelector)s})' % vars
+        'sum by (node_name) (catchpoint_font_content_type{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('font'),
 
     xmlLoadedBySizeNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (node_name) (catchpoint_xml_content_type{%(nodeNameSelector)s})' % vars
+        'sum by (node_name) (catchpoint_xml_content_type{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('xml'),
 
     mediaLoadedBySizeNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (node_name) (catchpoint_media_content_type{%(nodeNameSelector)s})' % vars
+        'sum by (node_name) (catchpoint_media_content_type{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('media'),
 
     imageLoadedByTypeNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (node_name) (catchpoint_image_count{%(nodeNameSelector)s})' % vars
+        'sum by (node_name) (catchpoint_image_count{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('image'),
 
     scriptLoadedByTypeNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (node_name) (catchpoint_script_count{%(nodeNameSelector)s})' % vars
+        'sum by (node_name) (catchpoint_script_count{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('script'),
 
     htmlLoadedByTypeNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (node_name) (catchpoint_html_count{%(nodeNameSelector)s})' % vars
+        'sum by (node_name) (catchpoint_html_count{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('html'),
 
     cssLoadedByTypeNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (node_name) (catchpoint_css_count{%(nodeNameSelector)s})' % vars
+        'sum by (node_name) (catchpoint_css_count{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('css'),
 
     fontLoadedByTypeNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (node_name) (catchpoint_font_count{%(nodeNameSelector)s})' % vars
+        'sum by (node_name) (catchpoint_font_count{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('font'),
 
     xmlLoadedByTypeNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (node_name) (catchpoint_xml_count{%(nodeNameSelector)s})' % vars
+        'sum by (node_name) (catchpoint_xml_count{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('xml'),
 
     mediaLoadedByTypeNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (node_name) (catchpoint_media_count{%(nodeNameSelector)s})' % vars
+        'sum by (node_name) (catchpoint_media_count{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('media'),
+
+    objectLoadedErrorNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (node_name) (catchpoint_error_objects_loaded{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('object loaded'),
+
+    DNSErrorNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (node_name) (catchpoint_dns_error{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('DNS'),
+
+    loadErrorNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (node_name) (catchpoint_load_error{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('load'),
+
+    timeoutErrorNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (node_name) (catchpoint_timeout_error{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('timeout'),
+
+    connectionErrorNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (node_name) (catchpoint_connection_error{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('connection'),
+
+    transactionErrorNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (node_name) (catchpoint_transaction_error{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('transaction'),
 
     errorsNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (test_name) (catchpoint_any_error{%(nodeNameSelector)s})' % vars
+        'sum by (node_name) (catchpoint_any_error{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
   },

--- a/catchpoint-mixin/targets.libsonnet
+++ b/catchpoint-mixin/targets.libsonnet
@@ -103,5 +103,225 @@ local utils = commonlib.utils {
         'topk(1, sum by (test_name) (sum_over_time(catchpoint_any_error{%(pureTestNameSelector)s}[$__interval:])))' % vars
       )
       + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
+
+    // Web performance by test name dashboard
+    pageCompletionTime:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        '(sum by (test_name) (catchpoint_document_complete_time{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
+
+    DNSResolution:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        '(sum by (test_name) (catchpoint_dns_time{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
+
+    contentHandlingLoad:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        '(sum by (test_name) (catchpoint_content_load_time{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s - load' % utils.labelsToPanelLegend(testNameLabel)),
+
+    contentHandlingRender:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        '(sum by (test_name) (catchpoint_render_start_time{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s - render' % utils.labelsToPanelLegend(testNameLabel)),
+
+    clientProcessing:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        '(sum by (test_name) (catchpoint_client_time{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
+
+    additionalDelay:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        '(sum by (test_name) (catchpoint_redirect_time{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
+
+    responseContentSize:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        '(sum by (test_name) (catchpoint_response_content_size{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s - content' % utils.labelsToPanelLegend(testNameLabel)),
+
+    responseHeaderSize:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        '(sum by (test_name) (catchpoint_response_header_size{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s - header' % utils.labelsToPanelLegend(testNameLabel)),
+
+    totalContentSize:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        '(sum by (test_name) (catchpoint_total_content_size{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s - content' % utils.labelsToPanelLegend(testNameLabel)),
+
+    totalHeaderSize:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        '(sum by (test_name) (catchpoint_total_header_size{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s - header' % utils.labelsToPanelLegend(testNameLabel)),
+
+    networkConnections:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        '(sum by (test_name) (catchpoint_connections_count{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
+
+    hostsContacted:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        '(sum by (test_name) (catchpoint_hosts_count{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
+
+    cacheAccess:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        '(sum by (test_name) (catchpoint_cached_count{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
+
+    requestsSuccessRatio:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        '(sum by (test_name) (catchpoint_requests_count{%(testNameSelector)s}) - catchpoint_failed_requests_count{%(testNameSelector)s}) / clamp_min(catchpoint_requests_count{%(testNameSelector)s}, 1)' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s - success' % utils.labelsToPanelLegend(testNameLabel)),
+
+    requestsFailureRatio:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'catchpoint_failed_requests_count{%(testNameSelector)s} / clamp_min(catchpoint_requests_count{%(testNameSelector)s}, 1)' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s - failure' % utils.labelsToPanelLegend(testNameLabel)),
+
+    redirections:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_redirections_count{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
+
+    imageLoadedBySize:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_image_content_type{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat(''),
+
+    scriptLoadedBySize:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_script_content_type{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat(''),
+
+    htmlLoadedBySize:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_html_content_type{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat(''),
+
+    cssLoadedBySize:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_css_content_type{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat(''),
+
+    fontLoadedBySize:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_font_content_type{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat(''),
+
+    xmlLoadedBySize:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_xml_content_type{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat(''),
+
+    mediaLoadedBySize:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_media_content_type{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat(''),
+
+
+    imageLoadedByType:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_image_count{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat(''),
+
+    scriptLoadedByType:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_script_count{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat(''),
+
+    htmlLoadedByType:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_html_count{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat(''),
+
+    cssLoadedByType:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_css_count{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat(''),
+
+    fontLoadedByType:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_font_count{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat(''),
+
+    xmlLoadedByType:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_xml_count{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat(''),
+
+    mediaLoadedByType:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_media_count{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat(''),
+
+    Errors:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_any_error{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat(''),
+
   },
 }

--- a/catchpoint-mixin/variables.libsonnet
+++ b/catchpoint-mixin/variables.libsonnet
@@ -65,7 +65,7 @@ local utils = commonlib.utils;
 
       nodeNameVariable:
         [root.datasources.prometheus]
-        + variablesFromLabels(groupLabels, instanceLabels, filteringSelector, multiInstance=true) + [nodeNameLabel],
+        + variablesFromLabels(groupLabels, instanceLabels + nodeNameLabel, filteringSelector, multiInstance=false),
 
       queriesSelector:
         '%s' % [
@@ -84,7 +84,7 @@ local utils = commonlib.utils;
 
       nodeNameSelector:
         '%s' % [
-          utils.labelsToPromQLSelector(groupLabels + testNameLabel),
+          utils.labelsToPromQLSelector(groupLabels + instanceLabels + nodeNameLabel),
         ],
 
       queriesGroupSelectorAdvanced:

--- a/catchpoint-mixin/variables.libsonnet
+++ b/catchpoint-mixin/variables.libsonnet
@@ -61,7 +61,7 @@ local utils = commonlib.utils;
 
       testNameVariable:
         [root.datasources.prometheus]
-        + variablesFromLabels(groupLabels, instanceLabels + testNameLabel, filteringSelector, multiInstance=false),
+        + variablesFromLabels(groupLabels, instanceLabels + testNameLabel, filteringSelector, multiInstance=false) + variablesFromLabels([], nodeNameLabel, filteringSelector, multiInstance=true),
 
       nodeNameVariable:
         [root.datasources.prometheus]
@@ -79,7 +79,7 @@ local utils = commonlib.utils;
 
       testNameSelector:
         '%s' % [
-          utils.labelsToPromQLSelector(groupLabels + instanceLabels + testNameLabel),
+          utils.labelsToPromQLSelector(groupLabels + instanceLabels + testNameLabel + nodeNameLabel),
         ],
 
       nodeNameSelector:

--- a/catchpoint-mixin/variables.libsonnet
+++ b/catchpoint-mixin/variables.libsonnet
@@ -61,7 +61,7 @@ local utils = commonlib.utils;
 
       testNameVariable:
         [root.datasources.prometheus]
-        + variablesFromLabels(groupLabels, instanceLabels, filteringSelector, multiInstance=true) + [testNameLabel],
+        + variablesFromLabels(groupLabels, instanceLabels + testNameLabel, filteringSelector, multiInstance=false),
 
       nodeNameVariable:
         [root.datasources.prometheus]

--- a/catchpoint-mixin/variables.libsonnet
+++ b/catchpoint-mixin/variables.libsonnet
@@ -65,7 +65,7 @@ local utils = commonlib.utils;
 
       nodeNameVariable:
         [root.datasources.prometheus]
-        + variablesFromLabels(groupLabels, instanceLabels + nodeNameLabel, filteringSelector, multiInstance=false),
+        + variablesFromLabels(groupLabels, instanceLabels + nodeNameLabel, filteringSelector, multiInstance=false) + variablesFromLabels([], testNameLabel, filteringSelector, multiInstance=true),
 
       queriesSelector:
         '%s' % [


### PR DESCRIPTION
Adds the web performance by test name dashboard onto the catchpoint mixin.
<img width="1703" alt="image" src="https://github.com/grafana/jsonnet-libs/assets/38274348/fa3c0b7c-6c2f-4f56-8d20-19871d1671ec">
<img width="1701" alt="image" src="https://github.com/grafana/jsonnet-libs/assets/38274348/e3dec7f7-31a1-47af-871c-16f546c0ca62">

