### PR TITLE
update cpu utilization thresholds and rule value to trigger alert

### DIFF
--- a/csp-mixin/alerts.libsonnet
+++ b/csp-mixin/alerts.libsonnet
@@ -7,7 +7,7 @@
           [
             {
               alert: 'AzureVMHighCpuUtilization',
-              expr: 'avg by (%s) (%s) > 80' %
+              expr: 'avg by (%s) (%s) > 85' %
                     [
                       std.join(',', this.config.groupLabels + this.config.instanceLabels),
                       this.signals.azurevm.cpuUtilization.asRuleExpression(),

--- a/csp-mixin/panels/azurevm.libsonnet
+++ b/csp-mixin/panels/azurevm.libsonnet
@@ -200,16 +200,16 @@ local commonlib = import 'common-lib/common/main.libsonnet';
                 mode: 'absolute',
                 steps: [
                   {
-                    color: 'green',
+                    color: 'yellow',
                     value: null,
                   },
                   {
-                    color: 'orange',
-                    value: 70,
+                    color: 'green',
+                    value: 30,
                   },
                   {
                     color: 'red',
-                    value: 90,
+                    value: 85,
                   },
                 ],
               },
@@ -410,16 +410,16 @@ local commonlib = import 'common-lib/common/main.libsonnet';
                 mode: 'absolute',
                 steps: [
                   {
-                    color: 'green',
+                    color: 'yellow',
                     value: null,
                   },
                   {
-                    color: 'orange',
-                    value: 70,
+                    color: 'green',
+                    value: 30,
                   },
                   {
                     color: 'red',
-                    value: 90,
+                    value: 85,
                   },
                 ],
               },


### PR DESCRIPTION
- Update cpu utilization thresholds to sync value with gcp compute engine value.
- Update rule value used to trigger the alert based on the previous red value