### PR TITLE
Add support for gauge metric in static-exporter

### DIFF
--- a/static-exporter/main.libsonnet
+++ b/static-exporter/main.libsonnet
@@ -35,7 +35,7 @@ local k = import 'ksonnet-util/kausal.libsonnet';
             function(acc, metric)
               acc + [
                 '# HELP %(name)s %(description)s' % metric,
-                '# TYPE %(name)s counter' % metric,
+                '# TYPE %(name)s %(metricType)s' % metric,
               ] + [
                 metric.name + value
                 for value in metric.values
@@ -47,13 +47,16 @@ local k = import 'ksonnet-util/kausal.libsonnet';
     }),
 
   metric:: {
-    new(name, description)::
+    new(name, description, metricType="counter")::
       self.withName(name)
-      + self.withDescription(description),
+      + self.withDescription(description)
+      + self.withMetricType(metricType),
 
     withName(name): { name: name },
 
     withDescription(description): { description: description },
+
+    withMetricType(metricType): { type: metricType },
 
     local generateValues(labelMap, value=1) =
       local labels = [


### PR DESCRIPTION
Add support for gauge metric in static-exporter
Keep default as `counter` to avoid any changes for other places