### PR TITLE
annotate changed_files output usage for zizmor to skip it

### DIFF
--- a/.github/workflows/test-mixins.yml
+++ b/.github/workflows/test-mixins.yml
@@ -57,12 +57,12 @@ jobs:
           dir_names: true
           dir_names_exclude_current_dir: true
           dir_names_max_depth: 1
-          files: | 
+          files: |
             **-mixin/
             **-observ-lib/
           matrix: true
       - name: List all changed mixins
-        run: echo '${{ steps.changed-mixins.outputs.all_changed_files }}'
+        run: echo '${{ steps.changed-mixins.outputs.all_changed_files }}' # zizmor: ignore[template-injection]
 
   lint-mixin:
     name: Test mixin
@@ -120,7 +120,6 @@ jobs:
         run: |
           # Wait for Grafana to be ready
           timeout 60s bash -c 'until curl -s http://localhost:3000/api/health | grep "ok"; do sleep 1; done'
-          
           # Try to deploy dashboards
           make deploy_dashboards
       - name: Run promtool test for rules


### PR DESCRIPTION
As [step-security/changed-files's output](https://github.com/step-security/changed-files/blob/main/action.yml#L138) already handles sanitization, also adding couple minor YAML syntax fixes.

Part of securing GH actions as followup from [the incident on April 26th 2025](https://grafana.com/blog/2025/04/27/grafana-security-update-no-customer-impact-from-github-workflow-vulnerability/).

--
Signed-off-by: JuanJo Ciarlante <juanjosec@gmail.com>
