### PR TITLE
[jaeger-agent-mixin] Align with OTel semantics, add additional Jaeger params.

### DIFF
--- a/jaeger-agent-mixin/test.jsonnet
+++ b/jaeger-agent-mixin/test.jsonnet
@@ -6,6 +6,8 @@ local lib = (import './jaeger.libsonnet') {
     cluster: 'CLUSTER',
     namespace: 'NAMESPACE',
     jaeger_agent_host: 'JAEGER_AGENT_HOST',
+    jaeger_sampler_type: 'const',
+    jaeger_sampler_param: '1',
     with_otel_resource_attrs: true,
     with_otel_container_resource_attrs: true,
   },


### PR DESCRIPTION
Updating this public repo so that the resource attributes which `jaeger-agent-mixin` uses for enrichment of traces align better with OTel semantics. This PR will also add additional `JAEGER_SAMPLER_TYPE` and `JAEGER_SAMPLER_PARAM` env vars if the mixin is configured to use them.