### PR TITLE
fix: OracleDB log expression typo

### DIFF
--- a/oracledb-mixin/dashboards/overview.libsonnet
+++ b/oracledb-mixin/dashboards/overview.libsonnet
@@ -279,7 +279,7 @@ local alertLogPanel(matcher) = {
     {
       datasource: lokiDatasource,
       editorMode: 'builder',
-      expr: '{' + matcher + '} |= `` | (filename=~"/.*/.*/diag/rdbms/.*/.*/trace/alert_.*log or log_type="oracledb")',
+      expr: '{' + matcher + '} |= `` | (filename=~"/.*/.*/diag/rdbms/.*/.*/trace/alert_.*log" or log_type="oracledb")',
       queryType: 'range',
       refId: 'A',
     },


### PR DESCRIPTION
### Description

Small typo in the log expression where closing quotation was missing for `filename`.

### Changes
* [fixed typo](https://github.com/grafana/jsonnet-libs/commit/8773f275a57a34833d966fab1bb837d5c8a62a0b)