### PR TITLE
Removes the id filter on docker mixin

### DIFF
--- a/docker-mixin/config.libsonnet
+++ b/docker-mixin/config.libsonnet
@@ -10,7 +10,7 @@
     uid: 'integration-docker',
     // ignore k8s nodes by default
     filteringSelector: 'job!="kubelet"',
-    containerSelector: 'id=~"/system.slice/docker.+", name!=""',
+    containerSelector: 'name!=""',
     //signals related
     groupLabels: ['job'],
     // host level


### PR DESCRIPTION
The ID filter was added as part of this PR
https://github.com/grafana/jsonnet-libs/pull/1316

It turns out this is not universally applicable as seen here:
https://github.com/grafana/support-escalations/issues/13845

This PR removes the ID filter.