### PR TITLE
[jaeger-agent-mixin] Add a container name resource attribute

### DIFF
--- a/jaeger-agent-mixin/jaeger.libsonnet
+++ b/jaeger-agent-mixin/jaeger.libsonnet
@@ -5,6 +5,7 @@ local k = import 'ksonnet-util/kausal.libsonnet';
     cluster: error 'Must define a cluster',
     namespace: error 'Must define a namespace',
     jaeger_agent_host: null,
+    //TODO: Deprecate with_otel_resource_attrs. All traces colleciton should use OTel semantics.
     with_otel_resource_attrs: false,
   },
 
@@ -14,13 +15,18 @@ local k = import 'ksonnet-util/kausal.libsonnet';
     if $._config.jaeger_agent_host == null
     then {}
     else
-      local jaegerTags = if $._config.with_otel_resource_attrs then
-        'namespace=%s,service.namespace=%s,cluster=%s' % [$._config.namespace, $._config.namespace, $._config.cluster]
-      else
-        'namespace=%s,cluster=%s' % [$._config.namespace, $._config.cluster];
-      container.withEnvMixin([
-        container.envType.new('JAEGER_AGENT_HOST', $._config.jaeger_agent_host),
-        container.envType.new('JAEGER_TAGS', jaegerTags),
-        container.envType.new('JAEGER_SAMPLER_MANAGER_HOST_PORT', 'http://%s:5778/sampling' % $._config.jaeger_agent_host),
-      ]),
+      {
+        local containerAttributes = if 'name' in self then ',k8s.container.name=%s' % self.name else '',
+
+        local jaegerTags = if $._config.with_otel_resource_attrs then
+          ('namespace=%s,service.namespace=%s,cluster=%s' % [$._config.namespace, $._config.namespace, $._config.cluster])
+          + containerAttributes
+        else
+          'namespace=%s,cluster=%s' % [$._config.namespace, $._config.cluster] + containerAttributes,
+        env+: [
+          { name: 'JAEGER_AGENT_HOST', value: $._config.jaeger_agent_host },
+          { name: 'JAEGER_TAGS', value: jaegerTags },
+          { name: 'JAEGER_SAMPLER_MANAGER_HOST_PORT', value: 'http://%s:5778/sampling' % $._config.jaeger_agent_host },
+        ],
+      },
 }

--- a/jaeger-agent-mixin/test.jsonnet
+++ b/jaeger-agent-mixin/test.jsonnet
@@ -1,0 +1,24 @@
+// Run tk eval test.jsonnet to see how the mixin works.
+//TODO: Add tests to the CI similar to the ones in jsonnet-libs/common-lib/common/signal/test_histogram.libsonnet
+
+local lib = (import './jaeger.libsonnet') {
+  _config+: {
+    cluster: 'CLUSTER',
+    namespace: 'NAMESPACE',
+    jaeger_agent_host: 'JAEGER_AGENT_HOST',
+    with_otel_resource_attrs: true,
+  },
+};
+
+local container = {
+  name: 'nginx',
+  image: 'nginx:1.14.2',
+  ports: [{ containerPort: 80 }],
+};
+
+{
+  _config: lib._config,
+  _mixin: lib.jaeger_mixin,
+
+  container: container + lib.jaeger_mixin,
+}


### PR DESCRIPTION
The container resource attribute is necessary so that [otelcol.processor.k8sattributes](https://grafana.com/docs/alloy/latest/reference/components/otelcol.processor.k8sattributes/) can enrich the telemetry with container attributes. Without that attribute, it will not know which container within the pod the spans are coming from.

Notice that we are adding the container attribute with OTel semantics, regardless whether `with_otel_resource_attrs` is set to `true`. I'm doing this because I'd like to deprecate `with_otel_resource_attrs` in favour of always using OTel semantics.

This is a public repository, and I hope no one in the general public depends on the fact that this mixin has been using non-OTel semantics.