### PR TITLE
Fix docker mixin panels

### DIFF
--- a/docker-mixin/g.libsonnet
+++ b/docker-mixin/g.libsonnet
@@ -1,1 +1,1 @@
-import 'github.com/grafana/grafonnet/gen/grafonnet-v10.0.0/main.libsonnet'
+import 'github.com/grafana/grafonnet/gen/grafonnet-v11.0.0/main.libsonnet'

--- a/docker-mixin/panels.libsonnet
+++ b/docker-mixin/panels.libsonnet
@@ -72,6 +72,7 @@ local commonlib = import 'common-lib/common/main.libsonnet';
 
     diskUsageBytes:
       commonlib.panels.disk.timeSeries.usage.new('Disk usage', targets=[])
+      + g.panel.timeSeries.standardOptions.withMin(0)
       + this.signals.container.diskUsageBytes.asPanelMixin(),
 
     diskIO:

--- a/docker-mixin/panels.libsonnet
+++ b/docker-mixin/panels.libsonnet
@@ -75,11 +75,12 @@ local commonlib = import 'common-lib/common/main.libsonnet';
       + this.signals.container.diskUsageBytes.asPanelMixin(),
 
     diskIO:
-      commonlib.panels.generic.timeSeries.base.new(
+      commonlib.panels.disk.timeSeries.iops.new(
         'Disk I/O',
         targets=[],
         description='The number of I/O requests per second for the device/volume.'
       )
-      + this.signals.container.diskIO.asPanelMixin(),
+      + this.signals.container.diskReads.asPanelMixin()
+      + this.signals.container.diskWrites.asPanelMixin(),
   },
 }

--- a/docker-mixin/panels.libsonnet
+++ b/docker-mixin/panels.libsonnet
@@ -44,7 +44,7 @@ local commonlib = import 'common-lib/common/main.libsonnet';
       this.signals.container.cpuUsage.asTimeSeries()
       + commonlib.panels.generic.timeSeries.base.stylize()
       + g.panel.timeSeries.fieldConfig.defaults.custom.stacking.withMode('normal')
-      + g.panel.timeSeries.fieldConfig.defaults.custom.withAxisSoftMax(1)
+      + g.panel.timeSeries.fieldConfig.defaults.custom.withAxisSoftMax(100)
       + g.panel.timeSeries.standardOptions.withMin(0),
 
     memory:

--- a/docker-mixin/signals/container.libsonnet
+++ b/docker-mixin/signals/container.libsonnet
@@ -51,7 +51,8 @@ function(this)
             exprWrappers: [
               ['8 *', ''],
             ],
-            legendCustomTemplate: '%s receive' % commonlib.utils.labelsToPanelLegend(s.legendLabels),
+            aggKeepLabels: ['interface'],
+            legendCustomTemplate: '%s(%s) receive' % [commonlib.utils.labelsToPanelLegend(s.legendLabels), 'interface'],
           },
         },
       },
@@ -66,7 +67,8 @@ function(this)
             exprWrappers: [
               ['8 *', ''],
             ],
-            legendCustomTemplate: '%s transmit' % commonlib.utils.labelsToPanelLegend(s.legendLabels),
+            aggKeepLabels: ['interface'],
+            legendCustomTemplate: '%s(%s) transmit' % [commonlib.utils.labelsToPanelLegend(s.legendLabels), 'interface'],
           },
         },
       },
@@ -79,7 +81,8 @@ function(this)
         sources: {
           cadvisor: {
             expr: 'container_network_receive_packets_dropped_total{%(queriesSelector)s}',
-            legendCustomTemplate: '%s rx drops' % commonlib.utils.labelsToPanelLegend(s.legendLabels),
+            aggKeepLabels: ['interface'],
+            legendCustomTemplate: '%s(%s) rx drops' % [commonlib.utils.labelsToPanelLegend(s.legendLabels), 'interface'],
           },
         },
       },
@@ -91,7 +94,8 @@ function(this)
         sources: {
           cadvisor: {
             expr: 'container_network_transmit_packets_dropped_total{%(queriesSelector)s}',
-            legendCustomTemplate: '%s tx drops' % commonlib.utils.labelsToPanelLegend(s.legendLabels),
+            aggKeepLabels: ['interface'],
+            legendCustomTemplate: '%s(%s) tx drops' % [commonlib.utils.labelsToPanelLegend(s.legendLabels), 'interface'],
           },
         },
       },
@@ -103,7 +107,8 @@ function(this)
         sources: {
           cadvisor: {
             expr: 'container_network_receive_errors_total{%(queriesSelector)s}',
-            legendCustomTemplate: '%s rx errors ' % commonlib.utils.labelsToPanelLegend(s.legendLabels),
+            aggKeepLabels: ['interface'],
+            legendCustomTemplate: '%s(%s) rx errors ' % [commonlib.utils.labelsToPanelLegend(s.legendLabels), 'interface'],
           },
         },
       },
@@ -115,7 +120,8 @@ function(this)
         sources: {
           cadvisor: {
             expr: 'container_network_transmit_errors_total{%(queriesSelector)s}',
-            legendCustomTemplate: '%s tx errors ' % commonlib.utils.labelsToPanelLegend(s.legendLabels),
+            aggKeepLabels: ['interface'],
+            legendCustomTemplate: '%s(%s) tx errors ' % [commonlib.utils.labelsToPanelLegend(s.legendLabels), 'interface'],
           },
         },
       },

--- a/docker-mixin/signals/container.libsonnet
+++ b/docker-mixin/signals/container.libsonnet
@@ -52,7 +52,7 @@ function(this)
               ['8 *', ''],
             ],
             aggKeepLabels: ['interface'],
-            legendCustomTemplate: '%s(%s) receive' % [commonlib.utils.labelsToPanelLegend(s.legendLabels), 'interface'],
+            legendCustomTemplate: '%s receive' % commonlib.utils.labelsToPanelLegend(s.legendLabels + ['interface']),
           },
         },
       },
@@ -68,7 +68,7 @@ function(this)
               ['8 *', ''],
             ],
             aggKeepLabels: ['interface'],
-            legendCustomTemplate: '%s(%s) transmit' % [commonlib.utils.labelsToPanelLegend(s.legendLabels), 'interface'],
+            legendCustomTemplate: '%s transmit' % commonlib.utils.labelsToPanelLegend(s.legendLabels + ['interface']),
           },
         },
       },
@@ -82,7 +82,7 @@ function(this)
           cadvisor: {
             expr: 'container_network_receive_packets_dropped_total{%(queriesSelector)s}',
             aggKeepLabels: ['interface'],
-            legendCustomTemplate: '%s(%s) rx drops' % [commonlib.utils.labelsToPanelLegend(s.legendLabels), 'interface'],
+            legendCustomTemplate: '%s rx drops' % commonlib.utils.labelsToPanelLegend(s.legendLabels + ['interface']),
           },
         },
       },
@@ -95,7 +95,7 @@ function(this)
           cadvisor: {
             expr: 'container_network_transmit_packets_dropped_total{%(queriesSelector)s}',
             aggKeepLabels: ['interface'],
-            legendCustomTemplate: '%s(%s) tx drops' % [commonlib.utils.labelsToPanelLegend(s.legendLabels), 'interface'],
+            legendCustomTemplate: '%s tx drops' % commonlib.utils.labelsToPanelLegend(s.legendLabels + ['interface']),
           },
         },
       },
@@ -108,7 +108,7 @@ function(this)
           cadvisor: {
             expr: 'container_network_receive_errors_total{%(queriesSelector)s}',
             aggKeepLabels: ['interface'],
-            legendCustomTemplate: '%s(%s) rx errors ' % [commonlib.utils.labelsToPanelLegend(s.legendLabels), 'interface'],
+            legendCustomTemplate: '%s rx errors' % commonlib.utils.labelsToPanelLegend(s.legendLabels + ['interface']),
           },
         },
       },
@@ -121,7 +121,7 @@ function(this)
           cadvisor: {
             expr: 'container_network_transmit_errors_total{%(queriesSelector)s}',
             aggKeepLabels: ['interface'],
-            legendCustomTemplate: '%s(%s) tx errors ' % [commonlib.utils.labelsToPanelLegend(s.legendLabels), 'interface'],
+            legendCustomTemplate: '%s tx errors' % commonlib.utils.labelsToPanelLegend(s.legendLabels + ['interface']),
           },
         },
       },
@@ -136,7 +136,7 @@ function(this)
           cadvisor: {
             expr: 'container_fs_usage_bytes{%(queriesSelector)s}',
             aggKeepLabels: ['device'],
-            legendCustomTemplate: '%s(%s)' % [commonlib.utils.labelsToPanelLegend(s.legendLabels), 'device'],
+            legendCustomTemplate: '%s' % commonlib.utils.labelsToPanelLegend(s.legendLabels + ['device']),
           },
         },
       },
@@ -149,7 +149,7 @@ function(this)
           cadvisor: {
             expr: 'container_fs_reads_total{%(queriesSelector)s}',
             aggKeepLabels: ['device'],
-            legendCustomTemplate: '%s(%s)' % [commonlib.utils.labelsToPanelLegend(s.legendLabels), 'device'],
+            legendCustomTemplate: '%s' % commonlib.utils.labelsToPanelLegend(s.legendLabels + ['device']),
           },
         },
       },
@@ -162,7 +162,7 @@ function(this)
           cadvisor: {
             expr: 'container_fs_writes_total{%(queriesSelector)s}',
             aggKeepLabels: ['device'],
-            legendCustomTemplate: '%s(%s)' % [commonlib.utils.labelsToPanelLegend(s.legendLabels), 'device'],
+            legendCustomTemplate: '%s' % commonlib.utils.labelsToPanelLegend(s.legendLabels + ['device']),
           },
         },
       },

--- a/docker-mixin/signals/container.libsonnet
+++ b/docker-mixin/signals/container.libsonnet
@@ -129,22 +129,34 @@ function(this)
         sources: {
           cadvisor: {
             expr: 'container_fs_usage_bytes{%(queriesSelector)s}',
-            legendCustomTemplate: '%s' % commonlib.utils.labelsToPanelLegend(s.legendLabels),
+            aggKeepLabels: ['device'],
+            legendCustomTemplate: '%s(%s)' % [commonlib.utils.labelsToPanelLegend(s.legendLabels), 'device'],
           },
         },
       },
-      diskIO: {
-        name: 'Disk I/O',
-        description: 'The number of I/O requests per second for the device/volume.',
+      diskReads: {
+        name: 'Disk reads',
+        description: 'The number of read requests per second for the device/volume.',
         type: 'counter',
-        unit: 'percent',
+        unit: 'ops',
         sources: {
           cadvisor: {
-            expr: 'container_fs_io_time_seconds_total{%(queriesSelector)s}',
-            exprWrappers: [
-              ['100 *', ''],
-            ],
-            legendCustomTemplate: '%s' % commonlib.utils.labelsToPanelLegend(s.legendLabels),
+            expr: 'container_fs_reads_total{%(queriesSelector)s}',
+            aggKeepLabels: ['device'],
+            legendCustomTemplate: '%s(%s)' % [commonlib.utils.labelsToPanelLegend(s.legendLabels), 'device'],
+          },
+        },
+      },
+      diskWrites: {
+        name: 'Disk writes',
+        description: 'The number of write requests per second for the device/volume.',
+        type: 'counter',
+        unit: 'ops',
+        sources: {
+          cadvisor: {
+            expr: 'container_fs_writes_total{%(queriesSelector)s}',
+            aggKeepLabels: ['device'],
+            legendCustomTemplate: '%s(%s)' % [commonlib.utils.labelsToPanelLegend(s.legendLabels), 'device'],
           },
         },
       },

--- a/docker-mixin/signals/container.libsonnet
+++ b/docker-mixin/signals/container.libsonnet
@@ -144,12 +144,12 @@ function(this)
         name: 'Disk reads',
         description: 'The number of read requests per second for the device/volume.',
         type: 'counter',
-        unit: 'ops',
+        unit: 'reqps',
         sources: {
           cadvisor: {
             expr: 'container_fs_reads_total{%(queriesSelector)s}',
             aggKeepLabels: ['device'],
-            legendCustomTemplate: '%s' % commonlib.utils.labelsToPanelLegend(s.legendLabels + ['device']),
+            legendCustomTemplate: '%s read' % commonlib.utils.labelsToPanelLegend(s.legendLabels + ['device']),
           },
         },
       },
@@ -157,12 +157,12 @@ function(this)
         name: 'Disk writes',
         description: 'The number of write requests per second for the device/volume.',
         type: 'counter',
-        unit: 'ops',
+        unit: 'reqps',
         sources: {
           cadvisor: {
             expr: 'container_fs_writes_total{%(queriesSelector)s}',
             aggKeepLabels: ['device'],
-            legendCustomTemplate: '%s' % commonlib.utils.labelsToPanelLegend(s.legendLabels + ['device']),
+            legendCustomTemplate: '%s write' % commonlib.utils.labelsToPanelLegend(s.legendLabels + ['device']),
           },
         },
       },


### PR DESCRIPTION
- Disk IO in seconds was way too small for containers. Split DiskIO signal into read/writes for more meaningful metrics.
- Legend improvements:
  - Add `{{device}}` to all disks signals 
  - Add `{{interface}}` to all network signals 
- fix softmax=100 on CPU panel.
<img width="2042" alt="image" src="https://github.com/user-attachments/assets/612acfe3-3b5e-44a7-ae69-65524e593dfe">
- Set min=0 to diskUsageBytes panel
