### PR TITLE
Add support for empty (filteringSelector='')

### DIFF
--- a/common-lib/common/variables/variables.libsonnet
+++ b/common-lib/common/variables/variables.libsonnet
@@ -10,15 +10,19 @@ local utils = import '../utils.libsonnet';
     varMetric='up',
     enableLokiLogs=false,
     customAllValue='.+',
-    prometheusDatasourceName='datasource',
-    prometheusDatasourceLabel='Data source',
+    prometheusDatasourceName=if enableLokiLogs then 'prometheus_datasource' else 'datasource',
+    prometheusDatasourceLabel=if enableLokiLogs then 'Prometheus datasource' else 'Data source',
   ): {
-       local varMetricTemplate =
-         if std.type(varMetric) == 'array'
-         then '{__name__=~"%s",%%s}' % std.join('|', std.uniq(varMetric))
+       local varMetricTemplate(varMetric, chainSelector) =
+         // check if chainSelector is not empty string (case when filtering selector is empty):
+         if std.type(varMetric) == 'array' && chainSelector != ''
+         then '{__name__=~"%s",%s}' % [std.join('|', std.uniq(varMetric)), chainSelector]
+         else if std.type(varMetric) == 'array' && chainSelector == ''
+         then '{__name__=~"%s"}' % std.join('|', std.uniq(varMetric))
          else if std.type(varMetric) == 'string'
-         then '%s{%%s}' % varMetric
+         then '%s{%s}' % [varMetric, chainSelector]
          else error ('varMetric must be array or string'),
+
        local root = self,
        local variablesFromLabels(groupLabels, instanceLabels, filteringSelector, multiInstance=true) =
          local chainVarProto(index, chainVar) =
@@ -26,7 +30,7 @@ local utils = import '../utils.libsonnet';
            + var.query.withDatasourceFromVariable(root.datasources.prometheus)
            + var.query.queryTypes.withLabelValues(
              chainVar.label,
-             varMetricTemplate % [chainVar.chainSelector],
+             varMetricTemplate(varMetric, chainVar.chainSelector),
            )
            + var.query.generalOptions.withLabel(utils.toSentenceCase(chainVar.label))
            + var.query.selectionOptions.withIncludeAll(
@@ -43,7 +47,7 @@ local utils = import '../utils.libsonnet';
              asc=true,
              caseInsensitive=false
            );
-         std.mapWithIndex(chainVarProto, utils.chainLabels(groupLabels + instanceLabels, [filteringSelector])),
+         std.mapWithIndex(chainVarProto, utils.chainLabels(groupLabels + instanceLabels, if std.length(filteringSelector) > 0 then [filteringSelector] else [])),
        datasources: {
          prometheus:
            var.datasource.new(prometheusDatasourceName, 'prometheus')


### PR DESCRIPTION
1) Add support for empty (filteringSelector='') to support cases when we don't want to have any static filter at all. 
You can now set filteringSelector to ''
and in queries this:
`{job!="", job=~"$job"}`
would become
`{job=~"$job"}`
2) Turn `datasource` to `prometheus_datasource` when loki is enabled this helps to pass dashboard-linter rule: