### PR TITLE
Fix "availabe" typos

### DIFF
--- a/windows-mixin/dashboards_out/disks
+++ b/windows-mixin/dashboards_out/disks
@@ -129,7 +129,7 @@
                   "legendFormat": "{{ volume }} available"
                }
             ],
-            "title": "Filesystem space availabe",
+            "title": "Filesystem space available",
             "type": "timeseries"
          },
          {

--- a/windows-observ-lib/dashboards_out/disks
+++ b/windows-observ-lib/dashboards_out/disks
@@ -129,7 +129,7 @@
                   "legendFormat": "{{ volume }} available"
                }
             ],
-            "title": "Filesystem space availabe",
+            "title": "Filesystem space available",
             "type": "timeseries"
          },
          {

--- a/windows-observ-lib/panels.libsonnet
+++ b/windows-observ-lib/panels.libsonnet
@@ -298,7 +298,7 @@ local utils = commonlib.utils;
       ),
       diskFreeTs:
         commonlib.panels.disk.timeSeries.available.new(
-          'Filesystem space availabe',
+          'Filesystem space available',
           targets=[
             t.diskFree,
           ],


### PR DESCRIPTION
Just spotted this in my dashboard

![image](https://github.com/user-attachments/assets/22397a59-47c0-46ff-b3a4-74633711a917)
