### PR TITLE
jvm-observ-lib: Add java_micrometer_with_suffixes option

### DIFF
--- a/jvm-observ-lib/README.md
+++ b/jvm-observ-lib/README.md
@@ -7,7 +7,8 @@ Supports the following sources:
 - `prometheus` (https://prometheus.github.io/client_java/instrumentation/jvm/#jvm-memory-metrics). This also works for jmx_exporter (javaagent mode) starting from 1.0.1 release.
 - `otel` (https://github.com/open-telemetry/opentelemetry-java-contrib/blob/main/jmx-metrics/docs/target-systems/jvm.md)
 - `otel_with_suffixes` same as otel with add_metric_suffixes=true in otelcollector
-- `java_micrometer` (springboot) (https://github.com/micrometer-metrics/micrometer/blob/main/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmMemoryMetrics.java)
+- `java_micrometer` (springboot) (https://github.com/micrometer-metrics/micrometer/blob/main/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmMemoryMetrics.java). Can be seen when Micrometer to OTEL bridge is used.
+- `java_micrometer_with_suffixes` (springboot) same, but with prometheus suffixes
 - `prometheus_old` client_java instrumentation prior to 1.0.0 release: (https://github.com/prometheus/client_java/releases/tag/v1.0.0-alpha-4). This also works for jmx_exporter (javaagent mode) prior to 1.0.1 release.
 - `jmx_exporter`. Works with jmx_exporter (both http and javaagent modes) and the folllowing snippet:
 
@@ -45,7 +46,7 @@ local jvm =
         uid: 'jvm-sample',
         dashboardNamePrefix: 'JVM',
         dashboardTags: ['java', 'jvm'],
-        metricsSource: 'java_micrometer', // or java_otel, prometheus,
+        metricsSource: 'java_micrometer_with_suffixes', // or java_otel, prometheus,
     }
   );
 jvm.asMonitoringMixin()

--- a/jvm-observ-lib/main.libsonnet
+++ b/jvm-observ-lib/main.libsonnet
@@ -15,7 +15,7 @@ local processlib = import 'process-observ-lib/main.libsonnet';
           filteringSelector: this.config.filteringSelector,
           groupLabels: this.config.groupLabels,
           instanceLabels: this.config.instanceLabels,
-          uid: this.config.uid,
+          uid: this.config.uid - '-jvm',
           dashboardNamePrefix: this.config.dashboardNamePrefix,
           dashboardTags: this.config.dashboardTags,
           metricsSource:
@@ -25,6 +25,7 @@ local processlib = import 'process-observ-lib/main.libsonnet';
             + (if std.member(this.config.metricsSource, 'prometheus') then ['prometheus'] else [])
             + (if std.member(this.config.metricsSource, 'jmx_exporter') then ['jmx_exporter'] else [])
             + (if std.member(this.config.metricsSource, 'prometheus_old') then ['prometheus'] else [])
+            + (if std.member(this.config.metricsSource, 'java_micrometer_with_suffixes') then ['java_micrometer_with_suffixes'] else [])
             + (if std.member(this.config.metricsSource, 'java_micrometer') then ['java_micrometer'] else []),
         }
       ),

--- a/jvm-observ-lib/signals/buffers.libsonnet
+++ b/jvm-observ-lib/signals/buffers.libsonnet
@@ -8,10 +8,11 @@ function(this)
     aggLevel: 'group',
     aggFunction: 'avg',
     discoveryMetric: {
-      java_micrometer: 'jvm_buffer_memory_used_bytes',  // https://github.com/micrometer-metrics/micrometer/blob/main/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmMemoryMetrics.java
-      prometheus: 'jvm_buffer_pool_used_bytes',  // https://prometheus.github.io/client_java/instrumentation/jvm/#jvm-buffer-pool-metrics
+      java_micrometer: 'jvm_buffer_memory_used',  // can be seen when otel micrometer bridge is used
+      java_micrometer_with_suffixes: 'jvm_buffer_memory_used_bytes',  // https://github.com/micrometer-metrics/micrometer/blob/main/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmMemoryMetrics.java
       otel: 'process_runtime_jvm_buffer_usage',
       otel_with_suffixes: 'process_runtime_jvm_buffer_usage_bytes',
+      prometheus: 'jvm_buffer_pool_used_bytes',  // https://prometheus.github.io/client_java/instrumentation/jvm/#jvm-buffer-pool-metrics
       prometheus_old: 'jvm_buffer_pool_used_bytes',
     },
     signals: {
@@ -23,6 +24,9 @@ function(this)
         optional: true,
         sources: {
           java_micrometer: {
+            expr: 'jvm_buffer_memory_used{%(queriesSelector)s}',
+          },
+          java_micrometer_with_suffixes: {
             expr: 'jvm_buffer_memory_used_bytes{%(queriesSelector)s}',
           },
           prometheus: {
@@ -47,6 +51,9 @@ function(this)
         optional: true,
         sources: {
           java_micrometer: {
+            expr: 'jvm_buffer_total_capacity{%(queriesSelector)s}',
+          },
+          java_micrometer_with_suffixes: {
             expr: 'jvm_buffer_total_capacity_bytes{%(queriesSelector)s}',
           },
           prometheus: {
@@ -71,6 +78,9 @@ function(this)
         optional: true,
         sources: {
           java_micrometer: {
+            expr: 'jvm_buffer_memory_used{%(queriesSelector)s}',
+          },
+          java_micrometer_with_suffixes: {
             expr: 'jvm_buffer_memory_used_bytes{%(queriesSelector)s}',
           },
           prometheus: {
@@ -95,6 +105,9 @@ function(this)
         optional: true,
         sources: {
           java_micrometer: {
+            expr: 'jvm_buffer_total_capacity{%(queriesSelector)s}',
+          },
+          java_micrometer_with_suffixes: {
             expr: 'jvm_buffer_total_capacity_bytes{%(queriesSelector)s}',
           },
           prometheus: {

--- a/jvm-observ-lib/signals/classes.libsonnet
+++ b/jvm-observ-lib/signals/classes.libsonnet
@@ -8,7 +8,8 @@ function(this)
     aggLevel: 'group',
     aggFunction: 'avg',
     discoveryMetric: {
-      java_micrometer: 'jvm_classes_loaded_classes',  // https://github.com/micrometer-metrics/micrometer/blob/main/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ClassLoaderMetrics.java
+      java_micrometer: 'jvm_classes_loaded',  // https://github.com/micrometer-metrics/micrometer/blob/main/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ClassLoaderMetrics.java
+      java_micrometer_with_suffixes: 'jvm_classes_loaded_classes',
       prometheus: 'jvm_classes_loaded',  // https://prometheus.github.io/client_java/instrumentation/jvm/#jvm-class-loading-metrics
       otel: 'process_runtime_jvm_classes_loaded',
       otel_with_suffixes: 'process_runtime_jvm_classes_loaded_total',
@@ -23,6 +24,9 @@ function(this)
         unit: 'short',
         sources: {
           java_micrometer: {
+            expr: 'jvm_classes_loaded{%(queriesSelector)s}',
+          },
+          java_micrometer_with_suffixes: {
             expr: 'jvm_classes_loaded_classes{%(queriesSelector)s}',
           },
           prometheus: {

--- a/jvm-observ-lib/signals/hikari.libsonnet
+++ b/jvm-observ-lib/signals/hikari.libsonnet
@@ -24,6 +24,7 @@ function(this)
             expr: 'hikaricp_connections{%(queriesSelector)s}',
             aggKeepLabels: ['pool'],
           },
+          java_micrometer_with_suffixes: self.java_micrometer,
           otel: {
             expr: 'hikaricp_connections{%(queriesSelector)s}',
             aggKeepLabels: ['pool'],
@@ -42,6 +43,10 @@ function(this)
             expr: 'hikaricp_connections_timeout_total{%(queriesSelector)s}',
             aggKeepLabels: ['pool'],
           },
+          java_micrometer_with_suffixes: {
+            expr: 'hikaricp_connections_timeout{%(queriesSelector)s}',
+            aggKeepLabels: ['pool'],
+          },
         },
       },
       connectionsActive: {
@@ -55,6 +60,7 @@ function(this)
             expr: 'hikaricp_connections_active{%(queriesSelector)s}',
             aggKeepLabels: ['pool'],
           },
+          java_micrometer_with_suffixes: self.java_micrometer,
           otel: {
             expr: 'hikaricp_connections_active{%(queriesSelector)s}',
             aggKeepLabels: ['pool'],
@@ -73,6 +79,7 @@ function(this)
             expr: 'hikaricp_connections_idle{%(queriesSelector)s}',
             aggKeepLabels: ['pool'],
           },
+          java_micrometer_with_suffixes: self.java_micrometer,
           otel: {
             expr: 'hikaricp_connections_idle{%(queriesSelector)s}',
             aggKeepLabels: ['pool'],
@@ -91,6 +98,7 @@ function(this)
             expr: 'hikaricp_connections_pending{%(queriesSelector)s}',
             aggKeepLabels: ['pool'],
           },
+          java_micrometer_with_suffixes: self.java_micrometer,
           otel: {
             expr: 'hikaricp_connections_pending{%(queriesSelector)s}',
             aggKeepLabels: ['pool'],
@@ -108,11 +116,19 @@ function(this)
         sources: {
           java_micrometer: {
             expr: |||
+              rate(hikaricp_connections_creation_sum{%(queriesSelector)s}[$__rate_interval])
+              /rate(hikaricp_connections_creation_count{%(queriesSelector)s}[$__rate_interval])
+            |||,
+            aggKeepLabels: ['pool'],
+          },
+          java_micrometer_with_suffixes: {
+            expr: |||
               rate(hikaricp_connections_creation_seconds_sum{%(queriesSelector)s}[$__rate_interval])
               /rate(hikaricp_connections_creation_seconds_count{%(queriesSelector)s}[$__rate_interval])
             |||,
             aggKeepLabels: ['pool'],
           },
+
         },
       },
       connectionsUsageDurationAvg: {
@@ -123,6 +139,13 @@ function(this)
         optional: true,
         sources: {
           java_micrometer: {
+            expr: |||
+              rate(hikaricp_connections_usage_sum{%(queriesSelector)s}[$__rate_interval])
+              /rate(hikaricp_connections_usage_count{%(queriesSelector)s}[$__rate_interval])
+            |||,
+            aggKeepLabels: ['pool'],
+          },
+          java_micrometer_with_suffixes: {
             expr: |||
               rate(hikaricp_connections_usage_seconds_sum{%(queriesSelector)s}[$__rate_interval])
               /rate(hikaricp_connections_usage_seconds_count{%(queriesSelector)s}[$__rate_interval])
@@ -139,6 +162,13 @@ function(this)
         optional: true,
         sources: {
           java_micrometer: {
+            expr: |||
+              rate(hikaricp_connections_acquire_sum{%(queriesSelector)s}[$__rate_interval])
+              /rate(hikaricp_connections_acquire_count{%(queriesSelector)s}[$__rate_interval])
+            |||,
+            aggKeepLabels: ['pool'],
+          },
+          java_micrometer_with_suffixes: {
             expr: |||
               rate(hikaricp_connections_acquire_seconds_sum{%(queriesSelector)s}[$__rate_interval])
               /rate(hikaricp_connections_acquire_seconds_count{%(queriesSelector)s}[$__rate_interval])

--- a/jvm-observ-lib/signals/logback.libsonnet
+++ b/jvm-observ-lib/signals/logback.libsonnet
@@ -21,6 +21,14 @@ function(this)
         sources: {
           java_micrometer: {
             expr: |||
+              logback_events{%(queriesSelector)s}
+            |||,
+            exprWrappers: [
+              ['topk(10,', ')'],
+            ],
+          },
+          java_micrometer_with_suffixes: {
+            expr: |||
               logback_events_total{%(queriesSelector)s}
             |||,
             exprWrappers: [
@@ -37,6 +45,12 @@ function(this)
         optional: true,
         sources: {
           java_micrometer: {
+            expr: 'logback_events{level="error", %(queriesSelector)s}',
+            exprWrappers: [
+              ['topk(10,', ')'],
+            ],
+          },
+          java_micrometer_with_suffixes: {
             expr: 'logback_events_total{level="error", %(queriesSelector)s}',
             exprWrappers: [
               ['topk(10,', ')'],

--- a/jvm-observ-lib/signals/memory.libsonnet
+++ b/jvm-observ-lib/signals/memory.libsonnet
@@ -6,7 +6,8 @@ function(this)
     aggLevel: 'group',
     aggFunction: 'avg',
     discoveryMetric: {
-      java_micrometer: 'jvm_memory_used_bytes',
+      java_micrometer: 'jvm_memory_used',
+      java_micrometer_with_suffixes: 'jvm_memory_used_bytes',
       prometheus: 'jvm_memory_used_bytes',  // https://prometheus.github.io/client_java/instrumentation/jvm/#jvm-memory-metrics
       otel: 'process_runtime_jvm_memory_usage',
       otel_with_suffixes: 'process_runtime_jvm_memory_usage_bytes',
@@ -23,6 +24,9 @@ function(this)
         sources: {
           //spring
           java_micrometer: {
+            expr: 'sum without (id) (jvm_memory_used{area="heap", %(queriesSelector)s})',
+          },
+          java_micrometer_with_suffixes: {
             expr: 'sum without (id) (jvm_memory_used_bytes{area="heap", %(queriesSelector)s})',
           },
           prometheus: {
@@ -58,6 +62,9 @@ function(this)
         unit: 'bytes',
         sources: {
           java_micrometer: {
+            expr: 'sum without (id) (jvm_memory_max{area="heap", %(queriesSelector)s} != -1)',
+          },
+          java_micrometer_with_suffixes: {
             expr: 'sum without (id) (jvm_memory_max_bytes{area="heap", %(queriesSelector)s} != -1)',
           },
           prometheus: self.java_micrometer,
@@ -83,6 +90,9 @@ function(this)
         sources: {
           //spring
           java_micrometer: {
+            expr: 'sum without (id) (jvm_memory_used{area="nonheap", %(queriesSelector)s})',
+          },
+          java_micrometer_with_suffixes: {
             expr: 'sum without (id) (jvm_memory_used_bytes{area="nonheap", %(queriesSelector)s})',
           },
           prometheus: self.java_micrometer,
@@ -107,6 +117,9 @@ function(this)
         unit: 'bytes',
         sources: {
           java_micrometer: {
+            expr: 'sum without (id) (jvm_memory_max{area="nonheap", %(queriesSelector)s} != -1)',
+          },
+          java_micrometer_with_suffixes: {
             expr: 'sum without (id) (jvm_memory_max_bytes{area="nonheap", %(queriesSelector)s} != -1)',
           },
           prometheus: self.java_micrometer,
@@ -133,6 +146,9 @@ function(this)
         unit: 'bytes',
         sources: {
           java_micrometer: {
+            expr: 'sum without (id) (jvm_memory_committed{area="heap", %(queriesSelector)s})',
+          },
+          java_micrometer_with_suffixes: {
             expr: 'sum without (id) (jvm_memory_committed_bytes{area="heap", %(queriesSelector)s})',
           },
           prometheus: self.java_micrometer,

--- a/jvm-observ-lib/signals/threads.libsonnet
+++ b/jvm-observ-lib/signals/threads.libsonnet
@@ -8,7 +8,8 @@ function(this)
     aggLevel: 'group',
     aggFunction: 'avg',
     discoveryMetric: {
-      java_micrometer: 'jvm_threads_live_threads',  // https://github.com/micrometer-metrics/micrometer/blob/main/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetrics.java
+      java_micrometer: 'jvm_threads_live',  // https://github.com/micrometer-metrics/micrometer/blob/main/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetrics.java
+      java_micrometer_with_suffixes: 'jvm_threads_live_threads',  // https://github.com/micrometer-metrics/micrometer/blob/main/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetrics.java
       prometheus: 'jvm_threads_current',  // https://prometheus.github.io/client_java/instrumentation/jvm/#jvm-memory-metrics
       otel: 'process_runtime_jvm_threads_count',
       otel_with_suffixes: self.otel,
@@ -23,6 +24,9 @@ function(this)
         unit: 'short',
         sources: {
           java_micrometer: {
+            expr: 'jvm_threads_live{%(queriesSelector)s}',
+          },
+          java_micrometer_with_suffixes: {
             expr: 'jvm_threads_live_threads{%(queriesSelector)s}',
           },
           prometheus: {
@@ -45,6 +49,9 @@ function(this)
         unit: 'short',
         sources: {
           java_micrometer: {
+            expr: 'jvm_threads_daemon{%(queriesSelector)s}',
+          },
+          java_micrometer_with_suffixes: {
             expr: 'jvm_threads_daemon_threads{%(queriesSelector)s}',
           },
           prometheus: {
@@ -70,6 +77,9 @@ function(this)
         optional: true,
         sources: {
           java_micrometer: {
+            expr: 'jvm_threads_peak{%(queriesSelector)s}',
+          },
+          java_micrometer_with_suffixes: {
             expr: 'jvm_threads_peak_threads{%(queriesSelector)s}',
           },
           prometheus: {
@@ -102,6 +112,10 @@ function(this)
         optional: true,
         sources: {
           java_micrometer: {
+            expr: 'sum by (state, %(agg)s) (jvm_threads_states{%(queriesSelector)s})',
+            legendCustomTemplate: '{{ state }}',
+          },
+          java_micrometer_with_suffixes: {
             expr: 'sum by (state, %(agg)s) (jvm_threads_states_threads{%(queriesSelector)s})',
             legendCustomTemplate: '{{ state }}',
           },

--- a/process-observ-lib/README.md
+++ b/process-observ-lib/README.md
@@ -4,12 +4,25 @@ This lib can be used to generate dashboards, rows, panels for generic OS process
 
 Supports the following sources:
 
-- prometheus
-- otel
-- java_otel
-- java_otel_with_suffixes (add_metric_suffixes=true in otelcollector)
-- java_micrometer (springboot)
-- jmx_exporter
+- `prometheus`. Should also work for jmx_exporter in javaagent mode
+- `otel`
+- `java_otel`
+- `java_micrometer` (springboot, can be seen when Micromter to OTEL bridge is used)
+- `java_micrometer_with_suffixes` (springboot when scraped from prometheus endpoint)
+- `jmx_exporter`. Works for both jmx_exporter modes: http and javaagent
+
+If you pick `jmx_exporter` option, make sure you add the following snippet to your jmx_exporter config:
+
+```yaml
+lowercaseOutputName: true
+lowercaseOutputLabelNames: true
+rules:
+  - pattern: java.lang<type=(.+), name=(.+)><(.+)>(\w+)
+    name: java_lang_$1_$4_$3_$2
+  - pattern: java.lang<type=(.+), name=(.+)><>(\w+)
+    name: java_lang_$1_$3_$2
+  - pattern : java.lang<type=(.*)>
+```
 
 ## Import
 

--- a/process-observ-lib/config.libsonnet
+++ b/process-observ-lib/config.libsonnet
@@ -18,7 +18,7 @@
   dashboardTimezone: 'default',
   dashboardRefresh: '1m',
 
-  metricsSource: ['prometheus'],  // or any combination of: prometheus, otel, otel_with_suffixes, java_otel, java_otel_with_suffixes, java_micrometer.
+  metricsSource: ['prometheus'],  // or any combination of: prometheus, otel, otel_with_suffixes, java_otel, java_otel_with_suffixes, java_micrometer, java_micrometer_with_suffixes.
   signals+:
     {
       system: (import './signals/system.libsonnet')(this),

--- a/process-observ-lib/signals/process.libsonnet
+++ b/process-observ-lib/signals/process.libsonnet
@@ -5,7 +5,8 @@ function(this)
       otel: 'runtime_uptime',
       otel_with_suffixes: 'runtime_uptime_milliseconds_total',
       java_otel: self.otel,  // some system metrics are calculated differently for java. (see system.libsonnet)
-      java_micrometer: 'process_uptime_seconds',  // https://docs.spring.io/spring-boot/docs/1.3.3.RELEASE/reference/html/production-ready-metrics.html
+      java_micrometer: 'process_uptime',  // https://docs.spring.io/spring-boot/docs/1.3.3.RELEASE/reference/html/production-ready-metrics.html
+      java_micrometer_with_suffixes: 'process_uptime_seconds',  // https://docs.spring.io/spring-boot/docs/1.3.3.RELEASE/reference/html/production-ready-metrics.html
       java_otel_with_suffixes: self.otel_with_suffixes,  // some system metrics are calculated differently for java. (see system.libsonnet),
       // https://prometheus.github.io/client_java/instrumentation/jvm/#process-metrics
       // https://github.com/prometheus/client_golang
@@ -41,6 +42,9 @@ function(this)
           java_otel: self.otel,
           java_otel_with_suffixes: self.otel_with_suffixes,
           java_micrometer: {
+            expr: 'process_uptime{%(queriesSelector)s}',
+          },
+          java_micrometer_with_suffixes: {
             expr: 'process_uptime_seconds{%(queriesSelector)s}',
           },
           jmx_exporter: {
@@ -59,6 +63,9 @@ function(this)
         unit: 'dateTimeAsIso',
         sources: {
           java_micrometer: {
+            expr: 'process_start_time{%(queriesSelector)s} * 1000',
+          },
+          java_micrometer_with_suffixes: {
             expr: 'process_start_time_seconds{%(queriesSelector)s} * 1000',
           },
           prometheus:
@@ -92,6 +99,7 @@ function(this)
           java_micrometer: {
             expr: 'process_cpu_usage{%(queriesSelector)s} * 100',
           },
+          java_micrometer_with_suffixes: self.java_micrometer,
           java_otel: {
             expr: 'process_runtime_jvm_cpu_utilization{%(queriesSelector)s} * 100',
           },
@@ -162,6 +170,9 @@ function(this)
           java_otel_with_suffixes: self.otel,
           java_otel: self.otel,
           java_micrometer: {
+            expr: 'process_files_open{%(queriesSelector)s}',
+          },
+          java_micrometer_with_suffixes: {
             expr: 'process_files_open_files{%(queriesSelector)s}',
           },
           prometheus: {
@@ -182,6 +193,9 @@ function(this)
           otel_with_suffixes: self.otel,
           java_otel_with_suffixes: self.otel,
           java_micrometer: {
+            expr: 'process_files_max{%(queriesSelector)s}',
+          },
+          java_micrometer_with_suffixes: {
             expr: 'process_files_max_files{%(queriesSelector)s}',
           },
           prometheus: {

--- a/process-observ-lib/signals/system.libsonnet
+++ b/process-observ-lib/signals/system.libsonnet
@@ -6,7 +6,8 @@ function(this)
       otel_with_suffixes: 'runtime_uptime_milliseconds_total',
       java_otel: self.otel,  // some system metrics are calculated differently for java
       java_otel_with_suffixes: self.otel_with_suffixes,
-      java_micrometer: 'process_uptime_seconds',
+      java_micrometer: 'process_uptime',
+      java_micrometer_with_suffixes: 'process_uptime_seconds',
       // https://prometheus.github.io/client_java/instrumentation/jvm/#process-metrics
       // https://github.com/prometheus/client_golang
       prometheus: 'process_start_time_seconds',
@@ -34,6 +35,7 @@ function(this)
           java_micrometer: {
             expr: 'system_load_average_1m{%(queriesSelector)s}',
           },
+          java_micrometer_with_suffixes: self.java_micrometer,
           jmx_exporter: {
             expr: 'java_lang_operatingsystem_systemloadaverage{%(queriesSelector)s}',
           },
@@ -49,6 +51,7 @@ function(this)
           java_micrometer: {
             expr: 'system_cpu_usage{%(queriesSelector)s} * 100',
           },
+          java_micrometer_with_suffixes: self.java_micrometer,
           java_otel: {
             expr: 'process_runtime_jvm_system_cpu_utilization{%(queriesSelector)s}',
           },
@@ -76,6 +79,7 @@ function(this)
           java_micrometer: {
             expr: 'system_cpu_count{%(queriesSelector)s}',
           },
+          java_micrometer_with_suffixes: self.java_micrometer,
         },
       },
     },


### PR DESCRIPTION
There is yet another metric pattern combination. When micrometer metrics are received through OTEL bridge then prometheus suffixes might not be added. Adding this option to jvm/process lib