### PR TITLE
Fix withDataLink() in generic.timeSeries and move to base from topk_percentage

### DIFF
--- a/common-lib/common/panels/generic/timeSeries/base.libsonnet
+++ b/common-lib/common/panels/generic/timeSeries/base.libsonnet
@@ -5,6 +5,7 @@ local fieldOverride = g.panel.timeSeries.fieldOverride;
 local custom = timeSeries.fieldConfig.defaults.custom;
 local defaults = timeSeries.fieldConfig.defaults;
 local options = timeSeries.options;
+local standardOptions = g.panel.timeSeries.standardOptions;
 local base = import '../base.libsonnet';
 base {
   new(title, targets, description=''):
@@ -29,5 +30,13 @@ base {
     // Style choice: Use simple legend without any values (cleaner look)
     + options.legend.withDisplayMode('list')
     + options.legend.withCalcs([]),
+
+  withDataLink(instanceLabels, drillDownDashboardUid):
+    standardOptions.withLinks(
+      {
+        url: '/d/' + drillDownDashboardUid + '?' + std.join('&', std.map(function(l) 'var-%s=${__field.labels.%s}' % [l, l], instanceLabels)) + '&${__url_time_range}&${datasource:queryparam}',
+        title: 'Drill down to this instance',
+      }
+    ),
 
 }

--- a/common-lib/common/panels/generic/timeSeries/topk_percentage.libsonnet
+++ b/common-lib/common/panels/generic/timeSeries/topk_percentage.libsonnet
@@ -27,13 +27,7 @@ base {
                        + g.query.prometheus.withLegendFormat('Mean');
     super.new(title, targets=[topTarget, meanTarget], description=description)
     + self.withDataLink(instanceLabels, drillDownDashboardUid),
-  withDataLink(instanceLabels, drillDownDashboardUid):
-    standardOptions.withLinks(
-      {
-        url: 'd/' + drillDownDashboardUid + '?' + std.join('&', std.map(function(l) 'var-%s=${__field.labels.%s}' % [l, l], instanceLabels)) + '&${__url_time_range}',
-        title: 'Drill down to this instance',
-      }
-    ),
+
   stylize(allLayers=true):
     (if allLayers then super.stylize() else {})
     + generic.percentage.stylize(allLayers=false)


### PR DESCRIPTION
Fix withDataLink() in generic.timeSeries and move this function to base.libsonnet from topk_percentage.libsonnet so it available to all timeSeries panels in commonlib.