### PR TITLE
handle large query ranges on azure deadlocks panels

### DIFF
--- a/csp-mixin/signals/azuresqldb.libsonnet
+++ b/csp-mixin/signals/azuresqldb.libsonnet
@@ -30,7 +30,7 @@ function(this)
         type: 'gauge',
         sources: {
           azuremonitor: {
-            expr: 'label_replace(azure_microsoft_sql_servers_databases_deadlock_total_count{%(queriesSelector)s}, "database", "$1", "resourceID", ".+/(.*)")',
+            expr: 'label_replace(max_over_time(azure_microsoft_sql_servers_databases_deadlock_total_count{%(queriesSelector)s}[$__interval]), "database", "$1", "resourceID", ".+/(.*)")',
             legendCustomTemplate: '{{database}}',
           },
         },


### PR DESCRIPTION
The query used by the Deadlocks by database panel is likely to miss showing non-zero values the larger the query range is. Since the metric is a count and showing any occurrences of non-zero values is crucial, using `max_over_time` for the query interval is appropriate.

See [this thread for context](https://raintank-corp.slack.com/archives/C036J5B39/p1751047074742109).