### PR TITLE
Add more compact legends in opensearch

### DIFF
--- a/opensearch-mixin/dashboards/opensearch-cluster-overview.libsonnet
+++ b/opensearch-mixin/dashboards/opensearch-cluster-overview.libsonnet
@@ -2,6 +2,7 @@ local g = import '../g.libsonnet';
 local grafana = import 'grafonnet/grafana.libsonnet';
 local prometheus = grafana.prometheus;
 local commonlib = import 'common-lib/common/main.libsonnet';
+local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
 local utils = commonlib.utils;
 
 local dashboardUidSuffix = '-cluster-overview';
@@ -14,6 +15,8 @@ local dashboardUidSuffix = '-cluster-overview';
     instanceLabels=[],
     varMetric='opensearch_cluster_status',
   ),
+
+  local legendGroupLabels = xtd.array.slice($._config.groupLabels, -1),
 
   local panels = (import '../panels.libsonnet').new(
     $._config.groupLabels,
@@ -35,7 +38,7 @@ local dashboardUidSuffix = '-cluster-overview';
           agg: std.join(',', $._config.groupLabels),
         },
         datasource=promDatasource,
-        legendFormat=utils.labelsToPanelLegend($._config.groupLabels)
+        legendFormat=utils.labelsToPanelLegend(legendGroupLabels)
       ),
     ],
     type: 'stat',
@@ -116,7 +119,7 @@ local dashboardUidSuffix = '-cluster-overview';
           agg: std.join(',', $._config.groupLabels),
         },
         datasource=promDatasource,
-        legendFormat=utils.labelsToPanelLegend($._config.groupLabels)
+        legendFormat=utils.labelsToPanelLegend(legendGroupLabels)
       ),
     ],
     type: 'stat',
@@ -175,7 +178,7 @@ local dashboardUidSuffix = '-cluster-overview';
           agg: std.join(',', $._config.groupLabels),
         },
         datasource=promDatasource,
-        legendFormat=utils.labelsToPanelLegend($._config.groupLabels)
+        legendFormat=utils.labelsToPanelLegend(legendGroupLabels)
       ),
     ],
     type: 'stat',
@@ -234,7 +237,7 @@ local dashboardUidSuffix = '-cluster-overview';
           agg: std.join(',', $._config.groupLabels),
         },
         datasource=promDatasource,
-        legendFormat=utils.labelsToPanelLegend($._config.groupLabels)
+        legendFormat=utils.labelsToPanelLegend(legendGroupLabels)
       ),
     ],
     type: 'stat',
@@ -293,7 +296,7 @@ local dashboardUidSuffix = '-cluster-overview';
           agg: std.join(',', $._config.groupLabels),
         },
         datasource=promDatasource,
-        legendFormat=utils.labelsToPanelLegend($._config.groupLabels)
+        legendFormat=utils.labelsToPanelLegend(legendGroupLabels)
       ),
 
     ],
@@ -587,7 +590,7 @@ local dashboardUidSuffix = '-cluster-overview';
           agg: std.join(',', $._config.groupLabels),
         },
         datasource=promDatasource,
-        legendFormat=utils.labelsToPanelLegend($._config.groupLabels),
+        legendFormat=utils.labelsToPanelLegend(legendGroupLabels),
       ),
     ],
     type: 'timeseries',
@@ -666,7 +669,7 @@ local dashboardUidSuffix = '-cluster-overview';
           agg: std.join(',', $._config.groupLabels),
         },
         datasource=promDatasource,
-        legendFormat=utils.labelsToPanelLegend($._config.groupLabels),
+        legendFormat=utils.labelsToPanelLegend(legendGroupLabels),
       ),
     ],
     type: 'timeseries',
@@ -745,7 +748,7 @@ local dashboardUidSuffix = '-cluster-overview';
           agg: std.join(',', $._config.groupLabels),
         },
         datasource=promDatasource,
-        legendFormat=utils.labelsToPanelLegend($._config.groupLabels),
+        legendFormat=utils.labelsToPanelLegend(legendGroupLabels),
       ),
     ],
     type: 'timeseries',
@@ -824,7 +827,7 @@ local dashboardUidSuffix = '-cluster-overview';
           agg: std.join(',', $._config.groupLabels),
         },
         datasource=promDatasource,
-        legendFormat=utils.labelsToPanelLegend($._config.groupLabels),
+        legendFormat=utils.labelsToPanelLegend(legendGroupLabels),
       ),
     ],
     type: 'timeseries',

--- a/opensearch-mixin/dashboards/opensearch-node-overview.libsonnet
+++ b/opensearch-mixin/dashboards/opensearch-node-overview.libsonnet
@@ -3,7 +3,7 @@ local grafana = (import 'grafonnet/grafana.libsonnet');
 local commonlib = import 'common-lib/common/main.libsonnet';
 local utils = commonlib.utils;
 local prometheus = grafana.prometheus;
-
+local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
 local dashboardUidSuffix = '-node-overview';
 
 {
@@ -16,6 +16,8 @@ local dashboardUidSuffix = '-node-overview';
     varMetric='opensearch_os_cpu_percent',
     enableLokiLogs=$._config.enableLokiLogs,
   ),
+
+  local legendInstanceLabels = xtd.array.slice($._config.instanceLabels, -1),
 
   local panels = (import '../panels.libsonnet').new(
     $._config.groupLabels,
@@ -51,7 +53,7 @@ local dashboardUidSuffix = '-node-overview';
             agg: std.join(',', $._config.groupLabels + $._config.instanceLabels),
           },
         )
-        + g.query.prometheus.withLegendFormat(utils.labelsToPanelLegend($._config.instanceLabels)),
+        + g.query.prometheus.withLegendFormat(utils.labelsToPanelLegend(legendInstanceLabels)),
 
       ],
       description="CPU usage percentage of the node's Operating System.",
@@ -70,7 +72,7 @@ local dashboardUidSuffix = '-node-overview';
             agg: std.join(',', $._config.groupLabels + $._config.instanceLabels),
           },
         )
-        + g.query.prometheus.withLegendFormat(utils.labelsToPanelLegend($._config.instanceLabels)),
+        + g.query.prometheus.withLegendFormat(utils.labelsToPanelLegend(legendInstanceLabels)),
       ],
       description='Memory usage percentage of the node for the Operating System and OpenSearch',
     )
@@ -88,7 +90,7 @@ local dashboardUidSuffix = '-node-overview';
             agg: std.join(',', $._config.groupLabels + $._config.instanceLabels),
           },
         )
-        + g.query.prometheus.withLegendFormat('%s - read' % utils.labelsToPanelLegend($._config.instanceLabels)),
+        + g.query.prometheus.withLegendFormat('%s - read' % utils.labelsToPanelLegend(legendInstanceLabels)),
         g.query.prometheus.new(
           promDatasource.uid,
           'sum by(%(agg)s) (rate(opensearch_fs_io_total_write_bytes{%(queriesSelector)s}[$__rate_interval]))'
@@ -97,7 +99,7 @@ local dashboardUidSuffix = '-node-overview';
             agg: std.join(',', $._config.groupLabels + $._config.instanceLabels),
           },
         )
-        + g.query.prometheus.withLegendFormat('%s - write' % utils.labelsToPanelLegend($._config.instanceLabels)),
+        + g.query.prometheus.withLegendFormat('%s - write' % utils.labelsToPanelLegend(legendInstanceLabels)),
       ],
       description='Node file system read and write data.',
     )
@@ -115,7 +117,7 @@ local dashboardUidSuffix = '-node-overview';
             agg: std.join(',', $._config.groupLabels + $._config.instanceLabels),
           },
         )
-        + g.query.prometheus.withLegendFormat(utils.labelsToPanelLegend($._config.instanceLabels)),
+        + g.query.prometheus.withLegendFormat(utils.labelsToPanelLegend(legendInstanceLabels)),
       ],
       description='Number of open connections for the selected node.',
     )
@@ -134,7 +136,7 @@ local dashboardUidSuffix = '-node-overview';
             agg: std.join(',', $._config.groupLabels + $._config.instanceLabels),
           },
         )
-        + g.query.prometheus.withLegendFormat(utils.labelsToPanelLegend($._config.instanceLabels)),
+        + g.query.prometheus.withLegendFormat(utils.labelsToPanelLegend(legendInstanceLabels)),
       ],
       description='Disk usage percentage of the selected node.',
     ),
@@ -151,7 +153,7 @@ local dashboardUidSuffix = '-node-overview';
             agg: std.join(',', $._config.groupLabels + $._config.instanceLabels),
           },
         )
-        + g.query.prometheus.withLegendFormat(utils.labelsToPanelLegend($._config.instanceLabels)),
+        + g.query.prometheus.withLegendFormat(utils.labelsToPanelLegend(legendInstanceLabels)),
       ],
       description='Percentage of swap space used by OpenSearch and the Operating System on the selected node.',
     )
@@ -169,7 +171,7 @@ local dashboardUidSuffix = '-node-overview';
             agg: std.join(',', $._config.groupLabels + $._config.instanceLabels),
           },
         )
-        + g.query.prometheus.withLegendFormat('%s - sent' % utils.labelsToPanelLegend($._config.instanceLabels)),
+        + g.query.prometheus.withLegendFormat('%s - sent' % utils.labelsToPanelLegend(legendInstanceLabels)),
         g.query.prometheus.new(
           promDatasource.uid,
           'sum by (%(agg)s) (rate(opensearch_transport_rx_bytes_count{%(queriesSelector)s}[$__rate_interval])) * 8'
@@ -179,7 +181,7 @@ local dashboardUidSuffix = '-node-overview';
             agg: std.join(',', $._config.groupLabels + $._config.instanceLabels),
           }
 
-        ) + g.query.prometheus.withLegendFormat('%s - received' % utils.labelsToPanelLegend($._config.instanceLabels)),
+        ) + g.query.prometheus.withLegendFormat('%s - received' % utils.labelsToPanelLegend(legendInstanceLabels)),
       ],
       description='Node network traffic sent and received.',
     )
@@ -196,7 +198,7 @@ local dashboardUidSuffix = '-node-overview';
           agg: std.join(',', $._config.groupLabels + $._config.instanceLabels),
         },
         datasource=promDatasource,
-        legendFormat='%s - {{ name }}' % utils.labelsToPanelLegend($._config.instanceLabels),
+        legendFormat='%s - {{ name }}' % utils.labelsToPanelLegend(legendInstanceLabels),
         interval='1m',
       ),
     ],
@@ -284,7 +286,7 @@ local dashboardUidSuffix = '-node-overview';
           agg: std.join(',', $._config.groupLabels + $._config.instanceLabels),
         },
         datasource=promDatasource,
-        legendFormat='%s - used' % utils.labelsToPanelLegend($._config.instanceLabels),
+        legendFormat='%s - used' % utils.labelsToPanelLegend(legendInstanceLabels),
       ),
       prometheus.target(
         'sum by (%(agg)s) (opensearch_jvm_mem_heap_committed_bytes{%(queriesSelector)s})'
@@ -293,7 +295,7 @@ local dashboardUidSuffix = '-node-overview';
           agg: std.join(',', $._config.groupLabels + $._config.instanceLabels),
         },
         datasource=promDatasource,
-        legendFormat='%s - commited' % utils.labelsToPanelLegend($._config.instanceLabels),
+        legendFormat='%s - commited' % utils.labelsToPanelLegend(legendInstanceLabels),
       ),
     ],
     type: 'timeseries',
@@ -372,7 +374,7 @@ local dashboardUidSuffix = '-node-overview';
           agg: std.join(',', $._config.groupLabels + $._config.instanceLabels),
         },
         datasource=promDatasource,
-        legendFormat='%s - used' % utils.labelsToPanelLegend($._config.instanceLabels),
+        legendFormat='%s - used' % utils.labelsToPanelLegend(legendInstanceLabels),
       ),
       prometheus.target(
         'sum by (%(agg)s) (opensearch_jvm_mem_nonheap_committed_bytes{%(queriesSelector)s})'
@@ -381,7 +383,7 @@ local dashboardUidSuffix = '-node-overview';
           agg: std.join(',', $._config.groupLabels + $._config.instanceLabels),
         },
         datasource=promDatasource,
-        legendFormat='%s - commited' % utils.labelsToPanelLegend($._config.instanceLabels),
+        legendFormat='%s - commited' % utils.labelsToPanelLegend(legendInstanceLabels),
       ),
     ],
     type: 'timeseries',
@@ -460,7 +462,7 @@ local dashboardUidSuffix = '-node-overview';
           agg: std.join(',', $._config.groupLabels + $._config.instanceLabels),
         },
         datasource=promDatasource,
-        legendFormat=utils.labelsToPanelLegend($._config.instanceLabels),
+        legendFormat=utils.labelsToPanelLegend(legendInstanceLabels),
       ),
     ],
     type: 'timeseries',
@@ -543,7 +545,7 @@ local dashboardUidSuffix = '-node-overview';
           agg: std.join(',', $._config.groupLabels + $._config.instanceLabels),
         },
         datasource=promDatasource,
-        legendFormat='%s - {{bufferpool}}' % utils.labelsToPanelLegend($._config.instanceLabels),
+        legendFormat='%s - {{bufferpool}}' % utils.labelsToPanelLegend(legendInstanceLabels),
       ),
     ],
     type: 'timeseries',
@@ -626,7 +628,7 @@ local dashboardUidSuffix = '-node-overview';
           agg: std.join(',', $._config.groupLabels + $._config.instanceLabels),
         },
         datasource=promDatasource,
-        legendFormat=utils.labelsToPanelLegend($._config.instanceLabels),
+        legendFormat=utils.labelsToPanelLegend(legendInstanceLabels),
       ),
     ],
     type: 'timeseries',
@@ -710,7 +712,7 @@ local dashboardUidSuffix = '-node-overview';
           agg: std.join(',', $._config.groupLabels + $._config.instanceLabels),
         },
         datasource=promDatasource,
-        legendFormat=utils.labelsToPanelLegend($._config.instanceLabels),
+        legendFormat=utils.labelsToPanelLegend(legendInstanceLabels),
         interval='1m',
       ),
     ],
@@ -794,7 +796,7 @@ local dashboardUidSuffix = '-node-overview';
           agg: std.join(',', $._config.groupLabels + $._config.instanceLabels),
         },
         datasource=promDatasource,
-        legendFormat=utils.labelsToPanelLegend($._config.instanceLabels),
+        legendFormat=utils.labelsToPanelLegend(legendInstanceLabels),
         interval='1m',
       ),
     ],
@@ -874,7 +876,7 @@ local dashboardUidSuffix = '-node-overview';
           agg: std.join(',', $._config.groupLabels + $._config.instanceLabels),
         },
         datasource=promDatasource,
-        legendFormat='%s - {{bufferpool}}' % utils.labelsToPanelLegend($._config.instanceLabels),
+        legendFormat='%s - {{bufferpool}}' % utils.labelsToPanelLegend(legendInstanceLabels),
       ),
     ],
     type: 'timeseries',
@@ -965,7 +967,7 @@ local dashboardUidSuffix = '-node-overview';
           agg: std.join(',', $._config.groupLabels + $._config.instanceLabels),
         },
         datasource=promDatasource,
-        legendFormat=utils.labelsToPanelLegend($._config.instanceLabels),
+        legendFormat=utils.labelsToPanelLegend(legendInstanceLabels),
       ),
     ],
     type: 'timeseries',
@@ -1047,7 +1049,7 @@ local dashboardUidSuffix = '-node-overview';
           agg: std.join(',', $._config.groupLabels + $._config.instanceLabels),
         },
         datasource=promDatasource,
-        legendFormat=utils.labelsToPanelLegend($._config.instanceLabels),
+        legendFormat=utils.labelsToPanelLegend(legendInstanceLabels),
       ),
     ],
     type: 'timeseries',


### PR DESCRIPTION
Add more compact legends in opensearch mixin, similar to technique used in others libs/mixins, such as kafka-observ-lib:
https://github.com/grafana/jsonnet-libs/blob/master/kafka-observ-lib/signals/cluster.libsonnet#L53

This way a legend is more compact if more than one groupLabel, instanceLabel is used.