### PR TITLE
Fix windows fleet table

### DIFF
--- a/windows-observ-lib/panels.libsonnet
+++ b/windows-observ-lib/panels.libsonnet
@@ -138,7 +138,7 @@ local utils = commonlib.utils;
               options: {
                 include: {
                   //' 1' - would only match first occurence of group label, so no duplicates
-                  pattern: std.join(' 1|', this.config.groupLabels) + ' 1|' + instanceLabel + '|product|^hostname$|Value.+',
+                  pattern: std.join(' 1$|', this.config.groupLabels) + ' 1$|' + instanceLabel + '|product|^hostname$|Value.+',
                 },
               },
             },


### PR DESCRIPTION
This improves main table regex. Ensures to drop duplicated columnts with unuseful names like `job 10`, `job 11`, etc if number of metrics in table reaches that number.