### PR TITLE
Apache Airflow `k8s` plugin support

### DIFF
--- a/apache-airflow-mixin/config.libsonnet
+++ b/apache-airflow-mixin/config.libsonnet
@@ -12,5 +12,9 @@
     alertsCriticalFailedDAGs: 0,
 
     enableLokiLogs: true,
+    enableMultiCluster: false,
+
+    multiclusterSelector: 'job=~"$job"',
+    airflowSelector: if self.enableMultiCluster then 'job=~"$job", cluster=~"$cluster"' else 'job=~"$job"',
   },
 }

--- a/apache-airflow-mixin/dashboards/airflow-overview.libsonnet
+++ b/apache-airflow-mixin/dashboards/airflow-overview.libsonnet
@@ -9,15 +9,17 @@ local dashboardUid = 'apache-airflow-overview';
 local promDatasourceName = 'prometheus_datasource';
 local lokiDatasourceName = 'loki_datasource';
 
-local promDatasource = {
+local getMatcher(cfg) = '%(mssqlSelector)s, instance=~"$instance"' % cfg;
+
+local promDatasource(matcher) = {
   uid: '${%s}' % promDatasourceName,
 };
 
-local lokiDatasource = {
+local lokiDatasource(matcher) = {
   uid: '${%s}' % lokiDatasourceName,
 };
 
-local dagFileParsingErrorsPanel = {
+local dagFileParsingErrorsPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
@@ -98,7 +100,7 @@ local dagFileParsingErrorsPanel = {
   },
 };
 
-local slaMissesPanel = {
+local slaMissesPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
@@ -180,7 +182,7 @@ local slaMissesPanel = {
   },
 };
 
-local taskFailuresPanel = {
+local taskFailuresPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
@@ -262,7 +264,7 @@ local taskFailuresPanel = {
   },
 };
 
-local dagSuccessDurationPanel = {
+local dagSuccessDurationPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
@@ -343,7 +345,7 @@ local dagSuccessDurationPanel = {
   },
 };
 
-local dagFailedDurationPanel = {
+local dagFailedDurationPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
@@ -424,7 +426,7 @@ local dagFailedDurationPanel = {
   },
 };
 
-local taskDurationPanel = {
+local taskDurationPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
@@ -476,7 +478,7 @@ local taskDurationPanel = {
   transformations: [],
 };
 
-local taskCountSummaryPanel = {
+local taskCountSummaryPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
@@ -526,7 +528,7 @@ local taskCountSummaryPanel = {
   },
 };
 
-local taskCountsPanel = {
+local taskCountsPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
@@ -605,7 +607,7 @@ local taskCountsPanel = {
   pluginVersion: '9.2.3',
 };
 
-local taskLogsPanel = {
+local taskLogsPanel(matcher) = {
   datasource: lokiDatasource,
   targets: [
     {
@@ -639,7 +641,7 @@ local schedulerDetailsRow = {
   collapsed: false,
 };
 
-local dagScheduleDelayPanel = {
+local dagScheduleDelayPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
@@ -720,7 +722,7 @@ local dagScheduleDelayPanel = {
   },
 };
 
-local schedulerTasksPanel = {
+local schedulerTasksPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
@@ -806,7 +808,7 @@ local schedulerTasksPanel = {
   },
 };
 
-local executorTasksPanel = {
+local executorTasksPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
@@ -897,7 +899,7 @@ local executorTasksPanel = {
   },
 };
 
-local poolTaskSlotsPanel = {
+local poolTaskSlotsPanel(matcher) = {
   datasource: promDatasource,
   targets: [
     prometheus.target(
@@ -993,7 +995,7 @@ local poolTaskSlotsPanel = {
   },
 };
 
-local schedulerLogsPanel = {
+local schedulerLogsPanel(matcher) = {
   datasource: lokiDatasource,
   targets: [
     {

--- a/apache-airflow-mixin/dashboards/airflow-overview.libsonnet
+++ b/apache-airflow-mixin/dashboards/airflow-overview.libsonnet
@@ -11,11 +11,11 @@ local lokiDatasourceName = 'loki_datasource';
 
 local getMatcher(cfg) = '%(mssqlSelector)s, instance=~"$instance"' % cfg;
 
-local promDatasource(matcher) = {
+local promDatasource = {
   uid: '${%s}' % promDatasourceName,
 };
 
-local lokiDatasource(matcher) = {
+local lokiDatasource = {
   uid: '${%s}' % lokiDatasourceName,
 };
 

--- a/apache-airflow-mixin/dashboards/airflow-overview.libsonnet
+++ b/apache-airflow-mixin/dashboards/airflow-overview.libsonnet
@@ -1081,7 +1081,7 @@ local schedulerLogsPanel(matcher) = {
             template.new(
               'instance',
               promDatasource,
-              'label_values(airflow_scheduler_tasks_executable{%(airflowSelector)s}, instance)',
+              'label_values(airflow_scheduler_tasks_executable{%(airflowSelector)s}, instance)' % $._config,
               label='Instance',
               refresh=2,
               includeAll=true,
@@ -1092,7 +1092,7 @@ local schedulerLogsPanel(matcher) = {
             template.new(
               'dag_id',
               promDatasource,
-              'label_values(airflow_task_start_total{%(airflowSelector)s, instance=~"$instance"}, dag_id)',
+              'label_values(airflow_task_start_total{%(airflowSelector)s, instance=~"$instance"}, dag_id)' % $._config,
               label='DAG',
               refresh=2,
               includeAll=true,
@@ -1103,7 +1103,7 @@ local schedulerLogsPanel(matcher) = {
             template.new(
               'task_id',
               promDatasource,
-              'label_values(airflow_task_start_total{%(airflowSelector)s, instance=~"$instance", dag_id=~"$dag_id"}, task_id)',
+              'label_values(airflow_task_start_total{%(airflowSelector)s, instance=~"$instance", dag_id=~"$dag_id"}, task_id)' % $._config,
               label='Task',
               refresh=2,
               includeAll=true,
@@ -1114,7 +1114,7 @@ local schedulerLogsPanel(matcher) = {
             template.new(
               'state',
               promDatasource,
-              'label_values(airflow_task_finish_total{%(airflowSelector)s, instance=~"$instance", dag_id=~"$dag_id", task_id=~"$task_id"}, state)',
+              'label_values(airflow_task_finish_total{%(airflowSelector)s, instance=~"$instance", dag_id=~"$dag_id", task_id=~"$task_id"}, state)' % $._config,
               label='Task state',
               refresh=2,
               includeAll=true,
@@ -1125,7 +1125,7 @@ local schedulerLogsPanel(matcher) = {
             template.new(
               'pool_name',
               promDatasource,
-              'label_values(airflow_pool_open_slots{%(airflowSelector)s, instance=~"$instance"}, pool_name)',
+              'label_values(airflow_pool_open_slots{%(airflowSelector)s, instance=~"$instance"}, pool_name)' % $._config,
               label='Pool',
               refresh=2,
               includeAll=true,


### PR DESCRIPTION
### Description
This PR updates the Apache Airflow mixin to support use with the `k8s` plugin.

### Changes
* [default enableMultiCluster to false, add selectors](https://github.com/grafana/jsonnet-libs/commit/b96313a3c1a60bcca781e8f9869b8594a07d2a71)
* [panels take in matcher as argument](https://github.com/grafana/jsonnet-libs/commit/da6a35d9c2fd4214e8e57c839873d42fa1342096)
* [fixed typo](https://github.com/grafana/jsonnet-libs/commit/e81b882ce679312660823d0ac095738fadfec01d)
* [updated getMatcher and implemented it](https://github.com/grafana/jsonnet-libs/commit/8315bec154767a7937113768893c0e0ffef26618)
* [added config syntax to end of label_values where necessary](https://github.com/grafana/jsonnet-libs/commit/87ffb17b392e2ad9190a9fc31571e21d0804c5d1)