### PR TITLE
Fix typo in kafka alerts

### DIFF
--- a/kafka-observ-lib/alerts.libsonnet
+++ b/kafka-observ-lib/alerts.libsonnet
@@ -3,7 +3,7 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
 {
   new(this): {
     local instanceLabel = xtd.array.slice(this.config.instanceLabels, -1)[0],
-    local groupLabel = xtd.array.slice(this.config.instanceLabels, -1)[0],
+    local groupLabel = xtd.array.slice(this.config.groupLabels, -1)[0],
     groups+: [
       {
         name: this.config.uid + '-kafka-alerts',

--- a/kafka-observ-lib/alerts.libsonnet
+++ b/kafka-observ-lib/alerts.libsonnet
@@ -51,7 +51,7 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
               alert: 'KafkaISRExpandRate',
               expr: |||
                 sum without() (%s) != 0
-              ||| % this.signals.replicaManager.isrExpands.asRuleExpression(),
+              ||| % this.signals.brokerReplicaManager.isrExpands.asRuleExpression(),
               'for': '5m',
               keep_firing_for: '15m',
               labels: {
@@ -70,7 +70,7 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
               alert: 'KafkaISRShrinkRate',
               expr: |||
                 sum without() (%s) != 0
-              ||| % this.signals.replicaManager.isrShrinks.asRuleExpression(),
+              ||| % this.signals.brokerReplicaManager.isrShrinks.asRuleExpression(),
               'for': '5m',
               keep_firing_for: '15m',
               labels: {
@@ -91,7 +91,7 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
                 sum by (%s) (%s) > 0
               ||| % [
                 std.join(',', this.config.groupLabels),
-                this.signals.replicaManager.offlinePartitions.asRuleExpression(),
+                this.signals.brokerReplicaManager.offlinePartitions.asRuleExpression(),
               ],
               labels: {
                 severity: 'critical',
@@ -107,7 +107,7 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
               expr: |||
                 (%s) > 0
               ||| % [
-                this.signals.replicaManager.underReplicatedPartitions.asRuleExpression(),
+                this.signals.brokerReplicaManager.underReplicatedPartitions.asRuleExpression(),
               ],
               'for': '5m',
               labels: {
@@ -137,7 +137,7 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
             },
             {
               alert: 'KafkaUncleanLeaderElection',
-              expr: '(%s) != 0' % this.signals.replicaManager.uncleanLeaderElection.asRuleExpression(),
+              expr: '(%s) != 0' % this.signals.brokerReplicaManager.uncleanLeaderElection.asRuleExpression(),
               'for': '5m',
               labels: {
                 severity: 'critical',

--- a/kafka-observ-lib/config.libsonnet
+++ b/kafka-observ-lib/config.libsonnet
@@ -16,6 +16,7 @@
   jvmMetricsSource: ['prometheus_old', 'prometheus', 'jmx_exporter'],
 
   topicsFilteringSelector: 'topic!="__consumer_offsets"',
+  consumerGroupFilteringSelector: 'consumergroup!=""',
   zookeeperEnabled: true,
   totalTimeMsQuantile: '0.95',  // quantile to use for totalTimeMs metrics: 0.50, 0.75, 0.95, 0.98, 0.99, 0.999...
   zookeeperClientQuantile: '0.95',  // quantile to use for zookeeperClient metrics: 0.50, 0.75, 0.95, 0.98, 0.99, 0.999...

--- a/kafka-observ-lib/config.libsonnet
+++ b/kafka-observ-lib/config.libsonnet
@@ -15,8 +15,7 @@
   // 'prometheus' if you use jmx_exporter in javaagent mode and version 1.0.1 or newer
   jvmMetricsSource: ['prometheus_old', 'prometheus', 'jmx_exporter'],
 
-  //Can be regex:
-  topicsIgnoreSelector: '__consumer_offsets',
+  topicsFilteringSelector: 'topic!="__consumer_offsets"',
   zookeeperEnabled: true,
   totalTimeMsQuantile: '0.95',  // quantile to use for totalTimeMs metrics: 0.50, 0.75, 0.95, 0.98, 0.99, 0.999...
   zookeeperClientQuantile: '0.95',  // quantile to use for zookeeperClient metrics: 0.50, 0.75, 0.95, 0.98, 0.99, 0.999...
@@ -28,7 +27,8 @@
       consumerGroup: (import './signals/consumerGroup.libsonnet')(this),
       zookeeperClient: (import './signals/zookeeperClient.libsonnet')(this),
       totalTime: (import './signals/totalTime.libsonnet')(this),
-      replicaManager: (import './signals/replicaManager.libsonnet')(this),
+      brokerReplicaManager: (import './signals/brokerReplicaManager.libsonnet')(this),
+      clusterReplicaManager: (import './signals/clusterReplicaManager.libsonnet')(this),
       conversion: (import './signals/conversion.libsonnet')(this),
     },
 }

--- a/kafka-observ-lib/panels/replicaManager.libsonnet
+++ b/kafka-observ-lib/panels/replicaManager.libsonnet
@@ -3,43 +3,43 @@ local commonlib = import 'common-lib/common/main.libsonnet';
 {
   new(signals):: {
     isrShrinks:
-      signals.replicaManager.isrShrinks.asTimeSeries()
+      signals.brokerReplicaManager.isrShrinks.asTimeSeries()
       + commonlib.panels.generic.timeSeries.base.stylize(),
     isrExpands:
-      signals.replicaManager.isrExpands.asTimeSeries()
+      signals.brokerReplicaManager.isrExpands.asTimeSeries()
       + commonlib.panels.generic.timeSeries.base.stylize(),
     onlinePartitions:
-      signals.replicaManager.onlinePartitions.asTimeSeries()
+      signals.brokerReplicaManager.onlinePartitions.asTimeSeries()
       + commonlib.panels.generic.timeSeries.base.stylize(),
     offlinePartitions:
-      signals.replicaManager.offlinePartitions.asTimeSeries()
+      signals.brokerReplicaManager.offlinePartitions.asTimeSeries()
       + commonlib.panels.requests.timeSeries.errors.stylize(),
     underReplicatedPartitions:
-      signals.replicaManager.underReplicatedPartitions.asTimeSeries()
+      signals.brokerReplicaManager.underReplicatedPartitions.asTimeSeries()
       + commonlib.panels.requests.timeSeries.errors.stylize(),
     underMinISRPartitions:
-      signals.replicaManager.underMinISRPartitions.asTimeSeries()
+      signals.brokerReplicaManager.underMinISRPartitions.asTimeSeries()
       + commonlib.panels.requests.timeSeries.errors.stylize(),
 
-    //for overview:
+    //for overview (use cluster wide signals):
     uncleanLeaderElectionStat:
-      signals.replicaManager.uncleanLeaderElection.asStat()
+      signals.clusterReplicaManager.uncleanLeaderElection.asStat()
       + commonlib.panels.generic.stat.base.stylize(),
     preferredReplicaInbalanceStat:
-      signals.replicaManager.preferredReplicaInbalance.asStat()
+      signals.clusterReplicaManager.preferredReplicaInbalance.asStat()
       + commonlib.panels.generic.stat.base.stylize(),
 
     onlinePartitionsStat:
-      signals.replicaManager.onlinePartitions.asStat()
+      signals.clusterReplicaManager.onlinePartitions.asStat()
       + commonlib.panels.generic.stat.base.stylize(),
     offlinePartitionsStat:
-      signals.replicaManager.offlinePartitions.asStat()
+      signals.clusterReplicaManager.offlinePartitions.asStat()
       + commonlib.panels.generic.stat.base.stylize(),
     underReplicatedPartitionsStat:
-      signals.replicaManager.underReplicatedPartitions.asStat()
+      signals.clusterReplicaManager.underReplicatedPartitions.asStat()
       + commonlib.panels.generic.stat.base.stylize(),
     underMinISRPartitionsStat:
-      signals.replicaManager.underMinISRPartitions.asStat()
+      signals.clusterReplicaManager.underMinISRPartitions.asStat()
       + commonlib.panels.generic.stat.base.stylize(),
 
   },

--- a/kafka-observ-lib/signals/brokerReplicaManager.libsonnet
+++ b/kafka-observ-lib/signals/brokerReplicaManager.libsonnet
@@ -5,7 +5,7 @@ function(this)
     filteringSelector: this.filteringSelector,
     groupLabels: this.groupLabels,
     instanceLabels: this.instanceLabels,
-    aggLevel: 'group',
+    aggLevel: 'instance',
     aggFunction: 'sum',
     discoveryMetric: {
       prometheus: 'kafka_server_replicamanager_isrshrinks_total',

--- a/kafka-observ-lib/signals/clusterReplicaManager.libsonnet
+++ b/kafka-observ-lib/signals/clusterReplicaManager.libsonnet
@@ -1,0 +1,7 @@
+local commonlib = import 'common-lib/common/main.libsonnet';
+
+function(this)
+  this.signals.brokerReplicaManager {
+    aggLevel: 'group',
+    aggFunction: 'sum',
+  }

--- a/kafka-observ-lib/signals/consumerGroup.libsonnet
+++ b/kafka-observ-lib/signals/consumerGroup.libsonnet
@@ -2,7 +2,7 @@ local commonlib = import 'common-lib/common/main.libsonnet';
 
 function(this)
   {
-    filteringSelector: std.join(',', [this.filteringSelector, this.topicsFilteringSelector]),
+    filteringSelector: std.join(',', [this.filteringSelector, this.topicsFilteringSelector, this.consumerGroupFilteringSelector]),
     groupLabels: this.groupLabels,
     instanceLabels: ['topic', 'consumergroup'],  // this.instanceLabels is ommitted, as it would point to kafka_exporter instance.
     aggLevel: 'group',

--- a/kafka-observ-lib/signals/consumerGroup.libsonnet
+++ b/kafka-observ-lib/signals/consumerGroup.libsonnet
@@ -2,7 +2,7 @@ local commonlib = import 'common-lib/common/main.libsonnet';
 
 function(this)
   {
-    filteringSelector: this.filteringSelector + ', topic!~"%s"' % this.topicsIgnoreSelector,
+    filteringSelector: std.join(',', [this.filteringSelector, this.topicsFilteringSelector]),
     groupLabels: this.groupLabels,
     instanceLabels: ['topic', 'consumergroup'],  // this.instanceLabels is ommitted, as it would point to kafka_exporter instance.
     aggLevel: 'group',

--- a/kafka-observ-lib/signals/topic.libsonnet
+++ b/kafka-observ-lib/signals/topic.libsonnet
@@ -2,7 +2,7 @@ local commonlib = import 'common-lib/common/main.libsonnet';
 
 function(this)
   {
-    filteringSelector: this.filteringSelector + ', topic!~"%s"' % this.topicsIgnoreSelector,
+    filteringSelector: std.join(',', [this.filteringSelector, this.topicsFilteringSelector]),
     groupLabels: this.groupLabels,
     instanceLabels: ['topic'],  // this.instanceLabels is ommitted, as it would point to kafka_exporter instance.
     aggLevel: 'group',


### PR DESCRIPTION
- add ConsumerGroupFilteringSelector
- add TopicFilteringSelector (instead of TopicIgnoreSelector)
- Fix alerts for replicationManager by splitting signals of broker level/cluster level:
   - Alerts are firing per instance now (as expected)
   - Dashboards show panels per-instance or per-cluster, depending on what is required.
