### PR TITLE
[jaeger-agent-mixin] Use OTel attributes and container attributes by default

### DIFF
--- a/jaeger-agent-mixin/jaeger.libsonnet
+++ b/jaeger-agent-mixin/jaeger.libsonnet
@@ -7,9 +7,8 @@ local k = import 'ksonnet-util/kausal.libsonnet';
     jaeger_agent_host: null,
     jaeger_sampler_type: null,
     jaeger_sampler_param: null,
-    //TODO: Deprecate with_otel_resource_attrs. All traces colleciton should use OTel semantics.
-    with_otel_resource_attrs: false,
-    with_otel_container_resource_attrs: false,
+    with_otel_resource_attrs: true,
+    with_otel_container_resource_attrs: true,
   },
 
   local container = k.core.v1.container,


### PR DESCRIPTION
Some container attributes are required for the k8sattributes processor to add other container-related attributes, so it'd be good to enable this by default.