### PR TITLE
Fix: vSphere Mixin - Fixes Multiple Queries

### DIFF
--- a/vsphere-mixin/alerts.libsonnet
+++ b/vsphere-mixin/alerts.libsonnet
@@ -72,7 +72,7 @@
           {
             alert: 'VSphereHostWarningHighPacketErrors',
             expr: |||
-              100 * sum without (direction, object) (vcenter_host_network_packet_error_rate{%(filteringSelector)s}) / clamp_min(sum without (direction, object) (vcenter_host_network_packet_rate{%(filteringSelector)s}), 1) > %(alertsHighPacketErrors)s
+              100 * sum without (direction, object) (vcenter_host_network_packet_error_rate{object="",%(filteringSelector)s}) / clamp_min(sum without (direction, object) (vcenter_host_network_packet_rate{object="",%(filteringSelector)s}), 1) > %(alertsHighPacketErrors)s
             ||| % this.config,
             'for': '5m',
             labels: {

--- a/vsphere-mixin/panels.libsonnet
+++ b/vsphere-mixin/panels.libsonnet
@@ -113,17 +113,17 @@ local utils = commonlib.utils;
         commonlib.panels.generic.table.base.new(
           'Clusters table',
           targets=[
-            t.effectiveCPUClusters + g.query.prometheus.withFormat('table')
+            t.totalCPUClusters + g.query.prometheus.withFormat('table')
             + g.query.prometheus.withRange(true)
-            + g.query.prometheus.withRefId('effective_cpu')
+            + g.query.prometheus.withRefId('total_cpu')
             ,
             t.topCPUUtilizationClusters + g.query.prometheus.withFormat('table')
             + g.query.prometheus.withRange(true)
             + g.query.prometheus.withRefId('cpu_utilization')
             ,
-            t.effectiveMemoryClusters + g.query.prometheus.withFormat('table')
+            t.totalMemoryClusters + g.query.prometheus.withFormat('table')
             + g.query.prometheus.withRange(true)
-            + g.query.prometheus.withRefId('effective_memory')
+            + g.query.prometheus.withRefId('total_memory')
             ,
             t.topMemoryUtilizationClusters + g.query.prometheus.withFormat('table')
             + g.query.prometheus.withRange(true)
@@ -162,7 +162,7 @@ local utils = commonlib.utils;
           ]),
         ])
         + table.standardOptions.withOverridesMixin([
-          fieldOverride.byName.new('CPU (limit)')
+          fieldOverride.byName.new('CPU')
           + fieldOverride.byName.withProperty('custom.align', 'left')
           + table.fieldOverride.byName.withProperty('custom.width', 140)
           + fieldOverride.byName.withPropertiesFromOptions(
@@ -183,7 +183,7 @@ local utils = commonlib.utils;
           ),
         ])
         + table.standardOptions.withOverridesMixin([
-          fieldOverride.byName.new('Memory (limit)')
+          fieldOverride.byName.new('Memory')
           + fieldOverride.byName.withProperty('custom.align', 'left')
           + table.fieldOverride.byName.withProperty('custom.width', 140)
           + fieldOverride.byName.withPropertiesFromOptions(
@@ -244,9 +244,9 @@ local utils = commonlib.utils;
               include: {
                 names: [
                   'vcenter_cluster_name',
-                  'Value #effective_cpu',
+                  'Value #total_cpu',
                   'Value #cpu_utilization',
-                  'Value #effective_memory',
+                  'Value #total_memory',
                   'Value #memory_utilization',
                   'Value #hosts_active',
                   'Value #hosts_inactive',
@@ -264,9 +264,9 @@ local utils = commonlib.utils;
               excludeByName: {},
               includeByName: {},
               indexByName: {
-                'Value #effective_cpu': 2,
+                'Value #total_cpu': 2,
                 'Value #cpu_utilization': 3,
-                'Value #effective_memory': 4,
+                'Value #total_memory': 4,
                 'Value #memory_utilization': 5,
                 'Value #hosts_active': 6,
                 'Value #hosts_inactive': 7,
@@ -277,9 +277,9 @@ local utils = commonlib.utils;
                 'vcenter_datacenter_name 1': 0,
               },
               renameByName: {
-                'Value #effective_cpu': 'CPU (limit)',
+                'Value #total_cpu': 'CPU',
                 'Value #cpu_utilization': 'CPU utilization',
-                'Value #effective_memory': 'Memory (limit)',
+                'Value #total_memory': 'Memory',
                 'Value #memory_utilization': 'Memory utilization',
                 'Value #hosts_active': 'Active ESXi',
                 'Value #hosts_inactive': 'Inactive ESXi',
@@ -434,7 +434,7 @@ local utils = commonlib.utils;
 
       topMemoryUtilizationHosts:
         commonlib.panels.generic.timeSeries.base.new(
-          'Top memory usage by ESXi hosts',
+          'Top memory utilization by ESXi hosts',
           targets=[t.topMemoryUtilizationHosts],
           description='The ESXi hosts with the highest memory utilization in the datacenter.'
         )

--- a/vsphere-mixin/panels.libsonnet
+++ b/vsphere-mixin/panels.libsonnet
@@ -311,6 +311,7 @@ local utils = commonlib.utils;
           ],
           description='Information about the datastores in the vCenter environment.'
         )
+        + table.standardOptions.withNoValue('NA')
         + table.standardOptions.withOverridesMixin([
           fieldOverride.byName.new('Disk total')
           + fieldOverride.byName.withProperty('custom.align', 'left')
@@ -728,6 +729,7 @@ local utils = commonlib.utils;
           ],
           description='Information about the disks associated with the ESXi hosts.'
         )
+        + table.standardOptions.withNoValue('NA')
         + table.standardOptions.withOverridesMixin([
           fieldOverride.byName.new('Throughput (R)')
           + fieldOverride.byName.withProperty('custom.align', 'left')
@@ -909,6 +911,7 @@ local utils = commonlib.utils;
           ],
           description='Information about the disks associated with the virtual machines.'
         )
+        + table.standardOptions.withNoValue('NA')
         + table.standardOptions.withOverridesMixin([
           fieldOverride.byName.new('Throughput (R)')
           + fieldOverride.byName.withProperty('custom.align', 'left')

--- a/vsphere-mixin/targets.libsonnet
+++ b/vsphere-mixin/targets.libsonnet
@@ -83,28 +83,28 @@ local utils = commonlib.utils {
     topCPUUtilizationClusters:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'topk ($top_resource_count, (100 * %(clusterSumBy)s (vcenter_host_cpu_usage_MHz{vcenter_cluster_name!="",%(queriesSelector)s}) / clamp_min(vcenter_cluster_cpu_effective{%(queriesSelector)s},1)))' % vars { clusterSumBy: clusterSumBy }
+        'topk ($top_resource_count, (100 * %(clusterSumBy)s (vcenter_host_cpu_usage_MHz{vcenter_cluster_name!="",%(queriesSelector)s}) / clamp_min(vcenter_cluster_cpu_limit{%(queriesSelector)s},1)))' % vars { clusterSumBy: clusterSumBy }
       )
       + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(clusterLegendLabel)),
 
     topMemoryUtilizationClusters:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'topk ($top_resource_count, (104857600 * %(clusterSumBy)s (vcenter_host_memory_usage_mebibytes{vcenter_cluster_name!="",%(queriesSelector)s}) / clamp_min(vcenter_cluster_memory_effective_bytes{%(queriesSelector)s},1)))' % vars { clusterSumBy: clusterSumBy }
+        'topk ($top_resource_count, (104857600 * %(clusterSumBy)s (vcenter_host_memory_usage_mebibytes{vcenter_cluster_name!="",%(queriesSelector)s}) / clamp_min(vcenter_cluster_memory_limit_bytes{%(queriesSelector)s},1)))' % vars { clusterSumBy: clusterSumBy }
       )
       + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(clusterLegendLabel)),
 
-    effectiveCPUClusters:
+    totalCPUClusters:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'vcenter_cluster_cpu_effective{%(queriesSelector)s}' % vars
+        'vcenter_cluster_cpu_limit{%(queriesSelector)s}' % vars
       )
       + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(clusterLegendLabel)),
 
-    effectiveMemoryClusters:
+    totalMemoryClusters:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'vcenter_cluster_memory_effective_bytes{%(queriesSelector)s}' % vars
+        'vcenter_cluster_memory_limit_bytes{%(queriesSelector)s}' % vars
       )
       + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(clusterLegendLabel)),
 
@@ -515,7 +515,7 @@ local utils = commonlib.utils {
     clusterCPUUtilization:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        '(100 * %(clusterSumBy)s (vcenter_host_cpu_usage_MHz{%(clusterQueriesSelector)s}) / clamp_min(vcenter_cluster_cpu_effective{%(clusterQueriesSelector)s}, 1))' % vars { clusterSumBy: clusterSumBy }
+        '(100 * %(clusterSumBy)s (vcenter_host_cpu_usage_MHz{%(clusterQueriesSelector)s}) / clamp_min(vcenter_cluster_cpu_limit{%(clusterQueriesSelector)s}, 1))' % vars { clusterSumBy: clusterSumBy }
       )
       + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(clusterLegendLabel)),
 
@@ -536,7 +536,7 @@ local utils = commonlib.utils {
     clusterMemoryUtilization:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        ' 104857600 * %(clusterSumBy)s (vcenter_host_memory_usage_mebibytes{%(clusterQueriesSelector)s}) / clamp_min(vcenter_cluster_memory_effective_bytes{%(clusterQueriesSelector)s}, 1)' % vars { clusterSumBy: clusterSumBy }
+        ' 104857600 * %(clusterSumBy)s (vcenter_host_memory_usage_mebibytes{%(clusterQueriesSelector)s}) / clamp_min(vcenter_cluster_memory_limit_bytes{%(clusterQueriesSelector)s}, 1)' % vars { clusterSumBy: clusterSumBy }
       )
       + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(clusterLegendLabel)),
 

--- a/vsphere-mixin/targets.libsonnet
+++ b/vsphere-mixin/targets.libsonnet
@@ -190,7 +190,7 @@ local utils = commonlib.utils {
     topPacketErrorRateHosts:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'topk ($top_resource_count, %(hostSumBy)s (vcenter_host_network_packet_error_rate{%(queriesSelector)s}) / clamp_min(%(hostSumBy)s (vcenter_host_network_packet_rate{%(queriesSelector)s}), 1))' % vars { hostSumBy: hostSumBy }
+        'topk ($top_resource_count, %(hostSumBy)s (vcenter_host_network_packet_error_rate{object="",%(queriesSelector)s}) / clamp_min(%(hostSumBy)s (vcenter_host_network_packet_rate{object="",%(queriesSelector)s}), 1))' % vars { hostSumBy: hostSumBy }
       )
       + prometheusQuery.withLegendFormat('%s' % utils.labelsToPanelLegend(hostLegendLabel)),
 
@@ -257,28 +257,28 @@ local utils = commonlib.utils {
     hostNetworkTransmittedThroughputRate:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        '%(sumWithout)s (vcenter_host_network_throughput{direction="transmitted", %(hostQueriesSelector)s})' % vars { sumWithout: sumWithout }
+        'vcenter_host_network_throughput{direction="transmitted", object="", %(hostQueriesSelector)s}' % vars
       )
       + prometheusQuery.withLegendFormat('%s - transmitted' % utils.labelsToPanelLegend(hostLegendLabel)),
 
     hostNetworkReceivedThroughputRate:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        '%(sumWithout)s (vcenter_host_network_throughput{direction="received", %(hostQueriesSelector)s})' % vars { sumWithout: sumWithout }
+        'vcenter_host_network_throughput{direction="received", object="", %(hostQueriesSelector)s}' % vars
       )
       + prometheusQuery.withLegendFormat('%s - received' % utils.labelsToPanelLegend(hostLegendLabel)),
 
     hostPacketReceivedErrorRate:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        '%(sumWithout)s (vcenter_host_network_packet_error_rate{direction="received", %(hostQueriesSelector)s}) / clamp_min(%(sumWithout)s (vcenter_host_network_packet_rate{direction="received", %(hostQueriesSelector)s}), 1) != 0' % vars { sumWithout: sumWithout }
+        'vcenter_host_network_packet_error_rate{direction="received", object="", %(hostQueriesSelector)s} / clamp_min(vcenter_host_network_packet_rate{direction="received", object="", %(hostQueriesSelector)s}, 1) != 0' % vars
       )
       + prometheusQuery.withLegendFormat('%s - received' % utils.labelsToPanelLegend(hostLegendLabel)),
 
     hostPacketTransmittedErrorRate:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        '%(sumWithout)s (vcenter_host_network_packet_error_rate{direction="transmitted", %(hostQueriesSelector)s}) / clamp_min(%(sumWithout)s (vcenter_host_network_packet_rate{direction="transmitted", %(hostQueriesSelector)s}), 1) != 0' % vars { sumWithout: sumWithout }
+        'vcenter_host_network_packet_error_rate{direction="transmitted", object="", %(hostQueriesSelector)s} / clamp_min(vcenter_host_network_packet_rate{direction="transmitted", object="", %(hostQueriesSelector)s}, 1) != 0' % vars
       )
       + prometheusQuery.withLegendFormat('%s - transmitted' % utils.labelsToPanelLegend(hostLegendLabel)),
 
@@ -345,13 +345,13 @@ local utils = commonlib.utils {
     hostVMNetworkThroughput:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'label_join(%(sumWithout)s (vcenter_vm_network_usage{%(hostNoVAppQueriesSelector)s}), "vm_path", "/", "vcenter_resource_pool_inventory_path","vcenter_vm_name") or label_join(%(sumWithout)s (vcenter_vm_network_usage{%(hostNoRPoolQueriesSelector)s}), "vm_path", "/", "vcenter_virtual_app_inventory_path","vcenter_vm_name") or label_join(%(sumWithout)s (vcenter_vm_network_usage{%(hostNoRPoolOrVAppQueriesSelector)s}), "vm_path", "/", "vcenter_vm_name")' % vars { sumWithout: sumWithout }
+        'label_join(%(sumWithoutDirection)s (vcenter_vm_network_usage{object!="", %(hostNoVAppQueriesSelector)s}), "vm_path", "/", "vcenter_resource_pool_inventory_path","vcenter_vm_name") or label_join(%(sumWithoutDirection)s (vcenter_vm_network_usage{object!="", %(hostNoRPoolQueriesSelector)s}), "vm_path", "/", "vcenter_virtual_app_inventory_path","vcenter_vm_name") or label_join(%(sumWithoutDirection)s (vcenter_vm_network_usage{object!="", %(hostNoRPoolOrVAppQueriesSelector)s}), "vm_path", "/", "vcenter_vm_name")' % vars { sumWithoutDirection: sumWithoutDirection }
       ),
 
     hostVMPacketDropRate:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'label_join(%(sumWithoutDirection)s (vcenter_vm_network_packet_drop_rate{%(hostNoVAppQueriesSelector)s}) / clamp_min(%(sumWithoutDirection)s (vcenter_vm_network_packet_rate{%(hostNoVAppQueriesSelector)s}), 1), "vm_path", "/", "vcenter_resource_pool_inventory_path","vcenter_vm_name") or label_join(%(sumWithoutDirection)s (vcenter_vm_network_packet_drop_rate{%(hostNoRPoolQueriesSelector)s}) / clamp_min(%(sumWithoutDirection)s (vcenter_vm_network_packet_rate{%(hostNoRPoolQueriesSelector)s}), 1), "vm_path", "/", "vcenter_virtual_app_inventory_path","vcenter_vm_name") or label_join(%(sumWithoutDirection)s (vcenter_vm_network_packet_drop_rate{%(hostNoRPoolOrVAppQueriesSelector)s}) / clamp_min(%(sumWithoutDirection)s (vcenter_vm_network_packet_rate{%(hostNoRPoolOrVAppQueriesSelector)s}), 1), "vm_path", "/", "vcenter_vm_name")' % vars { sumWithoutDirection: sumWithoutDirection }
+        'label_join(%(sumWithoutDirection)s (vcenter_vm_network_packet_drop_rate{object!="", %(hostNoVAppQueriesSelector)s}) / clamp_min(%(sumWithoutDirection)s (vcenter_vm_network_packet_rate{object!="", %(hostNoVAppQueriesSelector)s}), 1), "vm_path", "/", "vcenter_resource_pool_inventory_path","vcenter_vm_name") or label_join(%(sumWithoutDirection)s (vcenter_vm_network_packet_drop_rate{object!="", %(hostNoRPoolQueriesSelector)s}) / clamp_min(%(sumWithoutDirection)s (vcenter_vm_network_packet_rate{object!="", %(hostNoRPoolQueriesSelector)s}), 1), "vm_path", "/", "vcenter_virtual_app_inventory_path","vcenter_vm_name") or label_join(%(sumWithoutDirection)s (vcenter_vm_network_packet_drop_rate{object!="", %(hostNoRPoolOrVAppQueriesSelector)s}) / clamp_min(%(sumWithoutDirection)s (vcenter_vm_network_packet_rate{object!="", %(hostNoRPoolOrVAppQueriesSelector)s}), 1), "vm_path", "/", "vcenter_vm_name")' % vars { sumWithoutDirection: sumWithoutDirection }
       ),
 
     vmCPUUsage:
@@ -413,28 +413,28 @@ local utils = commonlib.utils {
     vmNetworkTransmittedThroughputRate:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        '%(sumWithout)s (vcenter_vm_network_throughput_bytes_per_sec{direction="transmitted", %(virtualMachinesQueriesSelector)s})' % vars { sumWithout: sumWithout }
+        'vcenter_vm_network_throughput_bytes_per_sec{direction="transmitted", object="", %(virtualMachinesQueriesSelector)s}' % vars
       )
       + prometheusQuery.withLegendFormat('%s - transmitted' % vmLegend),
 
     vmNetworkReceivedThroughputRate:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        '%(sumWithout)s (vcenter_vm_network_throughput_bytes_per_sec{direction="received", %(virtualMachinesQueriesSelector)s})' % vars { sumWithout: sumWithout }
+        'vcenter_vm_network_throughput_bytes_per_sec{direction="received", object="", %(virtualMachinesQueriesSelector)s}' % vars
       )
       + prometheusQuery.withLegendFormat('%s - received' % vmLegend),
 
     vmPacketReceivedDropRate:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        '%(sumWithout)s (vcenter_vm_network_packet_drop_rate{direction="received", %(virtualMachinesQueriesSelector)s}) / clamp_min(%(sumWithout)s (vcenter_vm_network_packet_rate{direction="received", %(virtualMachinesQueriesSelector)s}), 1) != 0' % vars { sumWithout: sumWithout }
+        'vcenter_vm_network_packet_drop_rate{direction="received", object="", %(virtualMachinesQueriesSelector)s} / clamp_min(vcenter_vm_network_packet_rate{direction="received", object="", %(virtualMachinesQueriesSelector)s}, 1) != 0' % vars
       )
       + prometheusQuery.withLegendFormat('%s - received' % vmLegend),
 
     vmPacketTransmittedDropRate:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        '%(sumWithout)s (vcenter_vm_network_packet_drop_rate{direction="transmitted", %(virtualMachinesQueriesSelector)s}) / clamp_min(%(sumWithout)s (vcenter_vm_network_packet_rate{direction="transmitted", %(virtualMachinesQueriesSelector)s}), 1) != 0' % vars { sumWithout: sumWithout }
+        'vcenter_vm_network_packet_drop_rate{direction="transmitted", object="", %(virtualMachinesQueriesSelector)s} / clamp_min(vcenter_vm_network_packet_rate{direction="transmitted", object="", %(virtualMachinesQueriesSelector)s}, 1) != 0' % vars
       )
       + prometheusQuery.withLegendFormat('%s - transmitted' % vmLegend),
 
@@ -567,7 +567,7 @@ local utils = commonlib.utils {
     clusterHostDiskThroughput:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        '%(sumWithoutDirection)s (vcenter_host_disk_throughput{%(clusterQueriesSelector)s})' % vars { sumWithoutDirection: sumWithoutDirection }
+        '%(sumWithoutDirection)s (vcenter_host_disk_throughput{object="",%(clusterQueriesSelector)s})' % vars { sumWithoutDirection: sumWithoutDirection }
       ),
 
     clusterHostDiskLatency:
@@ -579,13 +579,13 @@ local utils = commonlib.utils {
     clusterHostNetworkThroughput:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        '%(sumWithout)s (vcenter_host_network_usage{%(clusterQueriesSelector)s})' % vars { sumWithout: sumWithout }
+        '%(sumWithoutDirection)s (vcenter_host_network_usage{object="",%(clusterQueriesSelector)s})' % vars { sumWithoutDirection: sumWithoutDirection }
       ),
 
     clusterHostPacketErrorRate:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        '%(sumWithoutDirection)s (vcenter_host_network_packet_error_rate{%(clusterQueriesSelector)s}) / clamp_min(%(sumWithoutDirection)s (vcenter_host_network_packet_rate{%(clusterQueriesSelector)s}), 1)' % vars { sumWithoutDirection: sumWithoutDirection }
+        '%(sumWithoutDirection)s (vcenter_host_network_packet_error_rate{object="",%(clusterQueriesSelector)s}) / clamp_min(%(sumWithoutDirection)s (vcenter_host_network_packet_rate{object="",%(clusterQueriesSelector)s}), 1)' % vars { sumWithoutDirection: sumWithoutDirection }
       ),
 
     clusterVMCPUUsage:
@@ -627,13 +627,13 @@ local utils = commonlib.utils {
     clusterVMNetworkThroughput:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'label_join(%(sumWithout)s (vcenter_vm_network_usage{%(clusterNoVAppQueriesSelector)s}), "vm_path", "/", "vcenter_resource_pool_inventory_path","vcenter_vm_name") or label_join(%(sumWithout)s (vcenter_vm_network_usage{%(clusterNoRPoolQueriesSelector)s}), "vm_path", "/", "vcenter_virtual_app_inventory_path","vcenter_vm_name") or label_join(%(sumWithout)s (vcenter_vm_network_usage{%(clusterNoRPoolOrVAppQueriesSelector)s}), "vm_path", "/", "vcenter_vm_name")' % vars { sumWithout: sumWithout }
+        'label_join(%(sumWithoutDirection)s (vcenter_vm_network_usage{object="",%(clusterNoVAppQueriesSelector)s}), "vm_path", "/", "vcenter_resource_pool_inventory_path","vcenter_vm_name") or label_join(%(sumWithoutDirection)s (vcenter_vm_network_usage{object="",%(clusterNoRPoolQueriesSelector)s}), "vm_path", "/", "vcenter_virtual_app_inventory_path","vcenter_vm_name") or label_join(%(sumWithoutDirection)s (vcenter_vm_network_usage{object="",%(clusterNoRPoolOrVAppQueriesSelector)s}), "vm_path", "/", "vcenter_vm_name")' % vars { sumWithoutDirection: sumWithoutDirection }
       ),
 
     clusterVMPacketDropRate:
       prometheusQuery.new(
         '${' + vars.datasources.prometheus.name + '}',
-        'label_join(%(sumWithoutDirection)s (vcenter_vm_network_packet_drop_rate{%(clusterNoVAppQueriesSelector)s}) / clamp_min(%(sumWithoutDirection)s (vcenter_vm_network_packet_rate{%(clusterNoVAppQueriesSelector)s}), 1), "vm_path", "/", "vcenter_resource_pool_inventory_path", "vcenter_vm_name") or label_join(%(sumWithoutDirection)s (vcenter_vm_network_packet_drop_rate{%(clusterNoRPoolQueriesSelector)s}) / clamp_min(%(sumWithoutDirection)s (vcenter_vm_network_packet_rate{%(clusterNoRPoolQueriesSelector)s}), 1), "vm_path", "/", "vcenter_virtual_app_inventory_path","vcenter_vm_name") or label_join(%(sumWithoutDirection)s (vcenter_vm_network_packet_drop_rate{%(clusterNoRPoolOrVAppQueriesSelector)s}) / clamp_min(%(sumWithoutDirection)s (vcenter_vm_network_packet_rate{%(clusterNoRPoolOrVAppQueriesSelector)s}), 1), "vm_path", "/", "vcenter_vm_name")' % vars { sumWithoutDirection: sumWithoutDirection }
+        'label_join(%(sumWithoutDirection)s (vcenter_vm_network_packet_drop_rate{object="",%(clusterNoVAppQueriesSelector)s}) / clamp_min(%(sumWithoutDirection)s (vcenter_vm_network_packet_rate{object="",%(clusterNoVAppQueriesSelector)s}), 1), "vm_path", "/", "vcenter_resource_pool_inventory_path", "vcenter_vm_name") or label_join(%(sumWithoutDirection)s (vcenter_vm_network_packet_drop_rate{object="",%(clusterNoRPoolQueriesSelector)s}) / clamp_min(%(sumWithoutDirection)s (vcenter_vm_network_packet_rate{object="",%(clusterNoRPoolQueriesSelector)s}), 1), "vm_path", "/", "vcenter_virtual_app_inventory_path","vcenter_vm_name") or label_join(%(sumWithoutDirection)s (vcenter_vm_network_packet_drop_rate{object="",%(clusterNoRPoolOrVAppQueriesSelector)s}) / clamp_min(%(sumWithoutDirection)s (vcenter_vm_network_packet_rate{object="",%(clusterNoRPoolOrVAppQueriesSelector)s}), 1), "vm_path", "/", "vcenter_vm_name")' % vars { sumWithoutDirection: sumWithoutDirection }
       ),
   },
 }


### PR DESCRIPTION
Alert fixed to not aggregate both `object` label and already pre-aggregated non `object` label metric values together.

Fixes a number of aggregated queries where aggregation wasn't needed (stopped aggregating `object` label metric values when there was already a pre-aggregated non `object` label metric value).

Also changes a few utilization calculations to use a better metric ("limit" vs "effective") in the denominator (more appropriate and no longer get > 100% values).

Some other minor naming tweaks to panels.

New dashboards should be uploaded [here](https://keithschmitty.grafana.net/dashboards/f/ddmbphlezuku8d/final-vsphere)