### PR TITLE
Use ifHighSpeed in place of ifSpeed to accomodate interfaces faster than ~4.2Gb

### DIFF
--- a/snmp-mixin/dashboards/snmp-overview.json
+++ b/snmp-mixin/dashboards/snmp-overview.json
@@ -704,7 +704,7 @@
           "datasource": {
             "uid": "$prometheus_datasource"
           },
-          "expr": "max by (ifDescr) (ifSpeed{job_snmp=~\"$job\", instance=~\"$instance\", snmp_target=~\"$snmp_target\", ifDescr=~\"$interface\"})",
+          "expr": "max by (ifDescr) (ifHighSpeed{job_snmp=~\"$job\", instance=~\"$instance\", snmp_target=~\"$snmp_target\", ifDescr=~\"$interface\"})",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,


### PR DESCRIPTION
When showing data for interfaces faster than ~4.2Gb, the speed would be capped.

Using `ifHighSpeed` allows 10Gb+ interfaces to be correctly reported.