### PR TITLE
Varnish `k8s` plugin support

### DIFF
--- a/varnish-mixin/README.md
+++ b/varnish-mixin/README.md
@@ -54,6 +54,20 @@ scrape_configs:
           __path__: /var/log/varnish/varnishncsa*.log*
 ```
 
+#### Varnish Cache logs in Kubernetes
+
+To collect logs from Varnish Cache when running in a kubernetes environment, `varnishncsa` and Alloy sidecars must be added to the deployment configuration. Additional ConfigMaps for custom Alloy configurations must be created. The deployment will need an additional volume for logs and all sidecars will need `volumeMounts` for that volume.
+
+For `varnishncsa` to run, the log file needs to already exist. This can be accomplished with an `initContainer`. 
+
+The `varnishncsa` sidecars need to run as a user with the appropriate permissions to write to the log file(s). If there are
+frontend and backend logs, two separate sidecars will need to be defined, customized to start `varnishncsa` with the appropriate flags.
+
+Refer to [this documentation](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/integrations/integration-reference/integration-varnish-cache/#set-up-varnish-cache-logging) for more information on the commands and flags needed for frontend/backend logging. Additionally, for further details on varnishncsa refer to [this documentation](https://varnish-cache.org/docs/trunk/reference/varnishncsa.html).
+
+A single Alloy sidecar with a custom configuration can be defined to collect all the logs, assuming the appropriate volumes are 
+mounted and that the log files are all located in the same location.
+
 ## Alerts overview
 
 | Alert                             | Summary                                                                             |

--- a/varnish-mixin/README.md
+++ b/varnish-mixin/README.md
@@ -58,7 +58,14 @@ scrape_configs:
 
 To collect logs from Varnish Cache when running in a kubernetes environment, `varnishncsa` and Alloy sidecars must be added to the deployment configuration. Additional ConfigMaps for custom Alloy configurations must be created. The deployment will need an additional volume for logs and all sidecars will need `volumeMounts` for that volume.
 
-For `varnishncsa` to run, the log file needs to already exist. This can be accomplished with an `initContainer`. 
+> For `varnishncsa` to run, the log file needs to already exist. This can be accomplished with an `initContainer`.
+
+The mixin is expecting `filename` to match with the following regex patterns for frontend and/or backend logs:
+```regex
+/var/log/varnish/varnishncsa-frontend.*.log|/opt/varnish/log/varnishncsa-frontend.*.log
+/var/log/varnish/varnishncsa-backend.*.log|/opt/varnish/log/varnishncsa-backend.*.log
+```
+It is necessary for the log location in your deployment to match these patterns.
 
 The `varnishncsa` sidecars need to run as a user with the appropriate permissions to write to the log file(s). If there are
 frontend and backend logs, two separate sidecars will need to be defined, customized to start `varnishncsa` with the appropriate flags.

--- a/varnish-mixin/config.libsonnet
+++ b/varnish-mixin/config.libsonnet
@@ -13,5 +13,8 @@
     alertsCriticalSessionsDropped: 0,
     alertsCriticalBackendUnhealthy: 0,
     enableLokiLogs: true,
+    enableMultiCluster: false,
+    multiclusterSelector: 'job=~"$job"',
+    varnishSelector: if self.enableMultiCluster then 'job=~"$job", cluster=~"$cluster"' else 'job=~"$job"',
   },
 }

--- a/varnish-mixin/dashboards/varnish-overview.libsonnet
+++ b/varnish-mixin/dashboards/varnish-overview.libsonnet
@@ -1174,7 +1174,7 @@ local frontendLogsPanel(matcher) = {
     {
       datasource: lokiDatasource,
       editorMode: 'code',
-      expr: '{' + matcher + '} |= `` | (' + frontendLogFilter + ' or log_type="frontend")',
+      expr: '{' + matcher + ', ' + frontendLogFilter + '}',
       queryType: 'range',
       refId: 'A',
     },
@@ -1200,7 +1200,7 @@ local backendLogsPanel(matcher) = {
     {
       datasource: lokiDatasource,
       editorMode: 'code',
-      expr: '{' + matcher + '} |= `` | (' + backendLogFilter + ' or log_type="backend")',
+      expr: '{' + matcher + ', ' + backendLogFilter + '}',
       queryType: 'range',
       refId: 'A',
     },

--- a/varnish-mixin/dashboards/varnish-overview.libsonnet
+++ b/varnish-mixin/dashboards/varnish-overview.libsonnet
@@ -1262,7 +1262,7 @@ local backendLogsPanel(matcher) = {
               refresh=2,
               includeAll=true,
               multi=true,
-              allValues='',
+              allValues='.+',
               sort=0
             ),
             template.new(
@@ -1285,7 +1285,7 @@ local backendLogsPanel(matcher) = {
               refresh=2,
               includeAll=true,
               multi=true,
-              allValues='',
+              allValues='.+',
               sort=0
             ),
           ],

--- a/varnish-mixin/dashboards/varnish-overview.libsonnet
+++ b/varnish-mixin/dashboards/varnish-overview.libsonnet
@@ -1266,9 +1266,21 @@ local backendLogsPanel(matcher) = {
               sort=0
             ),
             template.new(
+              'cluster',
+              promDatasource,
+              'label_values(varnish_main_sessions{%(multiclusterSelector)s}, cluster)' % $._config,
+              label='Cluster',
+              refresh=2,
+              includeAll=true,
+              multi=true,
+              allValues='.*',
+              hide=if $._config.enableMultiCluster then '' else 'variable',
+              sort=0
+            ),
+            template.new(
               'instance',
               promDatasource,
-              'label_values(varnish_main_sessions,instance)',
+              'label_values(varnish_main_sessions{%(multiclusterSelector)s},instance)' % $._config,
               label='Instance',
               refresh=2,
               includeAll=true,

--- a/varnish-mixin/dashboards/varnish-overview.libsonnet
+++ b/varnish-mixin/dashboards/varnish-overview.libsonnet
@@ -1280,7 +1280,7 @@ local backendLogsPanel(matcher) = {
             template.new(
               'instance',
               promDatasource,
-              'label_values(varnish_main_sessions{%(multiclusterSelector)s},instance)' % $._config,
+              'label_values(varnish_main_sessions{%(varnishSelector)s},instance)' % $._config,
               label='Instance',
               refresh=2,
               includeAll=true,


### PR DESCRIPTION
### Description
This PR updates the Varnish mixin to support the `k8s` plugin

Logs for this integration required sidecar forwarding and having `alloy` read from an actual file on the container's filesystem, rather than reading logs from the container's `stdout`. With this, even though it's `k8s` we're still going to have a `filename` label and it makes sense here.

### Changes
* [add selectors to config and updated dashboard](https://github.com/grafana/jsonnet-libs/commit/e3b9af484f79ad5e128de4faa25d72e194fb7d18)
* [updated overview dashboard filter labels](https://github.com/grafana/jsonnet-libs/commit/0da2899ff6d1743788cdbeb620ce0b134d547c55)
* [update allValues to .+ for job and instance labels](https://github.com/grafana/jsonnet-libs/commit/ddb6429f53bc12af7f0c9d64160f3588f88bce29)
* [removed log_type because filename is present in a k8s context due to the nature of log collection](https://github.com/grafana/jsonnet-libs/commit/68f1375eac90119f083e1572f9dcd1be154c8487) 

