### PR TITLE
Add per-mixin workflow for linting

### DIFF
--- a/.github/workflows/lint-mixins.yml
+++ b/.github/workflows/lint-mixins.yml
@@ -39,6 +39,7 @@ jobs:
           dir_names_max_depth: 1
           files: | 
             **-mixin/
+            **-observ-lib/
           matrix: true
           
       - name: List all changed mixins

--- a/.github/workflows/lint-mixins.yml
+++ b/.github/workflows/lint-mixins.yml
@@ -79,5 +79,3 @@ jobs:
       - name: Lint Mixin
         working-directory: ./${{ matrix.mixin }}
         run: mixtool lint mixin.libsonnet
-
-    

--- a/.github/workflows/lint-mixins.yml
+++ b/.github/workflows/lint-mixins.yml
@@ -1,0 +1,44 @@
+---
+name: "Lint Mixins"
+
+permissions:
+  contents: read
+
+on:
+  # To conserve resources we only run tests against main in PRs
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check-for-changed-mixins:
+    name: Check for changed mixins
+    runs-on: ubuntu-latest
+    outputs:
+      changed-mixins: ${{ steps.changed-mixins.outputs.all_changed_files }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.18
+      
+      - name: Install CI dependencies
+        run: make install-ci-deps
+      
+      - name: Get changed mixins
+        id: changed-mixins
+        uses: tj-actions/changed-files@v44
+        with:
+          dir_names: true
+          dir_names_exclude_current_dir: true
+          dir_names_max_depth: 1
+          files: **-mixin/
+          matrix: true
+          
+      - name: List all changed mixins:
+        run: echo '${{ steps.changed-mixins.outputs.all_changed_files }}'

--- a/.github/workflows/lint-mixins.yml
+++ b/.github/workflows/lint-mixins.yml
@@ -1,5 +1,5 @@
 ---
-name: "Lint Mixins"
+name: Mixin
 
 permissions:
   contents: read
@@ -8,11 +8,11 @@ on:
   # To conserve resources we only run tests against main in PRs
   pull_request:
     branches:
-      - main
+      - master
 
 jobs:
   check-for-changed-mixins:
-    name: Check for changed mixins
+    name: Check for changes
     runs-on: ubuntu-latest
     outputs:
       changed-mixins: ${{ steps.changed-mixins.outputs.all_changed_files }}
@@ -37,8 +37,47 @@ jobs:
           dir_names: true
           dir_names_exclude_current_dir: true
           dir_names_max_depth: 1
-          files: **-mixin/
+          files: | 
+            **-mixin/
           matrix: true
           
-      - name: List all changed mixins:
+      - name: List all changed mixins
         run: echo '${{ steps.changed-mixins.outputs.all_changed_files }}'
+
+  lint-mixin:
+    name: Run Mixtool
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: write
+      pull-requests: write
+      repository-projects: write
+    timeout-minutes: 15
+    needs: [check-for-changed-mixins]
+    strategy:
+      matrix:
+        mixin: ${{ fromJSON(needs.check-for-changed-mixins.outputs.changed-mixins) }}
+      fail-fast: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.18
+      
+      - name: Install CI dependencies
+        run: make install-ci-deps
+
+      - name: Install Mixin dependencies
+        working-directory: ./${{ matrix.mixin }}
+        run: jb install
+
+      - name: Lint Mixin
+        working-directory: ./${{ matrix.mixin }}
+        run: mixtool lint mixin.libsonnet
+
+    


### PR DESCRIPTION
This PR reintroduces mixin linting via the use of [mixtool](https://github.com/monitoring-mixins/mixtool), but in an updated fashion to only account for changes made to any given mixins in the current working push request.

This is done to avoid blocking PR authors when mixins outwith the changes they're making fail linting. 