### PR TITLE
prometheus: set resource requests for watch container

### DIFF
--- a/prometheus/prometheus.libsonnet
+++ b/prometheus/prometheus.libsonnet
@@ -121,7 +121,8 @@ local kausal = import 'ksonnet-util/kausal.libsonnet';
       '-',
       '-sS',
       'http://localhost:%(prometheus_port)s%(prometheus_web_route_prefix)s-/reload' % _config,
-    ]),
+    ])
+    + k.util.resourcesRequests('10m', '10Mi'),
 
   local pvc = k.core.v1.persistentVolumeClaim,
 


### PR DESCRIPTION
_Cherry-picking the change from https://github.com/crdsonnet/prometheus-libsonnet/pull/7_

Set some resource requests based on usage observation across a varied fleet of Prometheus instances.