### PR TITLE
Docker mixin: Adds root cgroup filter to filter out root cgroup stats

### DIFF
--- a/docker-mixin/config.libsonnet
+++ b/docker-mixin/config.libsonnet
@@ -9,8 +9,8 @@
     //prefix
     uid: 'integration-docker',
     // ignore k8s nodes by default
-    filteringSelector: 'job!="kubelet", id=~"/system.slice/docker.+", name!=""',
-    machineSelector: 'job!="kubelet"',
+    filteringSelector: 'job!="kubelet"',
+    containerSelector: 'id=~"/system.slice/docker.+", name!=""',
 
     //signals related
     groupLabels: ['job'],

--- a/docker-mixin/config.libsonnet
+++ b/docker-mixin/config.libsonnet
@@ -9,7 +9,7 @@
     //prefix
     uid: 'integration-docker',
     // ignore k8s nodes by default
-    filteringSelector: 'job!="kubelet"',
+    filteringSelector: 'job!="kubelet", name!=""',
 
 
     //signals related

--- a/docker-mixin/config.libsonnet
+++ b/docker-mixin/config.libsonnet
@@ -9,8 +9,8 @@
     //prefix
     uid: 'integration-docker',
     // ignore k8s nodes by default
-    filteringSelector: 'job!="kubelet", name!=""',
-
+    filteringSelector: 'job!="kubelet", id=~"/system.slice/docker.+", name!=""',
+    machineSelector: 'job!="kubelet"',
 
     //signals related
     groupLabels: ['job'],

--- a/docker-mixin/config.libsonnet
+++ b/docker-mixin/config.libsonnet
@@ -11,7 +11,6 @@
     // ignore k8s nodes by default
     filteringSelector: 'job!="kubelet"',
     containerSelector: 'id=~"/system.slice/docker.+", name!=""',
-
     //signals related
     groupLabels: ['job'],
     // host level

--- a/docker-mixin/signals/container.libsonnet
+++ b/docker-mixin/signals/container.libsonnet
@@ -2,7 +2,7 @@ local commonlib = import './common-lib/common/main.libsonnet';
 function(this)
   {
     local s = self,
-    filteringSelector: this.filteringSelector,
+    filteringSelector: this.filteringSelector + ', ' + this.containerSelector,
     groupLabels: this.groupLabels,
     instanceLabels: this.instanceLabels + s.legendLabels,
     legendLabels: ['name'],

--- a/docker-mixin/signals/machine.libsonnet
+++ b/docker-mixin/signals/machine.libsonnet
@@ -46,7 +46,7 @@ function(this)
                 )
               / 
               avg(
-                  machine_memory_bytes{%(queriesSelector)s}
+                  machine_memory_bytes{%(machineSelector)s}
               ) * 100
             |||,
           },
@@ -63,7 +63,7 @@ function(this)
               avg(
                 sum by (instance) (container_memory_usage_bytes{%(queriesSelector)s})
                 /
-                avg by (instance) (machine_memory_bytes{%(queriesSelector)s})
+                avg by (instance) (machine_memory_bytes{%(machineSelector)s})
               ) * 100
             |||,
           },

--- a/docker-mixin/signals/machine.libsonnet
+++ b/docker-mixin/signals/machine.libsonnet
@@ -18,7 +18,7 @@ function(this)
         type: 'raw',
         sources: {
           cadvisor: {
-            expr: 'count(container_last_seen{%(queriesSelector)s})',
+            expr: 'count(container_last_seen{%%(queriesSelector)s, %(containerSelector)s})' % {containerSelector: this.containerSelector},
           },
         },
       },
@@ -28,7 +28,7 @@ function(this)
         type: 'raw',
         sources: {
           cadvisor: {
-            expr: 'count (sum by (image) (container_last_seen{%(queriesSelector)s}))',
+            expr: 'count (sum by (image) (container_last_seen{%%(queriesSelector)s, %(containerSelector)s}))' % {containerSelector: this.containerSelector},
           },
         },
       },
@@ -42,13 +42,13 @@ function(this)
           cadvisor: {
             expr: |||
               sum(
-                container_spec_memory_reservation_limit_bytes{%(queriesSelector)s}
+                container_spec_memory_reservation_limit_bytes{%%(queriesSelector)s, %(containerSelector)s}
                 )
               / 
               avg(
-                  machine_memory_bytes{%(machineSelector)s}
+                  machine_memory_bytes{%%(queriesSelector)s}
               ) * 100
-            |||,
+            ||| % {containerSelector: this.containerSelector},
           },
         },
       },
@@ -61,11 +61,11 @@ function(this)
           cadvisor: {
             expr: |||
               avg(
-                sum by (instance) (container_memory_usage_bytes{%(queriesSelector)s})
+                sum by (instance) (container_memory_usage_bytes{%%(queriesSelector)s, %(containerSelector)s})
                 /
-                avg by (instance) (machine_memory_bytes{%(machineSelector)s})
+                avg by (instance) (machine_memory_bytes{%%(queriesSelector)s})
               ) * 100
-            |||,
+            ||| % {containerSelector: this.containerSelector},
           },
         },
       },
@@ -76,7 +76,7 @@ function(this)
         unit: 'percent',
         sources: {
           cadvisor: {
-            expr: 'avg by (%(agg)s, name) (rate(container_cpu_usage_seconds_total{%(queriesSelector)s}[$__rate_interval])) * 100',
+            expr: 'avg by (%%(agg)s, name) (rate(container_cpu_usage_seconds_total{%%(queriesSelector)s, %(containerSelector)s}[$__rate_interval])) * 100' % {containerSelector: this.containerSelector},
             legendCustomTemplate: commonlib.utils.labelsToPanelLegend(this.instanceLabels),
           },
         },

--- a/docker-mixin/signals/machine.libsonnet
+++ b/docker-mixin/signals/machine.libsonnet
@@ -18,7 +18,7 @@ function(this)
         type: 'raw',
         sources: {
           cadvisor: {
-            expr: 'count(container_last_seen{%%(queriesSelector)s, %(containerSelector)s})' % {containerSelector: this.containerSelector},
+            expr: 'count(container_last_seen{%%(queriesSelector)s, %(containerSelector)s})' % { containerSelector: this.containerSelector },
           },
         },
       },
@@ -28,7 +28,7 @@ function(this)
         type: 'raw',
         sources: {
           cadvisor: {
-            expr: 'count (sum by (image) (container_last_seen{%%(queriesSelector)s, %(containerSelector)s}))' % {containerSelector: this.containerSelector},
+            expr: 'count (sum by (image) (container_last_seen{%%(queriesSelector)s, %(containerSelector)s}))' % { containerSelector: this.containerSelector },
           },
         },
       },
@@ -48,7 +48,7 @@ function(this)
               avg(
                   machine_memory_bytes{%%(queriesSelector)s}
               ) * 100
-            ||| % {containerSelector: this.containerSelector},
+            ||| % { containerSelector: this.containerSelector },
           },
         },
       },
@@ -65,7 +65,7 @@ function(this)
                 /
                 avg by (instance) (machine_memory_bytes{%%(queriesSelector)s})
               ) * 100
-            ||| % {containerSelector: this.containerSelector},
+            ||| % { containerSelector: this.containerSelector },
           },
         },
       },
@@ -76,7 +76,7 @@ function(this)
         unit: 'percent',
         sources: {
           cadvisor: {
-            expr: 'avg by (%%(agg)s, name) (rate(container_cpu_usage_seconds_total{%%(queriesSelector)s, %(containerSelector)s}[$__rate_interval])) * 100' % {containerSelector: this.containerSelector},
+            expr: 'avg by (%%(agg)s, name) (rate(container_cpu_usage_seconds_total{%%(queriesSelector)s, %(containerSelector)s}[$__rate_interval])) * 100' % { containerSelector: this.containerSelector },
             legendCustomTemplate: commonlib.utils.labelsToPanelLegend(this.instanceLabels),
           },
         },


### PR DESCRIPTION
Adds a root cgroup filter - otherwise metrics get inflated when metrics are counted which do not have a `name` label.