### PR TITLE
WIP: Updates Alerts, README, Config. VM Dashboard finished.

### DIFF
--- a/vsphere/README.md
+++ b/vsphere/README.md
@@ -4,8 +4,8 @@ The vSphere mixin is a set of configurable Grafana dashboards and alerts.
 
 The vSphere mixin contains the following dashboards:
 
-- vSphere cluster
 - vSphere overview
+- vSphere cluster
 - vSphere hosts
 - vSphere virtual machines
 - vSphere logs
@@ -18,33 +18,35 @@ and the following alerts:
 - VSphereDatastoreCriticalDiskUtilization
 - VSphereHostWarningHighPacketErrors
 
-## vSphere clusters
-
-The vSphere clusters dashboard provides details on cluster CPU and memory while giving a high-level view of hosts and VMs.
-
-![vSphere clusters dashboard]()
-
 ## vSphere overview
 
-The vSphere overview dashboard provides details on CPU, memory, resource pools, ESXi hosts, and datastores.
+The vSphere overview dashboard provides both overview and CPU, memory, network throughput details for clusters, resource pools, ESXi hosts, and datastores.
 
 ![vSphere overview dashboard]()
 
+## vSphere clusters
+
+The vSphere clusters dashboard provides details on cluster and resource pool CPU and memory while giving a high-level view of resource pools, ESXi hosts and VMs.
+
+![vSphere clusters dashboard]()
+
 ## vSphere hosts
 
-The vSphere hosts dashboard provides details on CPU, memory, network, disks, and VMs.
+The vSphere hosts dashboard provides details on ESXi host CPU, memory, network, disks, and VMs.
 
 ![vSphere hosts dashboard]()
 
 ## vSphere virtual machines
 
-The vSphere virtual machines dashboard provides details on CPU, memory, network, and disks.
+The vSphere virtual machines dashboard provides details on VM CPU, memory, network, and disks.
 
 ![vSphere virtual machines dashboard]()
 
 ## vSphere logs
 
 The vSphere logs dashboard provides details on the vSphere system. [Promtail and Loki needs to be installed](https://grafana.com/docs/loki/latest/installation/) and provisioned for logs with your Grafana instance.
+
+In addition, logs must be forwarded from your ESXi hosts to a vCenter server as described [here](https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-vcenter-configuration/GUID-9633A961-A5C3-4658-B099-B81E0512DC21.html).
 
 ![vSphere logs dashboard]()
 
@@ -68,11 +70,11 @@ In order for the selectors to properly work for system logs ingested into your l
 
 | Alert                                   | Summary                                                                                                                                                                                   |
 | --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| VSphereHostInfoCPUUtilization           | CPU is approaching a high threshold of utilization for an ESXi host. High CPU utilization may lead to performance degradation and potential downtime.                                     |
-| VSphereHostWarningMemoryUtilization     | Memory is approaching a high threshold of utilization for an ESXi host. High memory utilization may cause the host to become unresponsive and impact the performance of virtual machines. |
+| VSphereHostInfoCPUUtilization           | CPU is approaching a high threshold of utilization for an ESXi host. High CPU utilization may lead to performance degradation and potential downtime for virtual machines running on this host.                                     |
+| VSphereHostWarningMemoryUtilization     | Memory is approaching a high threshold of utilization for an ESXi host. High memory utilization may cause the host to become unresponsive and impact the performance of virtual machines running on this host. |
 | VSphereDatastoreWarningDiskUtilization  | Disk space is approaching a warning threshold of utilization for a datastore. Low disk space may prevent virtual machines from functioning properly and cause data loss.                  |
-| VSphereDatastoreCriticalDiskUtilization | Disk space is approaching a critical threshold of utilization for a datastore. Critically low disk space may cause virtual machines to crash and result in significant data loss.         |
-| VSphereHostWarningHighPacketErrors      | High percentage of packet errors seen for ESXi host. High packet errors may indicate network issues that can lead to poor performance and connectivity problems for virtual machines.     |
+| VSphereDatastoreCriticalDiskUtilization | Disk space is approaching a critical threshold of utilization for a datastore. Low disk space may prevent virtual machines from functioning properly and cause data loss.         |
+| VSphereHostWarningHighPacketErrors      | High percentage of packet errors seen for ESXi host. High packet errors may indicate network issues that can lead to poor performance and connectivity problems for virtual machines running on this host.     |
 
 Default thresholds can be configured in `config.libsonnet`
 

--- a/vsphere/alerts.libsonnet
+++ b/vsphere/alerts.libsonnet
@@ -15,7 +15,7 @@
               severity: 'info',
             },
             annotations: {
-              summary: 'CPU is approaching a high threshold of utilization for an ESXi host. High CPU utilization may lead to performance degradation and potential downtime.',
+              summary: 'CPU is approaching a high threshold of utilization for an ESXi host. High CPU utilization may lead to performance degradation and potential downtime for virtual machines running on a host.',
               description: |||
                 The CPU utilization of the host system {{ $labels.vcenter_host_name }} is now above %(alertsHighCPUUtilization)s%%. The current value is {{ $value | printf "%%.2f" }}%%.
               ||| % this.config,
@@ -31,7 +31,7 @@
               severity: 'warning',
             },
             annotations: {
-              summary: 'Memory is approaching a high threshold of utilization for an ESXi host. High memory utilization may cause the host to become unresponsive and impact the performance of virtual machines.',
+              summary: 'Memory is approaching a high threshold of utilization for an ESXi host. High memory utilization may cause the host to become unresponsive and impact the performance of virtual machines running on this host.',
               description: |||
                 The memory utilization of the host system {{ $labels.vcenter_host_name }} is now above %(alertsHighMemoryUtilization)s%%. The current value is {{ $value | printf "%%.2f" }}%%.
               ||| % this.config,
@@ -63,7 +63,7 @@
               severity: 'critical',
             },
             annotations: {
-              summary: 'Disk space is approaching a critical threshold of utilization for a datastore. Critically low disk space may cause virtual machines to crash and result in significant data loss.',
+              summary: 'Disk space is approaching a critical threshold of utilization for a datastore. Low disk space may prevent virtual machines from functioning properly and cause data loss.',
               description: |||
                 The disk utilization of the datastore {{ $labels.vcenter_datastore_name }} is now above %(alertsCriticalDiskUtilization)s%%. The current value is {{ $value | printf "%%.2f" }}%%.
               ||| % this.config,
@@ -72,14 +72,14 @@
           {
             alert: 'VSphereHostWarningHighPacketErrors',
             expr: |||
-              100 * sum without (job, direction, object) (vcenter_host_network_packet_errors{%(filteringSelector)s}) / sum without (job, direction, object) (vcenter_host_network_packet_count{%(filteringSelector)s}) > %(alertsHighPacketErrors)s
+              100 * sum without (direction, object) (vcenter_host_network_packet_errors{%(filteringSelector)s}) / clamp_min(sum without (direction, object) (vcenter_host_network_packet_count{%(filteringSelector)s}), 1) > %(alertsHighPacketErrors)s
             ||| % this.config,
             'for': '5m',
             labels: {
               severity: 'warning',
             },
             annotations: {
-              summary: 'High percentage of packet errors seen for ESXi host. High packet errors may indicate network issues that can lead to poor performance and connectivity problems for virtual machines.',
+              summary: 'High percentage of packet errors seen for ESXi host. High packet errors may indicate network issues that can lead to poor performance and connectivity problems for virtual machines running on this host.',
               description: |||
                 The percentage of packet errors on the ESXi host {{ $labels.vcenter_host_name }} is now above %(alertsHighPacketErrors)s%%. The current value is {{ $value | printf "%%.2f" }}%%.
               ||| % this.config,

--- a/vsphere/config.libsonnet
+++ b/vsphere/config.libsonnet
@@ -2,11 +2,9 @@
   // Static selector to apply to ALL dashboard variables of type query, panel queries, alerts and recording rules.
   filteringSelector: 'job=~"integrations/vsphere"',
   // Used to identify 'group' of instances.
-  groupLabels: ['job', 'vcenter_datacenter_name', 'vcenter_cluster_name'],
-  hostLabels: ['vcenter_host_name'],
-  resourcePoolLabels: ['vcenter_resource_pool_name'],
+  groupLabels: ['job', 'vcenter_datacenter_name'],
   datastoreLabels: ['job', 'vcenter_datacenter_name'],
-  virtualMachineLabels: ['vcenter_vm_name'],
+  virtualMachineLabels: ['vcenter_cluster_name', 'vcenter_host_name', 'vcenter_resource_pool_inventory_path', 'vcenter_virtual_app_inventory_path', 'vcenter_vm_name'],
   // Prefix all dashboards uids and alert groups
   uid: 'vSphere',
   // Prefix for all Dashboards and (optional) rule groups
@@ -17,12 +15,12 @@
   dashboardRefresh: '1m',
 
   // Alert thresholds
-
   alertsHighCPUUtilization: 90,
   alertsHighMemoryUtilization: 90,
   alertsWarningDiskUtilization: 75,
   alertsCriticalDiskUtilization: 90,
   alertsHighPacketErrors: 20,
+  
   // Logs lib related
   // Set to false to disable logs dashboard and logs annotations
   enableLokiLogs: true,

--- a/vsphere/dashboards.libsonnet
+++ b/vsphere/dashboards.libsonnet
@@ -107,8 +107,10 @@ local logslib = import 'logs-lib/logs/main.libsonnet';
               panels.vmMemoryUtilization,
               panels.vmModifiedMemory { gridPos+: { w: 24 } },
               panels.vmNetworkThroughputRate,
-              panels.vmPacketRate,
+              panels.vmPacketDropRate,
               g.panel.row.new('Disks row'),
+              panels.vmDiskUsage,
+              panels.vmDiskUtilization,
               panels.vmDisksTable { gridPos+: { w: 24 } },
             ], 12, 6
           )

--- a/vsphere/main.libsonnet
+++ b/vsphere/main.libsonnet
@@ -7,13 +7,11 @@ local targets = import './targets.libsonnet';
 local variables = import './variables.libsonnet';
 
 {
-
   withConfigMixin(config): {
     config+: config,
   },
 
   new(): {
-
     local this = self,
     config: config,
 


### PR DESCRIPTION
Here is a the new [VM Dashboard](https://keithschmitty.grafana.net/d/vsphere-virtual-machines-1/vsphere-virtual-machines?orgId=1&from=1716988076000&to=1716992530000&var-prometheus_datasource=grafanacloud-prom&var-job=All&var-vcenter_datacenter_name=All&var-vcenter_cluster_name=All&var-vcenter_host_name=All&var-vcenter_resource_pool_inventory_path=All&var-vcenter_virtual_app_inventory_path=All&var-vcenter_vm_name=All) with data to play with.

Off the top of my head:

- Added virtual app variable
- VM selectors show full path to not be confusing on duplicate names (pull from vapp or rpool path)
- Reworked variable dependencies (now standalone hosts show up as well)
- Reworked selectors that get put into VM dashboard queries.
- Fixed some incorrect VM dashboard queries.
- Tweaked a few alert descriptions
- Added a couple of new panels for general VM disk info
- Table for disks fixes incorrect queries. Also shows info for individual disks.

I'm going to go start making some smaller PRs into Bomin's original branch so we can getting some of his Vivify tasks completed. This should get the alerts & the VM dashboard one across the finish line at least.

