### PR TITLE
GitHub actions: address last template-injection issue reported by zizmor

### DIFF
--- a/.github/workflows/test-mixins.yml
+++ b/.github/workflows/test-mixins.yml
@@ -62,7 +62,9 @@ jobs:
             **-observ-lib/
           matrix: true
       - name: List all changed mixins
-        run: echo '${{ steps.changed-mixins.outputs.all_changed_files }}'
+        env:
+          ALL_CHANGED_FILES: ${{ steps.changed-mixins.outputs.all_changed_files }}
+        run: echo "${ALL_CHANGED_FILES}"
 
   lint-mixin:
     name: Test mixin


### PR DESCRIPTION
I re-run zizmor and there was one last info-level issue. Since it's easy I'm addressing it:

```
info[template-injection]: code injection via template expansion
  --> ./.github/workflows/test-mixins.yml:64:9
   |
64 |       - name: List all changed mixins
   |         ----------------------------- info: this step
65 |         run: echo '${{ steps.changed-mixins.outputs.all_changed_files }}'
   |         ----------------------------------------------------------------- info: steps.changed-mixins.outputs.all_changed_files may expand into attacker-controllable code
   |
   = note: audit confidence → Low
```