### PR TITLE
Add Catchpoint Nodename dashboard

### DIFF
--- a/catchpoint-mixin/dashboards.libsonnet
+++ b/catchpoint-mixin/dashboards.libsonnet
@@ -76,12 +76,31 @@ local logslib = import 'logs-lib/logs/main.libsonnet';
         + g.dashboard.withPanels(
           g.util.grid.wrapPanels(
             [
-
+              panels.pageCompletionTimeNodeName,
+              panels.DNSResolutionNodeName,
+              panels.contentHandlingNodeName { gridPos+: { w: 8 } },
+              panels.clientProcessingNodeName { gridPos+: { w: 8 } },
+              panels.additionalDelayNodeName { gridPos+: { w: 8 } },
+              g.panel.row.new('Response'),
+              panels.responseContentSizeNodeName,
+              panels.totalContentSizeNodeName,
+              g.panel.row.new('Network activity'),
+              panels.networkConnectionsNodeName { gridPos+: { w: 8 } },
+              panels.hostsContactedNodeName { gridPos+: { w: 8 } },
+              panels.cacheAccessNodeName { gridPos+: { w: 8 } },
+              g.panel.row.new('Request'),
+              panels.requestsRatioNodeName,
+              panels.redirectionsNodeName,
+              g.panel.row.new('Content type'),
+              panels.contentTypesLoadedBySizeNodeName,
+              panels.contentLoadedByTypeNodeName,
+              g.panel.row.new('Errors'),
+              panels.errorsNodeName { gridPos+: { w: 24 } },
             ], 12, 6
           )
         )
         // hide link to self
-        + root.applyCommon(vars, uid + '-nodename-overview', tags, links { catchpointNodeNameOverview+:: {} }, annotations, timezone, refresh, period),
+        + root.applyCommon(vars.nodeNameVariable, uid + '-nodename-overview', tags, links { catchpointNodeNameOverview+:: {} }, annotations, timezone, refresh, period),
     },
 
   //Apply common options(uids, tags, annotations etc..) to all dashboards above

--- a/catchpoint-mixin/dashboards.libsonnet
+++ b/catchpoint-mixin/dashboards.libsonnet
@@ -89,13 +89,12 @@ local logslib = import 'logs-lib/logs/main.libsonnet';
               panels.hostsContactedNodeName { gridPos+: { w: 8 } },
               panels.cacheAccessNodeName { gridPos+: { w: 8 } },
               g.panel.row.new('Request'),
-              panels.requestsRatioNodeName,
+              panels.requestSucessRatioNodeName,
               panels.redirectionsNodeName,
-              g.panel.row.new('Content type'),
-              panels.contentTypesLoadedBySizeNodeName,
-              panels.contentLoadedByTypeNodeName,
-              g.panel.row.new('Errors'),
-              panels.errorsNodeName { gridPos+: { w: 24 } },
+              g.panel.row.new('Errors and content types'),
+              panels.errorsNodeName { gridPos+: { w: 8 } },
+              panels.contentTypesLoadedBySizeNodeName { gridPos+: { w: 8 } },
+              panels.contentLoadedByTypeNodeName { gridPos+: { w: 8 } },
             ], 12, 6
           )
         )

--- a/catchpoint-mixin/panels.libsonnet
+++ b/catchpoint-mixin/panels.libsonnet
@@ -247,7 +247,6 @@ local utils = commonlib.utils;
           barGauge.thresholdStep.withColor('super-light-green'),
         ]),
 
-
       errors:
         barGauge.new(title='Errors')
         + barGauge.queryOptions.withTargets([t.objectLoadedError, t.DNSError, t.loadError, t.timeoutError, t.connectionError, t.transactionError])
@@ -341,7 +340,6 @@ local utils = commonlib.utils;
         + g.panel.timeSeries.standardOptions.withUnit('hosts')
         + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
 
-
       cacheAccessNodeName:
         commonlib.panels.generic.timeSeries.base.new(
           'Cache access',
@@ -388,7 +386,6 @@ local utils = commonlib.utils;
         + barGauge.standardOptions.thresholds.withSteps([
           barGauge.thresholdStep.withColor('super-light-green'),
         ]),
-
 
       errorsNodeName:
         barGauge.new(title='Errors')

--- a/catchpoint-mixin/panels.libsonnet
+++ b/catchpoint-mixin/panels.libsonnet
@@ -132,11 +132,7 @@ local utils = commonlib.utils;
         commonlib.panels.generic.timeSeries.base.new(
           'Connection and DNS resolution',
           targets=[t.DNSResolution, t.SSLTime, t.connectTime],
-<<<<<<< HEAD
           description='Time taken to establish an SSL handshake, DNS resolution, and connect.'
-=======
-          description='Time taken establish an SSL handshake, DNS resolution and connect.'
->>>>>>> 9dbd01b (added extra selector, changed layout, revamped queries)
         )
         + g.panel.timeSeries.standardOptions.withUnit('ms')
         + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
@@ -163,11 +159,7 @@ local utils = commonlib.utils;
         commonlib.panels.generic.timeSeries.base.new(
           'Additional delays',
           targets=[t.additionalDelay, t.waitTime],
-<<<<<<< HEAD
           description='Additional delays encountered due to redirects, as well as time from successful connection to receiving the first byte.'
-=======
-          description='Additional delays encountered due to redirects as well as time from successful connection to receiving the first byte.'
->>>>>>> 9dbd01b (added extra selector, changed layout, revamped queries)
         )
         + g.panel.timeSeries.standardOptions.withUnit('ms')
         + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),

--- a/catchpoint-mixin/panels.libsonnet
+++ b/catchpoint-mixin/panels.libsonnet
@@ -260,5 +260,141 @@ local utils = commonlib.utils;
           barGauge.standardOptions.threshold.step.withValue(1) + barGauge.thresholdStep.withColor('super-light-red'),
         ]),
 
+      // Web Performance by Node Name Dashboard Panels
+      pageCompletionTimeNodeName:
+        commonlib.panels.generic.timeSeries.base.new(
+          'Page completion time',
+          targets=[t.pageCompletionTimeNodeName],
+          description='Time taken for the browser to fully render the page after all resources are downloaded.'
+        )
+        + g.panel.timeSeries.standardOptions.withUnit('ms')
+        + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
+
+      DNSResolutionNodeName:
+        commonlib.panels.generic.timeSeries.base.new(
+          'Connection and DNS resolution',
+          targets=[t.DNSResolutionNodeName],
+          description='Time taken to establish a connection to the URL and resolve the domain name, which is critical for identifying network connectivity and DNS resolution issues.'
+        )
+        + g.panel.timeSeries.standardOptions.withUnit('ms')
+        + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
+
+      contentHandlingNodeName:
+        commonlib.panels.generic.timeSeries.base.new(
+          'Content handling',
+          targets=[t.contentHandlingLoadNodeName, t.contentHandlingRenderNodeName],
+          description='Time taken to load and render content on the webpage.'
+        )
+        + g.panel.timeSeries.standardOptions.withUnit('ms')
+        + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
+
+      clientProcessingNodeName:
+        commonlib.panels.generic.timeSeries.base.new(
+          'Client processing',
+          targets=[t.clientProcessingNodeName],
+          description='Client processing time, which reflects the time spent on client-side processing, including script execution and rendering.'
+        )
+        + g.panel.timeSeries.standardOptions.withUnit('ms')
+        + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
+
+      additionalDelayNodeName:
+        commonlib.panels.generic.timeSeries.base.new(
+          'Additional delays',
+          targets=[t.additionalDelayNodeName],
+          description='Additional delays encountered due to redirects.'
+        )
+        + g.panel.timeSeries.standardOptions.withUnit('ms')
+        + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
+
+      responseContentSizeNodeName:
+        commonlib.panels.generic.timeSeries.base.new(
+          'Response content size',
+          targets=[t.responseContentSizeNodeName, t.responseHeaderSizeNodeName],
+          description='Size of the HTTP response content in bytes.'
+        )
+        + g.panel.timeSeries.standardOptions.withUnit('decbytes')
+        + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
+
+      totalContentSizeNodeName:
+        commonlib.panels.generic.timeSeries.base.new(
+          'Total content size',
+          targets=[t.totalContentSizeNodeName, t.totalHeaderSizeNodeName],
+          description='Total size of the HTTP response content and headers in bytes.'
+        )
+        + g.panel.timeSeries.standardOptions.withUnit('decbytes')
+        + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
+
+      networkConnectionsNodeName:
+        commonlib.panels.generic.timeSeries.base.new(
+          'Network connections',
+          targets=[t.networkConnectionsNodeName],
+          description='Number of connections made.'
+        )
+        + g.panel.timeSeries.standardOptions.withUnit('conn')
+        + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
+
+      hostsContactedNodeName:
+        commonlib.panels.generic.timeSeries.base.new(
+          'Hosts contacted',
+          targets=[t.hostsContactedNodeName],
+          description='Number of hosts contacted.'
+        )
+        + g.panel.timeSeries.standardOptions.withUnit('hosts')
+        + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
+
+
+      cacheAccessNodeName:
+        commonlib.panels.generic.timeSeries.base.new(
+          'Cache access',
+          targets=[t.cacheAccessNodeName],
+          description='Number of cached elements accessed.'
+        )
+        + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
+
+      requestsRatioNodeName:
+        commonlib.panels.generic.timeSeries.base.new(
+          'Requests success/failure ratio',
+          targets=[t.requestsSuccessRatioNodeName],
+          description='Success ratio of requests made.'
+        )
+        + g.panel.timeSeries.standardOptions.withUnit('percentunit')
+        + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
+
+      redirectionsNodeName:
+        commonlib.panels.generic.timeSeries.base.new(
+          'Redirects',
+          targets=[t.redirectionsNodeName],
+          description='Number of HTTP redirections encountered.'
+        )
+        + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
+
+      contentTypesLoadedBySizeNodeName:
+        pieChart.new(title='Content types loaded by size')
+        + pieChart.queryOptions.withTargets([t.imageLoadedBySizeNodeName, t.htmlLoadedBySizeNodeName, t.cssLoadedBySizeNodeName, t.scriptLoadedBySizeNodeName, t.fontLoadedBySizeNodeName, t.xmlLoadedBySizeNodeName, t.mediaLoadedBySizeNodeName])
+        + pieChart.options.legend.withPlacement('right')
+        + pieChart.options.withTooltipMixin({
+          mode: 'multi',
+          sort: 'desc',
+        })
+        + pieChart.panelOptions.withDescription('Size of content loaded in bytes')
+        + pieChart.standardOptions.withUnit('decbytes'),
+
+      contentLoadedByTypeNodeName:
+        barGauge.new(title='Content loaded by type')
+        + barGauge.queryOptions.withTargets([t.imageLoadedByTypeNodeName, t.htmlLoadedByTypeNodeName, t.cssLoadedByTypeNodeName, t.scriptLoadedByTypeNodeName, t.fontLoadedByTypeNodeName, t.xmlLoadedByTypeNodeName, t.mediaLoadedByTypeNodeName])
+        + barGauge.panelOptions.withDescription('Number of elements loaded.')
+        + barGauge.options.withOrientation('horizontal')
+        + barGauge.standardOptions.thresholds.withSteps([
+          barGauge.thresholdStep.withColor('super-light-green'),
+        ]),
+
+      errorsNodeName:
+        commonlib.panels.generic.timeSeries.base.new(
+          'Errors',
+          targets=[t.errorsNodeName],
+          description='Indicates if any errors occurred.'
+        )
+        + g.panel.timeSeries.standardOptions.withUnit('err')
+        + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
     },
 }

--- a/catchpoint-mixin/panels.libsonnet
+++ b/catchpoint-mixin/panels.libsonnet
@@ -357,6 +357,8 @@ local utils = commonlib.utils;
           description='Success ratio of requests made.'
         )
         + g.panel.timeSeries.standardOptions.withUnit('percentunit')
+        + g.panel.timeSeries.standardOptions.withMax(1)
+        + g.panel.timeSeries.standardOptions.withMin(0)
         + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
 
       redirectionsNodeName:

--- a/catchpoint-mixin/panels.libsonnet
+++ b/catchpoint-mixin/panels.libsonnet
@@ -132,7 +132,11 @@ local utils = commonlib.utils;
         commonlib.panels.generic.timeSeries.base.new(
           'Connection and DNS resolution',
           targets=[t.DNSResolution, t.SSLTime, t.connectTime],
+<<<<<<< HEAD
           description='Time taken to establish an SSL handshake, DNS resolution, and connect.'
+=======
+          description='Time taken establish an SSL handshake, DNS resolution and connect.'
+>>>>>>> 9dbd01b (added extra selector, changed layout, revamped queries)
         )
         + g.panel.timeSeries.standardOptions.withUnit('ms')
         + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
@@ -159,7 +163,11 @@ local utils = commonlib.utils;
         commonlib.panels.generic.timeSeries.base.new(
           'Additional delays',
           targets=[t.additionalDelay, t.waitTime],
+<<<<<<< HEAD
           description='Additional delays encountered due to redirects, as well as time from successful connection to receiving the first byte.'
+=======
+          description='Additional delays encountered due to redirects as well as time from successful connection to receiving the first byte.'
+>>>>>>> 9dbd01b (added extra selector, changed layout, revamped queries)
         )
         + g.panel.timeSeries.standardOptions.withUnit('ms')
         + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
@@ -199,7 +207,6 @@ local utils = commonlib.utils;
         )
         + g.panel.timeSeries.standardOptions.withUnit('hosts')
         + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
-
 
       cacheAccess:
         commonlib.panels.generic.timeSeries.base.new(
@@ -264,7 +271,7 @@ local utils = commonlib.utils;
       pageCompletionTimeNodeName:
         commonlib.panels.generic.timeSeries.base.new(
           'Page completion time',
-          targets=[t.pageCompletionTimeNodeName],
+          targets=[t.pageCompletionTimeNodeName, t.pageTotalLoadTimeNodeName],
           description='Time taken for the browser to fully render the page after all resources are downloaded.'
         )
         + g.panel.timeSeries.standardOptions.withUnit('ms')
@@ -273,8 +280,8 @@ local utils = commonlib.utils;
       DNSResolutionNodeName:
         commonlib.panels.generic.timeSeries.base.new(
           'Connection and DNS resolution',
-          targets=[t.DNSResolutionNodeName],
-          description='Time taken to establish a connection to the URL and resolve the domain name, which is critical for identifying network connectivity and DNS resolution issues.'
+          targets=[t.DNSResolutionNodeName, t.SSLTimeNodeName, t.connectTimeNodeName],
+          description='Time taken establish an SSL handshake, DNS resolution and connect.'
         )
         + g.panel.timeSeries.standardOptions.withUnit('ms')
         + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
@@ -282,7 +289,7 @@ local utils = commonlib.utils;
       contentHandlingNodeName:
         commonlib.panels.generic.timeSeries.base.new(
           'Content handling',
-          targets=[t.contentHandlingLoadNodeName, t.contentHandlingRenderNodeName],
+          targets=[t.contentHandlingLoad, t.contentHandlingRender],
           description='Time taken to load and render content on the webpage.'
         )
         + g.panel.timeSeries.standardOptions.withUnit('ms')
@@ -300,8 +307,8 @@ local utils = commonlib.utils;
       additionalDelayNodeName:
         commonlib.panels.generic.timeSeries.base.new(
           'Additional delays',
-          targets=[t.additionalDelayNodeName],
-          description='Additional delays encountered due to redirects.'
+          targets=[t.additionalDelayNodeName, t.waitTimeNodeName],
+          description='Additional delays encountered due to redirects as well as time from successful connection to receiving the first byte.'
         )
         + g.panel.timeSeries.standardOptions.withUnit('ms')
         + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
@@ -351,10 +358,10 @@ local utils = commonlib.utils;
         )
         + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
 
-      requestsRatioNodeName:
+      requestSucessRatioNodeName:
         commonlib.panels.generic.timeSeries.base.new(
-          'Requests success/failure ratio',
-          targets=[t.requestsSuccessRatioNodeName],
+          'Requests success ratio',
+          targets=[t.requestSuccessRatioNodeName],
           description='Success ratio of requests made.'
         )
         + g.panel.timeSeries.standardOptions.withUnit('percentunit')
@@ -388,13 +395,16 @@ local utils = commonlib.utils;
           barGauge.thresholdStep.withColor('super-light-green'),
         ]),
 
+
       errorsNodeName:
-        commonlib.panels.generic.timeSeries.base.new(
-          'Errors',
-          targets=[t.errorsNodeName],
-          description='Indicates if any errors occurred.'
-        )
-        + g.panel.timeSeries.standardOptions.withUnit('err')
-        + g.panel.timeSeries.fieldConfig.defaults.custom.withSpanNulls('true'),
+        barGauge.new(title='Errors')
+        + barGauge.queryOptions.withTargets([t.objectLoadedErrorNodeName, t.DNSErrorNodeName, t.loadErrorNodeName, t.timeoutErrorNodeName, t.connectionErrorNodeName, t.transactionErrorNodeName])
+        + barGauge.panelOptions.withDescription('Indicates various potential errors that are occuring.')
+        + barGauge.options.withOrientation('horizontal')
+        + barGauge.standardOptions.withMax(1)
+        + barGauge.standardOptions.thresholds.withSteps([
+          barGauge.thresholdStep.withColor('super-light-green'),
+          barGauge.standardOptions.threshold.step.withValue(1) + barGauge.thresholdStep.withColor('super-light-red'),
+        ]),
     },
 }

--- a/catchpoint-mixin/targets.libsonnet
+++ b/catchpoint-mixin/targets.libsonnet
@@ -412,217 +412,288 @@ local utils = commonlib.utils {
     pageCompletionTimeNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (test_name) (catchpoint_document_complete_time{%(nodeNameSelector)s})' % vars
+        'sum by (test_name) (catchpoint_document_complete_time{%(testNameSelector)s})' % vars
       )
-      + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
+      + prometheusQuery.withLegendFormat('%s - completion' % utils.labelsToPanelLegend(testNameLabel)),
+
+    pageTotalLoadTimeNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_total_time{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s - load' % utils.labelsToPanelLegend(testNameLabel)),
 
     DNSResolutionNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (test_name) (catchpoint_dns_time{%(nodeNameSelector)s})' % vars
+        'sum by (test_name) (catchpoint_dns_time{%(testNameSelector)s})' % vars
       )
-      + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
+      + prometheusQuery.withLegendFormat('%s - DNS' % utils.labelsToPanelLegend(testNameLabel)),
+
+    SSLTimeNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_ssl_time{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s - SSL' % utils.labelsToPanelLegend(testNameLabel)),
+
+    connectTimeNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_connect_time{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s - connect' % utils.labelsToPanelLegend(testNameLabel)),
 
     contentHandlingLoadNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (test_name) (catchpoint_content_load_time{%(nodeNameSelector)s})' % vars
+        'sum by (test_name) (catchpoint_content_load_time{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('%s - load' % utils.labelsToPanelLegend(testNameLabel)),
+
 
     contentHandlingRenderNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (test_name) (catchpoint_render_start_time{%(nodeNameSelector)s})' % vars
+        'sum by (test_name) (catchpoint_render_start_time{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('%s - render' % utils.labelsToPanelLegend(testNameLabel)),
 
     clientProcessingNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (test_name) (catchpoint_client_time{%(nodeNameSelector)s})' % vars
+        'sum by (test_name) (catchpoint_client_time{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
 
     additionalDelayNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (test_name) (catchpoint_redirect_time{%(nodeNameSelector)s})' % vars
+        'sum by (test_name) (catchpoint_redirect_time{%(testNameSelector)s})' % vars
       )
-      + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
+      + prometheusQuery.withLegendFormat('%s - redirect' % utils.labelsToPanelLegend(testNameLabel)),
+
+    waitTimeNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_wait_time{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s - wait' % utils.labelsToPanelLegend(testNameLabel)),
 
     responseContentSizeNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (test_name) (catchpoint_response_content_size{%(nodeNameSelector)s})' % vars
+        'sum by (test_name) (catchpoint_response_content_size{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('%s - content' % utils.labelsToPanelLegend(testNameLabel)),
 
     responseHeaderSizeNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (test_name) (catchpoint_response_header_size{%(nodeNameSelector)s})' % vars
+        'sum by (test_name) (catchpoint_response_header_size{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('%s - header' % utils.labelsToPanelLegend(testNameLabel)),
 
     totalContentSizeNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (test_name) (catchpoint_total_content_size{%(nodeNameSelector)s})' % vars
+        'sum by (test_name) (catchpoint_total_content_size{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('%s - content' % utils.labelsToPanelLegend(testNameLabel)),
 
     totalHeaderSizeNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (test_name) (catchpoint_total_header_size{%(nodeNameSelector)s})' % vars
+        'sum by (test_name) (catchpoint_total_header_size{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('%s - header' % utils.labelsToPanelLegend(testNameLabel)),
 
     networkConnectionsNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (test_name) (catchpoint_connections_count{%(nodeNameSelector)s})' % vars
+        'sum by (test_name) (catchpoint_connections_count{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
 
     hostsContactedNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (test_name) (catchpoint_hosts_count{%(nodeNameSelector)s})' % vars
+        'sum by (test_name) (catchpoint_hosts_count{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
 
     cacheAccessNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (test_name) (catchpoint_cached_count{%(nodeNameSelector)s})' % vars
+        'sum by (test_name) (catchpoint_cached_count{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
 
-    requestsSuccessRatioNodeName:
+    requestSuccessRatioNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        '(avg by (test_name) (catchpoint_requests_count{%(nodeNameSelector)s}) - avg by (test_name) (catchpoint_failed_requests_count{%(nodeNameSelector)s})) / avg by (test_name) (catchpoint_requests_count{%(nodeNameSelector)s})' % vars
+        '(avg by (test_name) (catchpoint_requests_count{%(testNameSelector)s}) - avg by (test_name) (catchpoint_failed_requests_count{%(testNameSelector)s})) / avg by (test_name) (catchpoint_requests_count{%(testNameSelector)s})' % vars
       )
-      + prometheusQuery.withLegendFormat('%s - success' % utils.labelsToPanelLegend(testNameLabel)),
+      + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
 
     requestsFailureRatioNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'avg by (test_name) (catchpoint_failed_requests_count{%(nodeNameSelector)s}) / clamp_min(avg by (test_name) (catchpoint_requests_count{%(nodeNameSelector)s}), 1)' % vars
+        'avg by (test_name) (catchpoint_failed_requests_count{%(testNameSelector)s}) / clamp_min(avg by (test_name) (catchpoint_requests_count{%(testNameSelector)s}), 1)' % vars
       )
       + prometheusQuery.withLegendFormat('%s - failure' % utils.labelsToPanelLegend(testNameLabel)),
 
     redirectionsNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (test_name) (catchpoint_redirections_count{%(nodeNameSelector)s})' % vars
+        'sum by (test_name) (catchpoint_redirections_count{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
 
     imageLoadedBySizeNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (node_name) (catchpoint_image_content_type{%(nodeNameSelector)s})' % vars
+        'sum by (node_name) (catchpoint_image_content_type{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('image'),
 
     scriptLoadedBySizeNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (node_name) (catchpoint_script_content_type{%(nodeNameSelector)s})' % vars
+        'sum by (node_name) (catchpoint_script_content_type{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('script'),
 
     htmlLoadedBySizeNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (node_name) (catchpoint_html_content_type{%(nodeNameSelector)s})' % vars
+        'sum by (node_name) (catchpoint_html_content_type{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('html'),
 
     cssLoadedBySizeNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (node_name) (catchpoint_css_content_type{%(nodeNameSelector)s})' % vars
+        'sum by (node_name) (catchpoint_css_content_type{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('css'),
 
     fontLoadedBySizeNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (node_name) (catchpoint_font_content_type{%(nodeNameSelector)s})' % vars
+        'sum by (node_name) (catchpoint_font_content_type{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('font'),
 
     xmlLoadedBySizeNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (node_name) (catchpoint_xml_content_type{%(nodeNameSelector)s})' % vars
+        'sum by (node_name) (catchpoint_xml_content_type{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('xml'),
 
     mediaLoadedBySizeNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (node_name) (catchpoint_media_content_type{%(nodeNameSelector)s})' % vars
+        'sum by (node_name) (catchpoint_media_content_type{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('media'),
 
     imageLoadedByTypeNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (node_name) (catchpoint_image_count{%(nodeNameSelector)s})' % vars
+        'sum by (node_name) (catchpoint_image_count{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('image'),
 
     scriptLoadedByTypeNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (node_name) (catchpoint_script_count{%(nodeNameSelector)s})' % vars
+        'sum by (node_name) (catchpoint_script_count{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('script'),
 
     htmlLoadedByTypeNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (node_name) (catchpoint_html_count{%(nodeNameSelector)s})' % vars
+        'sum by (node_name) (catchpoint_html_count{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('html'),
 
     cssLoadedByTypeNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (node_name) (catchpoint_css_count{%(nodeNameSelector)s})' % vars
+        'sum by (node_name) (catchpoint_css_count{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('css'),
 
     fontLoadedByTypeNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (node_name) (catchpoint_font_count{%(nodeNameSelector)s})' % vars
+        'sum by (node_name) (catchpoint_font_count{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('font'),
 
     xmlLoadedByTypeNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (node_name) (catchpoint_xml_count{%(nodeNameSelector)s})' % vars
+        'sum by (node_name) (catchpoint_xml_count{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('xml'),
 
     mediaLoadedByTypeNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (node_name) (catchpoint_media_count{%(nodeNameSelector)s})' % vars
+        'sum by (node_name) (catchpoint_media_count{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('media'),
+
+    objectLoadedErrorNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (node_name) (catchpoint_error_objects_loaded{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('object loaded'),
+
+    DNSErrorNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (node_name) (catchpoint_dns_error{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('DNS'),
+
+    loadErrorNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (node_name) (catchpoint_load_error{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('load'),
+
+    timeoutErrorNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (node_name) (catchpoint_timeout_error{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('timeout'),
+
+    connectionErrorNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (node_name) (catchpoint_connection_error{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('connection'),
+
+    transactionErrorNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (node_name) (catchpoint_transaction_error{%(testNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('transaction'),
 
     errorsNodeName:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'sum by (test_name) (catchpoint_any_error{%(nodeNameSelector)s})' % vars
+        'sum by (node_name) (catchpoint_any_error{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
   },

--- a/catchpoint-mixin/targets.libsonnet
+++ b/catchpoint-mixin/targets.libsonnet
@@ -118,7 +118,6 @@ local utils = commonlib.utils {
       )
       + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
 
-
     // Web performance by test name dashboard
     pageCompletionTime:
       prometheusQuery.new(
@@ -161,7 +160,6 @@ local utils = commonlib.utils {
         'sum by (node_name) (catchpoint_content_load_time{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('%s - load' % utils.labelsToPanelLegend(nodeNameLabel)),
-
 
     contentHandlingRender:
       prometheusQuery.new(
@@ -450,7 +448,6 @@ local utils = commonlib.utils {
         'sum by (test_name) (catchpoint_content_load_time{%(testNameSelector)s})' % vars
       )
       + prometheusQuery.withLegendFormat('%s - load' % utils.labelsToPanelLegend(testNameLabel)),
-
 
     contentHandlingRenderNodeName:
       prometheusQuery.new(

--- a/catchpoint-mixin/targets.libsonnet
+++ b/catchpoint-mixin/targets.libsonnet
@@ -408,5 +408,222 @@ local utils = commonlib.utils {
       )
       + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(nodeNameLabel)),
 
+    // Web performance by node name dashboard
+    pageCompletionTimeNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_document_complete_time{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
+
+    DNSResolutionNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_dns_time{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
+
+    contentHandlingLoadNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_content_load_time{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s - load' % utils.labelsToPanelLegend(testNameLabel)),
+
+    contentHandlingRenderNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_render_start_time{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s - render' % utils.labelsToPanelLegend(testNameLabel)),
+
+    clientProcessingNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_client_time{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
+
+    additionalDelayNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_redirect_time{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
+
+    responseContentSizeNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_response_content_size{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s - content' % utils.labelsToPanelLegend(testNameLabel)),
+
+    responseHeaderSizeNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_response_header_size{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s - header' % utils.labelsToPanelLegend(testNameLabel)),
+
+    totalContentSizeNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_total_content_size{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s - content' % utils.labelsToPanelLegend(testNameLabel)),
+
+    totalHeaderSizeNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_total_header_size{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s - header' % utils.labelsToPanelLegend(testNameLabel)),
+
+    networkConnectionsNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_connections_count{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
+
+    hostsContactedNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_hosts_count{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
+
+    cacheAccessNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_cached_count{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
+
+    requestsSuccessRatioNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        '(avg by (test_name) (catchpoint_requests_count{%(nodeNameSelector)s}) - avg by (test_name) (catchpoint_failed_requests_count{%(nodeNameSelector)s})) / avg by (test_name) (catchpoint_requests_count{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s - success' % utils.labelsToPanelLegend(testNameLabel)),
+
+    requestsFailureRatioNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'avg by (test_name) (catchpoint_failed_requests_count{%(nodeNameSelector)s}) / clamp_min(avg by (test_name) (catchpoint_requests_count{%(nodeNameSelector)s}), 1)' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s - failure' % utils.labelsToPanelLegend(testNameLabel)),
+
+    redirectionsNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_redirections_count{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
+
+    imageLoadedBySizeNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (node_name) (catchpoint_image_content_type{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('image'),
+
+    scriptLoadedBySizeNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (node_name) (catchpoint_script_content_type{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('script'),
+
+    htmlLoadedBySizeNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (node_name) (catchpoint_html_content_type{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('html'),
+
+    cssLoadedBySizeNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (node_name) (catchpoint_css_content_type{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('css'),
+
+    fontLoadedBySizeNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (node_name) (catchpoint_font_content_type{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('font'),
+
+    xmlLoadedBySizeNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (node_name) (catchpoint_xml_content_type{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('xml'),
+
+    mediaLoadedBySizeNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (node_name) (catchpoint_media_content_type{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('media'),
+
+    imageLoadedByTypeNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (node_name) (catchpoint_image_count{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('image'),
+
+    scriptLoadedByTypeNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (node_name) (catchpoint_script_count{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('script'),
+
+    htmlLoadedByTypeNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (node_name) (catchpoint_html_count{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('html'),
+
+    cssLoadedByTypeNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (node_name) (catchpoint_css_count{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('css'),
+
+    fontLoadedByTypeNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (node_name) (catchpoint_font_count{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('font'),
+
+    xmlLoadedByTypeNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (node_name) (catchpoint_xml_count{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('xml'),
+
+    mediaLoadedByTypeNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (node_name) (catchpoint_media_count{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('media'),
+
+    errorsNodeName:
+      prometheusQuery.new(
+        '${' + vars.datasources.prometheus.name + '}',
+        'sum by (test_name) (catchpoint_any_error{%(nodeNameSelector)s})' % vars
+      )
+      + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(testNameLabel)),
   },
 }

--- a/catchpoint-mixin/variables.libsonnet
+++ b/catchpoint-mixin/variables.libsonnet
@@ -74,7 +74,7 @@ local utils = commonlib.utils;
 
       nodeNameVariable:
         [root.datasources.prometheus]
-        + variablesFromLabels(groupLabels, instanceLabels, filteringSelector, multiInstance=true) + [nodeNameLabel],
+        + variablesFromLabels(groupLabels, instanceLabels + nodeNameLabel, filteringSelector, multiInstance=false),
 
       queriesSelector:
         '%s' % [
@@ -86,7 +86,7 @@ local utils = commonlib.utils;
         ],
       nodeNameSelector:
         '%s' % [
-          utils.labelsToPromQLSelector(groupLabels + testNameLabel),
+          utils.labelsToPromQLSelector(groupLabels + instanceLabels + nodeNameLabel),
         ],
 
       queriesGroupSelectorAdvanced:

--- a/catchpoint-mixin/variables.libsonnet
+++ b/catchpoint-mixin/variables.libsonnet
@@ -74,7 +74,7 @@ local utils = commonlib.utils;
 
       nodeNameVariable:
         [root.datasources.prometheus]
-        + variablesFromLabels(groupLabels, instanceLabels + nodeNameLabel, filteringSelector, multiInstance=false),
+        + variablesFromLabels(groupLabels, instanceLabels + nodeNameLabel, filteringSelector, multiInstance=false) + variablesFromLabels([], testNameLabel, filteringSelector, multiInstance=true),
 
       queriesSelector:
         '%s' % [


### PR DESCRIPTION
The following adds the Catchpoint web performance by node name dashboard.
<img width="1694" alt="image" src="https://github.com/grafana/jsonnet-libs/assets/38274348/445baf0d-d52a-4ab3-b577-897fad732906">
<img width="1683" alt="image" src="https://github.com/grafana/jsonnet-libs/assets/38274348/0a52c2a2-a865-4641-9533-64dd07778761">
