### PR TITLE
feat: IBM MQ log expression update

### DIFF
--- a/ibm-mq-mixin/config.libsonnet
+++ b/ibm-mq-mixin/config.libsonnet
@@ -6,8 +6,8 @@
     dashboardPeriod: 'now-1h',
     dashboardTimezone: 'default',
     dashboardRefresh: '1m',
-    logExpression: if self.enableMultiCluster then 'job=~"$job", cluster=~"$cluster"'
-    else 'job=~"$job"',
+    logExpression: if self.enableMultiCluster then 'job=~"$job", cluster=~"$cluster", qmgr=~"$qmgr"'
+    else 'job=~"$job", qmgr=~"$qmgr"',
 
     //alerts thresholds
     alertsExpiredMessages: 2,  //count

--- a/ibm-mq-mixin/dashboards/queue-manager-overview.libsonnet
+++ b/ibm-mq-mixin/dashboards/queue-manager-overview.libsonnet
@@ -1229,7 +1229,7 @@ local errorLogsPanel(cfg) = {
     {
       datasource: lokiDatasource,
       editorMode: 'code',
-      expr: '{' + logExpr(cfg.logExpression) + ', filename=~"/var/mqm/qmgrs/.*/errors/.*LOG", qmgr=~"$qmgr"} |= ``',
+      expr: '{' + logExpr(cfg.logExpression) + '} |= `` | (filename=~"/var/mqm/qmgrs/.*/errors/.*LOG" or log_type="mq-qmgr-error")',
       queryType: 'range',
       refId: 'A',
     },


### PR DESCRIPTION
### Description

> This is untested.

This PR updates the log expression for the IBM MQ dashboard to filter on `filename` OR `log_type`. Also, I put the `qmgr` label in the `logExpression` part of the configuration. 

The intention here is to update the `k8s-plugin` snippet to use the `log_type` label to avoid any potential confusion, as `filename` would have a value that doesn't point to a real log file.

However, if the logs coming from the MQ container do not include what we'd expect and the use of a sidecar/volumes is necessary, then perhaps the `filename` label would be used.


### Changes
* [update logExpression to include the queue manager label](https://github.com/grafana/jsonnet-libs/commit/60bb9856e8aa81bf1b847e86af6f6c77b7e9a33d)
* [update log expression to use filename and log_type label](https://github.com/grafana/jsonnet-libs/commit/5feeb2f9e367f04512df0b3dd25becb360c49ae5)