### PR TITLE
nginx-directory: configurable log_format

### DIFF
--- a/nginx-directory/config.libsonnet
+++ b/nginx-directory/config.libsonnet
@@ -2,6 +2,8 @@
   _config+:: {
     namespace: error 'namespace required',
     cluster_dns_suffix: error 'cluster_dns_suffix required',
+    // log_format is enclosed in single quotes in the config file. Make sure to escape them properly if you want to use them.
+    log_format: '$remote_addr - $remote_user [$time_local]  $status "$request" $body_bytes_sent "$http_referer" "$http_user_agent" "$http_x_forwarded_for"',
     title: 'Admin',
 
     admin_services+: [

--- a/nginx-directory/files/nginx.conf
+++ b/nginx-directory/files/nginx.conf
@@ -9,9 +9,7 @@ events {
 
 http {
   default_type application/octet-stream;
-  log_format   main '$remote_addr - $remote_user [$time_local]  $status '
-    '"$request" $body_bytes_sent "$http_referer" '
-    '"$http_user_agent" "$http_x_forwarded_for"';
+  log_format   main '%(log_format)s';
   access_log   /dev/stderr  main;
   sendfile     on;
   tcp_nopush   on;


### PR DESCRIPTION
Sometimes the log format of the nginx directory doesn't contain enough information, and sometimes it contains useless information.

For example, $remote_addr is often the gateway that forwards the request, and $remote_user is empty when running behind an oauth proxy.

This makes log_format configurable, so each deployment can adjust it to their needs (for example, to read the forwarded oauth user header).

I'm replacing the multiline definition of this with a single line, which cause a non-zero diff even with the default config.

