### PR TITLE
Fix the wrong utils.ncHistogramLeRate implementation

### DIFF
--- a/mixin-utils/test/test_native-classic-histogram.libsonnet
+++ b/mixin-utils/test/test_native-classic-histogram.libsonnet
@@ -169,6 +169,26 @@ test.new(std.thisFile)
   )
 )
 + test.case.new(
+  name='histogram le rate defaults and le is +Inf',
+  test=test.expect.eq(
+    actual=utils.ncHistogramLeRate('request_duration_seconds', 'cluster="cluster1", job="job1"', '+Inf'),
+    expected={
+      classic: 'rate(request_duration_seconds_bucket{cluster="cluster1", job="job1", le=~"\\+Inf"}[$__rate_interval])',
+      native: 'histogram_fraction(0, +Inf, rate(request_duration_seconds{cluster="cluster1", job="job1"}[$__rate_interval]))*histogram_count(rate(request_duration_seconds{cluster="cluster1", job="job1"}[$__rate_interval]))',
+    },
+  )
+)
++ test.case.new(
+  name='histogram le rate defaults and le is -Inf',
+  test=test.expect.eq(
+    actual=utils.ncHistogramLeRate('request_duration_seconds', 'cluster="cluster1", job="job1"', '-Inf'),
+    expected={
+      classic: 'rate(request_duration_seconds_bucket{cluster="cluster1", job="job1", le=~"-Inf"}[$__rate_interval])',
+      native: 'histogram_fraction(0, -Inf, rate(request_duration_seconds{cluster="cluster1", job="job1"}[$__rate_interval]))*histogram_count(rate(request_duration_seconds{cluster="cluster1", job="job1"}[$__rate_interval]))',
+    },
+  )
+)
++ test.case.new(
   name='histogram le rate defaults and le is float with different interval',
   test=test.expect.eq(
     actual=utils.ncHistogramLeRate('request_duration_seconds', 'cluster="cluster1", job="job1"', '0.1', '5m'),

--- a/mixin-utils/test/test_native-classic-histogram.libsonnet
+++ b/mixin-utils/test/test_native-classic-histogram.libsonnet
@@ -153,7 +153,7 @@ test.new(std.thisFile)
   test=test.expect.eq(
     actual=utils.ncHistogramLeRate('request_duration_seconds', 'cluster="cluster1", job="job1"', '0.1'),
     expected={
-      classic: 'rate(request_duration_seconds_bucket{cluster="cluster1", job="job1", le=~"0.1"}[$__rate_interval])',
+      classic: 'rate(request_duration_seconds_bucket{cluster="cluster1", job="job1", le="0.1"}[$__rate_interval])',
       native: 'histogram_fraction(0, 0.1, rate(request_duration_seconds{cluster="cluster1", job="job1"}[$__rate_interval]))*histogram_count(rate(request_duration_seconds{cluster="cluster1", job="job1"}[$__rate_interval]))',
     },
   )
@@ -173,7 +173,7 @@ test.new(std.thisFile)
   test=test.expect.eq(
     actual=utils.ncHistogramLeRate('request_duration_seconds', 'cluster="cluster1", job="job1"', '+Inf'),
     expected={
-      classic: 'rate(request_duration_seconds_bucket{cluster="cluster1", job="job1", le=~"\\+Inf"}[$__rate_interval])',
+      classic: 'rate(request_duration_seconds_bucket{cluster="cluster1", job="job1", le="+Inf"}[$__rate_interval])',
       native: 'histogram_fraction(0, +Inf, rate(request_duration_seconds{cluster="cluster1", job="job1"}[$__rate_interval]))*histogram_count(rate(request_duration_seconds{cluster="cluster1", job="job1"}[$__rate_interval]))',
     },
   )
@@ -183,7 +183,7 @@ test.new(std.thisFile)
   test=test.expect.eq(
     actual=utils.ncHistogramLeRate('request_duration_seconds', 'cluster="cluster1", job="job1"', '-Inf'),
     expected={
-      classic: 'rate(request_duration_seconds_bucket{cluster="cluster1", job="job1", le=~"-Inf"}[$__rate_interval])',
+      classic: 'rate(request_duration_seconds_bucket{cluster="cluster1", job="job1", le="-Inf"}[$__rate_interval])',
       native: 'histogram_fraction(0, -Inf, rate(request_duration_seconds{cluster="cluster1", job="job1"}[$__rate_interval]))*histogram_count(rate(request_duration_seconds{cluster="cluster1", job="job1"}[$__rate_interval]))',
     },
   )
@@ -193,7 +193,7 @@ test.new(std.thisFile)
   test=test.expect.eq(
     actual=utils.ncHistogramLeRate('request_duration_seconds', 'cluster="cluster1", job="job1"', '0.1', '5m'),
     expected={
-      classic: 'rate(request_duration_seconds_bucket{cluster="cluster1", job="job1", le=~"0.1"}[5m])',
+      classic: 'rate(request_duration_seconds_bucket{cluster="cluster1", job="job1", le="0.1"}[5m])',
       native: 'histogram_fraction(0, 0.1, rate(request_duration_seconds{cluster="cluster1", job="job1"}[5m]))*histogram_count(rate(request_duration_seconds{cluster="cluster1", job="job1"}[5m]))',
     },
   )

--- a/mixin-utils/test/test_native-classic-histogram.libsonnet
+++ b/mixin-utils/test/test_native-classic-histogram.libsonnet
@@ -154,7 +154,7 @@ test.new(std.thisFile)
     actual=utils.ncHistogramLeRate('request_duration_seconds', 'cluster="cluster1", job="job1"', '0.1'),
     expected={
       classic: 'rate(request_duration_seconds_bucket{cluster="cluster1", job="job1", le="0.1"}[$__rate_interval])',
-      native: 'histogram_fraction(0, 0.1, rate(request_duration_seconds{cluster="cluster1", job="job1"}[$__rate_interval]))*histogram_count(rate(request_duration_seconds{cluster="cluster1", job="job1"}[$__rate_interval]))',
+      native: 'histogram_fraction(0, 0.1, sum (\n  rate(request_duration_seconds{cluster="cluster1", job="job1"}[$__rate_interval]))\n)\n*\nhistogram_count(sum (\n  rate(request_duration_seconds{cluster="cluster1", job="job1"}[$__rate_interval]))\n)\n',
     },
   )
 )
@@ -164,7 +164,7 @@ test.new(std.thisFile)
     actual=utils.ncHistogramLeRate('request_duration_seconds', 'cluster="cluster1", job="job1"', '10'),
     expected={
       classic: 'rate(request_duration_seconds_bucket{cluster="cluster1", job="job1", le=~"10|10\\\\.0"}[$__rate_interval])',
-      native: 'histogram_fraction(0, 10.0, rate(request_duration_seconds{cluster="cluster1", job="job1"}[$__rate_interval]))*histogram_count(rate(request_duration_seconds{cluster="cluster1", job="job1"}[$__rate_interval]))',
+      native: 'histogram_fraction(0, 10.0, sum (\n  rate(request_duration_seconds{cluster="cluster1", job="job1"}[$__rate_interval]))\n)\n*\nhistogram_count(sum (\n  rate(request_duration_seconds{cluster="cluster1", job="job1"}[$__rate_interval]))\n)\n',
     },
   )
 )
@@ -174,7 +174,7 @@ test.new(std.thisFile)
     actual=utils.ncHistogramLeRate('request_duration_seconds', 'cluster="cluster1", job="job1"', '+Inf'),
     expected={
       classic: 'rate(request_duration_seconds_bucket{cluster="cluster1", job="job1", le="+Inf"}[$__rate_interval])',
-      native: 'histogram_fraction(0, +Inf, rate(request_duration_seconds{cluster="cluster1", job="job1"}[$__rate_interval]))*histogram_count(rate(request_duration_seconds{cluster="cluster1", job="job1"}[$__rate_interval]))',
+      native: 'histogram_fraction(0, +Inf, sum (\n  rate(request_duration_seconds{cluster="cluster1", job="job1"}[$__rate_interval]))\n)\n*\nhistogram_count(sum (\n  rate(request_duration_seconds{cluster="cluster1", job="job1"}[$__rate_interval]))\n)\n',
     },
   )
 )
@@ -184,7 +184,7 @@ test.new(std.thisFile)
     actual=utils.ncHistogramLeRate('request_duration_seconds', 'cluster="cluster1", job="job1"', '-Inf'),
     expected={
       classic: 'rate(request_duration_seconds_bucket{cluster="cluster1", job="job1", le="-Inf"}[$__rate_interval])',
-      native: 'histogram_fraction(0, -Inf, rate(request_duration_seconds{cluster="cluster1", job="job1"}[$__rate_interval]))*histogram_count(rate(request_duration_seconds{cluster="cluster1", job="job1"}[$__rate_interval]))',
+      native: 'histogram_fraction(0, -Inf, sum (\n  rate(request_duration_seconds{cluster="cluster1", job="job1"}[$__rate_interval]))\n)\n*\nhistogram_count(sum (\n  rate(request_duration_seconds{cluster="cluster1", job="job1"}[$__rate_interval]))\n)\n',
     },
   )
 )
@@ -194,11 +194,20 @@ test.new(std.thisFile)
     actual=utils.ncHistogramLeRate('request_duration_seconds', 'cluster="cluster1", job="job1"', '0.1', '5m'),
     expected={
       classic: 'rate(request_duration_seconds_bucket{cluster="cluster1", job="job1", le="0.1"}[5m])',
-      native: 'histogram_fraction(0, 0.1, rate(request_duration_seconds{cluster="cluster1", job="job1"}[5m]))*histogram_count(rate(request_duration_seconds{cluster="cluster1", job="job1"}[5m]))',
+      native: 'histogram_fraction(0, 0.1, sum (\n  rate(request_duration_seconds{cluster="cluster1", job="job1"}[5m]))\n)\n*\nhistogram_count(sum (\n  rate(request_duration_seconds{cluster="cluster1", job="job1"}[5m]))\n)\n',
     },
   )
 )
-
++ test.case.new(
+  name='histogram le rate defaults and le is float with sum by',
+  test=test.expect.eq(
+    actual=utils.ncHistogramLeRate('request_duration_seconds', 'cluster="cluster1", job="job1"', '0.1', sum_by=['cluster', 'namespace']),
+    expected={
+      classic: 'rate(request_duration_seconds_bucket{cluster="cluster1", job="job1", le="0.1"}[$__rate_interval])',
+      native: 'histogram_fraction(0, 0.1, sum by (cluster, namespace) (\n  rate(request_duration_seconds{cluster="cluster1", job="job1"}[$__rate_interval]))\n)\n*\nhistogram_count(sum by (cluster, namespace) (\n  rate(request_duration_seconds{cluster="cluster1", job="job1"}[$__rate_interval]))\n)\n',
+    },
+  )
+)
 + test.case.new(
   name='commenting histogram query',
   test=test.expect.eq(

--- a/mixin-utils/utils.libsonnet
+++ b/mixin-utils/utils.libsonnet
@@ -145,14 +145,24 @@ local g = import 'grafana-builder/grafana.libsonnet';
   // The "le" value matcher for classic histograms can handle both Prometheus
   // or OpenMetrics formats, where whole numbers may or may not have ".0" at
   // the end.
-  ncHistogramLeRate(metric, selector, le, rate_interval='$__rate_interval')::
+  ncHistogramLeRate(metric, selector, le, rate_interval='$__rate_interval', sum_by=[])::
+    local sumBy = if std.length(sum_by) > 0 then ' by (%(lbls)s) ' % { lbls: std.join(', ', sum_by) } else ' ';
     local isWholeNumber(str) = str != '' && std.foldl(function(acc, c) acc && (c == '0' || c == '1' || c == '2' || c == '3' || c == '4' || c == '5' || c == '6' || c == '7' || c == '8' || c == '9'), std.stringChars(str), true);
     {
-      native: 'histogram_fraction(0, %(le)s, rate(%(metric)s{%(selector)s}[%(rateInterval)s]))*histogram_count(rate(%(metric)s{%(selector)s}[%(rateInterval)s]))' % {
+      native: |||
+        histogram_fraction(0, %(le)s, sum%(sumBy)s(
+          rate(%(metric)s{%(selector)s}[%(rateInterval)s]))
+        )
+        *
+        histogram_count(sum%(sumBy)s(
+          rate(%(metric)s{%(selector)s}[%(rateInterval)s]))
+        )
+      ||| % {
         le: if isWholeNumber(le) then le + '.0' else le,  // Treated as float number.
         metric: metric,
         rateInterval: rate_interval,
         selector: selector,
+        sumBy: sumBy,
       },
       classic: 'rate(%(metric)s_bucket{%(selector)s, %(le)s}[%(rateInterval)s])' % {
         // le is treated as string, thus it needs to account for Prometheus text format not having '.0', but OpenMetrics having it.

--- a/mixin-utils/utils.libsonnet
+++ b/mixin-utils/utils.libsonnet
@@ -157,7 +157,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
       classic: 'rate(%(metric)s_bucket{%(selector)s, %(le)s}[%(rateInterval)s])' % {
         // le is treated as string, thus it needs to account for Prometheus text format not having '.0', but OpenMetrics having it.
         // Also the resulting string in yaml is stored directly, so the \\ needs to be escaped to \\\\.
-        le: if isWholeNumber(le) then 'le=~"%(le)s|%(le)s\\\\.0"' % {le: le} else 'le="%s"' % le,
+        le: if isWholeNumber(le) then 'le=~"%(le)s|%(le)s\\\\.0"' % { le: le } else 'le="%s"' % le,
         metric: metric,
         rateInterval: rate_interval,
         selector: selector,

--- a/mixin-utils/utils.libsonnet
+++ b/mixin-utils/utils.libsonnet
@@ -147,6 +147,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
   // the end.
   ncHistogramLeRate(metric, selector, le, rate_interval='$__rate_interval')::
     local isWholeNumber(str) = str != '' && std.foldl(function(acc, c) acc && (c == '0' || c == '1' || c == '2' || c == '3' || c == '4' || c == '5' || c == '6' || c == '7' || c == '8' || c == '9'), std.stringChars(str), true);
+    local encodeInf(str) = if str == '+Inf' then '\\+Inf' else str;
     {
       native: 'histogram_fraction(0, %(le)s, rate(%(metric)s{%(selector)s}[%(rateInterval)s]))*histogram_count(rate(%(metric)s{%(selector)s}[%(rateInterval)s]))' % {
         le: if isWholeNumber(le) then le + '.0' else le,  // Treated as float number.
@@ -157,7 +158,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
       classic: 'rate(%(metric)s_bucket{%(selector)s, le=~"%(le)s"}[%(rateInterval)s])' % {
         // le is treated as string, thus it needs to account for Prometheus text format not having '.0', but OpenMetrics having it.
         // Also the resulting string in yaml is stored directly, so the \\ needs to be escaped to \\\\.
-        le: if isWholeNumber(le) then '%(le)s|%(le)s\\\\.0' % { le: le } else le,
+        le: if isWholeNumber(le) then '%(le)s|%(le)s\\\\.0' % { le: le } else encodeInf(le),
         metric: metric,
         rateInterval: rate_interval,
         selector: selector,


### PR DESCRIPTION
This PR fixes the wrong `utils.ncHistogramLeRate()` implementation. Namely, as stated in the native histogram [documentation](https://grafana.com/docs/mimir/next/visualize/native-histograms/#find-rate-of-observations), it is necessary to sum inside the `histogram_fraction` and not outside it. More precisely, this PR replaces 
```
sum by (cluster, namespace) (
  histogram_fraction(0, 0.1, rate(request_duration_seconds{cluster="cluster1", job="job1"}[$__rate_interval]))
 *
  histogram_count(rate(request_duration_seconds{cluster="cluster1", job="job1"}[$__rate_interval]))
)
```
with
```
histogram_fraction(0, 0.1, sum by (cluster, namespace) (
  rate(request_duration_seconds{cluster="cluster1", job="job1"}[$__rate_interval]))
)
*
histogram_count(sum by (cluster, namespace) (
  rate(request_duration_seconds{cluster="cluster1", job="job1"}[$__rate_interval]))
)
```


Moreover, this PR fixes the behaviour of `utils.ncHistogramLeRate` in case of `le=+Inf`. 
In case of the classic histogram, it used to generate the following regexp:
```
le=~"+Inf"
```
instead of 
```
le=~"\\+Inf"
```