### PR TITLE
Add support for otel_with_suffixes metricSource

### DIFF
--- a/golang-observ-lib/README.md
+++ b/golang-observ-lib/README.md
@@ -12,9 +12,9 @@ jb install https://github.com/grafana/jsonnet-libs/golang-observ-lib
 
 ## Examples
 
-Prometheus metrics' source:
+Prometheus metrics' source (`prometheus`):
 
 <img width="1737" alt="image" src="https://github.com/grafana/jsonnet-libs/assets/14870891/f1587d2f-b79b-4284-a4a8-e45b4e0ad183">
 
-OTel metrics' source:
+OTel metrics' source (`otel` or `otel_with_suffixes`):
 <img width="2047" alt="image" src="https://github.com/grafana/jsonnet-libs/assets/14870891/8df6283f-5ec7-427d-b99d-b19b8aa78d97">

--- a/golang-observ-lib/config.libsonnet
+++ b/golang-observ-lib/config.libsonnet
@@ -19,7 +19,8 @@
   dashboardRefresh: '1m',
 
   // otel: https://pkg.go.dev/go.opentelemetry.io/contrib/instrumentation/runtime
+  // otel_with_suffixes: when add_metric_suffixes=true in otelcollector
   // or prometheus
-  metricsSource: ['prometheus'],
+  metricsSource: ['prometheus', 'otel', 'otel_with_suffixes'],
   signals: (import './signals/golang.libsonnet')(this),
 }

--- a/golang-observ-lib/dashboards.libsonnet
+++ b/golang-observ-lib/dashboards.libsonnet
@@ -20,7 +20,10 @@ local g = import './g.libsonnet';
         + g.dashboard.withPanels(
           g.util.grid.wrapPanels(
             g.util.panel.resolveCollapsedFlagOnRows(
-              std.objectValues(this.grafana.rows)
+              [
+                this.grafana.rows.golangRuntime,
+                this.grafana.rows.golangMemory,
+              ],
             )
           )
         )

--- a/golang-observ-lib/mixin.libsonnet
+++ b/golang-observ-lib/mixin.libsonnet
@@ -5,7 +5,6 @@ local golang =
   + golanglib.withConfigMixin(
     {
       filteringSelector: 'job!=""',
-      metricsSource: ['otel', 'prometheus'],
     }
   );
 

--- a/golang-observ-lib/signals/golang.libsonnet
+++ b/golang-observ-lib/signals/golang.libsonnet
@@ -3,6 +3,7 @@ function(this)
     discoveryMetric: {
       prometheus: 'go_info',
       otel: 'process_runtime_go_goroutines',
+      otel_with_suffixes: self.otel,
     },
     filteringSelector: this.filteringSelector,
     groupLabels: this.groupLabels,
@@ -23,6 +24,9 @@ function(this)
             },
           otel: {
             expr: 'runtime_uptime{%(queriesSelector)s}/1000',
+          },
+          otel_with_suffixes: {
+            expr: 'runtime_uptime_milliseconds_total{%(queriesSelector)s}/1000',
           },
         },
       },
@@ -54,6 +58,7 @@ function(this)
             {
               expr: 'process_runtime_go_goroutines{%(queriesSelector)s}',
             },
+          otel_with_suffixes: self.otel,
         },
       },
       cgoCalls: {
@@ -67,6 +72,7 @@ function(this)
           otel: {
             expr: 'process_runtime_go_cgo_calls{%(queriesSelector)s}',
           },
+          otel_with_suffixes: self.otel,
         },
       },
       // gc duration:
@@ -119,6 +125,7 @@ function(this)
           otel: {
             expr: 'process_runtime_go_gc_pause_ns_bucket{%(queriesSelector)s}',
           },
+          otel_with_suffixes: self.otel,
         },
       },
       goThreads: {
@@ -192,6 +199,9 @@ function(this)
           otel: {
             expr: 'process_runtime_go_mem_heap_alloc{%(queriesSelector)s}',
           },
+          otel_with_suffixes: {
+            expr: 'process_runtime_go_mem_heap_alloc_bytes{%(queriesSelector)s}',
+          },
         },
       },
       memHeapIdleBytes: {
@@ -208,6 +218,10 @@ function(this)
           otel: {
             expr: 'process_runtime_go_mem_heap_idle{%(queriesSelector)s}',
           },
+          otel_with_suffixes: {
+            expr: 'process_runtime_go_mem_heap_idle_bytes{%(queriesSelector)s}',
+          },
+
         },
       },
       memHeapInUseBytes: {
@@ -224,6 +238,9 @@ function(this)
           otel: {
             expr: 'process_runtime_go_mem_heap_inuse{%(queriesSelector)s}',
           },
+          otel_with_suffixes: {
+            expr: 'process_runtime_go_mem_heap_inuse_bytes{%(queriesSelector)s}',
+          },
         },
       },
       memHeapReleasedBytes: {
@@ -239,6 +256,9 @@ function(this)
           },
           otel: {
             expr: 'process_runtime_go_mem_heap_released{%(queriesSelector)s}',
+          },
+          otel_with_suffixes: {
+            expr: 'process_runtime_go_mem_heap_released_bytes{%(queriesSelector)s}',
           },
         },
       },
@@ -258,6 +278,7 @@ function(this)
           otel: {
             expr: 'process_runtime_go_mem_heap_objects{%(queriesSelector)s}',
           },
+          otel_with_suffixes: self.otel,
         },
       },
 

--- a/jvm-observ-lib/README.md
+++ b/jvm-observ-lib/README.md
@@ -6,6 +6,7 @@ Supports the following sources:
 
 - `prometheus` (https://prometheus.github.io/client_java/instrumentation/jvm/#jvm-memory-metrics). This also works for jmx_exporter (javaagent mode) starting from 1.0.1 release.
 - `otel` (https://github.com/open-telemetry/opentelemetry-java-contrib/blob/main/jmx-metrics/docs/target-systems/jvm.md)
+- `otel_with_suffixes` same as otel with add_metric_suffixes=true in otelcollector
 - `java_micrometer` (springboot) (https://github.com/micrometer-metrics/micrometer/blob/main/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmMemoryMetrics.java)
 - `prometheus_old` client_java instrumentation prior to 1.0.0 release: (https://github.com/prometheus/client_java/releases/tag/v1.0.0-alpha-4). This also works for jmx_exporter (javaagent mode) prior to 1.0.1 release.
 - `jmx_exporter`. Works with jmx_exporter (both http and javaagent modes) and the folllowing snippet:

--- a/jvm-observ-lib/config.libsonnet
+++ b/jvm-observ-lib/config.libsonnet
@@ -6,7 +6,7 @@
   uid: 'jvm',
   dashboardNamePrefix: '',
   dashboardTags: ['java', 'jvm'],
-  metricsSource: ['java_micrometer', 'prometheus', 'prometheus_old', 'otel', 'jmx_exporter'],
+  metricsSource: ['java_micrometer', 'prometheus', 'prometheus_old', 'otel', 'otel_with_suffixes', 'jmx_exporter'],
   signals+:
     {
       memory: (import './signals/memory.libsonnet')(this),

--- a/jvm-observ-lib/main.libsonnet
+++ b/jvm-observ-lib/main.libsonnet
@@ -21,6 +21,7 @@ local processlib = import 'process-observ-lib/main.libsonnet';
           metricsSource:
             []
             + (if std.member(this.config.metricsSource, 'otel') then ['java_otel'] else [])
+            + (if std.member(this.config.metricsSource, 'otel_with_suffixes') then ['java_otel_with_suffixes'] else [])
             + (if std.member(this.config.metricsSource, 'prometheus') then ['prometheus'] else [])
             + (if std.member(this.config.metricsSource, 'jmx_exporter') then ['jmx_exporter'] else [])
             + (if std.member(this.config.metricsSource, 'prometheus_old') then ['prometheus'] else [])

--- a/jvm-observ-lib/signals/buffers.libsonnet
+++ b/jvm-observ-lib/signals/buffers.libsonnet
@@ -11,6 +11,7 @@ function(this)
       java_micrometer: 'jvm_buffer_memory_used_bytes',  // https://github.com/micrometer-metrics/micrometer/blob/main/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmMemoryMetrics.java
       prometheus: 'jvm_buffer_pool_used_bytes',  // https://prometheus.github.io/client_java/instrumentation/jvm/#jvm-buffer-pool-metrics
       otel: 'process_runtime_jvm_buffer_usage',
+      otel_with_suffixes: 'process_runtime_jvm_buffer_usage_bytes',
       prometheus_old: 'jvm_buffer_pool_used_bytes',
     },
     signals: {
@@ -29,6 +30,9 @@ function(this)
           },
           otel: {
             expr: 'process_runtime_jvm_buffer_usage{pool="direct", %(queriesSelector)s}',
+          },
+          otel_with_suffixes: {
+            expr: 'process_runtime_jvm_buffer_usage_bytes{pool="direct", %(queriesSelector)s}',
           },
           prometheus_old: {
             expr: 'jvm_buffer_pool_used_bytes{pool="direct", %(queriesSelector)s}',
@@ -51,6 +55,9 @@ function(this)
           otel: {
             expr: 'process_runtime_jvm_buffer_limit{pool="direct", %(queriesSelector)s}',
           },
+          otel_with_suffixes: {
+            expr: 'process_runtime_jvm_buffer_limit_bytes{pool="direct", %(queriesSelector)s}',
+          },
           prometheus_old: {
             expr: 'jvm_buffer_pool_capacity_bytes{pool="direct", %(queriesSelector)s}',
           },
@@ -72,6 +79,9 @@ function(this)
           otel: {
             expr: 'process_runtime_jvm_buffer_usage{pool="mapped", %(queriesSelector)s}',
           },
+          otel_with_suffixes: {
+            expr: 'process_runtime_jvm_buffer_usage_bytes{pool="mapped", %(queriesSelector)s}',
+          },
           prometheus_old: {
             expr: 'jvm_buffer_pool_used_bytes{pool="mapped", %(queriesSelector)s}',
           },
@@ -92,6 +102,9 @@ function(this)
           },
           otel: {
             expr: 'process_runtime_jvm_buffer_limit{pool="mapped", %(queriesSelector)s}',
+          },
+          otel_with_suffixes: {
+            expr: 'process_runtime_jvm_buffer_limit_bytes{pool="mapped", %(queriesSelector)s}',
           },
           prometheus_old: {
             expr: 'jvm_buffer_pool_capacity_bytes{pool="mapped", %(queriesSelector)s}',

--- a/jvm-observ-lib/signals/classes.libsonnet
+++ b/jvm-observ-lib/signals/classes.libsonnet
@@ -11,6 +11,7 @@ function(this)
       java_micrometer: 'jvm_classes_loaded_classes',  // https://github.com/micrometer-metrics/micrometer/blob/main/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ClassLoaderMetrics.java
       prometheus: 'jvm_classes_loaded',  // https://prometheus.github.io/client_java/instrumentation/jvm/#jvm-class-loading-metrics
       otel: 'process_runtime_jvm_classes_loaded',
+      otel_with_suffixes: 'process_runtime_jvm_classes_loaded_total',
       prometheus_old: 'jvm_classes_loaded',
       jmx_exporter: 'java_lang_classloading_loadedclasscount',
     },
@@ -29,6 +30,9 @@ function(this)
           },
           otel: {
             expr: 'process_runtime_jvm_classes_loaded{%(queriesSelector)s}',
+          },
+          otel_with_suffixes: {
+            expr: 'process_runtime_jvm_classes_loaded_total{%(queriesSelector)s}',
           },
           prometheus_old: {
             expr: 'jvm_classes_loaded{%(queriesSelector)s}',

--- a/jvm-observ-lib/signals/hikari.libsonnet
+++ b/jvm-observ-lib/signals/hikari.libsonnet
@@ -10,6 +10,7 @@ function(this)
     discoveryMetric: {
       java_micrometer: 'hikaricp_connections',  // https://github.com/brettwooldridge/HikariCP/blob/dev/src/main/java/com/zaxxer/hikari/metrics/micrometer/MicrometerMetricsTracker.java
       otel: 'hikaricp_connections',
+      otel_with_suffixes: self.otel,
     },
     signals: {
       connections: {
@@ -27,6 +28,7 @@ function(this)
             expr: 'hikaricp_connections{%(queriesSelector)s}',
             aggKeepLabels: ['pool'],
           },
+          otel_with_suffixes: self.otel,
         },
       },
       timeouts: {
@@ -57,6 +59,7 @@ function(this)
             expr: 'hikaricp_connections_active{%(queriesSelector)s}',
             aggKeepLabels: ['pool'],
           },
+          otel_with_suffixes: self.otel,
         },
       },
       connectionsIdle: {
@@ -74,6 +77,7 @@ function(this)
             expr: 'hikaricp_connections_idle{%(queriesSelector)s}',
             aggKeepLabels: ['pool'],
           },
+          otel_with_suffixes: self.otel,
         },
       },
       connectionsPending: {
@@ -90,7 +94,9 @@ function(this)
           otel: {
             expr: 'hikaricp_connections_pending{%(queriesSelector)s}',
             aggKeepLabels: ['pool'],
+
           },
+          otel_with_suffixes: self.otel,
         },
       },
       connectionsCreationDurationAvg: {
@@ -152,6 +158,10 @@ function(this)
             expr: 'hikaricp_connections_creation_bucket{%(queriesSelector)s}',
             aggKeepLabels: ['pool'],
           },
+          otel_with_suffixes: {
+            expr: 'hikaricp_connections_creation_seconds_bucket{%(queriesSelector)s}',
+            aggKeepLabels: ['pool'],
+          },
         },
       },
       connectionsUsageDurationP95: {
@@ -165,6 +175,10 @@ function(this)
             expr: 'hikaricp_connections_usage_bucket{%(queriesSelector)s}',
             aggKeepLabels: ['pool'],
           },
+          otel_with_suffixes: {
+            expr: 'hikaricp_connections_usage_seconds_bucket{%(queriesSelector)s}',
+            aggKeepLabels: ['pool'],
+          },
         },
       },
       connectionsAcquireDurationP95: {
@@ -176,6 +190,10 @@ function(this)
         sources: {
           otel: {
             expr: 'hikaricp_connections_acquire_bucket{%(queriesSelector)s}',
+            aggKeepLabels: ['pool'],
+          },
+          otel_with_suffixes: {
+            expr: 'hikaricp_connections_acquire_seconds_bucket{%(queriesSelector)s}',
             aggKeepLabels: ['pool'],
           },
         },

--- a/jvm-observ-lib/signals/memory.libsonnet
+++ b/jvm-observ-lib/signals/memory.libsonnet
@@ -9,6 +9,7 @@ function(this)
       java_micrometer: 'jvm_memory_used_bytes',
       prometheus: 'jvm_memory_used_bytes',  // https://prometheus.github.io/client_java/instrumentation/jvm/#jvm-memory-metrics
       otel: 'process_runtime_jvm_memory_usage',
+      otel_with_suffixes: 'process_runtime_jvm_memory_usage_bytes',
       prometheus_old: 'jvm_memory_bytes_max',
       jmx_exporter: 'java_lang_memory_heapmemoryusage_used',  //https://github.com/prometheus/jmx_exporter/blob/main/collector/src/test/java/io/prometheus/jmx/JmxCollectorTest.java#L195
     },
@@ -29,6 +30,9 @@ function(this)
           },
           otel: {
             expr: 'sum without (pool) (process_runtime_jvm_memory_usage{type="heap", %(queriesSelector)s})',
+          },
+          otel_with_suffixes: {
+            expr: 'sum without (pool) (process_runtime_jvm_memory_usage_bytes{type="heap", %(queriesSelector)s})',
           },
           prometheus_old: {
             expr: 'sum without (id) (jvm_memory_bytes_used{area="heap", %(queriesSelector)s})',
@@ -60,6 +64,9 @@ function(this)
           otel: {
             expr: 'sum without (pool) (process_runtime_jvm_memory_limit{type="heap", %(queriesSelector)s} != -1)',
           },
+          otel_with_suffixes: {
+            expr: 'sum without (pool) (process_runtime_jvm_memory_limit_bytes{type="heap", %(queriesSelector)s} != -1)',
+          },
           prometheus_old: {
             expr: 'sum without (id) (jvm_memory_bytes_max{area="heap", %(queriesSelector)s} != -1)',
           },
@@ -82,6 +89,9 @@ function(this)
           otel: {
             expr: 'sum without (pool) (process_runtime_jvm_memory_usage{type="non_heap", %(queriesSelector)s})',
           },
+          otel_with_suffixes: {
+            expr: 'sum without (pool) (process_runtime_jvm_memory_usage_bytes{type="non_heap", %(queriesSelector)s})',
+          },
           prometheus_old: {
             expr: 'sum without (id) (jvm_memory_bytes_used{area="nonheap", %(queriesSelector)s})',
           },
@@ -102,6 +112,9 @@ function(this)
           prometheus: self.java_micrometer,
           otel: {
             expr: 'sum without (pool) (process_runtime_jvm_memory_limit{type="non_heap", %(queriesSelector)s} != -1)',
+          },
+          otel_with_suffixes: {
+            expr: 'sum without (pool) (process_runtime_jvm_memory_limit_bytes{type="non_heap", %(queriesSelector)s} != -1)',
           },
           prometheus_old: {
             expr: 'sum without (id) (jvm_memory_bytes_max{area="nonheap", %(queriesSelector)s} != -1)',
@@ -126,6 +139,9 @@ function(this)
           otel: {
             expr: 'sum without (pool) (process_runtime_jvm_memory_committed{type="heap", %(queriesSelector)s})',
           },
+          otel_with_suffixes: {
+            expr: 'sum without (pool) (process_runtime_jvm_memory_committed_bytes{type="heap", %(queriesSelector)s})',
+          },
           prometheus_old: {
             expr: 'sum without (id) (jvm_memory_bytes_committed{area="heap", %(queriesSelector)s})',
           },
@@ -148,6 +164,9 @@ function(this)
           prometheus: self.java_micrometer,
           otel: {
             expr: 'sum without (pool) (process_runtime_jvm_memory_committed{type="non_heap", %(queriesSelector)s})',
+          },
+          otel_with_suffixes: {
+            expr: 'sum without (pool) (process_runtime_jvm_memory_committed_bytes{type="non_heap", %(queriesSelector)s})',
           },
           prometheus_old: {
             expr: 'sum without (id) (jvm_memory_bytes_committed{area="nonheap", %(queriesSelector)s})',

--- a/jvm-observ-lib/signals/threads.libsonnet
+++ b/jvm-observ-lib/signals/threads.libsonnet
@@ -11,6 +11,7 @@ function(this)
       java_micrometer: 'jvm_threads_live_threads',  // https://github.com/micrometer-metrics/micrometer/blob/main/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetrics.java
       prometheus: 'jvm_threads_current',  // https://prometheus.github.io/client_java/instrumentation/jvm/#jvm-memory-metrics
       otel: 'process_runtime_jvm_threads_count',
+      otel_with_suffixes: self.otel,
       prometheus_old: 'jvm_threads_current',
       jmx_exporter: 'java_lang_threading_threadcount',
     },
@@ -30,6 +31,7 @@ function(this)
           otel: {
             expr: 'sum without (daemon) (process_runtime_jvm_threads_count{%(queriesSelector)s})',
           },
+          otel_with_suffixes: self.otel,
           prometheus_old: self.prometheus,
           jmx_exporter: {
             expr: 'java_lang_threading_threadcount{%(queriesSelector)s}',
@@ -51,6 +53,7 @@ function(this)
           otel: {
             expr: 'process_runtime_jvm_threads_count{daemon="true", %(queriesSelector)s}',
           },
+          otel_with_suffixes: self.otel,
           prometheus_old: self.prometheus,
           jmx_exporter: {
             expr: 'java_lang_threading_daemonthreadcount{%(queriesSelector)s}',

--- a/process-observ-lib/README.md
+++ b/process-observ-lib/README.md
@@ -7,6 +7,7 @@ Supports the following sources:
 - prometheus
 - otel
 - java_otel
+- java_otel_with_suffixes (add_metric_suffixes=true in otelcollector)
 - java_micrometer (springboot)
 - jmx_exporter
 

--- a/process-observ-lib/config.libsonnet
+++ b/process-observ-lib/config.libsonnet
@@ -18,7 +18,7 @@
   dashboardTimezone: 'default',
   dashboardRefresh: '1m',
 
-  metricsSource: ['prometheus'],  // or any combination of: prometheus, otel, java_otel, java_micrometer.
+  metricsSource: ['prometheus'],  // or any combination of: prometheus, otel, otel_with_suffixes, java_otel, java_otel_with_suffixes, java_micrometer.
   signals+:
     {
       system: (import './signals/system.libsonnet')(this),

--- a/process-observ-lib/signals/process.libsonnet
+++ b/process-observ-lib/signals/process.libsonnet
@@ -2,18 +2,16 @@ function(this)
   {
     discoveryMetric: {
       // https://opentelemetry.io/docs/specs/semconv/system/process-metrics/
-
       otel: 'runtime_uptime',
+      otel_with_suffixes: 'runtime_uptime_milliseconds_total',
       java_otel: self.otel,  // some system metrics are calculated differently for java. (see system.libsonnet)
       java_micrometer: 'process_uptime_seconds',  // https://docs.spring.io/spring-boot/docs/1.3.3.RELEASE/reference/html/production-ready-metrics.html
-
+      java_otel_with_suffixes: self.otel_with_suffixes,  // some system metrics are calculated differently for java. (see system.libsonnet),
       // https://prometheus.github.io/client_java/instrumentation/jvm/#process-metrics
       // https://github.com/prometheus/client_golang
       prometheus: 'process_start_time_seconds',
-
       // acceptable if container has single process running
       cadvisor: 'container_cpu_usage_seconds_total',
-
       //https://github.com/prometheus/jmx_exporter/blob/main/collector/src/test/java/io/prometheus/jmx/JmxCollectorTest.java#L195
       jmx_exporter: 'java_lang_operatingsystem_processcputime',
     },
@@ -37,7 +35,11 @@ function(this)
           otel: {
             expr: 'process_uptime{%(queriesSelector)s}',
           },
+          otel_with_suffixes: {
+            expr: 'runtime_uptime_milliseconds_total{%(queriesSelector)s}',
+          },
           java_otel: self.otel,
+          java_otel_with_suffixes: self.otel_with_suffixes,
           java_micrometer: {
             expr: 'process_uptime_seconds{%(queriesSelector)s}',
           },
@@ -66,7 +68,11 @@ function(this)
           otel: {
             expr: 'process_start_time{%(queriesSelector)s} * 1000',
           },
+          otel_with_suffixes: {
+            expr: 'process_start_time_seconds{%(queriesSelector)s} * 1000',
+          },
           java_otel: self.otel,
+          java_otel_with_suffixes: self.otel_with_suffixes,
           cadvisor: {
             cadvisor: 'container_start_time_seconds{%(queriesSelector)s}',
           },
@@ -88,6 +94,9 @@ function(this)
           },
           java_otel: {
             expr: 'process_runtime_jvm_cpu_utilization{%(queriesSelector)s} * 100',
+          },
+          java_otel_with_suffixes: {
+            expr: 'process_runtime_jvm_cpu_utilization_ratio{%(queriesSelector)s} * 100',
           },
           prometheus: {
             // convert to gauge from counter to match others here.
@@ -149,6 +158,8 @@ function(this)
           otel: {
             expr: 'process_files_open{%(queriesSelector)s}',
           },
+          otel_with_suffixes: self.otel,
+          java_otel_with_suffixes: self.otel,
           java_otel: self.otel,
           java_micrometer: {
             expr: 'process_files_open_files{%(queriesSelector)s}',
@@ -168,6 +179,8 @@ function(this)
             expr: 'process_files_max{%(queriesSelector)s}',
           },
           java_otel: self.otel,
+          otel_with_suffixes: self.otel,
+          java_otel_with_suffixes: self.otel,
           java_micrometer: {
             expr: 'process_files_max_files{%(queriesSelector)s}',
           },

--- a/process-observ-lib/signals/system.libsonnet
+++ b/process-observ-lib/signals/system.libsonnet
@@ -3,7 +3,9 @@ function(this)
     discoveryMetric: {
       // https://opentelemetry.io/docs/specs/semconv/system/process-metrics/
       otel: 'runtime_uptime',
+      otel_with_suffixes: 'runtime_uptime_milliseconds_total',
       java_otel: self.otel,  // some system metrics are calculated differently for java
+      java_otel_with_suffixes: self.otel_with_suffixes,
       java_micrometer: 'process_uptime_seconds',
       // https://prometheus.github.io/client_java/instrumentation/jvm/#process-metrics
       // https://github.com/prometheus/client_golang
@@ -28,6 +30,7 @@ function(this)
           java_otel: {
             expr: 'process_runtime_jvm_system_cpu_load_1m{%(queriesSelector)s}',
           },
+          java_otel_with_suffixes: self.java_otel,
           java_micrometer: {
             expr: 'system_load_average_1m{%(queriesSelector)s}',
           },

--- a/process-observ-lib/signals/system.libsonnet
+++ b/process-observ-lib/signals/system.libsonnet
@@ -52,6 +52,9 @@ function(this)
           java_otel: {
             expr: 'process_runtime_jvm_system_cpu_utilization{%(queriesSelector)s}',
           },
+          java_otel_with_suffixes: {
+            expr: 'process_runtime_jvm_system_cpu_utilization_ratio{%(queriesSelector)s}',
+          },
           jmx_exporter: {
             expr: 'java_lang_operatingsystem_cpuload{%(queriesSelector)s}',
             exprWrappers: [


### PR DESCRIPTION
It is expected that otel metrics are transformted to Prometheus format via otel-collector/grafana alloy prometheusremotewrite exporter.

This change adds support of popular `add_metric_suffixes` option set to true in addition to false to observ libs.
https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/prometheusremotewriteexporter/README.md#getting-started