### PR TITLE
Add azure virtual network ddos dashboard to cspmixin

### DIFF
--- a/csp-mixin/config.libsonnet
+++ b/csp-mixin/config.libsonnet
@@ -12,6 +12,7 @@
         gcploadbalancer: (import './signals/gcploadbalancer.libsonnet')(this),
         gcpoadbalancerBackend: (import './signals/gcpoadbalancerBackend.libsonnet')(this),
         azureloadbalancer: (import './signals/azureloadbalancer.libsonnet')(this),
+        azurevirtualnetwork: (import './signals/azurevirtualnetwork.libsonnet')(this),
       },
     blobStorage: {
       enableAvailability: false,

--- a/csp-mixin/dashboards.libsonnet
+++ b/csp-mixin/dashboards.libsonnet
@@ -116,9 +116,9 @@ local commonlib = import 'common-lib/common/main.libsonnet';
                    + g.dashboard.withVariables(variables)
                    + g.dashboard.withPanels(
                      g.util.grid.wrapPanels(
-                      csplib.grafana.rows.vn_overview +
-                      csplib.grafana.rows.vn_bytes +
-                      csplib.grafana.rows.vn_packets
+                       csplib.grafana.rows.vn_overview +
+                       csplib.grafana.rows.vn_bytes +
+                       csplib.grafana.rows.vn_packets
                      )
                    ),
                } else {},

--- a/csp-mixin/dashboards.libsonnet
+++ b/csp-mixin/dashboards.libsonnet
@@ -107,7 +107,7 @@ local commonlib = import 'common-lib/common/main.libsonnet';
 
                  [csplib.config.uid + '-virtualnetwork.json']:
                    local variables = csplib.signals.azureloadbalancer.getVariablesMultiChoice();
-                   g.dashboard.new(csplib.config.dashboardNamePrefix + 'Virtual Network')
+                   g.dashboard.new(csplib.config.dashboardNamePrefix + 'Virtual network')
                    + g.dashboard.withUid(csplib.config.uid + '-virtualnetwork')
                    + g.dashboard.withTags(csplib.config.dashboardTags)
                    + g.dashboard.withTimezone(csplib.config.dashboardTimezone)

--- a/csp-mixin/dashboards.libsonnet
+++ b/csp-mixin/dashboards.libsonnet
@@ -104,5 +104,22 @@ local commonlib = import 'common-lib/common/main.libsonnet';
                        csplib.grafana.rows.alb_loadbalancers
                      )
                    ),
+
+                 [csplib.config.uid + '-virtualnetwork.json']:
+                   local variables = csplib.signals.azureloadbalancer.getVariablesMultiChoice();
+                   g.dashboard.new(csplib.config.dashboardNamePrefix + 'Virtual Network')
+                   + g.dashboard.withUid(csplib.config.uid + '-virtualnetwork')
+                   + g.dashboard.withTags(csplib.config.dashboardTags)
+                   + g.dashboard.withTimezone(csplib.config.dashboardTimezone)
+                   + g.dashboard.withRefresh(csplib.config.dashboardRefresh)
+                   + g.dashboard.timepicker.withTimeOptions(csplib.config.dashboardPeriod)
+                   + g.dashboard.withVariables(variables)
+                   + g.dashboard.withPanels(
+                     g.util.grid.wrapPanels(
+                      csplib.grafana.rows.vn_overview +
+                      csplib.grafana.rows.vn_bytes +
+                      csplib.grafana.rows.vn_packets
+                     )
+                   ),
                } else {},
 }

--- a/csp-mixin/panels.libsonnet
+++ b/csp-mixin/panels.libsonnet
@@ -845,23 +845,7 @@ local commonlib = import 'common-lib/common/main.libsonnet';
 
     // Azure Virtual Network
     vn_under_ddos:
-      this.signals.azurevirtualnetwork.underDdos.asStat()
-      + g.panel.timeSeries.standardOptions.withMappings(
-        {
-          type: 'value',
-          options: {
-            '0': {
-              text: 'OK',
-              index: 0,
-            },
-            '1': {
-              text: 'Under Attack',
-              color: 'dark-red',
-              index: 1,
-            },
-          },
-        }
-      ),
+      this.signals.azurevirtualnetwork.underDdos.asStat(),
 
     vn_pingmesh_avg:
       this.signals.azurevirtualnetwork.pingMeshAvgRoundrip.asTimeSeries(),

--- a/csp-mixin/panels.libsonnet
+++ b/csp-mixin/panels.libsonnet
@@ -842,5 +842,71 @@ local commonlib = import 'common-lib/common/main.libsonnet';
           },
         },
       ]),
+
+    // Azure Virtual Network
+    vn_under_ddos:
+      this.signals.azurevirtualnetwork.underDdos.asStat()
+      + g.panel.timeSeries.standardOptions.withMappings(
+        {
+          type: 'value',
+          options: {
+            '0': {
+              text: 'OK',
+              index: 0,
+            },
+            '1': {
+              text: 'Under Attack',
+              color: 'dark-red',
+              index: 1,
+            },
+          },
+        }
+      ),
+
+    vn_pingmesh_avg:
+      this.signals.azurevirtualnetwork.pingMeshAvgRoundrip.asTimeSeries(),
+
+    vn_packet_trigger:
+      commonlib.panels.generic.timeSeries.base.new('DDoS trigger packets by type', targets=[])
+      + g.panel.timeSeries.fieldConfig.defaults.custom.stacking.withMode('normal')
+      + this.signals.azurevirtualnetwork.synTriggerPackets.asPanelMixin()
+      + this.signals.azurevirtualnetwork.tcpTriggerPackets.asPanelMixin()
+      + this.signals.azurevirtualnetwork.udpTriggerPackets.asPanelMixin(),
+
+    vn_bytes_by_action:
+      commonlib.panels.generic.timeSeries.base.new('Bytes by DDoS action', targets=[])
+      + g.panel.timeSeries.fieldConfig.defaults.custom.stacking.withMode('normal')
+      + this.signals.azurevirtualnetwork.bytesDropped.asPanelMixin()
+      + this.signals.azurevirtualnetwork.bytesForwarded.asPanelMixin(),
+
+    vn_bytes_dropped_by_protocol:
+      commonlib.panels.generic.timeSeries.base.new('Bytes dropped in DDoS by protocol', targets=[])
+      + g.panel.timeSeries.fieldConfig.defaults.custom.stacking.withMode('normal')
+      + this.signals.azurevirtualnetwork.tcpBytesDropped.asPanelMixin()
+      + this.signals.azurevirtualnetwork.udpBytesDropped.asPanelMixin(),
+
+    vn_bytes_forwarded_by_protocol:
+      commonlib.panels.generic.timeSeries.base.new('Bytes forwarded in DDoS by protocol', targets=[])
+      + g.panel.timeSeries.fieldConfig.defaults.custom.stacking.withMode('normal')
+      + this.signals.azurevirtualnetwork.tcpBytesForwarded.asPanelMixin()
+      + this.signals.azurevirtualnetwork.udpBytesForwarded.asPanelMixin(),
+
+    vn_packets_by_action:
+      commonlib.panels.generic.timeSeries.base.new('Packets by DDoS action', targets=[])
+      + g.panel.timeSeries.fieldConfig.defaults.custom.stacking.withMode('normal')
+      + this.signals.azurevirtualnetwork.packetsDropped.asPanelMixin()
+      + this.signals.azurevirtualnetwork.packetsForwarded.asPanelMixin(),
+
+    vn_packets_dropped_by_protocol:
+      commonlib.panels.generic.timeSeries.base.new('Packets dropped in DDoS by protocol', targets=[])
+      + g.panel.timeSeries.fieldConfig.defaults.custom.stacking.withMode('normal')
+      + this.signals.azurevirtualnetwork.tcpPacketsDropped.asPanelMixin()
+      + this.signals.azurevirtualnetwork.udpPacketsDropped.asPanelMixin(),
+
+    vn_packets_forwarded_by_protocol:
+      commonlib.panels.generic.timeSeries.base.new('Packets forwarded in DDoS by protocol', targets=[])
+      + g.panel.timeSeries.fieldConfig.defaults.custom.stacking.withMode('normal')
+      + this.signals.azurevirtualnetwork.tcpPacketsForwarded.asPanelMixin()
+      + this.signals.azurevirtualnetwork.udpPacketsForwarded.asPanelMixin(),
   },
 }

--- a/csp-mixin/rows.libsonnet
+++ b/csp-mixin/rows.libsonnet
@@ -216,5 +216,51 @@ local g = import './g.libsonnet';
         + g.panel.gauge.gridPos.withW(12)
         + g.panel.gauge.gridPos.withH(8),
       ],
+
+      // Azure Virtual Network
+      vn_overview: [
+        g.panel.row.new("Overview"),
+        this.grafana.panels.vn_under_ddos
+        + g.panel.timeSeries.gridPos.withW(6)
+        + g.panel.timeSeries.gridPos.withH(6),
+
+        this.grafana.panels.vn_pingmesh_avg
+        + g.panel.timeSeries.gridPos.withW(6)
+        + g.panel.timeSeries.gridPos.withH(6),
+
+        this.grafana.panels.vn_packet_trigger
+        + g.panel.timeSeries.gridPos.withW(12)
+        + g.panel.timeSeries.gridPos.withH(6),
+      ],
+
+      vn_bytes: [
+        g.panel.row.new("Bytes"),
+        this.grafana.panels.vn_bytes_by_action
+        + g.panel.timeSeries.gridPos.withW(8)
+        + g.panel.timeSeries.gridPos.withH(8),
+
+        this.grafana.panels.vn_bytes_dropped_by_protocol
+        + g.panel.timeSeries.gridPos.withW(8)
+        + g.panel.timeSeries.gridPos.withH(8),
+
+        this.grafana.panels.vn_bytes_forwarded_by_protocol
+        + g.panel.timeSeries.gridPos.withW(8)
+        + g.panel.timeSeries.gridPos.withH(8),
+      ],
+
+      vn_packets: [
+        g.panel.row.new("Packets"),
+        this.grafana.panels.vn_packets_by_action
+        + g.panel.timeSeries.gridPos.withW(8)
+        + g.panel.timeSeries.gridPos.withH(8),
+
+        this.grafana.panels.vn_packets_dropped_by_protocol
+        + g.panel.timeSeries.gridPos.withW(8)
+        + g.panel.timeSeries.gridPos.withH(8),
+
+        this.grafana.panels.vn_packets_forwarded_by_protocol
+        + g.panel.timeSeries.gridPos.withW(8)
+        + g.panel.timeSeries.gridPos.withH(8),
+      ],
     },
 }

--- a/csp-mixin/rows.libsonnet
+++ b/csp-mixin/rows.libsonnet
@@ -219,7 +219,7 @@ local g = import './g.libsonnet';
 
       // Azure Virtual Network
       vn_overview: [
-        g.panel.row.new("Overview"),
+        g.panel.row.new('Overview'),
         this.grafana.panels.vn_under_ddos
         + g.panel.timeSeries.gridPos.withW(6)
         + g.panel.timeSeries.gridPos.withH(6),
@@ -234,7 +234,7 @@ local g = import './g.libsonnet';
       ],
 
       vn_bytes: [
-        g.panel.row.new("Bytes"),
+        g.panel.row.new('Bytes'),
         this.grafana.panels.vn_bytes_by_action
         + g.panel.timeSeries.gridPos.withW(8)
         + g.panel.timeSeries.gridPos.withH(8),
@@ -249,7 +249,7 @@ local g = import './g.libsonnet';
       ],
 
       vn_packets: [
-        g.panel.row.new("Packets"),
+        g.panel.row.new('Packets'),
         this.grafana.panels.vn_packets_by_action
         + g.panel.timeSeries.gridPos.withW(8)
         + g.panel.timeSeries.gridPos.withH(8),

--- a/csp-mixin/signals/azurevirtualnetwork.libsonnet
+++ b/csp-mixin/signals/azurevirtualnetwork.libsonnet
@@ -57,7 +57,7 @@ function(this)
       sources: {
         azuremonitor: {
           expr: 'azure_microsoft_network_virtualnetworks_tcpbytesdroppedddos_bytespersecond_maximum{%(queriesSelector)s}',
-          legendCustomTemplate: 'Dropped',
+          legendCustomTemplate: 'TCP Dropped',
         },
       },
     },
@@ -70,7 +70,7 @@ function(this)
       sources: {
         azuremonitor: {
           expr: 'azure_microsoft_network_virtualnetworks_tcpbytesforwardedddos_bytespersecond_maximum{%(queriesSelector)s}',
-          legendCustomTemplate: 'Forwarded',
+          legendCustomTemplate: 'TCP Forwarded',
         },
       },
     },
@@ -83,7 +83,7 @@ function(this)
       sources: {
         azuremonitor: {
           expr: 'azure_microsoft_network_virtualnetworks_tcpbytesinddos_bytespersecond_maximum{%(queriesSelector)s}',
-          legendCustomTemplate: 'Total',
+          legendCustomTemplate: 'TCP Total',
         },
       },
     },
@@ -96,7 +96,7 @@ function(this)
       sources: {
         azuremonitor: {
           expr: 'azure_microsoft_network_virtualnetworks_udpbytesdroppedddos_bytespersecond_maximum{%(queriesSelector)s}',
-          legendCustomTemplate: 'Dropped',
+          legendCustomTemplate: 'UDP Dropped',
         },
       },
     },
@@ -109,7 +109,7 @@ function(this)
       sources: {
         azuremonitor: {
           expr: 'azure_microsoft_network_virtualnetworks_udpbytesforwardedddos_bytespersecond_maximum{%(queriesSelector)s}',
-          legendCustomTemplate: 'Forwarded',
+          legendCustomTemplate: 'UDP Forwarded',
         },
       },
     },
@@ -122,7 +122,7 @@ function(this)
       sources: {
         azuremonitor: {
           expr: 'azure_microsoft_network_virtualnetworks_udpbytesinddos_bytespersecond_maximum{%(queriesSelector)s}',
-          legendCustomTemplate: 'Total',
+          legendCustomTemplate: 'UDP Total',
         },
       },
     },
@@ -170,7 +170,7 @@ function(this)
       sources: {
         azuremonitor: {
           expr: 'azure_microsoft_network_virtualnetworks_tcppacketsdroppedddos_countpersecond_maximum{%(queriesSelector)s}',
-          legendCustomTemplate: 'Dropped',
+          legendCustomTemplate: 'TCP Dropped',
         },
       },
     },
@@ -182,7 +182,7 @@ function(this)
       sources: {
         azuremonitor: {
           expr: 'azure_microsoft_network_virtualnetworks_tcppacketsforwardedddos_countpersecond_maximum{%(queriesSelector)s}',
-          legendCustomTemplate: 'Forwarded',
+          legendCustomTemplate: 'TCP Forwarded',
         },
       },
     },
@@ -194,7 +194,7 @@ function(this)
       sources: {
         azuremonitor: {
           expr: 'azure_microsoft_network_virtualnetworks_tcppacketsinddos_countpersecond_maximum{%(queriesSelector)s}',
-          legendCustomTemplate: 'Total',
+          legendCustomTemplate: 'TCP Total',
         },
       },
     },
@@ -206,7 +206,7 @@ function(this)
       sources: {
         azuremonitor: {
           expr: 'azure_microsoft_network_virtualnetworks_udppacketsdroppedddos_countpersecond_maximum{%(queriesSelector)s}',
-          legendCustomTemplate: 'Dropped',
+          legendCustomTemplate: 'UDP Dropped',
         },
       },
     },
@@ -218,7 +218,7 @@ function(this)
       sources: {
         azuremonitor: {
           expr: 'azure_microsoft_network_virtualnetworks_udppacketsforwardedddos_countpersecond_maximum{%(queriesSelector)s}',
-          legendCustomTemplate: 'Forwarded',
+          legendCustomTemplate: 'UDP Forwarded',
         },
       },
     },
@@ -230,7 +230,7 @@ function(this)
       sources: {
         azuremonitor: {
           expr: 'azure_microsoft_network_virtualnetworks_udppacketsinddos_countpersecond_maximum{%(queriesSelector)s}',
-          legendCustomTemplate: 'Total',
+          legendCustomTemplate: 'UDP Total',
         },
       },
     },

--- a/csp-mixin/signals/azurevirtualnetwork.libsonnet
+++ b/csp-mixin/signals/azurevirtualnetwork.libsonnet
@@ -1,0 +1,308 @@
+local commonlib = import 'common-lib/common/main.libsonnet';
+function(this)
+{
+  local s = self,
+  filteringSelector: this.filteringSelector,
+  groupLabels: this.groupLabels,
+  instanceLabels: this.instanceLabels,
+  aggLevel: 'instance',
+  discoveryMetric: {
+    azuremonitor: 'azure_microsoft_network_virtualnetworks_ifunderddosattack_maximum_count',
+  },
+  signals: {
+    bytesDropped: {
+      name: 'Bytes Dropped DDoS',
+      description: 'Inbound bytes per second dropped by DDoS protection.',
+      type: 'gauge',
+      unit: 'binBps',
+      sources: {
+        azuremonitor: {
+          expr: 'azure_microsoft_network_virtualnetworks_bytesdroppedddos_bytespersecond_maximum{%(queriesSelector)s}',
+          legendCustomTemplate: 'Dropped',
+        },
+      },
+    },
+    
+    bytesForwarded: {
+      name: 'Bytes Forwarded DDoS',
+      description: 'Inbound bytes per second forwarded by DDoS protection.',
+      type: 'gauge',
+      unit: 'binBps',
+      sources: {
+        azuremonitor: {
+          expr: 'azure_microsoft_network_virtualnetworks_bytesforwardedddos_bytespersecond_maximum{%(queriesSelector)s}',
+          legendCustomTemplate: 'Forwarded',
+        },
+      },
+    },
+    
+    bytesTotal: {
+      name: 'Bytes in DDoS',
+      description: 'Total bytes per second inbound in DDoS protection.',
+      type: 'gauge',
+      unit: 'binBps',
+      sources: {
+        azuremonitor: {
+          expr: 'azure_microsoft_network_virtualnetworks_bytesinddos_bytespersecond_maximum{%(queriesSelector)s}',
+          legendCustomTemplate: 'Total',
+        },
+      },
+    },
+    
+    tcpBytesDropped: {
+      name: 'TCP bytes Dropped DDoS',
+      description: 'Inbound TCP bytes per second dropped by DDoS protection.',
+      type: 'gauge',
+      unit: 'binBps',
+      sources: {
+        azuremonitor: {
+          expr: 'azure_microsoft_network_virtualnetworks_tcpbytesdroppedddos_bytespersecond_maximum{%(queriesSelector)s}',
+          legendCustomTemplate: 'Dropped',
+        },
+      },
+    },
+    
+    tcpBytesForwarded: {
+      name: 'TCP bytes Forwarded DDoS',
+      description: 'Inbound tcp bytes per second forwarded by DDoS protection.',
+      type: 'gauge',
+      unit: 'binBps',
+      sources: {
+        azuremonitor: {
+          expr: 'azure_microsoft_network_virtualnetworks_tcpbytesforwardedddos_bytespersecond_maximum{%(queriesSelector)s}',
+          legendCustomTemplate: 'Forwarded',
+        },
+      },
+    },
+    
+    tcpBytesTotal: {
+      name: 'TCP bytes in DDoS',
+      description: 'Total TCP bytes per second inbound in DDoS protection.',
+      type: 'gauge',
+      unit: 'binBps',
+      sources: {
+        azuremonitor: {
+          expr: 'azure_microsoft_network_virtualnetworks_tcpbytesinddos_bytespersecond_maximum{%(queriesSelector)s}',
+          legendCustomTemplate: 'Total',
+        },
+      },
+    },
+    
+    udpBytesDropped: {
+      name: 'UDP bytes Dropped DDoS',
+      description: 'Inbound UDP bytes per second dropped by DDoS protection.',
+      type: 'gauge',
+      unit: 'binBps',
+      sources: {
+        azuremonitor: {
+          expr: 'azure_microsoft_network_virtualnetworks_udpbytesdroppedddos_bytespersecond_maximum{%(queriesSelector)s}',
+          legendCustomTemplate: 'Dropped',
+        },
+      },
+    },
+    
+    udpBytesForwarded: {
+      name: 'UDP bytes Forwarded DDoS',
+      description: 'Inbound udp bytes per second forwarded by DDoS protection.',
+      type: 'gauge',
+      unit: 'binBps',
+      sources: {
+        azuremonitor: {
+          expr: 'azure_microsoft_network_virtualnetworks_udpbytesforwardedddos_bytespersecond_maximum{%(queriesSelector)s}',
+          legendCustomTemplate: 'Forwarded',
+        },
+      },
+    },
+    
+    udpBytesTotal: {
+      name: 'UDP bytes in DDoS',
+      description: 'Total UDP bytes per second inbound in DDoS protection.',
+      type: 'gauge',
+      unit: 'binBps',
+      sources: {
+        azuremonitor: {
+          expr: 'azure_microsoft_network_virtualnetworks_udpbytesinddos_bytespersecond_maximum{%(queriesSelector)s}',
+          legendCustomTemplate: 'Total',
+        },
+      },
+    },
+
+    packetsDropped: {
+      name: 'Packets Dropped DDoS',
+      description: 'Inbound packets per second dropped by DDoS protection',
+      type: 'gauge',
+      sources: {
+        azuremonitor: {
+          expr: 'azure_microsoft_network_virtualnetworks_packetsdroppedddos_countpersecond_maximum{%(queriesSelector)s}',
+          legendCustomTemplate: 'Dropped',
+        },
+      },
+    },
+
+    packetsForwarded: {
+      name: 'Packets Forwarded DDoS',
+      description: 'Inbound packets per second forwarded by DDoS protection',
+      type: 'gauge',
+      sources: {
+        azuremonitor: {
+          expr: 'azure_microsoft_network_virtualnetworks_packetsforwardedddos_countpersecond_maximum{%(queriesSelector)s}',
+          legendCustomTemplate: 'Forwarded',
+        },
+      },
+    },
+    
+    packetsTotal: {
+      name: 'Packets in DDoS',
+      description: 'Total packets per second inbound in DDoS protection.',
+      type: 'gauge',
+      sources: {
+        azuremonitor: {
+          expr: 'azure_microsoft_network_virtualnetworks_packetsinddos_countpersecond_maximum{%(queriesSelector)s}',
+          legendCustomTemplate: 'Total',
+        },
+      },
+    },
+
+    tcpPacketsDropped: {
+      name: 'TCP Packets Dropped DDoS',
+      description: 'Inbound TCP packets per second dropped by DDoS protection',
+      type: 'gauge',
+      sources: {
+        azuremonitor: {
+          expr: 'azure_microsoft_network_virtualnetworks_tcppacketsdroppedddos_countpersecond_maximum{%(queriesSelector)s}',
+          legendCustomTemplate: 'Dropped',
+        },
+      },
+    },
+
+    tcpPacketsForwarded: {
+      name: 'TCP packets Forwarded DDoS',
+      description: 'Inbound TCP packets per second forwarded by DDoS protection',
+      type: 'gauge',
+      sources: {
+        azuremonitor: {
+          expr: 'azure_microsoft_network_virtualnetworks_tcppacketsforwardedddos_countpersecond_maximum{%(queriesSelector)s}',
+          legendCustomTemplate: 'Forwarded',
+        },
+      },
+    },
+    
+    tcpPacketsTotal: {
+      name: 'TCP packets in DDoS',
+      description: 'Total TCP packets per second inbound in DDoS protection.',
+      type: 'gauge',
+      sources: {
+        azuremonitor: {
+          expr: 'azure_microsoft_network_virtualnetworks_tcppacketsinddos_countpersecond_maximum{%(queriesSelector)s}',
+          legendCustomTemplate: 'Total',
+        },
+      },
+    },
+
+    udpPacketsDropped: {
+      name: 'UDP Packets Dropped DDoS',
+      description: 'Inbound UDP packets per second dropped by DDoS protection',
+      type: 'gauge',
+      sources: {
+        azuremonitor: {
+          expr: 'azure_microsoft_network_virtualnetworks_udppacketsdroppedddos_countpersecond_maximum{%(queriesSelector)s}',
+          legendCustomTemplate: 'Dropped',
+        },
+      },
+    },
+
+    udpPacketsForwarded: {
+      name: 'UDP packets Forwarded DDoS',
+      description: 'Inbound UDP packets per second forwarded by DDoS protection',
+      type: 'gauge',
+      sources: {
+        azuremonitor: {
+          expr: 'azure_microsoft_network_virtualnetworks_udppacketsforwardedddos_countpersecond_maximum{%(queriesSelector)s}',
+          legendCustomTemplate: 'Forwarded',
+        },
+      },
+    },
+    
+    udpPacketsTotal: {
+      name: 'UDP packets in DDoS',
+      description: 'Total UDP packets per second inbound in DDoS protection.',
+      type: 'gauge',
+      sources: {
+        azuremonitor: {
+          expr: 'azure_microsoft_network_virtualnetworks_udppacketsinddos_countpersecond_maximum{%(queriesSelector)s}',
+          legendCustomTemplate: 'Total',
+        },
+      },
+    },
+    
+    pingMeshAvgRoundrip: {
+      name: 'Round trip time for Pings to a VM',
+      type: 'gauge',
+      unit: 'ms',
+      sources: {
+        azuremonitor: {
+          expr: 'azure_microsoft_network_virtualnetworks_pingmeshaveragerountdripms_milliseconds_average{%(queriesSelector)s}',
+        },
+      },
+    },
+    
+    pingMeshProbesFailed: {
+      name: 'Failed pings to a VM %',
+      type: 'gauge',
+      unit: 'percent',
+      sources: {
+        azuremonitor: {
+          expr: 'azure_microsoft_network_virtualnetworks_pingmeshprobesfailedpercent_percent_average{%(queriesSelector)s}',
+        },
+      },
+    },
+    
+    synTriggerPackets: {
+      name: 'SYN packets to trigger DDoS',
+      description: 'Inbound SYN packet count to trigger DDoS.',
+      type: 'gauge',
+      sources: {
+        azuremonitor: {
+          expr: 'azure_microsoft_network_virtualnetworks_ddostriggersynpackets_countpersecond_maximum{%(queriesSelector)s}',
+          legendCustomTemplate: 'SYN',
+        },
+      },
+    },
+    
+    tcpTriggerPackets: {
+      name: 'TCP packets to trigger DDoS',
+      description: 'Inbound TCP packet count to trigger DDoS.',
+      type: 'gauge',
+      sources: {
+        azuremonitor: {
+          expr: 'azure_microsoft_network_virtualnetworks_ddostriggertcppackets_countpersecond_maximum{%(queriesSelector)s}',
+          legendCustomTemplate: 'TCP',
+        },
+      },
+    },
+    
+    udpTriggerPackets: {
+      name: 'UDP packets to trigger DDoS',
+      description: 'Inbound UDP packet count to trigger DDoS.',
+      type: 'gauge',
+      sources: {
+        azuremonitor: {
+          expr: 'azure_microsoft_network_virtualnetworks_ddostriggerudppackets_countpersecond_maximum{%(queriesSelector)s}',
+          legendCustomTemplate: 'UDP',
+        },
+      },
+    },
+    
+    underDdos: {
+      name: 'Currently DDoS Status',
+      description: 'Is the system currently under DDoS attack or not.',
+      type: 'gauge',
+      sources: {
+        azuremonitor: {
+          expr: 'azure_microsoft_network_virtualnetworks_ifunderddosattack_count_maximum{%(queriesSelector)s}',
+          exprWrappers: [['','OR on() vector(0)']]
+        },
+      },
+    },
+  }
+}

--- a/csp-mixin/signals/azurevirtualnetwork.libsonnet
+++ b/csp-mixin/signals/azurevirtualnetwork.libsonnet
@@ -1,308 +1,324 @@
 local commonlib = import 'common-lib/common/main.libsonnet';
 function(this)
-{
-  local s = self,
-  filteringSelector: this.filteringSelector,
-  groupLabels: this.groupLabels,
-  instanceLabels: this.instanceLabels,
-  aggLevel: 'instance',
-  discoveryMetric: {
-    azuremonitor: 'azure_microsoft_network_virtualnetworks_ifunderddosattack_maximum_count',
-  },
-  signals: {
-    bytesDropped: {
-      name: 'Bytes Dropped DDoS',
-      description: 'Inbound bytes per second dropped by DDoS protection.',
-      type: 'gauge',
-      unit: 'binBps',
-      sources: {
-        azuremonitor: {
-          expr: 'azure_microsoft_network_virtualnetworks_bytesdroppedddos_bytespersecond_maximum{%(queriesSelector)s}',
-          legendCustomTemplate: 'Dropped',
+  {
+    local s = self,
+    filteringSelector: this.filteringSelector,
+    groupLabels: this.groupLabels,
+    instanceLabels: this.instanceLabels,
+    aggLevel: 'instance',
+    discoveryMetric: {
+      azuremonitor: 'azure_microsoft_network_virtualnetworks_ifunderddosattack_maximum_count',
+    },
+    signals: {
+      bytesDropped: {
+        name: 'Bytes dropped DDoS',
+        description: 'Inbound bytes per second dropped by DDoS protection.',
+        type: 'gauge',
+        unit: 'binBps',
+        sources: {
+          azuremonitor: {
+            expr: 'azure_microsoft_network_virtualnetworks_bytesdroppedddos_bytespersecond_maximum{%(queriesSelector)s}',
+            legendCustomTemplate: 'Dropped',
+          },
         },
       },
-    },
-    
-    bytesForwarded: {
-      name: 'Bytes Forwarded DDoS',
-      description: 'Inbound bytes per second forwarded by DDoS protection.',
-      type: 'gauge',
-      unit: 'binBps',
-      sources: {
-        azuremonitor: {
-          expr: 'azure_microsoft_network_virtualnetworks_bytesforwardedddos_bytespersecond_maximum{%(queriesSelector)s}',
-          legendCustomTemplate: 'Forwarded',
-        },
-      },
-    },
-    
-    bytesTotal: {
-      name: 'Bytes in DDoS',
-      description: 'Total bytes per second inbound in DDoS protection.',
-      type: 'gauge',
-      unit: 'binBps',
-      sources: {
-        azuremonitor: {
-          expr: 'azure_microsoft_network_virtualnetworks_bytesinddos_bytespersecond_maximum{%(queriesSelector)s}',
-          legendCustomTemplate: 'Total',
-        },
-      },
-    },
-    
-    tcpBytesDropped: {
-      name: 'TCP bytes Dropped DDoS',
-      description: 'Inbound TCP bytes per second dropped by DDoS protection.',
-      type: 'gauge',
-      unit: 'binBps',
-      sources: {
-        azuremonitor: {
-          expr: 'azure_microsoft_network_virtualnetworks_tcpbytesdroppedddos_bytespersecond_maximum{%(queriesSelector)s}',
-          legendCustomTemplate: 'TCP Dropped',
-        },
-      },
-    },
-    
-    tcpBytesForwarded: {
-      name: 'TCP bytes Forwarded DDoS',
-      description: 'Inbound tcp bytes per second forwarded by DDoS protection.',
-      type: 'gauge',
-      unit: 'binBps',
-      sources: {
-        azuremonitor: {
-          expr: 'azure_microsoft_network_virtualnetworks_tcpbytesforwardedddos_bytespersecond_maximum{%(queriesSelector)s}',
-          legendCustomTemplate: 'TCP Forwarded',
-        },
-      },
-    },
-    
-    tcpBytesTotal: {
-      name: 'TCP bytes in DDoS',
-      description: 'Total TCP bytes per second inbound in DDoS protection.',
-      type: 'gauge',
-      unit: 'binBps',
-      sources: {
-        azuremonitor: {
-          expr: 'azure_microsoft_network_virtualnetworks_tcpbytesinddos_bytespersecond_maximum{%(queriesSelector)s}',
-          legendCustomTemplate: 'TCP Total',
-        },
-      },
-    },
-    
-    udpBytesDropped: {
-      name: 'UDP bytes Dropped DDoS',
-      description: 'Inbound UDP bytes per second dropped by DDoS protection.',
-      type: 'gauge',
-      unit: 'binBps',
-      sources: {
-        azuremonitor: {
-          expr: 'azure_microsoft_network_virtualnetworks_udpbytesdroppedddos_bytespersecond_maximum{%(queriesSelector)s}',
-          legendCustomTemplate: 'UDP Dropped',
-        },
-      },
-    },
-    
-    udpBytesForwarded: {
-      name: 'UDP bytes Forwarded DDoS',
-      description: 'Inbound udp bytes per second forwarded by DDoS protection.',
-      type: 'gauge',
-      unit: 'binBps',
-      sources: {
-        azuremonitor: {
-          expr: 'azure_microsoft_network_virtualnetworks_udpbytesforwardedddos_bytespersecond_maximum{%(queriesSelector)s}',
-          legendCustomTemplate: 'UDP Forwarded',
-        },
-      },
-    },
-    
-    udpBytesTotal: {
-      name: 'UDP bytes in DDoS',
-      description: 'Total UDP bytes per second inbound in DDoS protection.',
-      type: 'gauge',
-      unit: 'binBps',
-      sources: {
-        azuremonitor: {
-          expr: 'azure_microsoft_network_virtualnetworks_udpbytesinddos_bytespersecond_maximum{%(queriesSelector)s}',
-          legendCustomTemplate: 'UDP Total',
-        },
-      },
-    },
 
-    packetsDropped: {
-      name: 'Packets Dropped DDoS',
-      description: 'Inbound packets per second dropped by DDoS protection',
-      type: 'gauge',
-      sources: {
-        azuremonitor: {
-          expr: 'azure_microsoft_network_virtualnetworks_packetsdroppedddos_countpersecond_maximum{%(queriesSelector)s}',
-          legendCustomTemplate: 'Dropped',
+      bytesForwarded: {
+        name: 'Bytes forwarded DDoS',
+        description: 'Inbound bytes per second forwarded by DDoS protection.',
+        type: 'gauge',
+        unit: 'binBps',
+        sources: {
+          azuremonitor: {
+            expr: 'azure_microsoft_network_virtualnetworks_bytesforwardedddos_bytespersecond_maximum{%(queriesSelector)s}',
+            legendCustomTemplate: 'Forwarded',
+          },
         },
       },
-    },
 
-    packetsForwarded: {
-      name: 'Packets Forwarded DDoS',
-      description: 'Inbound packets per second forwarded by DDoS protection',
-      type: 'gauge',
-      sources: {
-        azuremonitor: {
-          expr: 'azure_microsoft_network_virtualnetworks_packetsforwardedddos_countpersecond_maximum{%(queriesSelector)s}',
-          legendCustomTemplate: 'Forwarded',
+      bytesTotal: {
+        name: 'Bytes in DDoS',
+        description: 'Total bytes per second inbound in DDoS protection.',
+        type: 'gauge',
+        unit: 'binBps',
+        sources: {
+          azuremonitor: {
+            expr: 'azure_microsoft_network_virtualnetworks_bytesinddos_bytespersecond_maximum{%(queriesSelector)s}',
+            legendCustomTemplate: 'Total',
+          },
         },
       },
-    },
-    
-    packetsTotal: {
-      name: 'Packets in DDoS',
-      description: 'Total packets per second inbound in DDoS protection.',
-      type: 'gauge',
-      sources: {
-        azuremonitor: {
-          expr: 'azure_microsoft_network_virtualnetworks_packetsinddos_countpersecond_maximum{%(queriesSelector)s}',
-          legendCustomTemplate: 'Total',
-        },
-      },
-    },
 
-    tcpPacketsDropped: {
-      name: 'TCP Packets Dropped DDoS',
-      description: 'Inbound TCP packets per second dropped by DDoS protection',
-      type: 'gauge',
-      sources: {
-        azuremonitor: {
-          expr: 'azure_microsoft_network_virtualnetworks_tcppacketsdroppedddos_countpersecond_maximum{%(queriesSelector)s}',
-          legendCustomTemplate: 'TCP Dropped',
+      tcpBytesDropped: {
+        name: 'TCP bytes dropped DDoS',
+        description: 'Inbound TCP bytes per second dropped by DDoS protection.',
+        type: 'gauge',
+        unit: 'binBps',
+        sources: {
+          azuremonitor: {
+            expr: 'azure_microsoft_network_virtualnetworks_tcpbytesdroppedddos_bytespersecond_maximum{%(queriesSelector)s}',
+            legendCustomTemplate: 'TCP Dropped',
+          },
         },
       },
-    },
 
-    tcpPacketsForwarded: {
-      name: 'TCP packets Forwarded DDoS',
-      description: 'Inbound TCP packets per second forwarded by DDoS protection',
-      type: 'gauge',
-      sources: {
-        azuremonitor: {
-          expr: 'azure_microsoft_network_virtualnetworks_tcppacketsforwardedddos_countpersecond_maximum{%(queriesSelector)s}',
-          legendCustomTemplate: 'TCP Forwarded',
+      tcpBytesForwarded: {
+        name: 'TCP bytes forwarded DDoS',
+        description: 'Inbound TCP bytes per second forwarded by DDoS protection.',
+        type: 'gauge',
+        unit: 'binBps',
+        sources: {
+          azuremonitor: {
+            expr: 'azure_microsoft_network_virtualnetworks_tcpbytesforwardedddos_bytespersecond_maximum{%(queriesSelector)s}',
+            legendCustomTemplate: 'TCP forwarded',
+          },
         },
       },
-    },
-    
-    tcpPacketsTotal: {
-      name: 'TCP packets in DDoS',
-      description: 'Total TCP packets per second inbound in DDoS protection.',
-      type: 'gauge',
-      sources: {
-        azuremonitor: {
-          expr: 'azure_microsoft_network_virtualnetworks_tcppacketsinddos_countpersecond_maximum{%(queriesSelector)s}',
-          legendCustomTemplate: 'TCP Total',
-        },
-      },
-    },
 
-    udpPacketsDropped: {
-      name: 'UDP Packets Dropped DDoS',
-      description: 'Inbound UDP packets per second dropped by DDoS protection',
-      type: 'gauge',
-      sources: {
-        azuremonitor: {
-          expr: 'azure_microsoft_network_virtualnetworks_udppacketsdroppedddos_countpersecond_maximum{%(queriesSelector)s}',
-          legendCustomTemplate: 'UDP Dropped',
+      tcpBytesTotal: {
+        name: 'TCP bytes in DDoS',
+        description: 'Total TCP bytes per second inbound in DDoS protection.',
+        type: 'gauge',
+        unit: 'binBps',
+        sources: {
+          azuremonitor: {
+            expr: 'azure_microsoft_network_virtualnetworks_tcpbytesinddos_bytespersecond_maximum{%(queriesSelector)s}',
+            legendCustomTemplate: 'TCP Total',
+          },
         },
       },
-    },
 
-    udpPacketsForwarded: {
-      name: 'UDP packets Forwarded DDoS',
-      description: 'Inbound UDP packets per second forwarded by DDoS protection',
-      type: 'gauge',
-      sources: {
-        azuremonitor: {
-          expr: 'azure_microsoft_network_virtualnetworks_udppacketsforwardedddos_countpersecond_maximum{%(queriesSelector)s}',
-          legendCustomTemplate: 'UDP Forwarded',
+      udpBytesDropped: {
+        name: 'UDP bytes dropped DDoS',
+        description: 'Inbound UDP bytes per second dropped by DDoS protection.',
+        type: 'gauge',
+        unit: 'binBps',
+        sources: {
+          azuremonitor: {
+            expr: 'azure_microsoft_network_virtualnetworks_udpbytesdroppedddos_bytespersecond_maximum{%(queriesSelector)s}',
+            legendCustomTemplate: 'UDP Dropped',
+          },
         },
       },
-    },
-    
-    udpPacketsTotal: {
-      name: 'UDP packets in DDoS',
-      description: 'Total UDP packets per second inbound in DDoS protection.',
-      type: 'gauge',
-      sources: {
-        azuremonitor: {
-          expr: 'azure_microsoft_network_virtualnetworks_udppacketsinddos_countpersecond_maximum{%(queriesSelector)s}',
-          legendCustomTemplate: 'UDP Total',
+
+      udpBytesForwarded: {
+        name: 'UDP bytes forwarded DDoS',
+        description: 'Inbound UDP bytes per second forwarded by DDoS protection.',
+        type: 'gauge',
+        unit: 'binBps',
+        sources: {
+          azuremonitor: {
+            expr: 'azure_microsoft_network_virtualnetworks_udpbytesforwardedddos_bytespersecond_maximum{%(queriesSelector)s}',
+            legendCustomTemplate: 'UDP Forwarded',
+          },
         },
       },
-    },
-    
-    pingMeshAvgRoundrip: {
-      name: 'Round trip time for Pings to a VM',
-      type: 'gauge',
-      unit: 'ms',
-      sources: {
-        azuremonitor: {
-          expr: 'azure_microsoft_network_virtualnetworks_pingmeshaveragerountdripms_milliseconds_average{%(queriesSelector)s}',
+
+      udpBytesTotal: {
+        name: 'UDP bytes in DDoS',
+        description: 'Total UDP bytes per second inbound in DDoS protection.',
+        type: 'gauge',
+        unit: 'binBps',
+        sources: {
+          azuremonitor: {
+            expr: 'azure_microsoft_network_virtualnetworks_udpbytesinddos_bytespersecond_maximum{%(queriesSelector)s}',
+            legendCustomTemplate: 'UDP Total',
+          },
         },
       },
-    },
-    
-    pingMeshProbesFailed: {
-      name: 'Failed pings to a VM %',
-      type: 'gauge',
-      unit: 'percent',
-      sources: {
-        azuremonitor: {
-          expr: 'azure_microsoft_network_virtualnetworks_pingmeshprobesfailedpercent_percent_average{%(queriesSelector)s}',
+
+      packetsDropped: {
+        name: 'Packets dropped DDoS',
+        description: 'Inbound packets per second dropped by DDoS protection',
+        type: 'gauge',
+        sources: {
+          azuremonitor: {
+            expr: 'azure_microsoft_network_virtualnetworks_packetsdroppedddos_countpersecond_maximum{%(queriesSelector)s}',
+            legendCustomTemplate: 'Dropped',
+          },
         },
       },
-    },
-    
-    synTriggerPackets: {
-      name: 'SYN packets to trigger DDoS',
-      description: 'Inbound SYN packet count to trigger DDoS.',
-      type: 'gauge',
-      sources: {
-        azuremonitor: {
-          expr: 'azure_microsoft_network_virtualnetworks_ddostriggersynpackets_countpersecond_maximum{%(queriesSelector)s}',
-          legendCustomTemplate: 'SYN',
+
+      packetsForwarded: {
+        name: 'Packets forwarded DDoS',
+        description: 'Inbound packets per second forwarded by DDoS protection',
+        type: 'gauge',
+        sources: {
+          azuremonitor: {
+            expr: 'azure_microsoft_network_virtualnetworks_packetsforwardedddos_countpersecond_maximum{%(queriesSelector)s}',
+            legendCustomTemplate: 'Forwarded',
+          },
         },
       },
-    },
-    
-    tcpTriggerPackets: {
-      name: 'TCP packets to trigger DDoS',
-      description: 'Inbound TCP packet count to trigger DDoS.',
-      type: 'gauge',
-      sources: {
-        azuremonitor: {
-          expr: 'azure_microsoft_network_virtualnetworks_ddostriggertcppackets_countpersecond_maximum{%(queriesSelector)s}',
-          legendCustomTemplate: 'TCP',
+
+      packetsTotal: {
+        name: 'Packets in DDoS',
+        description: 'Total packets per second inbound in DDoS protection.',
+        type: 'gauge',
+        sources: {
+          azuremonitor: {
+            expr: 'azure_microsoft_network_virtualnetworks_packetsinddos_countpersecond_maximum{%(queriesSelector)s}',
+            legendCustomTemplate: 'Total',
+          },
         },
       },
-    },
-    
-    udpTriggerPackets: {
-      name: 'UDP packets to trigger DDoS',
-      description: 'Inbound UDP packet count to trigger DDoS.',
-      type: 'gauge',
-      sources: {
-        azuremonitor: {
-          expr: 'azure_microsoft_network_virtualnetworks_ddostriggerudppackets_countpersecond_maximum{%(queriesSelector)s}',
-          legendCustomTemplate: 'UDP',
+
+      tcpPacketsDropped: {
+        name: 'TCP packets dropped DDoS',
+        description: 'Inbound TCP packets per second dropped by DDoS protection',
+        type: 'gauge',
+        sources: {
+          azuremonitor: {
+            expr: 'azure_microsoft_network_virtualnetworks_tcppacketsdroppedddos_countpersecond_maximum{%(queriesSelector)s}',
+            legendCustomTemplate: 'TCP Dropped',
+          },
         },
       },
-    },
-    
-    underDdos: {
-      name: 'Currently DDoS Status',
-      description: 'Is the system currently under DDoS attack or not.',
-      type: 'gauge',
-      sources: {
-        azuremonitor: {
-          expr: 'azure_microsoft_network_virtualnetworks_ifunderddosattack_count_maximum{%(queriesSelector)s}',
-          exprWrappers: [['','OR on() vector(0)']]
+
+      tcpPacketsForwarded: {
+        name: 'TCP packets forwarded DDoS',
+        description: 'Inbound TCP packets per second forwarded by DDoS protection',
+        type: 'gauge',
+        sources: {
+          azuremonitor: {
+            expr: 'azure_microsoft_network_virtualnetworks_tcppacketsforwardedddos_countpersecond_maximum{%(queriesSelector)s}',
+            legendCustomTemplate: 'TCP Forwarded',
+          },
+        },
+      },
+
+      tcpPacketsTotal: {
+        name: 'TCP packets in DDoS',
+        description: 'Total TCP packets per second inbound in DDoS protection.',
+        type: 'gauge',
+        sources: {
+          azuremonitor: {
+            expr: 'azure_microsoft_network_virtualnetworks_tcppacketsinddos_countpersecond_maximum{%(queriesSelector)s}',
+            legendCustomTemplate: 'TCP Total',
+          },
+        },
+      },
+
+      udpPacketsDropped: {
+        name: 'UDP Packets dropped DDoS',
+        description: 'Inbound UDP packets per second dropped by DDoS protection',
+        type: 'gauge',
+        sources: {
+          azuremonitor: {
+            expr: 'azure_microsoft_network_virtualnetworks_udppacketsdroppedddos_countpersecond_maximum{%(queriesSelector)s}',
+            legendCustomTemplate: 'UDP Dropped',
+          },
+        },
+      },
+
+      udpPacketsForwarded: {
+        name: 'UDP packets forwarded DDoS',
+        description: 'Inbound UDP packets per second forwarded by DDoS protection',
+        type: 'gauge',
+        sources: {
+          azuremonitor: {
+            expr: 'azure_microsoft_network_virtualnetworks_udppacketsforwardedddos_countpersecond_maximum{%(queriesSelector)s}',
+            legendCustomTemplate: 'UDP Forwarded',
+          },
+        },
+      },
+
+      udpPacketsTotal: {
+        name: 'UDP packets in DDoS',
+        description: 'Total UDP packets per second inbound in DDoS protection.',
+        type: 'gauge',
+        sources: {
+          azuremonitor: {
+            expr: 'azure_microsoft_network_virtualnetworks_udppacketsinddos_countpersecond_maximum{%(queriesSelector)s}',
+            legendCustomTemplate: 'UDP Total',
+          },
+        },
+      },
+
+      pingMeshAvgRoundrip: {
+        name: 'Round trip time for pings to a VM',
+        type: 'gauge',
+        unit: 'ms',
+        sources: {
+          azuremonitor: {
+            expr: 'azure_microsoft_network_virtualnetworks_pingmeshaveragerountdripms_milliseconds_average{%(queriesSelector)s}',
+          },
+        },
+      },
+
+      pingMeshProbesFailed: {
+        name: 'Failed pings to a VM %',
+        type: 'gauge',
+        unit: 'percent',
+        sources: {
+          azuremonitor: {
+            expr: 'azure_microsoft_network_virtualnetworks_pingmeshprobesfailedpercent_percent_average{%(queriesSelector)s}',
+          },
+        },
+      },
+
+      synTriggerPackets: {
+        name: 'SYN packets to trigger DDoS',
+        description: 'Inbound SYN packet count to trigger DDoS.',
+        type: 'gauge',
+        sources: {
+          azuremonitor: {
+            expr: 'azure_microsoft_network_virtualnetworks_ddostriggersynpackets_countpersecond_maximum{%(queriesSelector)s}',
+            legendCustomTemplate: 'SYN',
+          },
+        },
+      },
+
+      tcpTriggerPackets: {
+        name: 'TCP packets to trigger DDoS',
+        description: 'Inbound TCP packet count to trigger DDoS.',
+        type: 'gauge',
+        sources: {
+          azuremonitor: {
+            expr: 'azure_microsoft_network_virtualnetworks_ddostriggertcppackets_countpersecond_maximum{%(queriesSelector)s}',
+            legendCustomTemplate: 'TCP',
+          },
+        },
+      },
+
+      udpTriggerPackets: {
+        name: 'UDP packets to trigger DDoS',
+        description: 'Inbound UDP packet count to trigger DDoS.',
+        type: 'gauge',
+        sources: {
+          azuremonitor: {
+            expr: 'azure_microsoft_network_virtualnetworks_ddostriggerudppackets_countpersecond_maximum{%(queriesSelector)s}',
+            legendCustomTemplate: 'UDP',
+          },
+        },
+      },
+
+      underDdos: {
+        name: 'Current DDoS status',
+        description: 'Is the system currently under DDoS attack or not.',
+        type: 'gauge',
+        sources: {
+          azuremonitor: {
+            expr: 'azure_microsoft_network_virtualnetworks_ifunderddosattack_count_maximum{%(queriesSelector)s}',
+            exprWrappers: [['', 'OR on() vector(0)']],
+            valueMappings: [
+              {
+                type: 'value',
+                options: {
+                  '0': {
+                    text: 'OK',
+                    index: 0,
+                  },
+                  '1': {
+                    text: 'Under Attack',
+                    color: 'dark-red',
+                    index: 1,
+                  },
+                },
+              },
+            ],
+          },
         },
       },
     },
   }
-}


### PR DESCRIPTION
Adds an azure virtual network dashboard that will visualize the metrics available in that azure monitor namespace.

Unfortunately, those metrics are almost exclusively for DDoS mitigation stats. So we'll likely never see them. Thus, the included screenshot is.. Pretty barren.

It *should* work, in the case of an actual DDoS event...

![image](https://github.com/user-attachments/assets/0b74c9ed-d6d7-425e-83d0-950ee00ede0e)
