### PR TITLE
Fix Disk space usage in Grafana 11.0

### DIFF
--- a/common-lib/common/panels/disk/table/usage.libsonnet
+++ b/common-lib/common/panels/disk/table/usage.libsonnet
@@ -245,7 +245,13 @@ base {
       fieldOverride.byName.new('Available')
       + fieldOverride.byName.withProperty('custom.width', '80'),
       fieldOverride.byName.new('Used, %')
-      + fieldOverride.byName.withProperty('custom.displayMode', 'basic')
+      + fieldOverride.byName.withProperty(
+        'custom.cellOptions', {
+          type: 'gauge',
+          mode: 'basic',
+          valueDisplayMode: 'text',
+        }
+      )
       + fieldOverride.byName.withPropertiesFromOptions(
         table.standardOptions.withMax(1)
         + table.standardOptions.withMin(0)


### PR DESCRIPTION
Fix disk space usage gauge view with Grafana 11.0 grafonnet.

With this fix it works again:

![image](https://github.com/user-attachments/assets/db003b68-504b-47a7-b6ab-ae3e66b0d88c)

