### PR TITLE
Add minstep interval to MSSQL mixin targets

### DIFF
--- a/mssql-mixin/dashboards/mssql-overview.libsonnet
+++ b/mssql-mixin/dashboards/mssql-overview.libsonnet
@@ -105,6 +105,7 @@ local batchRequestsPanel(matcher) = {
       'rate(mssql_batch_requests_total{' + matcher + '}[$__rate_interval])',
       datasource=promDatasource,
       legendFormat='{{instance}}',
+      interval='1m',
     ),
   ],
   type: 'timeseries',
@@ -163,7 +164,6 @@ local batchRequestsPanel(matcher) = {
     },
     overrides: [],
   },
-  interval: '1m',
   options: {
     legend: {
       calcs: [],
@@ -185,6 +185,7 @@ local severeErrorsPanel(matcher) = {
       'increase(mssql_kill_connection_errors_total{' + matcher + '}[$__rate_interval:])',
       datasource=promDatasource,
       legendFormat='{{instance}}',
+      interval='1m',
     ),
   ],
   type: 'timeseries',
@@ -243,7 +244,6 @@ local severeErrorsPanel(matcher) = {
     },
     overrides: [],
   },
-  interval: '1m',
   options: {
     legend: {
       calcs: [],
@@ -265,6 +265,7 @@ local deadlocksPanel(matcher) = {
       'rate(mssql_deadlocks_total{' + matcher + '}[$__rate_interval])',
       datasource=promDatasource,
       legendFormat='{{instance}}',
+      interval='1m',
     ),
   ],
   type: 'timeseries',
@@ -323,7 +324,6 @@ local deadlocksPanel(matcher) = {
     },
     overrides: [],
   },
-  interval: '1m',
   options: {
     legend: {
       calcs: [],
@@ -590,6 +590,7 @@ local databaseWriteStallDurationPanel(matcher) = {
       'increase(mssql_io_stall_seconds_total{' + matcher + ', db=~"$database", operation="write"}[$__rate_interval:])',
       datasource=promDatasource,
       legendFormat='{{instance}} - {{db}}',
+      interval='1m',
     ),
   ],
   type: 'timeseries',
@@ -644,7 +645,6 @@ local databaseWriteStallDurationPanel(matcher) = {
     },
     overrides: [],
   },
-  interval: '1m',
   options: {
     legend: {
       calcs: [],
@@ -666,6 +666,7 @@ local databaseReadStallDurationPanel(matcher) = {
       'increase(mssql_io_stall_seconds_total{' + matcher + ', db=~"$database", operation="read"}[$__rate_interval:])',
       datasource=promDatasource,
       legendFormat='{{instance}} - {{db}}',
+      interval='1m',
     ),
   ],
   type: 'timeseries',
@@ -720,7 +721,6 @@ local databaseReadStallDurationPanel(matcher) = {
     },
     overrides: [],
   },
-  interval: '1m',
   options: {
     legend: {
       calcs: [],
@@ -742,6 +742,7 @@ local transactionLogExpansionsPanel(matcher) = {
       'increase(mssql_log_growths_total{' + matcher + ', db=~"$database"}[$__rate_interval:])',
       datasource=promDatasource,
       legendFormat='{{instance}} - {{db}}',
+      interval='1m',
     ),
   ],
   type: 'timeseries',
@@ -800,7 +801,6 @@ local transactionLogExpansionsPanel(matcher) = {
     },
     overrides: [],
   },
-  interval: '1m',
   options: {
     legend: {
       calcs: [],

--- a/mssql-mixin/dashboards/mssql-pages.libsonnet
+++ b/mssql-mixin/dashboards/mssql-pages.libsonnet
@@ -256,6 +256,7 @@ local pageFaultsPanel(matcher) = {
       'increase(mssql_page_fault_count_total{' + matcher + '}[$__rate_interval:])',
       datasource=promDatasource,
       legendFormat='{{instance}}',
+      interval='1m',
     ),
   ],
   type: 'timeseries',
@@ -314,7 +315,6 @@ local pageFaultsPanel(matcher) = {
     },
     overrides: [],
   },
-  interval: '1m',
   options: {
     legend: {
       calcs: [],


### PR DESCRIPTION
This PR moves the `interval: '1m'` setting from the panel level to the target level for the MSSQL mixin, allowing it to be properly applied.