### PR TITLE
Snmp observ lib update: New cisco memory counter.

### DIFF
--- a/snmp-observ-lib/README.md
+++ b/snmp-observ-lib/README.md
@@ -9,7 +9,7 @@ The library supports multiple metrics sources that corresponds to different netw
 |metricsSource|Description|MIBs|Known devices|Links|snmp_exporter modules|
 |-|-|-|-|-|-|
 |generic           |Generic SNMP device|IF-MIB,SNMPv2-MIB    |default choice||system,if_mib,hrDevice,hrStorage|
-|cisco             | Cisco IoS devices |IF-MIB,SNMPv2-MIB, Cisco private mibs|Cisco C2900, Cisco C7600, Cisco MDS|-|system,if_mib,cisco_device,cisco_fc_fe|
+|cisco             | Cisco ASA, IOS, NX-OS, and IOS-XR devices |IF-MIB,SNMPv2-MIB, Cisco private mibs|Cisco C2900, Cisco C7600, Cisco Nexus 93180, Cisco MDS|https://www.cisco.com/c/en/us/td/docs/security/asa/asa918/configuration/general/asa-918-general-config/monitor-snmp.html|system,if_mib,cisco_device,cisco_fc_fe|
 |arista_sw            | Arista devices    |IF-MIB,SNMPv2-MIB,HOST-RESOURCES-MIB|-||system,if_mib,hrDevice,hrStorage,arista_sw|
 |brocade_fcs       | Brocade           |IF-MIB,SNMPv2-MIB,SW-MIB|Brocade 6520 v7.4.1c, Brocade 300 v7.0.0c,Brocade BL 5480 v6.3.1c|https://techdocs.broadcom.com/us/en/fibre-channel-networking/fabric-os/fabric-os-mib/9-1-x/understanding-brocade-snmp/loading-brocade-mibs/brocade-mib-files.html|system,if_mib|
 |brocade_foundry | Brocade Foundry | FOUNDRY-SN-AGENT-MIB | Brocade MLXe (System Mode: MLX), IronWare Version V5.4.0eT163, Foundry FLS648 Foundry Networks, Inc. FLS648, IronWare Version 04.1.00bT7e1, Foundry FWSX424 Foundry Networks, Inc. FWSX424, IronWare Version 02.0.00aT1e0||system,if_mib|

--- a/snmp-observ-lib/signals/interface.libsonnet
+++ b/snmp-observ-lib/signals/interface.libsonnet
@@ -235,7 +235,6 @@ function(this, level='interface')
             dell_network: self.generic,
             dlink_des: self.generic,
             extreme: self.generic,
-
             eltex_mes: self.generic,
             f5_bigip: self.generic,
             fortigate: self.generic,
@@ -305,7 +304,6 @@ function(this, level='interface')
             dell_network: self.generic,
             dlink_des: self.generic,
             extreme: self.generic,
-
             eltex_mes: self.generic,
             f5_bigip: self.generic,
             fortigate: self.generic,
@@ -342,7 +340,6 @@ function(this, level='interface')
             dell_network: self.generic,
             dlink_des: self.generic,
             extreme: self.generic,
-
             eltex_mes: self.generic,
             f5_bigip: self.generic,
             fortigate: self.generic,
@@ -378,7 +375,6 @@ function(this, level='interface')
             dell_network: self.generic,
             dlink_des: self.generic,
             extreme: self.generic,
-
             eltex_mes: self.generic,
             f5_bigip: self.generic,
             fortigate: self.generic,
@@ -414,7 +410,6 @@ function(this, level='interface')
             dell_network: self.generic,
             dlink_des: self.generic,
             extreme: self.generic,
-
             eltex_mes: self.generic,
             f5_bigip: self.generic,
             fortigate: self.generic,
@@ -450,7 +445,6 @@ function(this, level='interface')
             dell_network: self.generic,
             dlink_des: self.generic,
             extreme: self.generic,
-
             eltex_mes: self.generic,
             f5_bigip: self.generic,
             fortigate: self.generic,
@@ -486,7 +480,6 @@ function(this, level='interface')
             dell_network: self.generic,
             dlink_des: self.generic,
             extreme: self.generic,
-
             eltex_mes: self.generic,
             f5_bigip: self.generic,
             fortigate: self.generic,
@@ -522,7 +515,6 @@ function(this, level='interface')
             dell_network: self.generic,
             dlink_des: self.generic,
             extreme: self.generic,
-
             eltex_mes: self.generic,
             f5_bigip: self.generic,
             fortigate: self.generic,
@@ -852,7 +844,6 @@ function(this, level='interface')
                 dell_network: self.generic,
                 dlink_des: self.generic,
                 extreme: self.generic,
-
                 eltex_mes: self.generic,
                 f5_bigip: self.generic,
                 fortigate: self.generic,

--- a/snmp-observ-lib/signals/system.libsonnet
+++ b/snmp-observ-lib/signals/system.libsonnet
@@ -107,11 +107,10 @@ function(this)
           arista_sw: self.generic,
           brocade_fc: self.generic,
           brocade_foundry: self.generic,
-          cisco:
-            {
-              expr: 'label_replace(sysDescr{%(queriesSelector)s}, "sysDescr", "$1", "sysDescr", ".*Version(.+?),.*")',
-              infoLabel: 'sysDescr',
-            },
+          cisco: {
+            expr: 'label_replace(sysDescr{%(queriesSelector)s}, "sysDescr", "$1", "sysDescr", ".*Version ([0-9a-zA-Z\\\\.\\\\(\\\\)]+).*")',
+            infoLabel: 'sysDescr',
+          },
           dell_network: self.generic,
           dlink_des: self.generic,
           extreme: self.generic,


### PR DESCRIPTION
Add support for new counters introduced here: https://github.com/prometheus/snmp_exporter/pull/1374 
Also improves version parsing from sysDescr.