### PR TITLE
Fix typo in Dashboards

### DIFF
--- a/mongodb-mixin/dashboards/MongoDB_Cluster.json
+++ b/mongodb-mixin/dashboards/MongoDB_Cluster.json
@@ -1591,7 +1591,7 @@
           "refId": "A"
         }
       ],
-      "title": "Currrent Connections per Instance",
+      "title": "Current Connections per Instance",
       "type": "timeseries"
     },
     {
@@ -1672,7 +1672,7 @@
           "refId": "A"
         }
       ],
-      "title": "Currrent Connections per Instance",
+      "title": "Current Connections per Instance",
       "type": "timeseries"
     },
     {
@@ -1834,7 +1834,7 @@
           "refId": "A"
         }
       ],
-      "title": "Currrent Connections per Shard",
+      "title": "Current Connections per Shard",
       "type": "timeseries"
     },
     {


### PR DESCRIPTION
I'm a customer using Grafana Cloud. Found this typo using the MongoDB Dashboards, so here is a quick fix.