### PR TITLE
JVM Mixin: updating deprecated metric names

### DIFF
--- a/jvm-mixin/alerts.libsonnet
+++ b/jvm-mixin/alerts.libsonnet
@@ -6,7 +6,7 @@
         {
           alert: 'JvmMemoryFillingUp',
           expr: |||
-            jvm_memory_bytes_used / jvm_memory_bytes_max{area="heap"} > 0.8
+            jvm_memory_used_bytes / jvm_memory_max_bytes{area="heap"} > 0.8
           |||,
           'for': '5m',
           labels: {

--- a/jvm-mixin/jvm_rev1.libsonnet
+++ b/jvm-mixin/jvm_rev1.libsonnet
@@ -80,12 +80,12 @@
           steppedLine: false,
           targets: [
             {
-              expr: 'jvm_memory_bytes_used{job=~"$job", instance=~"$instance"}',
+              expr: 'jvm_memory_used_bytes{job=~"$job", instance=~"$instance"}',
               format: 'time_series',
               interval: '',
 
               legendFormat: '{{area}} memory [{{instance}}]',
-              metric: 'jvm_memory_bytes_used',
+              metric: 'jvm_memory_used_bytes',
               refId: 'A',
               step: 5,
             },
@@ -515,7 +515,7 @@
         multi: true,
         name: 'job',
         options: [],
-        query: 'label_values(jvm_memory_bytes_used,job)',
+        query: 'label_values(jvm_memory_used_bytes,job)',
         refresh: 1,
         regex: '',
         sort: 0,
@@ -535,7 +535,7 @@
         multi: true,
         name: 'instance',
         options: [],
-        query: 'label_values(jvm_memory_bytes_used{job=~"$job"},instance)',
+        query: 'label_values(jvm_memory_used_bytes{job=~"$job"},instance)',
         refresh: 1,
         regex: '',
         sort: 0,


### PR DESCRIPTION
Some metric names got updated, so we need to update the mixin.

Metric names reference: https://prometheus.github.io/client_java/instrumentation/jvm/#jvm-memory-metrics

Fixes https://github.com/grafana/cloud-onboarding/issues/6599