### PR TITLE
Add new metrics to windows observ lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,6 @@ The monitoring mixins in this repository use two linting tools to ensure quality
 
 Observability library is a flexible format to describe dashboards and alerts in a modular way so libraries can be imported into one another or into monitoring-mixins. Observability libraries can be found in folders with `-observ-lib` suffix. [Common library](https://github.com/grafana/jsonnet-libs/tree/master/common-lib) is also used to apply consistent style options.
 
-Some examples:
- - [windows-observ-lib](windows-observ-lib/)
-
  ### Observability libraries signal extention
 
  [Signal](https://github.com/grafana/jsonnet-libs/tree/master/common-lib/common/signal#signal) is the experimental extension to observability libraries format to declare metrics (signals) and then render them as different grafana panel types (timeseries, stat, table, etc), or alert rules.
@@ -56,6 +53,7 @@ Examples:
  - [process-observ-lib](process-observ-lib/)
  - [golang-observ-lib](golang-observ-lib/)
  - [csp-mixin](csp-mixin/)
+ - [windows-observ-lib](windows-observ-lib/)
 
  ## Prometheus rules testing for monitoring mixins and observability libraries
 

--- a/windows-observ-lib/README.md
+++ b/windows-observ-lib/README.md
@@ -63,6 +63,7 @@ local config = (import 'config.libsonnet')._config;
     uid: 'windows',
     // prefix dashboards titles
     dashboardNamePrefix: '',
+    metricSource: ['prometheus', 'prometheus_pre_0_30'],
     dashboardTags: ['windows'],
     dashboardPeriod: 'now-1h',
     dashboardTimezone: 'default',
@@ -100,7 +101,7 @@ Drill down disks dashboard:
 
 ## Collectors used:
 
-Grafana Agent or combination of windows_exporter/promtail can be used in order to collect data required.
+Grafana Agent/Alloy or combination of windows_exporter/promtail can be used in order to collect data required.
 
 The following collectors should be enabled in windows_exporter/windows integration:
 

--- a/windows-observ-lib/config.libsonnet
+++ b/windows-observ-lib/config.libsonnet
@@ -14,7 +14,7 @@
   dashboardNamePrefix: '',
 
   // 'prometheus_pre_0_30' points to old metrics schema prior to breaking changes in windows_exporter v0.30.0,
-  // 'prometheus' points to actual metrics schema.
+  // 'prometheus' points to current metrics schema.
   // Use any of the above or both.
   metricsSource: ['prometheus', 'prometheus_pre_0_30'],
 

--- a/windows-observ-lib/config.libsonnet
+++ b/windows-observ-lib/config.libsonnet
@@ -16,7 +16,7 @@
   // 'prometheus_pre_0_30' points to old metrics schema prior to breaking changes in windows_exporter v0.30.0,
   // 'prometheus' points to actual metrics schema.
   // Use any of the above or both.
-  metricsSource: ['prometheus', 'prometheus_pre_0_30'],  
+  metricsSource: ['prometheus', 'prometheus_pre_0_30'],
 
   // optional
   ignoreVolumes: 'HarddiskVolume.*',

--- a/windows-observ-lib/config.libsonnet
+++ b/windows-observ-lib/config.libsonnet
@@ -12,7 +12,11 @@
   dashboardTags: ['windows'],
   uid: 'windows',
   dashboardNamePrefix: '',
-  metricsSource: 'prometheus',  // metrics source for signals
+
+  // 'prometheus_pre_0_30' points to old metrics schema prior to breaking changes in windows_exporter v0.30.0,
+  // 'prometheus' points to actual metrics schema.
+  // Use any of the above or both.
+  metricsSource: ['prometheus', 'prometheus_pre_0_30'],  
 
   // optional
   ignoreVolumes: 'HarddiskVolume.*',

--- a/windows-observ-lib/dashboards_out/disks
+++ b/windows-observ-lib/dashboards_out/disks
@@ -21,7 +21,7 @@
                   "uid": "${prometheus_datasource}"
                },
                "enable": true,
-               "expr": "windows_system_system_up_time{job=~\"$job\",instance=~\"$instance\"}*1000 > $__from < $__to",
+               "expr": "windows_system_boot_time_timestamp_seconds{job=~\"$job\",instance=~\"$instance\"}\nor\nwindows_system_system_up_time{job=~\"$job\",instance=~\"$instance\"}*1000 > $__from < $__to",
                "hide": true,
                "iconColor": "light-yellow",
                "name": "Reboot",

--- a/windows-observ-lib/dashboards_out/fleet
+++ b/windows-observ-lib/dashboards_out/fleet
@@ -21,7 +21,7 @@
                   "uid": "${prometheus_datasource}"
                },
                "enable": true,
-               "expr": "windows_system_system_up_time{job=~\"$job\",instance=~\"$instance\"}*1000 > $__from < $__to",
+               "expr": "windows_system_boot_time_timestamp_seconds{job=~\"$job\",instance=~\"$instance\"}\nor\nwindows_system_system_up_time{job=~\"$job\",instance=~\"$instance\"}*1000 > $__from < $__to",
                "hide": true,
                "iconColor": "light-yellow",
                "name": "Reboot",
@@ -429,7 +429,7 @@
                      "type": "prometheus",
                      "uid": "${prometheus_datasource}"
                   },
-                  "expr": "time() - windows_system_system_up_time{job=~\"$job\",instance=~\"$instance\"}",
+                  "expr": "time() - windows_system_boot_time_timestamp_seconds{job=~\"$job\",instance=~\"$instance\"}\nor\ntime() - windows_system_system_up_time{job=~\"$job\",instance=~\"$instance\"}",
                   "format": "table",
                   "instant": true,
                   "legendFormat": "{{instance}}: Uptime",
@@ -440,7 +440,7 @@
                      "type": "prometheus",
                      "uid": "${prometheus_datasource}"
                   },
-                  "expr": "windows_cs_logical_processors{job=~\"$job\",instance=~\"$instance\"}",
+                  "expr": "windows_cpu_logical_processor{job=~\"$job\",instance=~\"$instance\"}\nor\nwindows_cs_logical_processors{job=~\"$job\",instance=~\"$instance\"}",
                   "format": "table",
                   "instant": true,
                   "legendFormat": "{{instance}}: Cores",
@@ -462,7 +462,7 @@
                      "type": "prometheus",
                      "uid": "${prometheus_datasource}"
                   },
-                  "expr": "windows_cs_physical_memory_bytes{job=~\"$job\",instance=~\"$instance\"}",
+                  "expr": "windows_cs_physical_memory_bytes{job=~\"$job\",instance=~\"$instance\"}\nor\nwindows_memory_physical_total_bytes{job=~\"$job\",instance=~\"$instance\"}",
                   "format": "table",
                   "instant": true,
                   "legendFormat": "Memory total",
@@ -473,7 +473,7 @@
                      "type": "prometheus",
                      "uid": "${prometheus_datasource}"
                   },
-                  "expr": "100 - windows_os_physical_memory_free_bytes{job=~\"$job\",instance=~\"$instance\"} / windows_cs_physical_memory_bytes{job=~\"$job\",instance=~\"$instance\"} * 100",
+                  "expr": "100 - windows_memory_physical_free_bytes{job=~\"$job\",instance=~\"$instance\"} / windows_memory_physical_total_bytes{job=~\"$job\",instance=~\"$instance\"} * 100\nor\n100 - windows_os_physical_memory_free_bytes{job=~\"$job\",instance=~\"$instance\"} / windows_cs_physical_memory_bytes{job=~\"$job\",instance=~\"$instance\"} * 100",
                   "format": "table",
                   "instant": true,
                   "legendFormat": "{{instance}}: Usage",
@@ -767,7 +767,7 @@
                      "type": "prometheus",
                      "uid": "${prometheus_datasource}"
                   },
-                  "expr": "topk(25,100 - windows_os_physical_memory_free_bytes{job=~\"$job\",instance=~\"$instance\"} / windows_cs_physical_memory_bytes{job=~\"$job\",instance=~\"$instance\"} * 100)",
+                  "expr": "topk(25,100 - windows_memory_physical_free_bytes{job=~\"$job\",instance=~\"$instance\"} / windows_memory_physical_total_bytes{job=~\"$job\",instance=~\"$instance\"} * 100\nor\n100 - windows_os_physical_memory_free_bytes{job=~\"$job\",instance=~\"$instance\"} / windows_cs_physical_memory_bytes{job=~\"$job\",instance=~\"$instance\"} * 100)",
                   "format": "time_series",
                   "instant": false,
                   "legendFormat": "{{instance}}",
@@ -778,7 +778,7 @@
                      "type": "prometheus",
                      "uid": "${prometheus_datasource}"
                   },
-                  "expr": "avg(100 - windows_os_physical_memory_free_bytes{job=~\"$job\",instance=~\"$instance\"} / windows_cs_physical_memory_bytes{job=~\"$job\",instance=~\"$instance\"} * 100)",
+                  "expr": "avg(100 - windows_memory_physical_free_bytes{job=~\"$job\",instance=~\"$instance\"} / windows_memory_physical_total_bytes{job=~\"$job\",instance=~\"$instance\"} * 100\nor\n100 - windows_os_physical_memory_free_bytes{job=~\"$job\",instance=~\"$instance\"} / windows_cs_physical_memory_bytes{job=~\"$job\",instance=~\"$instance\"} * 100)",
                   "format": "time_series",
                   "instant": false,
                   "legendFormat": "Mean",

--- a/windows-observ-lib/dashboards_out/logs
+++ b/windows-observ-lib/dashboards_out/logs
@@ -21,7 +21,7 @@
                   "uid": "${prometheus_datasource}"
                },
                "enable": true,
-               "expr": "windows_system_system_up_time{job=~\"$job\",instance=~\"$instance\"}*1000 > $__from < $__to",
+               "expr": "windows_system_boot_time_timestamp_seconds{job=~\"$job\",instance=~\"$instance\"}\nor\nwindows_system_system_up_time{job=~\"$job\",instance=~\"$instance\"}*1000 > $__from < $__to",
                "hide": true,
                "iconColor": "light-yellow",
                "name": "Reboot",

--- a/windows-observ-lib/dashboards_out/overview
+++ b/windows-observ-lib/dashboards_out/overview
@@ -21,7 +21,7 @@
                   "uid": "${prometheus_datasource}"
                },
                "enable": true,
-               "expr": "windows_system_system_up_time{job=~\"$job\",instance=~\"$instance\"}*1000 > $__from < $__to",
+               "expr": "windows_system_boot_time_timestamp_seconds{job=~\"$job\",instance=~\"$instance\"}\nor\nwindows_system_system_up_time{job=~\"$job\",instance=~\"$instance\"}*1000 > $__from < $__to",
                "hide": true,
                "iconColor": "light-yellow",
                "name": "Reboot",
@@ -128,7 +128,7 @@
                      "type": "prometheus",
                      "uid": "${prometheus_datasource}"
                   },
-                  "expr": "time() - windows_system_system_up_time{job=~\"$job\",instance=~\"$instance\"}",
+                  "expr": "time() - windows_system_boot_time_timestamp_seconds{job=~\"$job\",instance=~\"$instance\"}\nor\ntime() - windows_system_system_up_time{job=~\"$job\",instance=~\"$instance\"}",
                   "format": "time_series",
                   "instant": false,
                   "legendFormat": "{{instance}}: Uptime",
@@ -320,7 +320,7 @@
                      "type": "prometheus",
                      "uid": "${prometheus_datasource}"
                   },
-                  "expr": "windows_cs_logical_processors{job=~\"$job\",instance=~\"$instance\"}",
+                  "expr": "windows_cpu_logical_processor{job=~\"$job\",instance=~\"$instance\"}\nor\nwindows_cs_logical_processors{job=~\"$job\",instance=~\"$instance\"}",
                   "format": "time_series",
                   "instant": false,
                   "legendFormat": "{{instance}}: Cores",
@@ -368,7 +368,7 @@
                      "type": "prometheus",
                      "uid": "${prometheus_datasource}"
                   },
-                  "expr": "windows_cs_physical_memory_bytes{job=~\"$job\",instance=~\"$instance\"}",
+                  "expr": "windows_cs_physical_memory_bytes{job=~\"$job\",instance=~\"$instance\"}\nor\nwindows_memory_physical_total_bytes{job=~\"$job\",instance=~\"$instance\"}",
                   "format": "time_series",
                   "instant": false,
                   "legendFormat": "Memory total",
@@ -646,7 +646,7 @@
                      "type": "prometheus",
                      "uid": "${prometheus_datasource}"
                   },
-                  "expr": "100 - windows_os_physical_memory_free_bytes{job=~\"$job\",instance=~\"$instance\"} / windows_cs_physical_memory_bytes{job=~\"$job\",instance=~\"$instance\"} * 100",
+                  "expr": "100 - windows_memory_physical_free_bytes{job=~\"$job\",instance=~\"$instance\"} / windows_memory_physical_total_bytes{job=~\"$job\",instance=~\"$instance\"} * 100\nor\n100 - windows_os_physical_memory_free_bytes{job=~\"$job\",instance=~\"$instance\"} / windows_cs_physical_memory_bytes{job=~\"$job\",instance=~\"$instance\"} * 100",
                   "format": "time_series",
                   "instant": false,
                   "legendFormat": "{{instance}}: Usage",
@@ -730,7 +730,7 @@
                      "type": "prometheus",
                      "uid": "${prometheus_datasource}"
                   },
-                  "expr": "windows_cs_physical_memory_bytes{job=~\"$job\",instance=~\"$instance\"} - windows_os_physical_memory_free_bytes{job=~\"$job\",instance=~\"$instance\"}",
+                  "expr": "windows_cs_physical_memory_bytes{job=~\"$job\",instance=~\"$instance\"} - windows_os_physical_memory_free_bytes{job=~\"$job\",instance=~\"$instance\"}\nor\nwindows_memory_physical_total_bytes{job=~\"$job\",instance=~\"$instance\"} - windows_memory_physical_free_bytes{job=~\"$job\",instance=~\"$instance\"}",
                   "format": "time_series",
                   "instant": false,
                   "legendFormat": "Memory used",
@@ -741,7 +741,7 @@
                      "type": "prometheus",
                      "uid": "${prometheus_datasource}"
                   },
-                  "expr": "windows_cs_physical_memory_bytes{job=~\"$job\",instance=~\"$instance\"}",
+                  "expr": "windows_cs_physical_memory_bytes{job=~\"$job\",instance=~\"$instance\"}\nor\nwindows_memory_physical_total_bytes{job=~\"$job\",instance=~\"$instance\"}",
                   "format": "time_series",
                   "instant": false,
                   "legendFormat": "Memory total",

--- a/windows-observ-lib/dashboards_out/system
+++ b/windows-observ-lib/dashboards_out/system
@@ -21,7 +21,7 @@
                   "uid": "${prometheus_datasource}"
                },
                "enable": true,
-               "expr": "windows_system_system_up_time{job=~\"$job\",instance=~\"$instance\"}*1000 > $__from < $__to",
+               "expr": "windows_system_boot_time_timestamp_seconds{job=~\"$job\",instance=~\"$instance\"}\nor\nwindows_system_system_up_time{job=~\"$job\",instance=~\"$instance\"}*1000 > $__from < $__to",
                "hide": true,
                "iconColor": "light-yellow",
                "name": "Reboot",
@@ -474,7 +474,7 @@
                      "type": "prometheus",
                      "uid": "${prometheus_datasource}"
                   },
-                  "expr": "windows_os_timezone{job=~\"$job\",instance=~\"$instance\"}",
+                  "expr": "windows_os_timezone{job=~\"$job\",instance=~\"$instance\"}\nor ignoring(timezone)\nwindows_time_timezone{job=~\"$job\",instance=~\"$instance\"}",
                   "format": "table",
                   "instant": false,
                   "legendFormat": "{{instance}}: Timezone",
@@ -530,7 +530,7 @@
                      "type": "prometheus",
                      "uid": "${prometheus_datasource}"
                   },
-                  "expr": "clamp_max(windows_time_ntp_client_time_sources{job=~\"$job\",instance=~\"$instance\"}, 1)",
+                  "expr": "clamp_max(\n  windows_time_ntp_client_time_sources{job=~\"$job\",instance=~\"$instance\"}\n,1)",
                   "format": "time_series",
                   "instant": false,
                   "legendFormat": "NTP status",

--- a/windows-observ-lib/prometheus_rules_out/prometheus_alerts.yaml
+++ b/windows-observ-lib/prometheus_rules_out/prometheus_alerts.yaml
@@ -22,7 +22,9 @@ groups:
                 Consider investigating processes consuming high memory or increasing available memory.
             summary: High memory usage on Windows host.
           expr: |
-            (100 - windows_os_physical_memory_free_bytes{} / windows_cs_physical_memory_bytes{} * 100) > 90
+            (100 - windows_memory_physical_free_bytes{} / windows_memory_physical_total_bytes{} * 100
+            or
+            100 - windows_os_physical_memory_free_bytes{} / windows_cs_physical_memory_bytes{} * 100) > 90
           for: 15m
           keep_firing_for: 5m
           labels:
@@ -85,8 +87,12 @@ groups:
             description: Node {{ $labels.instance }} has rebooted {{ $value | humanize }} seconds ago.
             summary: Node has rebooted.
           expr: |
-            (time() - windows_system_system_up_time{}) < 600
+            (time() - windows_system_boot_time_timestamp_seconds{}
+            or
+            time() - windows_system_system_up_time{}) < 600
             and
-            ((time() - windows_system_system_up_time{} offset 10m)) > 600
+            ((time() - windows_system_boot_time_timestamp_seconds{} offset 10m)
+            or
+            (time() - windows_system_system_up_time{} offset 10m)) > 600
           labels:
             severity: info

--- a/windows-observ-lib/signals/memory.libsonnet
+++ b/windows-observ-lib/signals/memory.libsonnet
@@ -9,7 +9,8 @@ function(this)
     aggLevel: 'none',
     aggFunction: 'avg',
     discoveryMetric: {
-      prometheus: 'windows_cs_physical_memory_bytes',
+      prometheus: 'windows_memory_physical_total_bytes',
+      prometheus_pre_0_30: 'windows_cs_physical_memory_bytes',
     },
     signals: {
       memoryTotal: {
@@ -19,8 +20,12 @@ function(this)
         description: 'Total physical memory in bytes',
         unit: 'bytes',
         sources: {
-          prometheus: {
+          prometheus_pre_0_30: {
             expr: 'windows_cs_physical_memory_bytes{%(queriesSelector)s}',
+            legendCustomTemplate: 'Memory total',
+          },
+          prometheus: {
+            expr: 'windows_memory_physical_total_bytes{%(queriesSelector)s}',
             legendCustomTemplate: 'Memory total',
           },
         },
@@ -32,33 +37,44 @@ function(this)
         description: 'Free physical memory in bytes',
         unit: 'bytes',
         sources: {
-          prometheus: {
+          prometheus_pre_0_30: {
             expr: 'windows_os_physical_memory_free_bytes{%(queriesSelector)s}',
+          },
+          prometheus: {
+            expr: 'windows_memory_physical_free_bytes{%(queriesSelector)s}',
           },
         },
       },
       memoryUsed: {
         name: 'Memory used',
         nameShort: 'Used',
-        type: 'gauge',
+        type: 'raw',
         description: 'Used physical memory in bytes',
         unit: 'bytes',
         sources: {
-          prometheus: {
+          prometheus_pre_0_30: {
             expr: 'windows_cs_physical_memory_bytes{%(queriesSelector)s} - windows_os_physical_memory_free_bytes{%(queriesSelector)s}',
             legendCustomTemplate: 'Memory used',
           },
+          prometheus: {
+            expr: 'windows_memory_physical_total_bytes{%(queriesSelector)s} - windows_memory_physical_free_bytes{%(queriesSelector)s}',
+            legendCustomTemplate: 'Memory used',
+          },
+          
         },
       },
       memoryUsagePercent: {
         name: 'Memory usage',
         nameShort: 'Usage',
-        type: 'gauge',
+        type: 'raw',
         description: 'Memory usage percentage',
         unit: 'percent',
         sources: {
-          prometheus: {
+          prometheus_pre_0_30: {
             expr: '100 - windows_os_physical_memory_free_bytes{%(queriesSelector)s} / windows_cs_physical_memory_bytes{%(queriesSelector)s} * 100',
+          },
+          prometheus: {
+            expr: '100 - windows_memory_physical_free_bytes{%(queriesSelector)s} / windows_memory_physical_total_bytes{%(queriesSelector)s} * 100',
           },
         },
       },
@@ -81,21 +97,28 @@ function(this)
         description: 'Free page file space in bytes',
         unit: 'bytes',
         sources: {
-          prometheus: {
+          //https://github.com/prometheus-community/windows_exporter/pull/1735
+          prometheus_pre_0_30: {
             expr: 'windows_os_paging_free_bytes{%(queriesSelector)s}',
+          },
+          prometheus: {
+            expr: 'windows_pagefile_free_bytes{%(queriesSelector)s}',
           },
         },
       },
       memoryPageUsed: {
         name: 'Page file used',
         nameShort: 'Page used',
-        type: 'gauge',
+        type: 'raw',
         description: 'Used page file space in bytes',
         unit: 'bytes',
         sources: {
-          prometheus: {
+          prometheus_pre_0_30: {
             expr: 'windows_os_paging_limit_bytes{%(queriesSelector)s} - windows_os_paging_free_bytes{%(queriesSelector)s}',
           },
+          prometheus: {
+            expr: 'windows_pagefile_limit_bytes{%(queriesSelector)s} - windows_pagefile_free_bytes{%(queriesSelector)s}',
+          }
         },
       },
     },

--- a/windows-observ-lib/signals/memory.libsonnet
+++ b/windows-observ-lib/signals/memory.libsonnet
@@ -60,7 +60,7 @@ function(this)
             expr: 'windows_memory_physical_total_bytes{%(queriesSelector)s} - windows_memory_physical_free_bytes{%(queriesSelector)s}',
             legendCustomTemplate: 'Memory used',
           },
-          
+
         },
       },
       memoryUsagePercent: {
@@ -118,7 +118,7 @@ function(this)
           },
           prometheus: {
             expr: 'windows_pagefile_limit_bytes{%(queriesSelector)s} - windows_pagefile_free_bytes{%(queriesSelector)s}',
-          }
+          },
         },
       },
     },

--- a/windows-observ-lib/signals/system.libsonnet
+++ b/windows-observ-lib/signals/system.libsonnet
@@ -34,6 +34,9 @@ function(this)
         unit: 's',
         sources: {
           prometheus: {
+            expr: 'time() - windows_system_boot_time_timestamp_seconds{%(queriesSelector)s}',
+          },
+          prometheus_pre_0_30: {
             expr: 'time() - windows_system_system_up_time{%(queriesSelector)s}',
           },
         },
@@ -45,8 +48,12 @@ function(this)
         description: 'System boot time',
         unit: 's',
         sources: {
-          prometheus: {
+          prometheus_pre_0_30: {
             expr: 'windows_system_system_up_time{%(queriesSelector)s}',
+          },
+          // https://github.com/prometheus-community/windows_exporter/releases/tag/v0.30.0
+          prometheus: {
+            expr: 'windows_system_boot_time_timestamp_seconds{%(queriesSelector)s}',
           },
         },
       },
@@ -58,6 +65,9 @@ function(this)
         unit: 'short',
         sources: {
           prometheus: {
+            expr: 'windows_cpu_logical_processor{%(queriesSelector)s}',
+          },
+          prometheus_pre_0_30: {
             expr: 'windows_cs_logical_processors{%(queriesSelector)s}',
           },
         },
@@ -132,7 +142,8 @@ function(this)
         unit: 'short',
         sources: {
           prometheus: {
-            expr: 'clamp_max(windows_time_ntp_client_time_sources{%(queriesSelector)s}, 1)',
+            expr: 'windows_time_ntp_client_time_sources{%(queriesSelector)s}',
+            exprWrappers: [["clamp_max(", ",1)"]],
             legendCustomTemplate: 'NTP status',
           },
         },
@@ -171,6 +182,11 @@ function(this)
         unit: 'short',
         sources: {
           prometheus: {
+            expr: 'windows_time_clock_frequency_adjustment_ppb{%(queriesSelector)s}',
+            legendCustomTemplate: 'Time adjustments',
+          },
+          // https://github.com/prometheus-community/windows_exporter/pull/1910
+          prometheus_pre_0_30: {
             expr: 'windows_time_clock_frequency_adjustment_ppb_total{%(queriesSelector)s}',
             legendCustomTemplate: 'Time adjustments',
           },
@@ -184,6 +200,10 @@ function(this)
         unit: 'short',
         sources: {
           prometheus: {
+            expr: 'windows_time_timezone{%(queriesSelector)s}',
+            infoLabel: 'timezone',
+          },
+          prometheus_pre_0_30: {
             expr: 'windows_os_timezone{%(queriesSelector)s}',
             infoLabel: 'timezone',
           },

--- a/windows-observ-lib/signals/system.libsonnet
+++ b/windows-observ-lib/signals/system.libsonnet
@@ -143,7 +143,7 @@ function(this)
         sources: {
           prometheus: {
             expr: 'windows_time_ntp_client_time_sources{%(queriesSelector)s}',
-            exprWrappers: [["clamp_max(", ",1)"]],
+            exprWrappers: [['clamp_max(', ',1)']],
             legendCustomTemplate: 'NTP status',
           },
         },


### PR DESCRIPTION
This adds new metrics sources from windows_exporter 0.30.0+
see
https://github.com/prometheus-community/windows_exporter/releases/tag/v0.30.0
https://github.com/prometheus-community/windows_exporter/pull/1735
https://github.com/prometheus-community/windows_exporter/pull/1910

To enable use metricSource: `prometheus`. For older metrics, use `prometheus_pre_0.30`.
Or you can use both at the same time. (default).