### PR TITLE
Update all value to .+ for logs lib

### DIFF
--- a/logs-lib/logs/variables.libsonnet
+++ b/logs-lib/logs/variables.libsonnet
@@ -21,7 +21,7 @@ function(
         )
         + var.query.selectionOptions.withIncludeAll(
           value=true,
-          customAllValue='.*'
+          customAllValue='.+'
         )
         + var.query.selectionOptions.withMulti()
         + var.query.refresh.onTime()


### PR DESCRIPTION
Relates to: https://github.com/grafana/cloud-onboarding/issues/8058

`.*` causes issues with logs query
<img width="1475" alt="image" src="https://github.com/user-attachments/assets/0f9b47fc-2100-4334-965b-da23e457840e">
