### PR TITLE
Add google VPC dashboard to csp-mixin

### DIFF
--- a/csp-mixin/.lint
+++ b/csp-mixin/.lint
@@ -16,6 +16,14 @@ exclusions:
     - dashboard: "GCP Load Balancing"
     - dashboard: "Azure Virtual network"
       reason: "resourceName is the instance label"
+    - dashboard: "GCP Virtual private cloud"
+      reason: "project_id is the instance label"
+    - dashboard: "Azure Queue storage"
+      reason: "Using 'Bucket' as instance label"
+    - dashboard: "GCP Compute Engine"
+      reason: "Using instance_name as instance label"
+    - dashboard: "Azure Virtual Machines"
+      reason: "Aggregation is at the group level, and resourceName is used for instance label"
   target-job-rule:
       reason: "Using filtering selector with job"
   template-instance-rule:  
@@ -32,22 +40,34 @@ exclusions:
     - dashboard: "GCP Load Balancing"
     - dashboard: "Azure Virtual network"
       reason: "resourceName is the instance label"
+    - dashboard: "GCP Virtual private cloud"
+      reason: "project_id is the instance label"
+    - dashboard: "Azure Queue storage"
+      reason: "Using 'Bucket' as instance label"
+    - dashboard: "GCP Compute Engine"
+      reason: "Using instance_name as instance label"
+    - dashboard: "Azure Virtual Machines"
+      reason: "Aggregation is at the group level, and resourceName is used for instance label"
   panel-datasource-rule:
     reason: "Many panels use --Mixed-- DS"
   panel-units-rule:
-    reason: "Unit not necessary or provided in an override"
-    entries:
-    - panel: "API requests by type"
-    - panel: "eDTU utilization"
-    - panel: "Concurrent sessions"
-    - panel: "Requests Success Rate"
-    - dashboard: "Azure SQL database"
-    - dashboard: "Azure Load Balancing"
-    - dashboard: "Azure Elastic pool"
-    - dashboard: "Azure Blob storage"
-    - dashboard: "GCP Blob storage"
-    - dashboard: "Azure Virtual network"
-      reason: "False positive.. Need to look into this"
+    reason: |
+      Common-lib uses overrides for units in almost all cases, and the dashboard linter creates a false positive here.
+      When dashboard linter is updated, this exception should be removed and any remaining issues resolved.
+    # entries:
+    # - panel: "API requests by type"
+    # - panel: "eDTU utilization"
+    # - panel: "Concurrent sessions"
+    # - panel: "Requests Success Rate"
+    # - dashboard: "Azure SQL database"
+    # - dashboard: "Azure Load Balancing"
+    # - dashboard: "Azure Elastic pool"
+    # - dashboard: "Azure Blob storage"
+    # - dashboard: "GCP Blob storage"
+    # - dashboard: "Azure Virtual network"
+    #   reason: "False positive.. Need to look into this"
+    # - dashboard: "GCP Virtual private cloud"
+    #   reason: "False positive as above. Linter does not look at overrides."
   panel-title-description-rule:
     entries:
     - dashboard: Azure Service Bus

--- a/csp-mixin/config.libsonnet
+++ b/csp-mixin/config.libsonnet
@@ -18,6 +18,7 @@
         azurequeuestore: (import './signals/azurequeuestore.libsonnet')(this),
         gcpce: (import './signals/gcpce.libsonnet')(this),
         gcpceOverview: (import './signals/gcpceOverview.libsonnet')(this),
+        gcpvpc: (import './signals/gcpvpc.libsonnet')(this),
       },
     blobStorage: {
       enableAvailability: false,

--- a/csp-mixin/dashboards.libsonnet
+++ b/csp-mixin/dashboards.libsonnet
@@ -67,6 +67,28 @@ local commonlib = import 'common-lib/common/main.libsonnet';
               csplib.grafana.rows.gce_instance
             )
           ),
+
+        [csplib.config.uid + '-vpc.json']:
+          local variables = csplib.signals.gcpvpc.getVariablesMultiChoice();
+          g.dashboard.new(csplib.config.dashboardNamePrefix + 'Virtual private cloud')
+          + g.dashboard.withUid(csplib.config.uid + '-vpc')
+          + g.dashboard.withTags(csplib.config.dashboardTags)
+          + g.dashboard.withTimezone(csplib.config.dashboardTimezone)
+          + g.dashboard.withRefresh(csplib.config.dashboardRefresh)
+          + g.dashboard.timepicker.withTimeOptions(csplib.config.dashboardPeriod)
+          + g.dashboard.withVariables([
+            if std.asciiLower(v.label) == std.asciiLower('project_id')
+            then v { label: 'Project' }
+            else v
+            for v in variables
+          ])
+          + g.dashboard.withPanels(
+            g.util.grid.wrapPanels(
+              csplib.grafana.rows.gcpvpc_overview +
+              csplib.grafana.rows.gcpvpc_service +
+              csplib.grafana.rows.gcpvpc_tunnel,
+            ),
+          ),
       } else {}
              +
              if csplib.config.uid == 'azure' then

--- a/csp-mixin/panels/gcpvpc.libsonnet
+++ b/csp-mixin/panels/gcpvpc.libsonnet
@@ -66,7 +66,7 @@ local commonlib = import 'common-lib/common/main.libsonnet';
         [
           this.signals.gcpvpc.gcpvpc_service_topk_throughput_bytes.asTarget()
           + g.query.prometheus.withFormat('table')
-          + g.query.prometheus.withInstant(true)
+          + g.query.prometheus.withInstant(true),
         ],
         'Average throughput',
       ) + self._serviceTableCommon('Average throughput'),
@@ -79,7 +79,7 @@ local commonlib = import 'common-lib/common/main.libsonnet';
         [
           this.signals.gcpvpc.gcpvpc_service_topk_error_percent.asTarget()
           + g.query.prometheus.withFormat('table')
-          + g.query.prometheus.withInstant(true)
+          + g.query.prometheus.withInstant(true),
         ],
         'Average error rate',
       ) + self._serviceTableCommon('Average error rate'),

--- a/csp-mixin/panels/gcpvpc.libsonnet
+++ b/csp-mixin/panels/gcpvpc.libsonnet
@@ -1,0 +1,134 @@
+local g = import '../g.libsonnet';
+local commonlib = import 'common-lib/common/main.libsonnet';
+{
+  new(this): {
+    _serviceTableCommon(valueColNiceName)::
+      g.panel.table.queryOptions.withTransformations([
+        g.panel.table.queryOptions.transformation.withId('filterFieldsByName')
+        + g.panel.table.queryOptions.transformation.withOptions({
+          include: {
+            pattern: 'service_name.*|Value.*',
+          },
+        }),
+        g.panel.table.queryOptions.transformation.withId('joinByField')
+        + g.panel.table.queryOptions.transformation.withOptions({
+          byField: 'service_name',
+          mode: 'outer',
+        }),
+      ])
+      + g.panel.table.standardOptions.withOverrides([
+        {
+          matcher: {
+            id: 'byName',
+            options: 'service_name',
+          },
+          properties: [
+            {
+              id: 'displayName',
+              value: 'Service name',
+            },
+          ],
+        },
+        {
+          matcher: {
+            id: 'byName',
+            options: 'Value',
+          },
+          properties: [
+            {
+              id: 'displayName',
+              value: valueColNiceName,
+            },
+          ],
+        },
+      ]),
+
+
+    gcpvpc_services_in_use_count:
+      this.signals.gcpvpc.gcpvpc_services_in_use_count.asStat()
+      + g.panel.stat.standardOptions.color.withMode('fixed')
+      + g.panel.stat.standardOptions.color.withFixedColor('text'),
+
+    gcpvpc_subnets_in_use_count:
+      this.signals.gcpvpc.gcpvpc_subnets_in_use_count.asStat()
+      + g.panel.stat.standardOptions.color.withMode('fixed')
+      + g.panel.stat.standardOptions.color.withFixedColor('text'),
+
+    gcpvpc_fixed_usage_tier_network_egress:
+      this.signals.gcpvpc.gcpvpc_fixed_usage_tier_network_egress.asTimeSeries()
+      + g.panel.timeSeries.standardOptions.withNoValue('0'),
+
+    gcpvpc_service_topk_throughput:
+      this.signals.gcpvpc.gcpvpc_service_topk_throughput_bytes.common
+      + g.panel.table.standardOptions.withUnit('bps')
+      + commonlib.panels.generic.table.base.new(
+        'Top 5 services - Average throughput',
+        [
+          this.signals.gcpvpc.gcpvpc_service_topk_throughput_bytes.asTarget()
+          + g.query.prometheus.withFormat('table')
+          + g.query.prometheus.withInstant(true)
+        ],
+        'Average throughput',
+      ) + self._serviceTableCommon('Average throughput'),
+
+    gcpvpc_service_topk_error:
+      this.signals.gcpvpc.gcpvpc_service_topk_error_percent.common
+      + g.panel.table.standardOptions.withUnit('percent')
+      + commonlib.panels.generic.table.base.new(
+        'Top 5 services - Average error rate',
+        [
+          this.signals.gcpvpc.gcpvpc_service_topk_error_percent.asTarget()
+          + g.query.prometheus.withFormat('table')
+          + g.query.prometheus.withInstant(true)
+        ],
+        'Average error rate',
+      ) + self._serviceTableCommon('Average error rate'),
+
+    gcpvpc_service_throughput:
+      commonlib.panels.network.timeSeries.traffic.new('Total service network throughput', targets=[])
+      + commonlib.panels.network.timeSeries.traffic.withNegateOutPackets()
+      + g.panel.timeSeries.fieldConfig.defaults.custom.stacking.withMode('normal')
+      + this.signals.gcpvpc.gcpvpc_service_request_bytes.asPanelMixin()
+      + this.signals.gcpvpc.gcpvpc_service_response_bytes.asPanelMixin(),
+
+    gcpvpc_service_by_service_throughput:
+      commonlib.panels.network.timeSeries.traffic.new('Service network throughput by service', targets=[])
+      + commonlib.panels.network.timeSeries.traffic.withNegateOutPackets()
+      + g.panel.timeSeries.fieldConfig.defaults.custom.stacking.withMode('normal')
+      + this.signals.gcpvpc.gcpvpc_service_request_by_service_bytes.asPanelMixin()
+      + this.signals.gcpvpc.gcpvpc_service_response_by_service_bytes.asPanelMixin(),
+
+    gcpvpc_service_by_responsecode_throughput:
+      commonlib.panels.network.timeSeries.traffic.new('Service network throughput by response code', targets=[])
+      + commonlib.panels.network.timeSeries.traffic.withNegateOutPackets()
+      + g.panel.timeSeries.fieldConfig.defaults.custom.stacking.withMode('normal')
+      + this.signals.gcpvpc.gcpvpc_service_request_by_responsecode_bytes.asPanelMixin()
+      + this.signals.gcpvpc.gcpvpc_service_response_by_responsecode_bytes.asPanelMixin(),
+
+    gcpvpc_service_by_service_error_throughput:
+      commonlib.panels.network.timeSeries.errors.new('Service network throughput percent by service in error', targets=[])
+      + this.signals.gcpvpc.gcpvpc_service_request_by_service_error_bytes.asPanelMixin()
+      + this.signals.gcpvpc.gcpvpc_service_response_by_service_error_bytes.asPanelMixin(),
+
+    gcpvpc_tunnel_throughput:
+      commonlib.panels.network.timeSeries.traffic.new('Total tunnel network throughput', targets=[])
+      + commonlib.panels.network.timeSeries.traffic.withNegateOutPackets()
+      + g.panel.timeSeries.fieldConfig.defaults.custom.stacking.withMode('normal')
+      + this.signals.gcpvpc.gcpvpn_tunnel_egress_bytes.asPanelMixin()
+      + this.signals.gcpvpc.gcpvpn_tunnel_ingress_bytes.asPanelMixin(),
+
+    gcpvpc_tunnel_by_protocol_throughput:
+      commonlib.panels.network.timeSeries.traffic.new('Total tunnel network throughput by protocol', targets=[])
+      + commonlib.panels.network.timeSeries.traffic.withNegateOutPackets()
+      + g.panel.timeSeries.fieldConfig.defaults.custom.stacking.withMode('normal')
+      + this.signals.gcpvpc.gcpvpn_tunnel_egress_by_protocol_bytes.asPanelMixin()
+      + this.signals.gcpvpc.gcpvpn_tunnel_ingress_by_protocol_bytes.asPanelMixin(),
+
+    gcpvpc_tunnel_by_resource_type_throughput:
+      commonlib.panels.network.timeSeries.traffic.new('Total tunnel network throughput by resource type', targets=[])
+      + commonlib.panels.network.timeSeries.traffic.withNegateOutPackets()
+      + g.panel.timeSeries.fieldConfig.defaults.custom.stacking.withMode('normal')
+      + this.signals.gcpvpc.gcpvpn_tunnel_egress_by_resource_type_bytes.asPanelMixin()
+      + this.signals.gcpvpc.gcpvpn_tunnel_ingress_by_resource_type_bytes.asPanelMixin(),
+  },
+}

--- a/csp-mixin/panels/main.libsonnet
+++ b/csp-mixin/panels/main.libsonnet
@@ -9,5 +9,6 @@
     blobstore: (import './blobstore.libsonnet').new(this),
     gcploadbalancer: (import './gcploadbalancer.libsonnet').new(this),
     gcpce: (import './gcpce.libsonnet').new(this),
+    gcpvpc: (import './gcpvpc.libsonnet').new(this),
   },
 }

--- a/csp-mixin/rows.libsonnet
+++ b/csp-mixin/rows.libsonnet
@@ -509,5 +509,62 @@ local g = import './g.libsonnet';
           ]
         ),
       ],
+
+      gcpvpc_overview: [
+        g.panel.row.new('Overview'),
+        this.grafana.panels.gcpvpc.gcpvpc_services_in_use_count
+        + g.panel.timeSeries.gridPos.withW(12)
+        + g.panel.timeSeries.gridPos.withH(4),
+
+        this.grafana.panels.gcpvpc.gcpvpc_subnets_in_use_count
+        + g.panel.timeSeries.gridPos.withW(12)
+        + g.panel.timeSeries.gridPos.withH(4),
+
+        this.grafana.panels.gcpvpc.gcpvpc_fixed_usage_tier_network_egress
+        + g.panel.timeSeries.gridPos.withW(24)
+        + g.panel.timeSeries.gridPos.withH(8),
+      ],
+
+      gcpvpc_service: [
+        g.panel.row.new('Services'),
+        this.grafana.panels.gcpvpc.gcpvpc_service_topk_throughput
+        + g.panel.timeSeries.gridPos.withW(12)
+        + g.panel.timeSeries.gridPos.withH(8),
+
+        this.grafana.panels.gcpvpc.gcpvpc_service_topk_error
+        + g.panel.timeSeries.gridPos.withW(12)
+        + g.panel.timeSeries.gridPos.withH(8),
+
+        this.grafana.panels.gcpvpc.gcpvpc_service_throughput
+        + g.panel.timeSeries.gridPos.withW(12)
+        + g.panel.timeSeries.gridPos.withH(8),
+
+        this.grafana.panels.gcpvpc.gcpvpc_service_by_service_error_throughput
+        + g.panel.timeSeries.gridPos.withW(12)
+        + g.panel.timeSeries.gridPos.withH(8),
+
+        this.grafana.panels.gcpvpc.gcpvpc_service_by_service_throughput
+        + g.panel.timeSeries.gridPos.withW(12)
+        + g.panel.timeSeries.gridPos.withH(8),
+
+        this.grafana.panels.gcpvpc.gcpvpc_service_by_responsecode_throughput
+        + g.panel.timeSeries.gridPos.withW(12)
+        + g.panel.timeSeries.gridPos.withH(8),
+      ],
+
+      gcpvpc_tunnel: [
+        g.panel.row.new('VPN tunnels'),
+        this.grafana.panels.gcpvpc.gcpvpc_tunnel_throughput
+        + g.panel.timeSeries.gridPos.withW(24)
+        + g.panel.timeSeries.gridPos.withH(8),
+
+        this.grafana.panels.gcpvpc.gcpvpc_tunnel_by_protocol_throughput
+        + g.panel.timeSeries.gridPos.withW(12)
+        + g.panel.timeSeries.gridPos.withH(8),
+
+        this.grafana.panels.gcpvpc.gcpvpc_tunnel_by_resource_type_throughput
+        + g.panel.timeSeries.gridPos.withW(12)
+        + g.panel.timeSeries.gridPos.withH(8),
+      ],
     },
 }

--- a/csp-mixin/signals/gcpvpc.libsonnet
+++ b/csp-mixin/signals/gcpvpc.libsonnet
@@ -1,0 +1,295 @@
+local commonlib = import 'common-lib/common/main.libsonnet';
+function(this)
+  {
+    local s = self,
+    filteringSelector: this.filteringSelector,
+    groupLabels: ['job'],
+    instanceLabels: ['project_id'],
+    aggLevel: 'group',
+    discoveryMetric: {
+      stackdriver: 'stackdriver_networking_googleapis_com_location_networking_googleapis_com_fixed_standard_tier_usage',
+    },
+    signals: {
+      //
+      // Fixed Usage Tier
+      //
+      // available labels: ['bandwidth_policy_id', 'location', 'project_id', 'traffic_source']
+      gcpvpc_fixed_usage_tier_network_egress: {
+        name: 'Fixed standard tier network egress',
+        description: 'Rate in bytes of network egress on the fixed standard tier.',
+        type: 'gauge',
+        unit: 'bps',
+        sources: {
+          stackdriver: {
+            expr: 'stackdriver_networking_googleapis_com_location_networking_googleapis_com_fixed_standard_tier_usage{%(queriesSelector)s}',
+            aggKeepLabels: ['traffic_source'],
+          },
+        },
+      },
+
+      //
+      // Overview counters
+      //
+      gcpvpc_services_in_use_count: {
+        name: 'Total services in use',
+        description: 'Count of unique service names (including "UNKNOWN") with ingress or egress traffic.',
+        type: 'raw',
+        unit: 'short',
+        sources: {
+          stackdriver: {
+            expr: 'count(count by (service_name) (stackdriver_google_service_gce_client_networking_googleapis_com_google_service_response_bytes_count{%(queriesSelector)s} OR stackdriver_google_service_gce_client_networking_googleapis_com_google_service_request_bytes_count{%(queriesSelector)s}))',
+          },
+        },
+      },
+
+      gcpvpc_subnets_in_use_count: {
+        name: 'Total subnets in use',
+        description: 'Count of unique subnets (including the catch-all "LOCAL_IS_EXTERNAL") with ingress or egress traffic on services or a VPN tunnel.',
+        type: 'raw',
+        unit: 'short',
+        sources: {
+          stackdriver: {
+            expr: 'count(count by (local_subnetwork) (stackdriver_google_service_gce_client_networking_googleapis_com_google_service_response_bytes_count{%(queriesSelector)s} OR stackdriver_google_service_gce_client_networking_googleapis_com_google_service_request_bytes_count{%(queriesSelector)s} OR stackdriver_vpn_tunnel_networking_googleapis_com_vpn_tunnel_egress_bytes_count{%(queriesSelector)s} OR stackdriver_vpn_tunnel_networking_googleapis_com_vpn_tunnel_ingress_bytes_count{%(queriesSelector)s}))',
+          },
+        },
+      },
+
+      //
+      // Service Metrics
+      //
+
+      // available labels: ['instance_name', 'instance_id', 'local_network', 'local_network_interface', 'local_subnetwork', 'project_id', 'protocol', 'region', 'resource_type', 'response_code_class', 'service_name', 'service_region', 'zone']
+      gcpvpc_service_request_bytes: {
+        name: 'received',
+        description: '',
+        type: 'counter',
+        unit: 'bps',
+        aggFunction: 'sum',
+        sources: {
+          stackdriver: {
+            expr: 'stackdriver_google_service_gce_client_networking_googleapis_com_google_service_request_bytes_count{%(queriesSelector)s}',
+          },
+        },
+      },
+
+      // available labels: ['instance_name', 'instance_id', 'local_network', 'local_network_interface', 'local_subnetwork', 'project_id', 'protocol', 'region', 'resource_type', 'response_code_class', 'service_name', 'service_region', 'zone']
+      gcpvpc_service_response_bytes: {
+        name: 'transmitted',
+        description: '',
+        type: 'counter',
+        unit: 'bps',
+        aggFunction: 'sum',
+        sources: {
+          stackdriver: {
+            expr: 'stackdriver_google_service_gce_client_networking_googleapis_com_google_service_response_bytes_count{%(queriesSelector)s}',
+          },
+        },
+      },
+
+      // available labels: ['instance_name', 'instance_id', 'local_network', 'local_network_interface', 'local_subnetwork', 'project_id', 'protocol', 'region', 'resource_type', 'response_code_class', 'service_name', 'service_region', 'zone']
+      gcpvpc_service_topk_throughput_bytes: {
+        name: 'Top 5 services by network throughput.',
+        description: '',
+        type: 'gauge',
+        unit: 'bps',
+        aggFunction: 'avg',
+        sources: {
+          stackdriver: {
+            expr: 'stackdriver_google_service_gce_client_networking_googleapis_com_google_service_request_bytes_count{%(queriesSelector)s} + stackdriver_google_service_gce_client_networking_googleapis_com_google_service_response_bytes_count{%(queriesSelector)s}',
+            exprWrappers: [['topk(5,', ')']],
+            aggKeepLabels: ['service_name'],
+          },
+        },
+      },
+
+      // available labels: ['instance_name', 'instance_id', 'local_network', 'local_network_interface', 'local_subnetwork', 'project_id', 'protocol', 'region', 'resource_type', 'response_code_class', 'service_name', 'service_region', 'zone']
+      gcpvpc_service_topk_error_percent: {
+        name: 'Top 5 services by network error response code',
+        description: '',
+        type: 'gauge',
+        unit: 'percent',
+        aggFunction: 'avg',
+        sources: {
+          stackdriver: {
+            expr: '(stackdriver_google_service_gce_client_networking_googleapis_com_google_service_request_bytes_count{%(queriesSelector)s, response_code_class=~"500|400"} + stackdriver_google_service_gce_client_networking_googleapis_com_google_service_response_bytes_count{%(queriesSelector)s, response_code_class=~"500|400"}) / (stackdriver_google_service_gce_client_networking_googleapis_com_google_service_request_bytes_count{%(queriesSelector)s} + stackdriver_google_service_gce_client_networking_googleapis_com_google_service_response_bytes_count{%(queriesSelector)s})',
+            exprWrappers: [['topk(5,', ')']],
+            aggKeepLabels: ['service_name'],
+          },
+        },
+      },
+
+      // available labels: ['instance_name', 'instance_id', 'local_network', 'local_network_interface', 'local_subnetwork', 'project_id', 'protocol', 'region', 'resource_type', 'response_code_class', 'service_name', 'service_region', 'zone']
+      gcpvpc_service_request_by_responsecode_bytes: {
+        name: 'received',
+        description: '',
+        type: 'counter',
+        unit: 'bps',
+        aggFunction: 'sum',
+        sources: {
+          stackdriver: {
+            expr: 'stackdriver_google_service_gce_client_networking_googleapis_com_google_service_request_bytes_count{%(queriesSelector)s}',
+            aggKeepLabels: ['response_code_class'],
+          },
+        },
+      },
+
+      // available labels: ['instance_name', 'instance_id', 'local_network', 'local_network_interface', 'local_subnetwork', 'project_id', 'protocol', 'region', 'resource_type', 'response_code_class', 'service_name', 'service_region', 'zone']
+      gcpvpc_service_response_by_responsecode_bytes: {
+        name: 'transmitted',
+        description: '',
+        type: 'counter',
+        unit: 'bps',
+        aggFunction: 'sum',
+        sources: {
+          stackdriver: {
+            expr: 'stackdriver_google_service_gce_client_networking_googleapis_com_google_service_response_bytes_count{%(queriesSelector)s}',
+            aggKeepLabels: ['response_code_class'],
+          },
+        },
+      },
+
+      // available labels: ['instance_name', 'instance_id', 'local_network', 'local_network_interface', 'local_subnetwork', 'project_id', 'protocol', 'region', 'resource_type', 'response_code_class', 'service_name', 'service_region', 'zone']
+      gcpvpc_service_request_by_service_bytes: {
+        name: 'received',
+        description: '',
+        type: 'counter',
+        unit: 'bps',
+        aggFunction: 'sum',
+        sources: {
+          stackdriver: {
+            expr: 'stackdriver_google_service_gce_client_networking_googleapis_com_google_service_request_bytes_count{%(queriesSelector)s}',
+            aggKeepLabels: ['service_name'],
+          },
+        },
+      },
+
+      // available labels: ['instance_name', 'instance_id', 'local_network', 'local_network_interface', 'local_subnetwork', 'project_id', 'protocol', 'region', 'resource_type', 'response_code_class', 'service_name', 'service_region', 'zone']
+      gcpvpc_service_response_by_service_bytes: {
+        name: 'transmitted',
+        description: '',
+        type: 'counter',
+        unit: 'bps',
+        aggFunction: 'sum',
+        sources: {
+          stackdriver: {
+            expr: 'stackdriver_google_service_gce_client_networking_googleapis_com_google_service_response_bytes_count{%(queriesSelector)s}',
+            aggKeepLabels: ['service_name'],
+          },
+        },
+      },
+
+      // available labels: ['instance_name', 'instance_id', 'local_network', 'local_network_interface', 'local_subnetwork', 'project_id', 'protocol', 'region', 'resource_type', 'response_code_class', 'service_name', 'service_region', 'zone']
+      gcpvpc_service_request_by_service_error_bytes: {
+        name: 'received',
+        description: '',
+        type: 'raw',
+        unit: 'percent',
+        sources: {
+          stackdriver: {
+            expr: 'sum by (service_name) (stackdriver_google_service_gce_client_networking_googleapis_com_google_service_request_bytes_count{%(queriesSelector)s, response_code_class=~"500|400"}) / sum by (service_name) (stackdriver_google_service_gce_client_networking_googleapis_com_google_service_request_bytes_count{%(queriesSelector)s})',
+            legendCustomTemplate: '{{service_name}}: received',
+          },
+        },
+      },
+
+      // available labels: ['instance_name', 'instance_id', 'local_network', 'local_network_interface', 'local_subnetwork', 'project_id', 'protocol', 'region', 'resource_type', 'response_code_class', 'service_name', 'service_region', 'zone']
+      gcpvpc_service_response_by_service_error_bytes: {
+        name: 'transmitted',
+        description: '',
+        type: 'raw',
+        unit: 'percent',
+        sources: {
+          stackdriver: {
+            expr: 'sum by (service_name) (stackdriver_google_service_gce_client_networking_googleapis_com_google_service_response_bytes_count{%(queriesSelector)s, response_code_class=~"500|400"}) / sum by (service_name) (stackdriver_google_service_gce_client_networking_googleapis_com_google_service_response_bytes_count{%(queriesSelector)s})',
+            legendCustomTemplate: '{{service_name}}: transmitted',
+          },
+        },
+      },      
+
+      //
+      // VPN Tunnel Metrics
+      //
+
+      // available labels: ['local_location_type', 'local_network', 'local_project_id', 'local_project_number', 'local_region', 'local_resource_type', 'local_subnetwork', 'local_zone', 'project_id', 'protocol', 'region', 'tunnel_id']
+      gcpvpn_tunnel_egress_bytes: {
+        name: 'transmitted',
+        description: '',
+        type: 'counter',
+        unit: 'bps',
+        sources: {
+          stackdriver: {
+            expr: 'stackdriver_vpn_tunnel_networking_googleapis_com_vpn_tunnel_egress_bytes_count{%(queriesSelector)s}',
+          },
+        },
+      },
+
+      // available labels: ['local_location_type', 'local_network', 'local_project_id', 'local_project_number', 'local_region', 'local_resource_type', 'local_subnetwork', 'local_zone', 'project_id', 'protocol', 'region', 'tunnel_id']
+      gcpvpn_tunnel_ingress_bytes: {
+        name: 'received',
+        description: '',
+        type: 'counter',
+        unit: 'bps',
+        sources: {
+          stackdriver: {
+            expr: 'stackdriver_vpn_tunnel_networking_googleapis_com_vpn_tunnel_ingress_bytes_count{%(queriesSelector)s}',
+          },
+        },
+      },
+
+      // available labels: ['local_location_type', 'local_network', 'local_project_id', 'local_project_number', 'local_region', 'local_resource_type', 'local_subnetwork', 'local_zone', 'project_id', 'protocol', 'region', 'tunnel_id']
+      gcpvpn_tunnel_egress_by_protocol_bytes: {
+        name: 'transmitted',
+        description: '',
+        type: 'counter',
+        unit: 'bps',
+        sources: {
+          stackdriver: {
+            expr: 'stackdriver_vpn_tunnel_networking_googleapis_com_vpn_tunnel_egress_bytes_count{%(queriesSelector)s}',
+            aggKeepLabels: ['protocol'],
+          },
+        },
+      },
+
+      // available labels: ['local_location_type', 'local_network', 'local_project_id', 'local_project_number', 'local_region', 'local_resource_type', 'local_subnetwork', 'local_zone', 'project_id', 'protocol', 'region', 'tunnel_id']
+      gcpvpn_tunnel_ingress_by_protocol_bytes: {
+        name: 'received',
+        description: '',
+        type: 'counter',
+        unit: 'bps',
+        sources: {
+          stackdriver: {
+            expr: 'stackdriver_vpn_tunnel_networking_googleapis_com_vpn_tunnel_ingress_bytes_count{%(queriesSelector)s}',
+            aggKeepLabels: ['protocol'],
+          },
+        },
+      },
+
+      // available labels: ['local_location_type', 'local_network', 'local_project_id', 'local_project_number', 'local_region', 'local_resource_type', 'local_subnetwork', 'local_zone', 'project_id', 'protocol', 'region', 'tunnel_id']
+      gcpvpn_tunnel_egress_by_resource_type_bytes: {
+        name: 'transmitted',
+        description: '',
+        type: 'counter',
+        unit: 'bps',
+        sources: {
+          stackdriver: {
+            expr: 'stackdriver_vpn_tunnel_networking_googleapis_com_vpn_tunnel_egress_bytes_count{%(queriesSelector)s}',
+            aggKeepLabels: ['local_resource_type'],
+          },
+        },
+      },
+
+      // available labels: ['local_location_type', 'local_network', 'local_project_id', 'local_project_number', 'local_region', 'local_resource_type', 'local_subnetwork', 'local_zone', 'project_id', 'protocol', 'region', 'tunnel_id']
+      gcpvpn_tunnel_ingress_by_resource_type_bytes: {
+        name: 'received',
+        description: '',
+        type: 'counter',
+        unit: 'bps',
+        sources: {
+          stackdriver: {
+            expr: 'stackdriver_vpn_tunnel_networking_googleapis_com_vpn_tunnel_ingress_bytes_count{%(queriesSelector)s}',
+            aggKeepLabels: ['local_resource_type'],
+          },
+        },
+      },
+    },
+  }

--- a/csp-mixin/signals/gcpvpc.libsonnet
+++ b/csp-mixin/signals/gcpvpc.libsonnet
@@ -204,7 +204,7 @@ function(this)
             legendCustomTemplate: '{{service_name}}: transmitted',
           },
         },
-      },      
+      },
 
       //
       // VPN Tunnel Metrics

--- a/csp-mixin/signals/gcpvpc.libsonnet
+++ b/csp-mixin/signals/gcpvpc.libsonnet
@@ -37,7 +37,7 @@ function(this)
         unit: 'short',
         sources: {
           stackdriver: {
-            expr: 'count(count by (service_name) (stackdriver_google_service_gce_client_networking_googleapis_com_google_service_response_bytes_count{%(queriesSelector)s} OR stackdriver_google_service_gce_client_networking_googleapis_com_google_service_request_bytes_count{%(queriesSelector)s}))',
+            expr: 'count(count by (service_name) (stackdriver_google_service_gce_client_networking_googleapis_com_google_service_response_bytes_count{%(queriesSelector)s} OR stackdriver_google_service_gce_client_networking_googleapis_com_google_service_response_bytes_count{%(queriesSelector)s}))',
           },
         },
       },
@@ -91,7 +91,6 @@ function(this)
         name: 'Top 5 services by network throughput.',
         description: '',
         type: 'gauge',
-        unit: 'bps',
         aggFunction: 'avg',
         sources: {
           stackdriver: {
@@ -107,7 +106,6 @@ function(this)
         name: 'Top 5 services by network error response code',
         description: '',
         type: 'gauge',
-        unit: 'percent',
         aggFunction: 'avg',
         sources: {
           stackdriver: {


### PR DESCRIPTION
Adds one new dashboard for Google VPC data.

![image](https://github.com/user-attachments/assets/3d78fa96-d81c-4bed-b8fe-50dc3809e738)
![image](https://github.com/user-attachments/assets/6b5475b5-7677-43dd-86a9-b4d3c7dbb4ab)
