### PR TITLE
add withExprWrappersMixin

### DIFF
--- a/common-lib/common/signal/README.md
+++ b/common-lib/common/signal/README.md
@@ -21,9 +21,10 @@ Workflow to generate dashboards would be as follows:
 
 These functions modify one of the signal's property and then  return signal back. Can be used as part of the builder pattern.
 
-- withTopK(limit=25) - wraps signal expression into topk().
-- withOffset(offset) - adds offset modifier to the expression.
-- withFilteringSelectorMixin(mixin) - adds additional selector to filteringSelector used.
+- withTopK(limit=25) - wrap signal expression into topk().
+- withExprWrappersMixin(wrapper=[]) - wrap signal expression into additional function on top of existing wrappers.
+- withOffset(offset) - add offset modifier to the expression.
+- withFilteringSelectorMixin(mixin) - add additional selector to filteringSelector used.
 
 ### Render functions
 

--- a/common-lib/common/signal/base.libsonnet
+++ b/common-lib/common/signal/base.libsonnet
@@ -144,6 +144,19 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
             for source in this.sourceMaps
           ],
       },
+
+    withExprWrappersMixin(wrappers=[]):
+      this
+      {
+        sourceMaps:
+          [
+            source
+            {
+              exprWrappers+: [wrappers],
+            }
+            for source in this.sourceMaps
+          ],
+      },
     //Return as grafana panel target(query+legend)
     asTarget(name=signalName):
       prometheusQuery.new(
@@ -344,6 +357,12 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
                     std.mapWithIndex(function(i, e) { index: i, el: e }, this.vars.aggLabels)
                 },
                 renameByName:
+                  // If 'Value' is still present, then rename value to signal name.
+                  // this is the case if only single query is used in the table.
+                  {
+                    Value: name,
+                  }
+                  +
                   {
                     [label]: utils.toSentenceCase(label)
                     for label in this.vars.aggLabels

--- a/common-lib/common/signal/test_table.libsonnet
+++ b/common-lib/common/signal/test_table.libsonnet
@@ -83,7 +83,25 @@ local m1 = signal.init(
             pluginVersion: 'v11.0.0',
             targets: [{ datasource: { type: 'prometheus', uid: '${datasource}' }, expr: 'max by (job,instance) (\n  rate(apiserver_request_total{job="abc",job=~"$job",instance=~"$instance"}[5m])\n)', format: 'table', instant: true, legendFormat: '{{instance}}: Requests', refId: 'API server requests' }],
             title: 'API server requests',
-            transformations: [{ id: 'merge' }, { id: 'renameByRegex', options: { regex: 'Value #(.*)', renamePattern: '$1' } }, { id: 'filterFieldsByName', options: { include: { pattern: '^(?!Time).*$' } } }, { id: 'organize', options: { indexByName: { instance: 1, job: 0 }, renameByName: { instance: 'Instance', job: 'Job' } } }],
+            transformations: [
+              { id: 'merge' },
+              { id: 'renameByRegex', options: { regex: 'Value #(.*)', renamePattern: '$1' } },
+              { id: 'filterFieldsByName', options: { include: { pattern: '^(?!Time).*$' } } },
+              {
+                id: 'organize',
+                options:
+                  {
+                    indexByName: { instance: 1, job: 0 },
+                    renameByName:
+                      {
+                        Value: 'API server requests',
+                        instance: 'Instance',
+                        job: 'Job',
+                      },
+
+                  },
+              },
+            ],
             type: 'table',
           },
         },
@@ -108,7 +126,12 @@ local m1 = signal.init(
               id: 'organize',
               options: {
                 indexByName: { instance: 1, job: 0 },
-                renameByName: { instance: 'Instance', job: 'Job' },
+                renameByName:
+                  {
+                    Value: 'API server requests',
+                    instance: 'Instance',
+                    job: 'Job',
+                  },
               },
             },
           ],

--- a/common-lib/common/signal/test_with_exprWrappersMixin.libsonnet
+++ b/common-lib/common/signal/test_with_exprWrappersMixin.libsonnet
@@ -27,7 +27,7 @@ local m1 = signal.init(
 {
 
   asTarget: {
-    local raw = m1.withExprWrappersMixin(["sum(",")"]).asTarget(),
+    local raw = m1.withExprWrappersMixin(['sum(', ')']).asTarget(),
     testResult: test.suite({
       testLegend: {
         actual: raw.legendFormat,

--- a/common-lib/common/signal/test_with_exprWrappersMixin.libsonnet
+++ b/common-lib/common/signal/test_with_exprWrappersMixin.libsonnet
@@ -1,0 +1,43 @@
+local signal = import './signal.libsonnet';
+local test = import 'jsonnetunit/test.libsonnet';
+
+local m1 = signal.init(
+  filteringSelector=['job="abc"'],
+  interval='5m',
+  aggLevel='instance',
+  aggFunction='max',
+).addSignal(
+  name='API server requests',
+  nameShort='requests',
+  type='counter',
+  unit='requests',
+  description='API server calls.',
+  sourceMaps=[
+    {
+      expr: 'apiserver_request_total{%(queriesSelector)s}',
+      rangeFunction: 'rate',
+      aggKeepLabels: [],
+      legendCustomTemplate: null,
+      infoLabel: null,
+    },
+  ],
+)
+;
+
+{
+
+  asTarget: {
+    local raw = m1.withExprWrappersMixin(["sum(",")"]).asTarget(),
+    testResult: test.suite({
+      testLegend: {
+        actual: raw.legendFormat,
+        expect: '{{instance}}: requests',
+      },
+      testExpression: {
+        actual: raw.expr,
+        expect: 'sum(\n  max by (job,instance) (\n  rate(apiserver_request_total{job="abc",job=~"$job",instance=~"$instance"}[5m])\n)\n)',
+      },
+    }),
+  },
+
+}


### PR DESCRIPTION
1) add flexible withExprWrappersMixin , will be used in snmp observ lib.
2) handle asTable() cases when table panel has only single target.