### PR TITLE
Logs lib: make allValue configurable and add adhoc option

### DIFF
--- a/logs-lib/logs/main.libsonnet
+++ b/logs-lib/logs/main.libsonnet
@@ -16,6 +16,7 @@ local variables = import './variables.libsonnet';
     showLogsVolume=true,
     logsVolumeGroupBy='level',
     extraFilters='',
+    customAllValue='.+',
   ): {
 
     local this = self,
@@ -25,6 +26,7 @@ local variables = import './variables.libsonnet';
       datasourceRegex,
       filterSelector,
       labels,
+      customAllValue,
     ),
 
     targets: targets(

--- a/logs-lib/logs/main.libsonnet
+++ b/logs-lib/logs/main.libsonnet
@@ -17,6 +17,8 @@ local variables = import './variables.libsonnet';
     logsVolumeGroupBy='level',
     extraFilters='',
     customAllValue='.*',
+    adHocEnabled=false,
+    adHocLabels=[],
   ): {
 
     local this = self,
@@ -27,6 +29,8 @@ local variables = import './variables.libsonnet';
       filterSelector,
       labels,
       customAllValue,
+      adHocEnabled,
+      adHocLabels,
     ),
 
     targets: targets(

--- a/logs-lib/logs/main.libsonnet
+++ b/logs-lib/logs/main.libsonnet
@@ -16,7 +16,7 @@ local variables = import './variables.libsonnet';
     showLogsVolume=true,
     logsVolumeGroupBy='level',
     extraFilters='',
-    customAllValue='.+',
+    customAllValue='.*',
   ): {
 
     local this = self,

--- a/logs-lib/logs/variables.libsonnet
+++ b/logs-lib/logs/variables.libsonnet
@@ -9,6 +9,8 @@ function(
   filterSelector,
   labels,
   customAllValue,
+  adHocEnabled,
+  adHocLabels,
 )
   {
     // strip trailing or starting comma if present that are not accepted in LoqQL
@@ -47,14 +49,28 @@ function(
       + var.datasource.withRegex(datasourceRegex)
       + var.query.generalOptions.withLabel(datasourceLabel),
 
-    regex_search:
+    regexSearch:
       var.textbox.new('regex_search', default='')
       + var.query.generalOptions.withLabel('Regex search'),
 
+    adHoc:
+      var.adhoc.new('adhoc', 'loki', '${' + self.datasource.name + '}')
+      + var.adhoc.generalOptions.withLabel('Adhoc filters')
+      + var.adhoc.generalOptions.withDescription('Add additional filters')
+      + (if std.length(adHocLabels) > 0 then {
+           defaultKeys: [
+             {
+               text: l,
+               value: l,
+             }
+             for l in adHocLabels
+           ],
+         } else {}),
     toArray:
       [self.datasource]
       + variablesFromLabels(labels, _filteringSelector)
-      + [self.regex_search],
+      + [self.regexSearch]
+      + (if adHocEnabled then [self.adHoc] else []),
 
     queriesSelector:
       std.join(

--- a/logs-lib/logs/variables.libsonnet
+++ b/logs-lib/logs/variables.libsonnet
@@ -1,12 +1,14 @@
-local utils = import '../utils.libsonnet';
-local g = import './g.libsonnet';
+local g = import '../g.libsonnet';
 local var = g.dashboard.variable;
+local utils = import '../utils.libsonnet';
+
 function(
   datasourceName,
   datasourceLabel,
   datasourceRegex,
   filterSelector,
   labels,
+  customAllValue,
 )
   {
     // strip trailing or starting comma if present that are not accepted in LoqQL
@@ -24,7 +26,7 @@ function(
         )
         + var.query.selectionOptions.withIncludeAll(
           value=true,
-          customAllValue='.+'
+          customAllValue=customAllValue,
         )
         + var.query.selectionOptions.withMulti()
         + var.query.refresh.onTime()


### PR DESCRIPTION
Logs lib: 
- Make allValue configurable
- Add [adhoc](https://grafana.com/docs/grafana/latest/dashboards/variables/add-template-variables/#add-ad-hoc-filters) option
- Add additional adhoc option what labels can be used adhoc 
- Revert customAllValue to .* by default