### PR TITLE
fix/apache-solr-mixin - Fixes a number of issues for Apache Solr Mixin

### DIFF
--- a/apache-solr-mixin/dashboards/apache-solr-cluster-overview.libsonnet
+++ b/apache-solr-mixin/dashboards/apache-solr-cluster-overview.libsonnet
@@ -1653,7 +1653,7 @@ local getMatcher(cfg) = '%(solrSelector)s, solr_cluster=~"$solr_cluster"' % cfg;
             refresh=2,
             includeAll=true,
             multi=true,
-            allValues='.+',
+            allValues='.*',
             sort=1
           ),
           template.new(

--- a/apache-solr-mixin/dashboards/apache-solr-query-performance.libsonnet
+++ b/apache-solr-mixin/dashboards/apache-solr-query-performance.libsonnet
@@ -1578,7 +1578,7 @@ local getMatcher(cfg) = '%(solrSelector)s, solr_cluster=~"$solr_cluster", base_u
             refresh=2,
             includeAll=true,
             multi=true,
-            allValues='.+',
+            allValues='.*',
             sort=1
           ),
           template.new(

--- a/apache-solr-mixin/dashboards/apache-solr-resource-monitoring.libsonnet
+++ b/apache-solr-mixin/dashboards/apache-solr-resource-monitoring.libsonnet
@@ -1059,7 +1059,7 @@ local dispatchesPanel(matcher) = {
   },
 };
 
-local getMatcher(cfg) = '%(solrSelector)s, solr_cluster="$solr_cluster", base_url=~"$base_url"' % cfg;
+local getMatcher(cfg) = '%(solrSelector)s, solr_cluster=~"$solr_cluster", base_url=~"$base_url"' % cfg;
 
 {
   grafanaDashboards+:: {


### PR DESCRIPTION
Fixes issue with Resource Monitoring Dashboard where '~' was missing in queries for selector to `solr_cluster` variable.

Change custom allValues for solr_collection variable from `.+` to `.*` in Cluster Overview Dashboard to fix an issue in panels when `collection` label was not present in prometheus metrics.

Change custom allValues for solr_collection variable from `.+` to `.*` in Query Performance Dashboard to fix an issue in panels when `collection` label was not present in prometheus metrics.