### PR TITLE
feat: Wildfly log expression update

### DIFF
--- a/wildfly-mixin/dashboards/wildfly-overview.libsonnet
+++ b/wildfly-mixin/dashboards/wildfly-overview.libsonnet
@@ -340,7 +340,7 @@ local serverLogsPanel(matcher) = {
     {
       datasource: lokiDatasource,
       editorMode: 'code',
-      expr: '{filename=~"/opt/wildfly/.*/server.log",' + matcher + '}',
+      expr: '{' + matcher + '} |= `` | (filename=~"/opt/wildfly/.*/server.log" or log_type="wildfly")',
       queryType: 'range',
       refId: 'A',
     },


### PR DESCRIPTION
### Description

This PR updates the Wildfly mixin log expression to allow the `log_type` label. The intention is to allow k8s users to avoid any possible confusion around the `filename` label.

### Changes
* [update log expression to accept log_type label](https://github.com/grafana/jsonnet-libs/commit/1d9f1aad81bddf99feaa943331ee63ba57a9430c)