### PR TITLE
grafana-builder: add support for native/classic stat panel query

### DIFF
--- a/grafana-builder/grafana.libsonnet
+++ b/grafana-builder/grafana.libsonnet
@@ -332,17 +332,25 @@ local utils = import 'mixin-utils/utils.libsonnet';
   },
 
   statPanel(query, format='percentunit'):: {
+    local isNativeClassic = utils.isNativeClassicQuery(query),
     type: 'singlestat',
     thresholds: '70,80',
     format: format,
     targets: [
       {
-        expr: query,
+        expr: if isNativeClassic then utils.showClassicHistogramQuery(query) else query,
+        format: 'time_series',
+        instant: true,
+        refId: if isNativeClassic then 'A_classic' else 'A',
+      },
+    ] + if isNativeClassic then [
+      {
+        expr: utils.showNativeHistogramQuery(query),
         format: 'time_series',
         instant: true,
         refId: 'A',
       },
-    ],
+    ] else [],
   },
 
   tablePanel(queries, labelStyles):: {

--- a/mixin-utils/utils.libsonnet
+++ b/mixin-utils/utils.libsonnet
@@ -1,6 +1,8 @@
 local g = import 'grafana-builder/grafana.libsonnet';
 
 {
+  isNativeClassicQuery(query):: if std.isObject(query) then std.objectHas(query, 'native') && std.objectHas(query, 'classic') else false,
+
   // The ncHistogramQuantile (native classic histogram quantile) function is
   // used to calculate histogram quantiles from native histograms or classic
   // histograms. Metric name should be provided without _bucket suffix.


### PR DESCRIPTION
Seamlessly allow using statPanel with classic/native queries.