### PR TITLE
Add withQuantile function to commonlib

### DIFF
--- a/common-lib/CHANGELOG.md
+++ b/common-lib/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.3.3
+- [Signal] add `withQuantile(quantile=0.95)` to histogram signals.
+
 # 0.3.2
 - [Signal] Fix combining info metrics.
 
@@ -10,7 +13,6 @@
 - [Signal] Add new signal `log`.
 - [Signal] Add enableLokiLogs=true|false to signals init.
 - [Signal] `withExprWrappersMixin(offset)` - wrap signal expression into additional function on top of existing wrappers.
-
 
 # 0.2.0
 

--- a/common-lib/common/signal/README.md
+++ b/common-lib/common/signal/README.md
@@ -25,6 +25,7 @@ These functions modify one of the signal's property and then  return signal back
 - withExprWrappersMixin(wrapper=[]) - wrap signal expression into additional function on top of existing wrappers.
 - withOffset(offset) - add offset modifier to the expression.
 - withFilteringSelectorMixin(mixin) - add additional selector to filteringSelector used.
+- withQuantile(quantile=0.95) - add quantile modifier to the expression for histogram signals.
 
 ### Render functions
 
@@ -103,6 +104,7 @@ Signal's level:
 |sourceMaps[].valueMappings| Define signal's valueMappings in the same way defined in Grafana Dashboard Schema. |*|-|-|
 |sourceMaps[].legendCustomTemplate| A custom legend template could be defined with this to override automatic legend's generation|*|`null`|`{{topic}}`|
 |sourceMaps[].rangeFunction| Rate function to use for counter metrics.|rate,irate,delta,idelta,increase|`rate`|`increase`|
+|sourceMaps[].quantile| Only applicable to `histogram` metrics. Defines quantile for histogram metrics. |0.01-0.99|`0.99`|`0.95`|
 
 ## Expressions templating
 

--- a/common-lib/common/signal/base.libsonnet
+++ b/common-lib/common/signal/base.libsonnet
@@ -257,6 +257,7 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
             type,
             source.expr,
             exprWrappers=std.get(source, 'exprWrappers', default=[]),
+            q=std.get(source, 'quantile', default=0.95),
             aggLevel=aggLevel,
             rangeFunction=source.rangeFunction,
           ).applyFunctions()
@@ -274,6 +275,7 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
             type,
             source.expr,
             exprWrappers=std.get(source, 'exprWrappers', default=[]),
+            q=std.get(source, 'quantile', default=0.95),
             aggLevel='none',
             rangeFunction=source.rangeFunction,
           ).applyFunctions()

--- a/common-lib/common/signal/histogram.libsonnet
+++ b/common-lib/common/signal/histogram.libsonnet
@@ -30,6 +30,18 @@ base {
     )
 
     {
+      local this = self,
+      withQuantile(quantile=0.95):
+        self
+        {
+          sourceMaps:
+            [
+              source
+              {
+                quantile: quantile,
+              }
+              for source in super.sourceMaps
+            ],
+        },
     },
-
 }

--- a/common-lib/common/signal/signal.libsonnet
+++ b/common-lib/common/signal/signal.libsonnet
@@ -70,6 +70,7 @@ local stub = import './stub.libsonnet';
             type: std.get(signalsJson.signals[s], 'type', error 'Must provide type for signal %s' % signalsJson.signals[s].name),
             legendCustomTemplate: std.get(signalsJson.signals[s], 'legendCustomTemplate', std.get(signalsJson, 'legendCustomTemplate', null)),
             valueMappings: std.get(signalsJson.signals[s], 'valueMappings', []),
+            quantile: std.get(signalsJson.signals[s], 'quantile', 0.95),
           },
         ],
       )
@@ -132,6 +133,7 @@ local stub = import './stub.libsonnet';
                 infoLabel: std.get(source.value, 'infoLabel', null),
                 legendCustomTemplate: std.get(source.value, 'legendCustomTemplate', std.get(signalsJson, 'legendCustomTemplate', null)),
                 valueMappings: std.get(source.value, 'valueMappings', []),
+                quantile: std.get(source.value, 'quantile', 0.95),
               }
               for source in std.objectKeysValues(signalsJson.signals[s].sources)
               if std.member(validatedArr, source.key)
@@ -246,6 +248,7 @@ local stub = import './stub.libsonnet';
           type: type,
           legendCustomTemplate: null,
           valueMappings: [],
+          quantile: 0.95,
         },
       ],
     ):

--- a/common-lib/common/signal/test_gauge.libsonnet
+++ b/common-lib/common/signal/test_gauge.libsonnet
@@ -51,32 +51,49 @@ local gauge1 = signal.init(
       },
     }),
   },
+  asTargetWithcombinedTransformations: {
+    local raw = gauge1
+                .withTopK(3)
+                .withOffset('30m')
+                .withFilteringSelectorMixin('region="us-east"')
+                .asTarget(),
+    testResult: test.suite({
+      testExpression: {
+        actual: raw.expr,
+        expect: 'topk(3,\n  avg by (job) (\n  (up{job="integrations/agent",job=~"$job",instance=~"$instance",region="us-east"} offset 30m)\n)\n)',
+      },
+      testLegend: {
+        actual: raw.legendFormat,
+        expect: '{{job}}: Up',
+      },
+    }),
+  },
   asTimeSeries:
     {
-      raw:: gauge1.asTimeSeries(),
+      local raw = gauge1.asTimeSeries(),
       testResult: test.suite({
         testTStitle: {
-          actual: gauge1.asTimeSeries().title,
+          actual: raw.title,
           expect: 'Up metric',
         },
         testUnit: {
-          actual: gauge1.asTimeSeries().fieldConfig.overrides[0].properties[1].value,
+          actual: raw.fieldConfig.overrides[0].properties[1].value,
           expect: 'short',
         },
         testValueMapping: {
-          actual: gauge1.asTimeSeries().fieldConfig.overrides[0].properties[0].value,
+          actual: raw.fieldConfig.overrides[0].properties[0].value,
           expect: [{ options: { '0': { color: 'light-red', index: 0, text: 'Down' }, '1': { color: 'light-green', index: 1, text: 'Up' } }, type: 'value' }],
         },
         testTStype: {
-          actual: gauge1.asTimeSeries().type,
+          actual: raw.type,
           expect: 'timeseries',
         },
         testTSversion: {
-          actual: gauge1.asTimeSeries().pluginVersion,
+          actual: raw.pluginVersion,
           expect: 'v11.0.0',
         },
         testTSUid: {
-          actual: gauge1.asTimeSeries().datasource,
+          actual: raw.datasource,
           expect: {
             uid: '${datasource}',
             type: 'prometheus',

--- a/common-lib/common/signal/test_histogram.libsonnet
+++ b/common-lib/common/signal/test_histogram.libsonnet
@@ -26,40 +26,40 @@ local m1 = signal.init(
 
 {
   asTarget: {
-    raw:: m1.asTarget(),
+    local raw = m1.asTarget(),
     testResult: test.suite({
       testLegend: {
-        actual: m1.asTarget().legendFormat,
+        actual: raw.legendFormat,
         expect: '{{job}}: duration',
       },
       testExpression: {
-        actual: m1.asTarget().expr,
+        actual: raw.expr,
         expect: 'avg by (job) (\n  histogram_quantile(0.95, sum(rate(apiserver_request_duration_seconds_bucket{job="abc",job=~"$job",instance=~"$instance"}[10m])) by (le,job))\n)',
       },
     }),
   },
   asTimeSeries:
     {
-      raw:: m1.asTimeSeries(),
+      local raw = m1.asTimeSeries(),
       testResult: test.suite({
         testTStitle: {
-          actual: m1.asTimeSeries().title,
+          actual: raw.title,
           expect: 'API server duration',
         },
         testUnit: {
-          actual: m1.asTimeSeries().fieldConfig.overrides[0].properties[0].value,
+          actual: raw.fieldConfig.overrides[0].properties[0].value,
           expect: 'seconds',
         },
         testTStype: {
-          actual: m1.asTimeSeries().type,
+          actual: raw.type,
           expect: 'timeseries',
         },
         testTSversion: {
-          actual: m1.asTimeSeries().pluginVersion,
+          actual: raw.pluginVersion,
           expect: 'v11.0.0',
         },
         testTSUid: {
-          actual: m1.asTimeSeries().datasource,
+          actual: raw.datasource,
           expect: {
             uid: '${datasource}',
             type: 'prometheus',
@@ -67,4 +67,37 @@ local m1 = signal.init(
         },
       }),
     },
+  withCustomQuantile: {
+    local customHistogram = signal.init(
+      filteringSelector=['job="abc"'],
+      interval='10m',
+      aggLevel='group',
+      aggFunction='avg',
+    ).addSignal(
+      name='Custom quantile',
+      nameShort='p99',
+      type='histogram',
+      unit='seconds',
+      description='99th percentile',
+
+      sourceMaps=[{
+        expr: 'http_request_duration_seconds_bucket{%(queriesSelector)s}',
+        rangeFunction: 'rate',
+        aggKeepLabels: ['handler'],
+        quantile: 0.99,
+        infoLabel: null,
+      }],
+    ),
+
+    testResult: test.suite({
+      testDefaultQuantile: {
+        actual: customHistogram.asTarget().expr,
+        expect: 'avg by (job,handler) (\n  histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{job="abc",job=~"$job",instance=~"$instance"}[10m])) by (le,job,handler))\n)',
+      },
+      testCustomQuantile: {
+        actual: customHistogram.withQuantile(quantile=0.50).asTarget().expr,
+        expect: 'avg by (job,handler) (\n  histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket{job="abc",job=~"$job",instance=~"$instance"}[10m])) by (le,job,handler))\n)',
+      },
+    }),
+  },
 }


### PR DESCRIPTION
Previously, quantile in histogram metrics was pinned to 0.95. Now it can be changed to any value by using withQuantile() modifier, even producing multiple expressions from the single signal.