### PR TITLE
Windows memory and service signals fix

### DIFF
--- a/windows-observ-lib/README.md
+++ b/windows-observ-lib/README.md
@@ -105,7 +105,7 @@ Grafana Agent/Alloy or combination of windows_exporter/promtail can be used in o
 
 The following collectors should be enabled in windows_exporter/windows integration:
 
-`enabled_collectors: cpu,cs,logical_disk,net,os,service,system,textfile,time,diskdrive`
+`enabled_collectors: cpu,logical_disk,net,os,service,system,textfile,time,diskdrive,pagefile,memory`
 
 ### Logs collection
 

--- a/windows-observ-lib/alerts.libsonnet
+++ b/windows-observ-lib/alerts.libsonnet
@@ -160,22 +160,6 @@
                    },
                  },
                  {
-                   alert: 'WindowsServiceNotHealthy',
-                   expr: |||
-                     (%s) > 0
-                   ||| % [
-                     signals.services.serviceNotHealthy.asRuleExpression(),
-                   ],
-                   'for': '5m',
-                   labels: {
-                     severity: 'critical',
-                   },
-                   annotations: {
-                     summary: 'Windows service is not healthy.',
-                     description: "Windows service {{ $labels.name }} is not in healthy state, currently in '{{ $labels.status }}'.",
-                   },
-                 },
-                 {
                    alert: 'WindowsDiskDriveNotHealthy',
                    expr: |||
                      (%s) != 1
@@ -244,6 +228,25 @@
                    },
                  },
                ]
+               + if std.member(config.metricsSource, 'prometheus_pre_0_30') then 
+                [
+                  {
+                    alert: 'WindowsServiceNotHealthy',
+                    expr: |||
+                      (%s) > 0
+                    ||| % [
+                      signals.services.serviceNotHealthy.asRuleExpression(),
+                    ],
+                    'for': '5m',
+                    labels: {
+                      severity: 'critical',
+                    },
+                    annotations: {
+                      summary: 'Windows service is not healthy.',
+                      description: "Windows service {{ $labels.name }} is not in healthy state, currently in '{{ $labels.status }}'.",
+                    },
+                  }
+                ] else []
                + if config.enableADDashboard then ADAlerts else [],
       },
     ],

--- a/windows-observ-lib/alerts.libsonnet
+++ b/windows-observ-lib/alerts.libsonnet
@@ -122,12 +122,17 @@
                    annotations: {
                      summary: 'High memory usage on Windows host.',
                      description: |||
-                       Memory usage on host {{ $labels.%s }} is critically high, with {{ printf "%%.2f" $value }}%% of total memory used.
-                       This exceeds the threshold of %s%%.
-                       Current memory free: {{ with printf `windows_os_physical_memory_free_bytes{}` | query | first | value | humanize }}{{ . }}{{ end }}.
-                       Total memory: {{ with printf `windows_cs_physical_memory_bytes{}` | query | first | value | humanize }}{{ . }}{{ end }}.
+                       Memory usage on host {{ $labels.%(instanceLabel)s }} is critically high, with {{ printf "%%.2f" $value }}%% of total memory used.
+                       This exceeds the threshold of %(threshold)s%%.
+                       Current memory free: {{ with printf `%(memoryFree)s` | query | first | value | humanize }}{{ . }}{{ end }}.
+                       Total memory: {{ with printf `%(memoryTotal)s` | query | first | value | humanize }}{{ . }}{{ end }}.
                        Consider investigating processes consuming high memory or increasing available memory.
-                     ||| % [instanceLabel, config.alertMemoryUsageThresholdCritical],
+                     ||| % {
+                      instanceLabel: instanceLabel, 
+                      threshold: config.alertMemoryUsageThresholdCritical,
+                      memoryFree: signals.memory.memoryFree.asRuleExpression(),
+                      memoryTotal: signals.memory.memoryTotal.asRuleExpression(),
+                     },
                    },
                  },
                  {

--- a/windows-observ-lib/dashboards_out/overview
+++ b/windows-observ-lib/dashboards_out/overview
@@ -416,7 +416,7 @@
                      "type": "prometheus",
                      "uid": "${prometheus_datasource}"
                   },
-                  "expr": "windows_os_paging_limit_bytes{job=~\"$job\",instance=~\"$instance\"}",
+                  "expr": "windows_os_paging_limit_bytes{job=~\"$job\",instance=~\"$instance\"}\nor\nwindows_pagefile_limit_bytes{job=~\"$job\",instance=~\"$instance\"}",
                   "format": "time_series",
                   "instant": false,
                   "legendFormat": "{{instance}}: Page total",

--- a/windows-observ-lib/prometheus_rules_out/prometheus_alerts.yaml
+++ b/windows-observ-lib/prometheus_rules_out/prometheus_alerts.yaml
@@ -48,15 +48,6 @@ groups:
           keep_firing_for: 5m
           labels:
             severity: critical
-        - alert: WindowsServiceNotHealthy
-          annotations:
-            description: Windows service {{ $labels.name }} is not in healthy state, currently in '{{ $labels.status }}'.
-            summary: Windows service is not healthy.
-          expr: |
-            (windows_service_status{status!~"starting|stopping|ok", }) > 0
-          for: 5m
-          labels:
-            severity: critical
         - alert: WindowsDiskDriveNotHealthy
           annotations:
             description: Windows disk {{ $labels.name }} is not in healthy state, currently in '{{ $labels.status }}' status.
@@ -100,3 +91,12 @@ groups:
             (time() - windows_system_system_up_time{} offset 10m)) > 600
           labels:
             severity: info
+        - alert: WindowsServiceNotHealthy
+          annotations:
+            description: Windows service {{ $labels.name }} is not in healthy state, currently in '{{ $labels.status }}'.
+            summary: Windows service is not healthy.
+          expr: |
+            (windows_service_status{status!~"starting|stopping|ok", }) > 0
+          for: 5m
+          labels:
+            severity: critical

--- a/windows-observ-lib/prometheus_rules_out/prometheus_alerts.yaml
+++ b/windows-observ-lib/prometheus_rules_out/prometheus_alerts.yaml
@@ -17,8 +17,12 @@ groups:
             description: |
                 Memory usage on host {{ $labels.instance }} is critically high, with {{ printf "%.2f" $value }}% of total memory used.
                 This exceeds the threshold of 90%.
-                Current memory free: {{ with printf `windows_os_physical_memory_free_bytes{}` | query | first | value | humanize }}{{ . }}{{ end }}.
-                Total memory: {{ with printf `windows_cs_physical_memory_bytes{}` | query | first | value | humanize }}{{ . }}{{ end }}.
+                Current memory free: {{ with printf `windows_memory_physical_free_bytes{}
+                or
+                windows_os_physical_memory_free_bytes{}` | query | first | value | humanize }}{{ . }}{{ end }}.
+                Total memory: {{ with printf `windows_cs_physical_memory_bytes{}
+                or
+                windows_memory_physical_total_bytes{}` | query | first | value | humanize }}{{ . }}{{ end }}.
                 Consider investigating processes consuming high memory or increasing available memory.
             summary: High memory usage on Windows host.
           expr: |

--- a/windows-observ-lib/signals/memory.libsonnet
+++ b/windows-observ-lib/signals/memory.libsonnet
@@ -86,6 +86,9 @@ function(this)
         unit: 'bytes',
         sources: {
           prometheus: {
+            expr: 'windows_pagefile_limit_bytes{%(queriesSelector)s}',
+          },
+          prometheus_pre_0_30: {
             expr: 'windows_os_paging_limit_bytes{%(queriesSelector)s}',
           },
         },

--- a/windows-observ-lib/signals/services.libsonnet
+++ b/windows-observ-lib/signals/services.libsonnet
@@ -9,7 +9,8 @@ function(this)
     aggLevel: 'none',
     aggFunction: 'avg',
     discoveryMetric: {
-      prometheus: 'windows_service_status',
+      prometheus: 'windows_service_state',
+      prometheus_pre_0_30: 'windows_service_status',
     },
     signals: {
       serviceStatus: {
@@ -18,8 +19,10 @@ function(this)
         type: 'gauge',
         description: 'Windows service status',
         unit: 'short',
+        //https://github.com/prometheus-community/windows_exporter/pull/1584
+        optional: true,
         sources: {
-          prometheus: {
+          prometheus_pre_0_30: {
             expr: 'windows_service_status{%(queriesSelector)s}',
             legendCustomTemplate: '{{ name }}',
             valueMappings: [
@@ -46,10 +49,12 @@ function(this)
         name: 'Service not healthy',
         nameShort: 'Not healthy',
         type: 'gauge',
-        description: 'Services not in healthy state',
+        description: 'Service not in healthy state',
         unit: 'short',
+        optional: true,
         sources: {
-          prometheus: {
+
+          prometheus_pre_0_30: {
             expr: 'windows_service_status{status!~"starting|stopping|ok", %(queriesSelector)s}',
             legendCustomTemplate: '{{ name }} ({{ status }})',
           },

--- a/windows-observ-lib/tests/prometheus_alerts_test.yaml
+++ b/windows-observ-lib/tests/prometheus_alerts_test.yaml
@@ -6,9 +6,9 @@ evaluation_interval: 15m
 tests:
   - interval: 1m
     input_series:
-      - series: 'windows_os_physical_memory_free_bytes{instance="host1"}'
+      - series: 'windows_memory_physical_free_bytes{instance="host1"}'
         values: '10000000x15'
-      - series: 'windows_cs_physical_memory_bytes{instance="host1"}'
+      - series: 'windows_memory_physical_total_bytes{instance="host1"}'
         values: '1000000000x15'
       - series: 'windows_logical_disk_free_bytes{volume="C:", instance="host1"}'
         values: '10000000x15'


### PR DESCRIPTION
1. Fixes memory and pagefile signals.
2. service collector is also affected by windows_exporter changes, and metric we used no longer present with no direct replacement.  Marking this signal as only available in prometheus_pre_0_030.