### PR TITLE
Add support for renaming prometheus datasource and datasourceLabel in commonlib

### DIFF
--- a/common-lib/common/signal/README.md
+++ b/common-lib/common/signal/README.md
@@ -36,6 +36,8 @@ Init level:
 
 |Name|Description|Possible values|Example value|Default value|
 |-----|---|---|---|---|
+|datasource| Prometheus Datasource name. |*|`custom_datasource`|`datasource`|
+|datasourceLabel| Prometheus Datasource label. |*|`Custom data source`|`Data source`|
 |filteringSelector|Used to filter metric scopes. Added to all dashboards'(as part of `queriesSelector`) and alerts' queries. |*|`[job="blablablah]"`,|`['job!=""']`|
 |groupLabels| List of labels used to identify group of instance or whole service. |*|`[job]`|`[job]`|
 |instanceLabels| List of labels used to identify single entity or specific service instance. |*|`[instance]`|`['instance']`|
@@ -83,7 +85,7 @@ local g = import 'g.libsonnet';
 
 # define signals
     local s = commonlib.signals.init(
-        datasource='${datasource}',
+        datasource='datasource',
         instanceLabels=['instance','device'],
         groupLabels=['job'],
         filteringSelector=['job=integrations/test'],

--- a/common-lib/common/signal/base.libsonnet
+++ b/common-lib/common/signal/base.libsonnet
@@ -24,7 +24,7 @@ local signalUtils = import './utils.libsonnet';
     //Return as grafana panel target(query+legend)
     asTarget()::
       prometheusQuery.new(
-        datasource,
+        '${%s}' % datasource,
         self.asPanelExpression(),
       )
       + prometheusQuery.withRefId(name)
@@ -62,7 +62,7 @@ local signalUtils = import './utils.libsonnet';
 
     common::
       // override panel-wide --mixed-- datasource
-      prometheusQuery.withDatasource(datasource)
+      prometheusQuery.withDatasource('${%s}' % datasource)
       + g.panel.timeSeries.panelOptions.withDescription(description)
       + g.panel.timeSeries.standardOptions.withUnit(self.unit)
       + g.panel.timeSeries.standardOptions.withMappings(valueMapping)

--- a/common-lib/common/signal/signal.libsonnet
+++ b/common-lib/common/signal/signal.libsonnet
@@ -30,7 +30,8 @@ local stub = import './stub.libsonnet';
   // }
   unmarshallJson(signalsJson):
     self.init(
-      datasource='${datasource}',
+      datasource=std.get(signalsJson, 'datasource', 'datasource'),
+      datasourceLabel=std.get(signalsJson, 'datasourceLabel', 'Data source'),
       filteringSelector=[signalsJson.filteringSelector],
       groupLabels=signalsJson.groupLabels,
       instanceLabels=signalsJson.instanceLabels,
@@ -63,7 +64,8 @@ local stub = import './stub.libsonnet';
   unmarshallJsonMulti(signalsJson, type='prometheus'):
 
     self.init(
-      datasource='${datasource}',
+      datasource=std.get(signalsJson, 'datasource', 'datasource'),
+      datasourceLabel=std.get(signalsJson, 'datasourceLabel', 'Data source'),
       filteringSelector=[signalsJson.filteringSelector],
       groupLabels=signalsJson.groupLabels,
       instanceLabels=signalsJson.instanceLabels,
@@ -107,7 +109,8 @@ local stub = import './stub.libsonnet';
     },
 
   init(
-    datasource='${datasource}',
+    datasource='datasource',
+    datasourceLabel='Data source',
     filteringSelector=['job!=""'],
     groupLabels=['job'],
     instanceLabels=['instance'],
@@ -133,6 +136,8 @@ local stub = import './stub.libsonnet';
       groupLabels,
       instanceLabels,
       varMetric=varMetric,
+      prometheusDatasourceName=datasource,
+      prometheusDatasourceLabel=datasourceLabel,
     ),
     // vars are used in templating(legend+expressions)
     templatingVariables: {

--- a/common-lib/common/signal/test_marshall_json.libsonnet
+++ b/common-lib/common/signal/test_marshall_json.libsonnet
@@ -3,6 +3,8 @@ local test = import 'jsonnetunit/test.libsonnet';
 
 local jsonSignals =
   {
+    datasource: 'custom_datasource',
+    datasourceLabel: 'Custom datasource',
     aggLevel: 'group',
     groupLabels: ['job'],
     instanceLabels: ['instance'],
@@ -65,15 +67,15 @@ local signals = signal.unmarshallJson(jsonSignals);
     testResult: test.suite({
       testDS: {
         actual: raw[0],
-        expect: { label: 'Data source', name: 'datasource', query: 'prometheus', regex: '', type: 'datasource' },
+        expect: { label: 'Custom datasource', name: 'custom_datasource', query: 'prometheus', regex: '', type: 'datasource' },
       },
       testGroupSelector: {
         actual: raw[1],
-        expect: { allValue: '.+', datasource: { type: 'prometheus', uid: '${datasource}' }, includeAll: true, label: 'Job', multi: true, name: 'job', query: 'label_values(up2{job="integrations/agent"}, job)', refresh: 2, sort: 1, type: 'query' },
+        expect: { allValue: '.+', datasource: { type: 'prometheus', uid: '${custom_datasource}' }, includeAll: true, label: 'Job', multi: true, name: 'job', query: 'label_values(up2{job="integrations/agent"}, job)', refresh: 2, sort: 1, type: 'query' },
       },
       testInstanceSelector: {
         actual: raw[2],
-        expect: { allValue: '.+', datasource: { type: 'prometheus', uid: '${datasource}' }, includeAll: true, label: 'Instance', multi: true, name: 'instance', query: 'label_values(up2{job="integrations/agent",job=~"$job"}, instance)', refresh: 2, sort: 1, type: 'query' },
+        expect: { allValue: '.+', datasource: { type: 'prometheus', uid: '${custom_datasource}' }, includeAll: true, label: 'Instance', multi: true, name: 'instance', query: 'label_values(up2{job="integrations/agent",job=~"$job"}, instance)', refresh: 2, sort: 1, type: 'query' },
       },
     }),
   },
@@ -83,15 +85,15 @@ local signals = signal.unmarshallJson(jsonSignals);
     testResult: test.suite({
       testDS: {
         actual: raw[0],
-        expect: { label: 'Data source', name: 'datasource', query: 'prometheus', regex: '', type: 'datasource' },
+        expect: { label: 'Custom datasource', name: 'custom_datasource', query: 'prometheus', regex: '', type: 'datasource' },
       },
       testGroupSelector: {
         actual: raw[1],
-        expect: { allValue: '.+', datasource: { type: 'prometheus', uid: '${datasource}' }, includeAll: true, label: 'Job', multi: true, name: 'job', query: 'label_values(up2{job="integrations/agent"}, job)', refresh: 2, sort: 1, type: 'query' },
+        expect: { allValue: '.+', datasource: { type: 'prometheus', uid: '${custom_datasource}' }, includeAll: true, label: 'Job', multi: true, name: 'job', query: 'label_values(up2{job="integrations/agent"}, job)', refresh: 2, sort: 1, type: 'query' },
       },
       testInstanceSelector: {
         actual: raw[2],
-        expect: { allValue: '.+', datasource: { type: 'prometheus', uid: '${datasource}' }, includeAll: false, label: 'Instance', multi: false, name: 'instance', query: 'label_values(up2{job="integrations/agent",job=~"$job"}, instance)', refresh: 2, sort: 1, type: 'query' },
+        expect: { allValue: '.+', datasource: { type: 'prometheus', uid: '${custom_datasource}' }, includeAll: false, label: 'Instance', multi: false, name: 'instance', query: 'label_values(up2{job="integrations/agent",job=~"$job"}, instance)', refresh: 2, sort: 1, type: 'query' },
       },
     }),
   },
@@ -125,7 +127,7 @@ local signals = signal.unmarshallJson(jsonSignals);
         testUid: {
           actual: panel.datasource,
           expect: {
-            uid: '${datasource}',
+            uid: '${custom_datasource}',
             type: 'prometheus',
           },
         },

--- a/common-lib/common/variables/variables.libsonnet
+++ b/common-lib/common/variables/variables.libsonnet
@@ -10,6 +10,8 @@ local utils = import '../utils.libsonnet';
     varMetric='up',
     enableLokiLogs=false,
     customAllValue='.+',
+    prometheusDatasourceName='datasource',
+    prometheusDatasourceLabel='Data source',
   ): {
 
        local root = self,
@@ -39,14 +41,9 @@ local utils = import '../utils.libsonnet';
          std.mapWithIndex(chainVarProto, utils.chainLabels(groupLabels + instanceLabels, [filteringSelector])),
        datasources: {
          prometheus:
-           var.datasource.new('datasource', 'prometheus')
-           + var.datasource.generalOptions.withLabel('Data source')
+           var.datasource.new(prometheusDatasourceName, 'prometheus')
+           + var.datasource.generalOptions.withLabel(prometheusDatasourceLabel)
            + var.datasource.withRegex(''),
-         loki:
-           var.datasource.new('loki_datasource', 'loki')
-           + var.datasource.generalOptions.withLabel('Loki data source')
-           + var.datasource.withRegex('')
-           + var.datasource.generalOptions.showOnDashboard.withNothing(),
        },
        // Use on dashboards where multiple entities can be selected, like fleet dashboards
        multiInstance:
@@ -69,11 +66,14 @@ local utils = import '../utils.libsonnet';
      }
      + if enableLokiLogs then self.withLokiLogs() else {},
 
-  withLokiLogs(): {
+  withLokiLogs(
+    lokiDatasourceName='loki_datasource',
+    lokiDatasourceLabel='Loki data source',
+  ): {
     datasources+: {
       loki:
-        var.datasource.new('loki_datasource', 'loki')
-        + var.datasource.generalOptions.withLabel('Loki data source')
+        var.datasource.new(lokiDatasourceName, 'loki')
+        + var.datasource.generalOptions.withLabel(lokiDatasourceLabel)
         + var.datasource.withRegex('')
         + var.datasource.generalOptions.showOnDashboard.withNothing(),
     },


### PR DESCRIPTION
Can be used to rename datasource name and label in signals:

for example:
```
local dockerlib = import './main.libsonnet';


local docker =
  dockerlib.new() +
  dockerlib.withConfigMixin(
    (import './config.libsonnet')._config
    {
      signals+: {
        machine+: {
          datasource: 'prometheus custom ds',
          datasourceLabel: 'custom_prom',
        },
        container+: {
          datasource: 'prometheus custom ds',
          datasourceLabel: 'custom_prom',
        },
      },
    },
  );

docker.asMonitoringMixin()
```