### PR TITLE
feat: Apache CouchDB log expression update

### DIFF
--- a/apache-couchdb-mixin/dashboards/couchdb-nodes.libsonnet
+++ b/apache-couchdb-mixin/dashboards/couchdb-nodes.libsonnet
@@ -1225,7 +1225,7 @@ local systemLogsPanel(cfg) = {
     {
       datasource: lokiDatasource,
       editorMode: 'code',
-      expr: '{' + getMatcher(cfg) + ', filename="/var/log/couchdb/couchdb.log"} |~ "$log_level"',
+      expr: '{' + getMatcher(cfg) + '} |= `` | (filename=~"/var/log/couchdb/couchdb.log" or log_type="couchdb") |~ "$log_level"',
       queryType: 'range',
       refId: 'A',
     },


### PR DESCRIPTION
### Description

This PR updates the log expression for the Apache CouchDB mixin to allow the `log_type` label and the `filename` label. The intention is to allow users running CouchDB in k8s to not have to provide a value to the `filename` label in order to get logs, instead they can just copy/paste the configuration as is, only needing to update important values for things to work, avoiding potential confusion.

### Changes
* [update couchdb log expression to accept log_type label](https://github.com/grafana/jsonnet-libs/commit/4cdca0b5f183113f55b1c734c23eed6697273a26)