### PR TITLE
CouchDB logs support for k8s plugin

### DIFF
--- a/apache-couchdb-mixin/dashboards/couchdb-nodes.libsonnet
+++ b/apache-couchdb-mixin/dashboards/couchdb-nodes.libsonnet
@@ -1219,13 +1219,37 @@ local logTypesPanel(cfg) = {
   },
 };
 
-local systemLogsPanel(cfg) = {
+local systemLogsPanel(cfg) = if cfg.enableMultiCluster then {
   datasource: lokiDatasource,
   targets: [
     {
       datasource: lokiDatasource,
       editorMode: 'code',
       expr: '{' + getMatcher(cfg) + ', filename="/var/log/couchdb/couchdb.log"} |~ "$log_level"',
+      queryType: 'range',
+      refId: 'A',
+    },
+  ],
+  type: 'logs',
+  title: 'System logs',
+  description: 'Recent logs from the Apache CouchDB logs file for a node.',
+  options: {
+    dedupStrategy: 'none',
+    enableLogDetails: true,
+    prettifyLogMessage: false,
+    showCommonLabels: false,
+    showLabels: false,
+    showTime: false,
+    sortOrder: 'Descending',
+    wrapLogMessage: false,
+  },
+} else {
+  datasource: lokiDatasource,
+  targets: [
+    {
+      datasource: lokiDatasource,
+      editorMode: 'code',
+      expr: '{' + getMatcher(cfg) + '} |~ "$log_level"',
       queryType: 'range',
       refId: 'A',
     },

--- a/apache-couchdb-mixin/dashboards/couchdb-nodes.libsonnet
+++ b/apache-couchdb-mixin/dashboards/couchdb-nodes.libsonnet
@@ -1219,7 +1219,7 @@ local logTypesPanel(cfg) = {
   },
 };
 
-local systemLogsPanel(cfg) = if cfg.enableMultiCluster then {
+local systemLogsPanel(cfg) = if !cfg.enableMultiCluster then {
   datasource: lokiDatasource,
   targets: [
     {


### PR DESCRIPTION
### Description

This PR updates the mixin to include a conditional for the `systemLogsPanel`. If `enableMultiCluster` is `true`, the `filename` label in the query is dropped.

### Changes
* [added conditional for couchdb systemLogsPanel when enableMultiCluster is true](https://github.com/grafana/jsonnet-libs/commit/a594c71bd755c898a6ae227834031b3ccbcd6a7d) 
* [fix conditional for k8s logs](https://github.com/grafana/jsonnet-libs/commit/51c9294237e40af6fc85c192970cdbb13d3a9b9b)