### PR TITLE
feat: OracleDB logs expression update

### DIFF
--- a/oracledb-mixin/dashboards/overview.libsonnet
+++ b/oracledb-mixin/dashboards/overview.libsonnet
@@ -279,7 +279,7 @@ local alertLogPanel(matcher) = {
     {
       datasource: lokiDatasource,
       editorMode: 'builder',
-      expr: '{' + matcher + '} |= `` | (filename=~"/.*/.*/diag/rdbms/.*/.*/trace/alert_.*log or log_type="oracledb-alert")',
+      expr: '{' + matcher + '} |= `` | (filename=~"/.*/.*/diag/rdbms/.*/.*/trace/alert_.*log or log_type="oracledb")',
       queryType: 'range',
       refId: 'A',
     },

--- a/oracledb-mixin/dashboards/overview.libsonnet
+++ b/oracledb-mixin/dashboards/overview.libsonnet
@@ -279,7 +279,7 @@ local alertLogPanel(matcher) = {
     {
       datasource: lokiDatasource,
       editorMode: 'builder',
-      expr: '{filename=~"/.*/.*/diag/rdbms/.*/.*/trace/alert_.*log",' + matcher + '}',
+      expr: '{' + matcher + '} |= `` | (filename=~"/.*/.*/diag/rdbms/.*/.*/trace/alert_.*log or log_type="oracledb")',
       queryType: 'range',
       refId: 'A',
     },

--- a/oracledb-mixin/dashboards/overview.libsonnet
+++ b/oracledb-mixin/dashboards/overview.libsonnet
@@ -279,7 +279,7 @@ local alertLogPanel(matcher) = {
     {
       datasource: lokiDatasource,
       editorMode: 'builder',
-      expr: '{' + matcher + '} |= `` | (filename=~"/.*/.*/diag/rdbms/.*/.*/trace/alert_.*log or log_type="oracledb")',
+      expr: '{' + matcher + '} |= `` | (filename=~"/.*/.*/diag/rdbms/.*/.*/trace/alert_.*log or log_type="oracledb-alert")',
       queryType: 'range',
       refId: 'A',
     },


### PR DESCRIPTION
### Description

The expression for logs required a label called `filename` with a value that equates to an alert log file path. In `k8s` this file is not something that is read from. Requiring an arbitrary label with a value to a path that does not exist is potentially confusing.

The solution, alter the expression to accept `filename=pathToAlertLogs` or `log_type="oracledb"` and in the `k8s` plugin snippets for collecting logs, we add `log_type="oracledb"` and users can just copy/paste the config without potentially becoming confused.

#### Important note:
The OracleDB container logs are more than just logs from the alert file and there's not a clear way to filter on just the ones we'd get from the alert log. 

### Changes
* [update log expression to match on filename or log_type labels](https://github.com/grafana/jsonnet-libs/commit/b2299dcd738d1456beba454c6e01fc49223f15c6)
* [update log_type to match on oracledb-alert](https://github.com/grafana/jsonnet-libs/commit/98df3c13feea9919206e4bd764f862aae2eb5ce0)
* [revert oracledb-alert to oracledb for log_type](https://github.com/grafana/jsonnet-libs/commit/5a60ca8ae3007883efb976a6e28d2e5163f4db12)