### PR TITLE
chore: snmp-observ-lib update

### DIFF
--- a/snmp-observ-lib/config.libsonnet
+++ b/snmp-observ-lib/config.libsonnet
@@ -19,6 +19,11 @@
   alertInterfaceDownSelector: 'ifAlias=~".*(?i:(uplink|internet|WAN)|ISP).*"',
   alertInterfaceDownSeverity: 'warning',
 
+  // Enable to workaround issue with counters on Cisco NX-OS overloading issue.
+  // This will clamp max interface traffic possible to 1000Gbps.
+  clampQueryEnabled: true,
+  clampSpeed: '100*10^9',  // 1000 GBps
+
   // cpuSelector for metricsSources with HOST-RESOURCE-MIB:
   cpuSelector: 'hrDeviceType="1.3.6.1.2.1.25.3.1.3"',
   // memorySelector for metricsSources with HOST-RESOURCE-MIB:

--- a/snmp-observ-lib/dashboards_out/snmp-fleet.json
+++ b/snmp-observ-lib/dashboards_out/snmp-fleet.json
@@ -77,7 +77,7 @@
                      "properties": [
                         {
                            "id": "displayName",
-                           "value": "Interfaces count"
+                           "value": "Interfaces"
                         },
                         {
                            "id": "unit",
@@ -503,7 +503,7 @@
                   "expr": "count by (job,instance) (\n  ifOperStatus{job=~\"$job\",instance=~\"$instance\"}\n)",
                   "format": "table",
                   "instant": true,
-                  "legendFormat": "{{instance}}: Interfaces count",
+                  "legendFormat": "{{instance}}: Interfaces",
                   "refId": "Interfaces total"
                },
                {

--- a/snmp-observ-lib/signals/interface.libsonnet
+++ b/snmp-observ-lib/signals/interface.libsonnet
@@ -14,7 +14,7 @@ function(this, level='interface')
     local bitsWrapper = ['(', ')*8'],
     local nonZeroWrapper = ['(', ')>0'],
     //set max limit to workaround for TB-PB/sec spikes when counters are overloaded too quickly on very busy interfaces.
-    local clampQuery = ['', '\n# set max limit to workaround for TB-PB/sec spikes when counters are overloaded too quickly on very busy interfaces.\n<100*10^9'],
+    local clampQuery = ['', '\n# set max limit to workaround for TB-PB/sec spikes when counters are overloaded too quickly on very busy interfaces.\n<' + this.clampSpeed],
     discoveryMetric: {
       generic: 'ifOperStatus',
       arista_sw: self.generic,
@@ -52,7 +52,7 @@ function(this, level='interface')
             generic:
               {
                 expr: 'ifHCInOctets{%(queriesSelector)s}',
-                exprWrappers: [bitsWrapper, clampQuery],
+                exprWrappers: [bitsWrapper] + if this.clampQueryEnabled then [clampQuery] else [],
               },
             arista_sw: self.generic,
             brocade_fc: self.generic,
@@ -86,7 +86,7 @@ function(this, level='interface')
             generic:
               {
                 expr: 'ifHCOutOctets{%(queriesSelector)s} ',
-                exprWrappers: [bitsWrapper, clampQuery],
+                exprWrappers: [bitsWrapper] + if this.clampQueryEnabled then [clampQuery] else [],
               },
             arista_sw: self.generic,
             brocade_fc: self.generic,
@@ -530,7 +530,7 @@ function(this, level='interface')
         },
         interfacesCount: self.ifOperStatus {
           name: 'Interfaces total',
-          nameShort: 'Interfaces count',
+          nameShort: 'Interfaces',
           description: |||
             Device interface count
           |||,


### PR DESCRIPTION
- shorter interface column
- add configurable clampQuery to workaround traffic not properly calculated and shown for some devices (like NX-OS).