### PR TITLE
feat: traefik alerts

### DIFF
--- a/traefik-mixin/README.md
+++ b/traefik-mixin/README.md
@@ -31,20 +31,32 @@ The following Prometheus alerts are included:
 
 ## Configuration
 
-You can configure alert thresholds and labels in `config.libsonnet`:
+You can configure alert thresholds, selectors, and labels in `config.libsonnet`:
 
 ```jsonnet
 {
   _config+:: {
     traefik_tls_expiry_days_critical: 7,   // critical threshold (days)
     traefik_tls_expiry_days_warning: 14,   // warning threshold (days)
+    filteringSelector: '',                 // optional metric label selector for all alerts
+    // Example:
+    // filteringSelector: "component=\"traefik\",environment=\"production\"",
+    groupLabels: 'job, environment',       // for config reload alert (sum by)
+    instanceLabels: 'instance',            // for TLS alerts (max by)
     alertLabels: {},                       // optional alert labels
+    // Example:
+    // alertLabels: {
+    //   environment: 'production',
+    //   component: 'traefik',
+    // },
     alertAnnotations: {},                  // optional alert annotations
-    timeSeriesLabels: "component=\"traefik\",environment=\"production\"", // optional time series labels
-    sumByLabels: "instance",              // optional sum by labels
-    maxByLabels: "sans",                  // optional max by labels
+    // Example:
+    // alertAnnotations: {
+    //   runbook: 'https://runbooks.example.com/traefik-tls',
+    //   grafana: 'https://grafana.example.com/d/traefik',
+    // },
   },
 }
 ```
 
-For more advanced uses of mixins, see https://github.com/monitoring-mixins/docs.
+For more advanced uses of mixins, see [monitoring-mixins/docs](https://github.com/monitoring-mixins/docs).

--- a/traefik-mixin/README.md
+++ b/traefik-mixin/README.md
@@ -5,14 +5,14 @@ The Traefik mixin is a set of configurable, reusable, and extensible dashboards 
 To use them, you need to have mixtool and jsonnetfmt installed. If you have a working Go development environment, it's easiest to run the following:
 
 ```shell
-$ go get github.com/monitoring-mixins/mixtool/cmd/mixtool
-$ go get github.com/google/go-jsonnet/cmd/jsonnetfmt
+go get github.com/monitoring-mixins/mixtool/cmd/mixtool
+go get github.com/google/go-jsonnet/cmd/jsonnetfmt
 ```
 
 You can then build the Prometheus rules files and dashboards for Grafana:
 
 ```shell
-$ make build
+make build
 ```
 
 This will generate:
@@ -26,6 +26,25 @@ This will generate:
 The following Prometheus alerts are included:
 
 - **TraefikConfigReloadFailuresIncreasing**: Fires if Traefik is failing to reload its config.
-- **TraefikTLSCertificatesExpiring**: Fires if Traefik is serving certificates that will expire soon.
+- **TraefikTLSCertificatesExpiring**: Fires if Traefik is serving certificates that will expire very soon (critical, threshold configurable).
+- **TraefikTLSCertificatesExpiringSoon**: Fires if Traefik is serving certificates that will expire soon (warning, threshold configurable, only fires if the expiry is less than the warning threshold but greater than the critical threshold).
+
+## Configuration
+
+You can configure alert thresholds and labels in `config.libsonnet`:
+
+```jsonnet
+{
+  _config+:: {
+    traefik_tls_expiry_days_critical: 7,   // critical threshold (days)
+    traefik_tls_expiry_days_warning: 14,   // warning threshold (days)
+    alertLabels: {},                       // optional alert labels
+    alertAnnotations: {},                  // optional alert annotations
+    timeSeriesLabels: "component=\"traefik\",environment=\"production\"", // optional time series labels
+    sumByLabels: "instance",              // optional sum by labels
+    maxByLabels: "sans",                  // optional max by labels
+  },
+}
+```
 
 For more advanced uses of mixins, see https://github.com/monitoring-mixins/docs.

--- a/traefik-mixin/README.md
+++ b/traefik-mixin/README.md
@@ -1,10 +1,31 @@
-The Traefik mixin is a set of configurable, reusable, and extensible dashboards based on the metrics exported by Traefik itself. It also creates suitable dashboard descriptions for Grafana.
+# traefik-mixin
+
+The Traefik mixin is a set of configurable, reusable, and extensible dashboards based on the metrics exported by Traefik itself. It also creates suitable dashboard descriptions for Grafana. Lastly, some alerts are also included.
 
 To use them, you need to have mixtool and jsonnetfmt installed. If you have a working Go development environment, it's easiest to run the following:
 
+```shell
 $ go get github.com/monitoring-mixins/mixtool/cmd/mixtool
 $ go get github.com/google/go-jsonnet/cmd/jsonnetfmt
-You can then build the Prometheus rules files alerts.yaml and rules.yaml and a directory dashboard_out with the JSON dashboard files for Grafana:
+```
 
+You can then build the Prometheus rules files and dashboards for Grafana:
+
+```shell
 $ make build
+```
+
+This will generate:
+
+- Prometheus alerts in `prometheus_rules_out/prometheus_alerts.yaml`
+- Prometheus rules in `prometheus_rules_out/prometheus_rules.yaml` (if you have rules defined)
+- Grafana dashboards in `dashboards_out/`
+
+## Included Alerts
+
+The following Prometheus alerts are included:
+
+- **TraefikConfigReloadFailuresIncreasing**: Fires if Traefik is failing to reload its config.
+- **TraefikTLSCertificatesExpiring**: Fires if Traefik is serving certificates that will expire soon.
+
 For more advanced uses of mixins, see https://github.com/monitoring-mixins/docs.

--- a/traefik-mixin/README.md
+++ b/traefik-mixin/README.md
@@ -41,8 +41,9 @@ You can configure alert thresholds, selectors, and labels in `config.libsonnet`:
     filteringSelector: '',                 // optional metric label selector for all alerts
     // Example:
     // filteringSelector: "component=\"traefik\",environment=\"production\"",
-    groupLabels: 'job, environment',       // for config reload alert (sum by)
-    instanceLabels: 'instance',            // for TLS alerts (max by)
+    groupLabels: 'job, environment',
+    instanceLabels: 'instance',
+
     alertLabels: {},                       // optional alert labels
     // Example:
     // alertLabels: {

--- a/traefik-mixin/alerts/alerts.libsonnet
+++ b/traefik-mixin/alerts/alerts.libsonnet
@@ -8,7 +8,7 @@
           {
             alert: 'TraefikConfigReloadFailuresIncreasing',
             expr: |||
-              sum by (%(sumByLabels)s) (rate(traefik_config_reloads_failure_total{%(timeSeriesLabels)s}[5m])) > 0
+              sum by (%(groupLabels)s) (rate(traefik_config_reloads_failure_total{%(filteringSelector)s}[5m])) > 0
             ||| % $._config,
             'for': '5m',
             labels: {
@@ -22,7 +22,7 @@
           {
             alert: 'TraefikTLSCertificatesExpiring',
             expr: |||
-              max by (%(maxByLabels)s) ((last_over_time(traefik_tls_certs_not_after{%(timeSeriesLabels)s}[5m]) - time()) / 86400) < %(traefik_tls_expiry_days_critical)s
+              max by (%(instanceLabels)s, sans) ((last_over_time(traefik_tls_certs_not_after{%(filteringSelector)s}[5m]) - time()) / 86400) < %(traefik_tls_expiry_days_critical)s
             ||| % $._config,
             'for': '5m',
             labels: {
@@ -38,7 +38,7 @@
           {
             alert: 'TraefikTLSCertificatesExpiringSoon',
             expr: |||
-              max by (%(maxByLabels)s) ((last_over_time(traefik_tls_certs_not_after{%(timeSeriesLabels)s}[5m]) - time()) / 86400) < %(traefik_tls_expiry_days_warning)s > %(traefik_tls_expiry_days_critical)s
+              max by (%(instanceLabels)s, sans) ((last_over_time(traefik_tls_certs_not_after{%(filteringSelector)s}[5m]) - time()) / 86400) < %(traefik_tls_expiry_days_warning)s > %(traefik_tls_expiry_days_critical)s
             ||| % $._config,
             'for': '5m',
             labels: {

--- a/traefik-mixin/alerts/alerts.libsonnet
+++ b/traefik-mixin/alerts/alerts.libsonnet
@@ -14,6 +14,7 @@
               severity: 'critical',
             } + std.get($._config, 'alertLabels', {}),
             annotations: {
+              summary: 'Traefik is failing to reload its configuration.',
               description: 'Traefik is failing to reload its config',
             } + std.get($._config, 'alertAnnotations', {}),
           },
@@ -27,6 +28,7 @@
               severity: 'critical',
             } + std.get($._config, 'alertLabels', {}),
             annotations: {
+              summary: 'A Traefik-served TLS certificate will expire very soon.',
               description: |||
                 The minimum number of days until a Traefik-served certificate expires is {{ printf "%%.0f" $value }} days on {{ $labels.sans }} which is below the critical threshold of %(traefik_tls_expiry_days_critical)s.
               ||| % $._config,
@@ -42,6 +44,7 @@
               severity: 'warning',
             } + std.get($._config, 'alertLabels', {}),
             annotations: {
+              summary: 'A Traefik-served TLS certificate will expire soon.',
               description: |||
                 The minimum number of days until a Traefik-served certificate expires is {{ printf "%%.0f" $value }} days on {{ $labels.sans }} which is less than %(traefik_tls_expiry_days_warning)s but greater than %(traefik_tls_expiry_days_critical)s.
               ||| % $._config,

--- a/traefik-mixin/alerts/alerts.libsonnet
+++ b/traefik-mixin/alerts/alerts.libsonnet
@@ -17,7 +17,7 @@
               summary: 'Traefik is failing to reload its configuration.',
               description: |||
                 Traefik is failing to reload its config in {{ $labels.%(firstGroupLabel)s }}.
-              ||| % {firstGroupLabel: std.split($._config.groupLabels, ',')[0]},
+              ||| % { firstGroupLabel: std.split($._config.groupLabels, ',')[0] },
             } + std.get($._config, 'alertAnnotations', {}),
           },
           {

--- a/traefik-mixin/alerts/alerts.libsonnet
+++ b/traefik-mixin/alerts/alerts.libsonnet
@@ -6,7 +6,7 @@
         // TraefikConfigReloadFailuresIncreasing
         {
           alert: 'TraefikConfigReloadFailuresIncreasing',
-          expr: "sum(rate(traefik_config_reloads_failure_total[5m])) > 0",
+          expr: 'sum(rate(traefik_config_reloads_failure_total[5m])) > 0',
           'for': '5m',
           labels: {
             severity: 'critical',
@@ -18,7 +18,7 @@
         // TraefikTLSCertificatesExpiring
         {
           alert: 'TraefikTLSCertificatesExpiring',
-          expr: "max by (sans) ((last_over_time(traefik_tls_certs_not_after[5m]) - time()) / 86400) < 7",
+          expr: 'max by (sans) ((last_over_time(traefik_tls_certs_not_after[5m]) - time()) / 86400) < 7',
           'for': '5m',
           labels: {
             severity: 'critical',

--- a/traefik-mixin/alerts/alerts.libsonnet
+++ b/traefik-mixin/alerts/alerts.libsonnet
@@ -16,8 +16,8 @@
             annotations: {
               summary: 'Traefik is failing to reload its configuration.',
               description: |||
-                Traefik is failing to reload its config in {{ $labels.environment }}.
-              |||,
+                Traefik is failing to reload its config in {{ $labels.%(firstGroupLabel)s }}.
+              ||| % {firstGroupLabel: std.split($._config.groupLabels, ',')[0]},
             } + std.get($._config, 'alertAnnotations', {}),
           },
           {

--- a/traefik-mixin/alerts/alerts.libsonnet
+++ b/traefik-mixin/alerts/alerts.libsonnet
@@ -1,33 +1,57 @@
 {
-  groups+: [
-    {
-      name: 'traefik',
-      rules: [
-        // TraefikConfigReloadFailuresIncreasing
-        {
-          alert: 'TraefikConfigReloadFailuresIncreasing',
-          expr: 'sum(rate(traefik_config_reloads_failure_total[5m])) > 0',
-          'for': '5m',
-          labels: {
-            severity: 'critical',
+  prometheusAlerts+:: {
+    groups+: [
+      {
+        name: 'traefik',
+        rules: [
+          // TraefikConfigReloadFailuresIncreasing
+          {
+            alert: 'TraefikConfigReloadFailuresIncreasing',
+            expr: |||
+              sum by (%(sumByLabels)s) (rate(traefik_config_reloads_failure_total{%(timeSeriesLabels)s}[5m])) > 0
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'critical',
+            } + std.get($._config, 'alertLabels', {}),
+            annotations: {
+              description: 'Traefik is failing to reload its config',
+            } + std.get($._config, 'alertAnnotations', {}),
           },
-          annotations: {
-            description: 'Traefik is failing to reload its config',
+          // TraefikTLSCertificatesExpiring (critical)
+          {
+            alert: 'TraefikTLSCertificatesExpiring',
+            expr: |||
+              max by (%(maxByLabels)s) ((last_over_time(traefik_tls_certs_not_after{%(timeSeriesLabels)s}[5m]) - time()) / 86400) < %(traefik_tls_expiry_days_critical)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'critical',
+            } + std.get($._config, 'alertLabels', {}),
+            annotations: {
+              description: |||
+                The minimum number of days until a Traefik-served certificate expires is {{ printf "%%.0f" $value }} days on {{ $labels.sans }} which is below the critical threshold of %(traefik_tls_expiry_days_critical)s.
+              ||| % $._config,
+            } + std.get($._config, 'alertAnnotations', {}),
           },
-        },
-        // TraefikTLSCertificatesExpiring
-        {
-          alert: 'TraefikTLSCertificatesExpiring',
-          expr: 'max by (sans) ((last_over_time(traefik_tls_certs_not_after[5m]) - time()) / 86400) < 7',
-          'for': '5m',
-          labels: {
-            severity: 'critical',
+          // TraefikTLSCertificatesExpiring (warning)
+          {
+            alert: 'TraefikTLSCertificatesExpiringSoon',
+            expr: |||
+              max by (%(maxByLabels)s) ((last_over_time(traefik_tls_certs_not_after{%(timeSeriesLabels)s}[5m]) - time()) / 86400) < %(traefik_tls_expiry_days_warning)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'warning',
+            } + std.get($._config, 'alertLabels', {}),
+            annotations: {
+              description: |||
+                The minimum number of days until a Traefik-served certificate expires is {{ printf "%%.0f" $value }} days on {{ $labels.sans }} which is below the warning threshold of %(traefik_tls_expiry_days_warning)s.
+              ||| % $._config,
+            } + std.get($._config, 'alertAnnotations', {}),
           },
-          annotations: {
-            description: 'Traefik is serving certificates that will expire soon',
-          },
-        },
-      ],
-    },
-  ],
+        ],
+      },
+    ],
+  },
 }

--- a/traefik-mixin/alerts/alerts.libsonnet
+++ b/traefik-mixin/alerts/alerts.libsonnet
@@ -7,7 +7,7 @@
           {
             alert: 'TraefikConfigReloadFailuresIncreasing',
             expr: |||
-              sum by (%(groupLabels)s) (rate(traefik_config_reloads_failure_total{%(filteringSelector)s}[5m])) > 0
+              sum by (%(groupLabels)s, environment) (rate(traefik_config_reloads_failure_total{%(filteringSelector)s}[5m])) > 0
             ||| % $._config,
             'for': '5m',
             labels: {
@@ -15,7 +15,9 @@
             } + std.get($._config, 'alertLabels', {}),
             annotations: {
               summary: 'Traefik is failing to reload its configuration.',
-              description: 'Traefik is failing to reload its config',
+              description: |||
+                Traefik is failing to reload its config in {{ $labels.environment }}.
+              |||,
             } + std.get($._config, 'alertAnnotations', {}),
           },
           {

--- a/traefik-mixin/alerts/alerts.libsonnet
+++ b/traefik-mixin/alerts/alerts.libsonnet
@@ -38,7 +38,7 @@
           {
             alert: 'TraefikTLSCertificatesExpiringSoon',
             expr: |||
-              max by (%(maxByLabels)s) ((last_over_time(traefik_tls_certs_not_after{%(timeSeriesLabels)s}[5m]) - time()) / 86400) < %(traefik_tls_expiry_days_warning)s
+              max by (%(maxByLabels)s) ((last_over_time(traefik_tls_certs_not_after{%(timeSeriesLabels)s}[5m]) - time()) / 86400) < %(traefik_tls_expiry_days_warning)s > %(traefik_tls_expiry_days_critical)s
             ||| % $._config,
             'for': '5m',
             labels: {
@@ -46,7 +46,7 @@
             } + std.get($._config, 'alertLabels', {}),
             annotations: {
               description: |||
-                The minimum number of days until a Traefik-served certificate expires is {{ printf "%%.0f" $value }} days on {{ $labels.sans }} which is below the warning threshold of %(traefik_tls_expiry_days_warning)s.
+                The minimum number of days until a Traefik-served certificate expires is {{ printf "%%.0f" $value }} days on {{ $labels.sans }} which is less than %(traefik_tls_expiry_days_warning)s but greater than %(traefik_tls_expiry_days_critical)s.
               ||| % $._config,
             } + std.get($._config, 'alertAnnotations', {}),
           },

--- a/traefik-mixin/alerts/alerts.libsonnet
+++ b/traefik-mixin/alerts/alerts.libsonnet
@@ -4,7 +4,6 @@
       {
         name: 'traefik',
         rules: [
-          // TraefikConfigReloadFailuresIncreasing
           {
             alert: 'TraefikConfigReloadFailuresIncreasing',
             expr: |||
@@ -18,7 +17,6 @@
               description: 'Traefik is failing to reload its config',
             } + std.get($._config, 'alertAnnotations', {}),
           },
-          // TraefikTLSCertificatesExpiring (critical)
           {
             alert: 'TraefikTLSCertificatesExpiring',
             expr: |||
@@ -34,7 +32,6 @@
               ||| % $._config,
             } + std.get($._config, 'alertAnnotations', {}),
           },
-          // TraefikTLSCertificatesExpiring (warning)
           {
             alert: 'TraefikTLSCertificatesExpiringSoon',
             expr: |||

--- a/traefik-mixin/alerts/alerts.libsonnet
+++ b/traefik-mixin/alerts/alerts.libsonnet
@@ -7,7 +7,7 @@
           {
             alert: 'TraefikConfigReloadFailuresIncreasing',
             expr: |||
-              sum by (%(groupLabels)s, environment) (rate(traefik_config_reloads_failure_total{%(filteringSelector)s}[5m])) > 0
+              sum by (%(groupLabels)s) (rate(traefik_config_reloads_failure_total{%(filteringSelector)s}[5m])) > 0
             ||| % $._config,
             'for': '5m',
             labels: {

--- a/traefik-mixin/alerts/alerts.libsonnet
+++ b/traefik-mixin/alerts/alerts.libsonnet
@@ -1,0 +1,33 @@
+{
+  groups+: [
+    {
+      name: 'traefik',
+      rules: [
+        // TraefikConfigReloadFailuresIncreasing
+        {
+          alert: 'TraefikConfigReloadFailuresIncreasing',
+          expr: "sum(rate(traefik_config_reloads_failure_total[5m])) > 0",
+          'for': '5m',
+          labels: {
+            severity: 'critical',
+          },
+          annotations: {
+            description: 'Traefik is failing to reload its config',
+          },
+        },
+        // TraefikTLSCertificatesExpiring
+        {
+          alert: 'TraefikTLSCertificatesExpiring',
+          expr: "max by (sans) ((last_over_time(traefik_tls_certs_not_after[5m]) - time()) / 86400) < 7",
+          'for': '5m',
+          labels: {
+            severity: 'critical',
+          },
+          annotations: {
+            description: 'Traefik is serving certificates that will expire soon',
+          },
+        },
+      ],
+    },
+  ],
+}

--- a/traefik-mixin/config.libsonnet
+++ b/traefik-mixin/config.libsonnet
@@ -7,7 +7,7 @@
     // Example:
     // filteringSelector: "component=\"traefik\",environment=\"production\"",
     // for config reload alert
-    groupLabels: 'job, environment',
+    groupLabels: 'job',
     // for TLS alerts
     instanceLabels: 'instance',
     alertLabels: {},

--- a/traefik-mixin/config.libsonnet
+++ b/traefik-mixin/config.libsonnet
@@ -1,0 +1,26 @@
+{
+  _config+:: {
+    // alerts thresholds
+    traefik_tls_expiry_days_critical: 7,
+    traefik_tls_expiry_days_warning: 14,
+    timeSeriesLabels: '',
+    // Example:
+    // timeSeriesLabels: "component=\"traefik\",environment=\"production\"",
+    // for config alert
+    sumByLabels: 'instance',
+    // for TLS alerts
+    maxByLabels: 'sans',
+    alertLabels: {},
+    // Example:
+    // alertLabels: {
+    //   environment: 'production',
+    //   component: 'traefik',
+    // },
+    alertAnnotations: {},
+    // Example:
+    // alertAnnotations: {
+    //   runbook: 'https://runbooks.example.com/traefik-tls',
+    //   grafana: 'https://grafana.example.com/d/traefik',
+    // },
+  },
+}

--- a/traefik-mixin/config.libsonnet
+++ b/traefik-mixin/config.libsonnet
@@ -3,13 +3,13 @@
     // alerts thresholds
     traefik_tls_expiry_days_critical: 7,
     traefik_tls_expiry_days_warning: 14,
-    timeSeriesLabels: '',
+    filteringSelector: '',
     // Example:
-    // timeSeriesLabels: "component=\"traefik\",environment=\"production\"",
-    // for config alert
-    sumByLabels: 'instance',
+    // filteringSelector: "component=\"traefik\",environment=\"production\"",
+    // for config reload alert
+    groupLabels: 'job, environment',
     // for TLS alerts
-    maxByLabels: 'sans',
+    instanceLabels: 'instance',
     alertLabels: {},
     // Example:
     // alertLabels: {

--- a/traefik-mixin/mixin.libsonnet
+++ b/traefik-mixin/mixin.libsonnet
@@ -2,4 +2,5 @@
   grafanaDashboards+:: {
     'traefikdash.json': (import 'dashboards/traefikdash.json'),
   },
+  prometheusAlerts+:: (import 'alerts/alerts.libsonnet'),
 }

--- a/traefik-mixin/mixin.libsonnet
+++ b/traefik-mixin/mixin.libsonnet
@@ -2,5 +2,5 @@
   grafanaDashboards+:: {
     'traefikdash.json': (import 'dashboards/traefikdash.json'),
   },
-  prometheusAlerts+:: (import 'alerts/alerts.libsonnet'),
-}
+} + (import 'alerts/alerts.libsonnet') +
+(import 'config.libsonnet')

--- a/traefik-mixin/prometheus_rules_out/prometheus_alerts.yaml
+++ b/traefik-mixin/prometheus_rules_out/prometheus_alerts.yaml
@@ -21,9 +21,9 @@ groups:
   - alert: TraefikTLSCertificatesExpiringSoon
     annotations:
       description: |
-        The minimum number of days until a Traefik-served certificate expires is {{ printf "%.0f" $value }} days on {{ $labels.sans }} which is below the warning threshold of 14.
+        The minimum number of days until a Traefik-served certificate expires is {{ printf "%.0f" $value }} days on {{ $labels.sans }} which is less than 14 but greater than 7.
     expr: |
-      max by (sans) ((last_over_time(traefik_tls_certs_not_after{}[5m]) - time()) / 86400) < 14
+      max by (sans) ((last_over_time(traefik_tls_certs_not_after{}[5m]) - time()) / 86400) < 14 > 7
     for: 5m
     labels:
       severity: warning

--- a/traefik-mixin/prometheus_rules_out/prometheus_alerts.yaml
+++ b/traefik-mixin/prometheus_rules_out/prometheus_alerts.yaml
@@ -7,7 +7,7 @@ groups:
         Traefik is failing to reload its config in {{ $labels.job }}.
       summary: Traefik is failing to reload its configuration.
     expr: |
-      sum by (job, environment) (rate(traefik_config_reloads_failure_total{}[5m])) > 0
+      sum by (job) (rate(traefik_config_reloads_failure_total{}[5m])) > 0
     for: 5m
     labels:
       severity: critical

--- a/traefik-mixin/prometheus_rules_out/prometheus_alerts.yaml
+++ b/traefik-mixin/prometheus_rules_out/prometheus_alerts.yaml
@@ -4,7 +4,7 @@ groups:
   - alert: TraefikConfigReloadFailuresIncreasing
     annotations:
       description: |
-        Traefik is failing to reload its config in {{ $labels.environment }}.
+        Traefik is failing to reload its config in {{ $labels.job }}.
       summary: Traefik is failing to reload its configuration.
     expr: |
       sum by (job, environment) (rate(traefik_config_reloads_failure_total{}[5m])) > 0

--- a/traefik-mixin/prometheus_rules_out/prometheus_alerts.yaml
+++ b/traefik-mixin/prometheus_rules_out/prometheus_alerts.yaml
@@ -1,0 +1,18 @@
+groups:
+- name: traefik
+  rules:
+  - alert: TraefikConfigReloadFailuresIncreasing
+    annotations:
+      description: Traefik is failing to reload its config
+    expr: sum(rate(traefik_config_reloads_failure_total[5m])) > 0
+    for: 5m
+    labels:
+      severity: critical
+  - alert: TraefikTLSCertificatesExpiring
+    annotations:
+      description: Traefik is serving certificates that will expire soon
+    expr: max by (sans) ((last_over_time(traefik_tls_certs_not_after[5m]) - time())
+      / 86400) < 7
+    for: 5m
+    labels:
+      severity: critical

--- a/traefik-mixin/prometheus_rules_out/prometheus_alerts.yaml
+++ b/traefik-mixin/prometheus_rules_out/prometheus_alerts.yaml
@@ -1,33 +1,33 @@
 groups:
-- name: traefik
-  rules:
-  - alert: TraefikConfigReloadFailuresIncreasing
-    annotations:
-      description: |
-        Traefik is failing to reload its config in {{ $labels.job }}.
-      summary: Traefik is failing to reload its configuration.
-    expr: |
-      sum by (job) (rate(traefik_config_reloads_failure_total{}[5m])) > 0
-    for: 5m
-    labels:
-      severity: critical
-  - alert: TraefikTLSCertificatesExpiring
-    annotations:
-      description: |
-        The minimum number of days until a Traefik-served certificate expires is {{ printf "%.0f" $value }} days on {{ $labels.sans }} which is below the critical threshold of 7.
-      summary: A Traefik-served TLS certificate will expire very soon.
-    expr: |
-      max by (instance, sans) ((last_over_time(traefik_tls_certs_not_after{}[5m]) - time()) / 86400) < 7
-    for: 5m
-    labels:
-      severity: critical
-  - alert: TraefikTLSCertificatesExpiringSoon
-    annotations:
-      description: |
-        The minimum number of days until a Traefik-served certificate expires is {{ printf "%.0f" $value }} days on {{ $labels.sans }} which is less than 14 but greater than 7.
-      summary: A Traefik-served TLS certificate will expire soon.
-    expr: |
-      max by (instance, sans) ((last_over_time(traefik_tls_certs_not_after{}[5m]) - time()) / 86400) < 14 > 7
-    for: 5m
-    labels:
-      severity: warning
+    - name: traefik
+      rules:
+        - alert: TraefikConfigReloadFailuresIncreasing
+          annotations:
+            description: |
+                Traefik is failing to reload its config in {{ $labels.job }}.
+            summary: Traefik is failing to reload its configuration.
+          expr: |
+            sum by (job) (rate(traefik_config_reloads_failure_total{}[5m])) > 0
+          for: 5m
+          labels:
+            severity: critical
+        - alert: TraefikTLSCertificatesExpiring
+          annotations:
+            description: |
+                The minimum number of days until a Traefik-served certificate expires is {{ printf "%.0f" $value }} days on {{ $labels.sans }} which is below the critical threshold of 7.
+            summary: A Traefik-served TLS certificate will expire very soon.
+          expr: |
+            max by (instance, sans) ((last_over_time(traefik_tls_certs_not_after{}[5m]) - time()) / 86400) < 7
+          for: 5m
+          labels:
+            severity: critical
+        - alert: TraefikTLSCertificatesExpiringSoon
+          annotations:
+            description: |
+                The minimum number of days until a Traefik-served certificate expires is {{ printf "%.0f" $value }} days on {{ $labels.sans }} which is less than 14 but greater than 7.
+            summary: A Traefik-served TLS certificate will expire soon.
+          expr: |
+            max by (instance, sans) ((last_over_time(traefik_tls_certs_not_after{}[5m]) - time()) / 86400) < 14 > 7
+          for: 5m
+          labels:
+            severity: warning

--- a/traefik-mixin/prometheus_rules_out/prometheus_alerts.yaml
+++ b/traefik-mixin/prometheus_rules_out/prometheus_alerts.yaml
@@ -4,6 +4,7 @@ groups:
   - alert: TraefikConfigReloadFailuresIncreasing
     annotations:
       description: Traefik is failing to reload its config
+      summary: Traefik is failing to reload its configuration.
     expr: |
       sum by (job, environment) (rate(traefik_config_reloads_failure_total{}[5m])) > 0
     for: 5m
@@ -13,6 +14,7 @@ groups:
     annotations:
       description: |
         The minimum number of days until a Traefik-served certificate expires is {{ printf "%.0f" $value }} days on {{ $labels.sans }} which is below the critical threshold of 7.
+      summary: A Traefik-served TLS certificate will expire very soon.
     expr: |
       max by (instance, sans) ((last_over_time(traefik_tls_certs_not_after{}[5m]) - time()) / 86400) < 7
     for: 5m
@@ -22,6 +24,7 @@ groups:
     annotations:
       description: |
         The minimum number of days until a Traefik-served certificate expires is {{ printf "%.0f" $value }} days on {{ $labels.sans }} which is less than 14 but greater than 7.
+      summary: A Traefik-served TLS certificate will expire soon.
     expr: |
       max by (instance, sans) ((last_over_time(traefik_tls_certs_not_after{}[5m]) - time()) / 86400) < 14 > 7
     for: 5m

--- a/traefik-mixin/prometheus_rules_out/prometheus_alerts.yaml
+++ b/traefik-mixin/prometheus_rules_out/prometheus_alerts.yaml
@@ -4,15 +4,26 @@ groups:
   - alert: TraefikConfigReloadFailuresIncreasing
     annotations:
       description: Traefik is failing to reload its config
-    expr: sum(rate(traefik_config_reloads_failure_total[5m])) > 0
+    expr: |
+      sum by (instance) (rate(traefik_config_reloads_failure_total{}[5m])) > 0
     for: 5m
     labels:
       severity: critical
   - alert: TraefikTLSCertificatesExpiring
     annotations:
-      description: Traefik is serving certificates that will expire soon
-    expr: max by (sans) ((last_over_time(traefik_tls_certs_not_after[5m]) - time())
-      / 86400) < 7
+      description: |
+        The minimum number of days until a Traefik-served certificate expires is {{ printf "%.0f" $value }} days on {{ $labels.sans }} which is below the critical threshold of 7.
+    expr: |
+      max by (sans) ((last_over_time(traefik_tls_certs_not_after{}[5m]) - time()) / 86400) < 7
     for: 5m
     labels:
       severity: critical
+  - alert: TraefikTLSCertificatesExpiringSoon
+    annotations:
+      description: |
+        The minimum number of days until a Traefik-served certificate expires is {{ printf "%.0f" $value }} days on {{ $labels.sans }} which is below the warning threshold of 14.
+    expr: |
+      max by (sans) ((last_over_time(traefik_tls_certs_not_after{}[5m]) - time()) / 86400) < 14
+    for: 5m
+    labels:
+      severity: warning

--- a/traefik-mixin/prometheus_rules_out/prometheus_alerts.yaml
+++ b/traefik-mixin/prometheus_rules_out/prometheus_alerts.yaml
@@ -5,7 +5,7 @@ groups:
     annotations:
       description: Traefik is failing to reload its config
     expr: |
-      sum by (instance) (rate(traefik_config_reloads_failure_total{}[5m])) > 0
+      sum by (job, environment) (rate(traefik_config_reloads_failure_total{}[5m])) > 0
     for: 5m
     labels:
       severity: critical
@@ -14,7 +14,7 @@ groups:
       description: |
         The minimum number of days until a Traefik-served certificate expires is {{ printf "%.0f" $value }} days on {{ $labels.sans }} which is below the critical threshold of 7.
     expr: |
-      max by (sans) ((last_over_time(traefik_tls_certs_not_after{}[5m]) - time()) / 86400) < 7
+      max by (instance, sans) ((last_over_time(traefik_tls_certs_not_after{}[5m]) - time()) / 86400) < 7
     for: 5m
     labels:
       severity: critical
@@ -23,7 +23,7 @@ groups:
       description: |
         The minimum number of days until a Traefik-served certificate expires is {{ printf "%.0f" $value }} days on {{ $labels.sans }} which is less than 14 but greater than 7.
     expr: |
-      max by (sans) ((last_over_time(traefik_tls_certs_not_after{}[5m]) - time()) / 86400) < 14 > 7
+      max by (instance, sans) ((last_over_time(traefik_tls_certs_not_after{}[5m]) - time()) / 86400) < 14 > 7
     for: 5m
     labels:
       severity: warning

--- a/traefik-mixin/prometheus_rules_out/prometheus_alerts.yaml
+++ b/traefik-mixin/prometheus_rules_out/prometheus_alerts.yaml
@@ -3,7 +3,8 @@ groups:
   rules:
   - alert: TraefikConfigReloadFailuresIncreasing
     annotations:
-      description: Traefik is failing to reload its config
+      description: |
+        Traefik is failing to reload its config in {{ $labels.environment }}.
       summary: Traefik is failing to reload its configuration.
     expr: |
       sum by (job, environment) (rate(traefik_config_reloads_failure_total{}[5m])) > 0


### PR DESCRIPTION
Adds two basic Traefik alerts. One for config reloads failing and the other for TLS certificate expiry.