### PR TITLE
fix(mixin-utils): remove std.prune and use std.filter instead

### DIFF
--- a/mixin-utils/test/Makefile
+++ b/mixin-utils/test/Makefile
@@ -4,4 +4,5 @@ vendor jsonnetfile.lock.json: jsonnetfile.json
 	jb install
 
 tests: jsonnetfile.lock.json vendor
-	jsonnet -J vendor/ test_*.libsonnet
+	jsonnet -J vendor/ ./test_native-classic-histogram.libsonnet
+	jsonnet -J vendor/ ./test_remove_rules.libsonnet

--- a/mixin-utils/test/test_remove_rules.libsonnet
+++ b/mixin-utils/test/test_remove_rules.libsonnet
@@ -1,0 +1,284 @@
+local utils = import '../utils.libsonnet';
+local test = import 'github.com/jsonnet-libs/testonnet/main.libsonnet';
+
+local config = {
+  prometheusAlerts: {
+    groups: [
+      {
+        name: 'group1',
+        rules: [
+          {
+            alert: 'alert1',
+          },
+          {
+            alert: 'alert2',
+          },
+        ],
+      },
+      {
+        name: 'group2',
+        rules: [
+          {
+            alert: 'alert3',
+          },
+          {
+            alert: 'alert4',
+          },
+        ],
+      },
+    ],
+  },
+  prometheusRules: {
+    groups: [
+      {
+        name: 'group3',
+        rules: [
+          {
+            record: 'record1',
+          },
+          {
+            record: 'record2',
+          },
+        ],
+      },
+      {
+        name: 'group4',
+        rules: [
+          {
+            record: 'record3',
+          },
+          {
+            record: 'record4',
+          },
+        ],
+      },
+    ],
+  },
+};
+
+test.new(std.thisFile)
+
++ test.case.new(
+  'removeAlertRuleGroup',
+  test.expect.eq(
+    actual=config + utils.removeAlertRuleGroup('group1'),
+    expected={
+      prometheusAlerts: {
+        groups: [
+          {
+            name: 'group2',
+            rules: [
+              {
+                alert: 'alert3',
+              },
+              {
+                alert: 'alert4',
+              },
+            ],
+          },
+        ],
+      },
+      prometheusRules: {
+        groups: [
+          {
+            name: 'group3',
+            rules: [
+              {
+                record: 'record1',
+              },
+              {
+                record: 'record2',
+              },
+            ],
+          },
+          {
+            name: 'group4',
+            rules: [
+              {
+                record: 'record3',
+              },
+              {
+                record: 'record4',
+              },
+            ],
+          },
+        ],
+      },
+    }
+  )
+)
+
++ test.case.new(
+  'removeRecordingRuleGroup',
+  test.expect.eq(
+    actual=config + utils.removeRecordingRuleGroup('group4'),
+    expected={
+      prometheusAlerts: {
+        groups: [
+          {
+            name: 'group1',
+            rules: [
+              {
+                alert: 'alert1',
+              },
+              {
+                alert: 'alert2',
+              },
+            ],
+          },
+          {
+            name: 'group2',
+            rules: [
+              {
+                alert: 'alert3',
+              },
+              {
+                alert: 'alert4',
+              },
+            ],
+          },
+        ],
+      },
+      prometheusRules: {
+        groups: [
+          {
+            name: 'group3',
+            rules: [
+              {
+                record: 'record1',
+              },
+              {
+                record: 'record2',
+              },
+            ],
+          },
+        ],
+      },
+    }
+  )
+)
+
++ test.case.new(
+  'removeAlertRuleGroup with groupname from recording rules (noop)',
+  test.expect.eq(
+    actual=config + utils.removeAlertRuleGroup('group4'),
+    expected=config
+  )
+)
++ test.case.new(
+  'removeRecordingRuleGroup with groupname from alert rules (noop)',
+  test.expect.eq(
+    actual=config + utils.removeRecordingRuleGroup('group2'),
+    expected=config
+  )
+)
+
++ test.case.new(
+  'removeAlerts',
+  test.expect.eq(
+    actual=config + utils.removeAlerts(['alert1', 'alert4']),
+    expected={
+      prometheusAlerts: {
+        groups: [
+          {
+            name: 'group1',
+            rules: [
+              {
+                alert: 'alert2',
+              },
+            ],
+          },
+          {
+            name: 'group2',
+            rules: [
+              {
+                alert: 'alert3',
+              },
+            ],
+          },
+        ],
+      },
+      prometheusRules: {
+        groups: [
+          {
+            name: 'group3',
+            rules: [
+              {
+                record: 'record1',
+              },
+              {
+                record: 'record2',
+              },
+            ],
+          },
+          {
+            name: 'group4',
+            rules: [
+              {
+                record: 'record3',
+              },
+              {
+                record: 'record4',
+              },
+            ],
+          },
+        ],
+      },
+    }
+  )
+)
+
++ test.case.new(
+  'removeAlerts - object (backwards compatible)',
+  test.expect.eq(
+    actual=config + utils.removeAlerts({ alert1: {}, alert4: {} }),
+    expected={
+      prometheusAlerts: {
+        groups: [
+          {
+            name: 'group1',
+            rules: [
+              {
+                alert: 'alert2',
+              },
+            ],
+          },
+          {
+            name: 'group2',
+            rules: [
+              {
+                alert: 'alert3',
+              },
+            ],
+          },
+        ],
+      },
+      prometheusRules: {
+        groups: [
+          {
+            name: 'group3',
+            rules: [
+              {
+                record: 'record1',
+              },
+              {
+                record: 'record2',
+              },
+            ],
+          },
+          {
+            name: 'group4',
+            rules: [
+              {
+                record: 'record3',
+              },
+              {
+                record: 'record4',
+              },
+            ],
+          },
+        ],
+      },
+    }
+  )
+)

--- a/mixin-utils/utils.libsonnet
+++ b/mixin-utils/utils.libsonnet
@@ -409,7 +409,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
       if 'alert' in rule && std.objectHas(overrides, rule.alert)
       then rule + overrides[rule.alert]
       else rule,
-    local overrideInGroup(group) = group + { rules: std.map(overrideRule, super.rules) },
+    local overrideInGroup(group) = group { rules: std.map(overrideRule, super.rules) },
     prometheusAlerts+:: {
       groups: std.map(overrideInGroup, super.groups),
     },
@@ -421,7 +421,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
       then std.objectFields(alerts)
       else alerts,
     local removeRule(rule) = !std.member(alertNames, std.get(rule, 'alert', '')),
-    local removeInGroup(group) = group + { rules: std.filter(removeRule, super.rules) },
+    local removeInGroup(group) = group { rules: std.filter(removeRule, super.rules) },
     prometheusAlerts+:: {
       groups: std.map(removeInGroup, super.groups),
     },

--- a/mixin-utils/utils.libsonnet
+++ b/mixin-utils/utils.libsonnet
@@ -416,7 +416,11 @@ local g = import 'grafana-builder/grafana.libsonnet';
   },
 
   removeAlerts(alerts):: {
-    local removeRule(rule) = !std.member(alerts, std.get(rule, 'alert', '')),
+    local alertNames =
+      if std.isObject(alerts)
+      then std.objectFields(alerts)
+      else alerts,
+    local removeRule(rule) = !std.member(alertNames, std.get(rule, 'alert', '')),
     local removeInGroup(group) = group + { rules: std.filter(removeRule, super.rules) },
     prometheusAlerts+:: {
       groups: std.map(removeInGroup, super.groups),

--- a/mixin-utils/utils.libsonnet
+++ b/mixin-utils/utils.libsonnet
@@ -397,11 +397,11 @@ local g = import 'grafana-builder/grafana.libsonnet';
   },
 
   removeAlertRuleGroup(ruleName):: {
-    prometheusAlerts+:: $.removeRuleGroup(ruleName),
+    prometheusAlerts+: $.removeRuleGroup(ruleName),
   },
 
   removeRecordingRuleGroup(ruleName):: {
-    prometheusRules+:: $.removeRuleGroup(ruleName),
+    prometheusRules+: $.removeRuleGroup(ruleName),
   },
 
   overrideAlerts(overrides):: {
@@ -410,7 +410,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
       then rule + overrides[rule.alert]
       else rule,
     local overrideInGroup(group) = group { rules: std.map(overrideRule, super.rules) },
-    prometheusAlerts+:: {
+    prometheusAlerts+: {
       groups: std.map(overrideInGroup, super.groups),
     },
   },
@@ -422,7 +422,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
       else alerts,
     local removeRule(rule) = !std.member(alertNames, std.get(rule, 'alert', '')),
     local removeInGroup(group) = group { rules: std.filter(removeRule, super.rules) },
-    prometheusAlerts+:: {
+    prometheusAlerts+: {
       groups: std.map(removeInGroup, super.groups),
     },
   },


### PR DESCRIPTION
The use of `std.prune(std.map())` is slow and uses a big stack, on big
rulesets this can cause a 'RUNTIME ERROR: max stack frames exceeded.'.

It is better to use `std.filter()` to remove an element from an array.
