### PR TITLE
chore: rfrail3 moved to rfmoz

### DIFF
--- a/apache-http-mixin/README.md
+++ b/apache-http-mixin/README.md
@@ -2,7 +2,7 @@
 
 Apache HTTP mixin is a set of configurable Grafana dashboards and alerts based on the metrics exported by the [Apache exporter](https://github.com/Lusitaniae/apache_exporter).
 
-Based on Apache dashboard by rfrail3: https://github.com/rfrail3/grafana-dashboards.
+Based on Apache dashboard by rfmoz: https://github.com/rfmoz/grafana-dashboards.
 
 ![image](https://user-images.githubusercontent.com/14870891/170320166-91bf48a6-0e21-48fd-873b-2483ee402339.png)
 

--- a/grafana/example/tanka/jsonnetfile.json
+++ b/grafana/example/tanka/jsonnetfile.json
@@ -40,7 +40,7 @@
     {
       "source": {
         "git": {
-          "remote": "https://github.com/rfrail3/grafana-dashboards.git",
+          "remote": "https://github.com/rfmoz/grafana-dashboards.git",
           "subdir": "prometheus"
         }
       },

--- a/prometheus-ksonnet/jsonnetfile.json
+++ b/prometheus-ksonnet/jsonnetfile.json
@@ -112,7 +112,7 @@
     {
       "source": {
         "git": {
-          "remote": "https://github.com/rfrail3/grafana-dashboards.git",
+          "remote": "https://github.com/rfmoz/grafana-dashboards.git",
           "subdir": ""
         }
       },

--- a/prometheus-ksonnet/mixins.libsonnet
+++ b/prometheus-ksonnet/mixins.libsonnet
@@ -83,7 +83,7 @@
     node_exporter_full: {
       grafanaDashboardFolder: 'node_exporter',
       grafanaDashboards+:: {
-        'node-exporter-full.json': (import 'github.com/rfrail3/grafana-dashboards/prometheus/node-exporter-full.json'),
+        'node-exporter-full.json': (import 'github.com/rfmoz/grafana-dashboards/prometheus/node-exporter-full.json'),
       },
     },
 


### PR DESCRIPTION
https://github.com/rfrail3/grafana-dashboards is moved to https://github.com/rfmoz/grafana-dashboards/