### PR TITLE
Add + timeSeries.queriesSelector.withMaxDataPoints(100) to logslib

### DIFF
--- a/logs-lib/logs/panels.libsonnet
+++ b/logs-lib/logs/panels.libsonnet
@@ -27,8 +27,6 @@ function(
       + custom.withDrawStyle('bars')
       + custom.stacking.withMode('normal')
       + custom.withFillOpacity(50)
-      // should be set, otherwise interval is around 1s by default
-      + timeSeries.queryOptions.withInterval('30s')
       + options.tooltip.withMode('multi')
       + options.tooltip.withSort('desc')
       + timeSeries.standardOptions.withUnit('none')

--- a/logs-lib/logs/panels.libsonnet
+++ b/logs-lib/logs/panels.libsonnet
@@ -23,6 +23,7 @@ function(
       + timeSeries.queryOptions.withDatasource(
         logsVolumeTarget.datasource.type, logsVolumeTarget.datasource.uid
       )
+      + timeSeries.queriesSelector.withMaxDataPoints(100)
       + custom.withDrawStyle('bars')
       + custom.stacking.withMode('normal')
       + custom.withFillOpacity(50)


### PR DESCRIPTION
This controls max number of bars on the logs lib dashboard. Otherwise, they can become too thin on large intervals, putting too heavy load on backend.