### PR TITLE
Update version signal for snmp-observ-lib(cisco)

### DIFF
--- a/common-lib/CHANGELOG.md
+++ b/common-lib/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.3.2
+- [Signal] Fix combining info metrics.
+
 # 0.3.1
 - [Signal] Fix optional signals (type=stub).
 - [Signal] Add optional signals documentation.

--- a/common-lib/common/signal/base.libsonnet
+++ b/common-lib/common/signal/base.libsonnet
@@ -25,7 +25,7 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
     sourceMaps:: sourceMaps,
     combineUniqueExpressions(expressions)::
       std.join(
-        '\nor\n',
+        if type == 'info' then '\nor ignoring(%s)\n' % std.join(',', this.combineUniqueInfoLabels(sourceMaps)) else '\nor\n',
         std.uniq(  // keep unique only
           std.sort(expressions)
         )

--- a/common-lib/common/signal/test_info_combined.libsonnet
+++ b/common-lib/common/signal/test_info_combined.libsonnet
@@ -33,39 +33,39 @@ local m1 = signal.init(
 {
 
   asTarget: {
-    raw:: m1.asTarget(),
+    local raw = m1.asTarget(),
     testResult: test.suite({
       testExpression: {
-        actual: m1.asTarget().expr,
+        actual: raw.expr,
         expect: 'go_info{job="abc",job=~"$job",instance=~"$instance"}',
       },
     }),
   },
   asStat:
     {
-      raw:: m1.asStat(),
+      local raw = m1.asStat(),
       testResult: test.suite({
         testTStitle: {
-          actual: m1.asStat().title,
+          actual: raw.title,
           expect: 'Go version',
         },
         testType: {
-          actual: m1.asStat().type,
+          actual: raw.type,
           expect: 'stat',
         },
         testTSversion: {
-          actual: m1.asStat().pluginVersion,
+          actual: raw.pluginVersion,
           expect: 'v11.0.0',
         },
         testTSUid: {
-          actual: m1.asStat().datasource,
+          actual: raw.datasource,
           expect: {
             uid: '${datasource}',
             type: 'prometheus',
           },
         },
         testInfoLabel: {
-          actual: m1.asStat().options.reduceOptions.fields,
+          actual: raw.options.reduceOptions.fields,
           expect: '/^' + '(version|version2)' + '$/',
         },
       }),

--- a/common-lib/common/signal/test_marshall_json_multi_combined.libsonnet
+++ b/common-lib/common/signal/test_marshall_json_multi_combined.libsonnet
@@ -51,10 +51,12 @@ local jsonSignals =
         sources: {
           otel: {
             expr: 'foo_info{%(queriesSelector)s}',
-
             infoLabel: 'version',
           },
-          prometheus: {},
+          prometheus: {
+            expr: 'foo_info2{%(queriesSelector)s}',
+            infoLabel: 'version2',
+          },
         },
       },
       status: {
@@ -135,6 +137,15 @@ local signals = signal.unmarshallJsonMulti(jsonSignals, ['otel', 'prometheus']);
       testExpression: {
         actual: panel.expr,
         expect: 'avg by (job,abc) (\n  abc{job="integrations/agent",job=~"$job",instance=~"$instance"}\n)\nor\navg by (job,xxx) (\n  abc2{job="integrations/agent",job=~"$job",instance=~"$instance"}\n)',
+      },
+    }),
+  },
+  asTargetInfo: {
+    local raw = signals.foo_info.asTarget(),
+    testResult: test.suite({
+      testExpression: {
+        actual: raw.expr,
+        expect: 'avg by (job,xxx,version) (\n  foo_info{job="integrations/agent",job=~"$job",instance=~"$instance"}\n)\nor ignoring(version,version2)\navg by (job,xxx,version2) (\n  foo_info2{job="integrations/agent",job=~"$job",instance=~"$instance"}\n)',
       },
     }),
   },

--- a/snmp-observ-lib/alerts.libsonnet
+++ b/snmp-observ-lib/alerts.libsonnet
@@ -233,7 +233,7 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
               expr: |||
                       (%s) == 2
                       # only alert if interface is adminatratively up:
-                      and (%s) != 1
+                      and (%s) != 2
                     |||
                     % [
                       this.signals.interface.ifOperStatus.withFilteringSelectorMixin(this.config.alertInterfaceDownSelector).asRuleExpression(),

--- a/snmp-observ-lib/alerts.libsonnet
+++ b/snmp-observ-lib/alerts.libsonnet
@@ -240,7 +240,7 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
                       this.signals.interface.ifAdminStatus.asRuleExpression(),
                     ],
               labels: {
-                severity: 'warning',
+                severity: this.config.alertInterfaceDownSeverity,
               },
               annotations: {
                 summary: 'Network interface is down on SNMP device.',

--- a/snmp-observ-lib/alerts.libsonnet
+++ b/snmp-observ-lib/alerts.libsonnet
@@ -6,7 +6,7 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
     local groupLabel = xtd.array.slice(this.config.groupLabels, -1)[0],
     groups+: [
       {
-        name: this.config.uid + '-fc-snmp-alerts',
+        name: this.config.uid + '-fc-alerts',
         rules:
           [
             {
@@ -152,7 +152,7 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
           ],
       },
       {
-        name: this.config.uid + '-snmp-alerts',
+        name: this.config.uid + '-alerts',
         rules:
           [
             {
@@ -321,7 +321,7 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
           ],
       },
       {
-        name: this.config.uid + '-snmp-exporter-alerts',
+        name: this.config.uid + '-exporter-alerts',
         rules:
           [
             {

--- a/snmp-observ-lib/config.libsonnet
+++ b/snmp-observ-lib/config.libsonnet
@@ -16,7 +16,9 @@
   metricsSource: ['generic', 'cisco', 'mikrotik', 'juniper'],
 
   //only fire alerts 'interface is down' for the following selector:
-  alertInterfaceDownSelector: 'ifAlias=~".*(?i:(uplink|internet|WAN)).*"',
+  alertInterfaceDownSelector: 'ifAlias=~".*(?i:(uplink|internet|WAN)|ISP).*"',
+  alertInterfaceDownSeverity: 'warning',
+
   // cpuSelector for metricsSources with HOST-RESOURCE-MIB:
   cpuSelector: 'hrDeviceType="1.3.6.1.2.1.25.3.1.3"',
   // memorySelector for metricsSources with HOST-RESOURCE-MIB:

--- a/snmp-observ-lib/dashboards.libsonnet
+++ b/snmp-observ-lib/dashboards.libsonnet
@@ -29,7 +29,7 @@ local logslib = import 'logs-lib/logs/main.libsonnet';
             this.signals.system.getVariablesSingleChoice(),
             keyF=function(x) x.name
           ),
-          uid + '-snmp-fleet',
+          uid + '-fleet',
           tags,
           links { backToFleet+:: {} },
           annotations,
@@ -58,7 +58,7 @@ local logslib = import 'logs-lib/logs/main.libsonnet';
             this.signals.interface.getVariablesMultiChoice(),
             keyF=function(x) x.name
           ),
-          uid + '-snmp-overview',
+          uid + '-overview',
           tags,
           links,
           annotations,

--- a/snmp-observ-lib/signals/memory.libsonnet
+++ b/snmp-observ-lib/signals/memory.libsonnet
@@ -71,7 +71,7 @@ function(this)
               (ciscoMemoryPoolUsed{ciscoMemoryPoolType="1", %(queriesSelector)s} + ciscoMemoryPoolFree{ciscoMemoryPoolType="1", %(queriesSelector)s}) * 100)
             |||,
             // keeping this label for now for future improvements
-            // aggKeepLabels: ['ciscoMemoryPoolName', cempMemPoolName'],
+            // aggKeepLabels: ['ciscoMemoryPoolName', 'cempMemPoolName'],
           },
           dell_network: {
             expr: 'dellNetCpuUtilMemUsage{%(queriesSelector)s}',

--- a/snmp-observ-lib/signals/system.libsonnet
+++ b/snmp-observ-lib/signals/system.libsonnet
@@ -103,13 +103,20 @@ function(this)
         |||,
         type: 'info',
         sources: {
-          generic: self.cisco,
+          generic: {
+            expr: 'label_replace(sysDescr{%(queriesSelector)s}, "version", "$1", "sysDescr", ".*Version ([0-9a-zA-Z\\\\.\\\\(\\\\)]+).*")',
+            infoLabel: 'version',
+          },
           arista_sw: self.generic,
           brocade_fc: self.generic,
           brocade_foundry: self.generic,
           cisco: {
-            expr: 'label_replace(sysDescr{%(queriesSelector)s}, "sysDescr", "$1", "sysDescr", ".*Version ([0-9a-zA-Z\\\\.\\\\(\\\\)]+).*")',
-            infoLabel: 'sysDescr',
+            expr: |||
+              label_replace(
+                ciscoImageString{ciscoImageString=~"CW_VERSION.+", %(queriesSelector)s}, "version", "$1", "ciscoImageString", "CW_VERSION\\$(.+)\\$"
+              )
+            |||,
+            infoLabel: 'version',
           },
           dell_network: self.generic,
           dlink_des: self.generic,


### PR DESCRIPTION
1) Update version signal for snmp-observ-lib(cisco) (https://github.com/prometheus/snmp_exporter/pull/1375)
2) remove duplicates from dashboards/alert groups uids
3) Fix alert interfaceDown and make its severity configurable.