### PR TITLE
Fix 'mixtool lint'  in commonlib/logslib

### DIFF
--- a/common-lib/common/variables/variables.libsonnet
+++ b/common-lib/common/variables/variables.libsonnet
@@ -11,7 +11,7 @@ local utils = import '../utils.libsonnet';
     enableLokiLogs=false,
     customAllValue='.+',
     prometheusDatasourceName=if enableLokiLogs then 'prometheus_datasource' else 'datasource',
-    prometheusDatasourceLabel=if enableLokiLogs then 'Prometheus datasource' else 'Data source',
+    prometheusDatasourceLabel=if enableLokiLogs then 'Prometheus data source' else 'Data source',
   ): {
        local varMetricTemplate(varMetric, chainSelector) =
          // check if chainSelector is not empty string (case when filtering selector is empty):

--- a/logs-lib/logs/targets.libsonnet
+++ b/logs-lib/logs/targets.libsonnet
@@ -30,7 +30,7 @@ function(
         sum by (%s) (count_over_time({%s}
         |~ "$regex_search"
         %s
-        [$__interval]))
+        [$__auto]))
       ||| % [
         logsVolumeGroupBy,
         variables.queriesSelector,


### PR DESCRIPTION
This should fix the following mixtool lint warnings:

```
[target-logql-auto-rule] 'Windows logs': Dashboard 'Windows logs', panel 'Logs volume', target idx '0' LogQL query uses fixed duration: should use $__auto
```

and

```
[template-datasource-rule] 'Windows fleet overview': Dashboard 'Windows fleet overview' templated data source variable labeled 'Prometheus datasource', should be labeled 'Prometheus data source'
```