### PR TITLE
Make asserts template variable replacement more flexible

### DIFF
--- a/grafana-cloud-integration-utils/util.libsonnet
+++ b/grafana-cloud-integration-utils/util.libsonnet
@@ -292,8 +292,8 @@ local integration_version_panel(version, statusPanelDataSource, height, width, x
               if std.objectHas(target, 'expr') then
                 target {
                   expr: local temp = std.strReplace(target.expr, '${', '___DOLLAR_BRACE___');
-                        local replaced = std.strReplace(temp, '{', '{asserts_env=~"$env", asserts_site=~"$site", ');
-                        std.strReplace(replaced, '___DOLLAR_BRACE___', '${'),
+                       local replaced = std.strReplace(temp, '{', '{asserts_env=~"$env", asserts_site=~"$site", ');
+                       std.strReplace(replaced, '___DOLLAR_BRACE___', '${'),
                 }
               else target
               for target in panel.targets
@@ -311,8 +311,8 @@ local integration_version_panel(version, statusPanelDataSource, height, width, x
                   if std.objectHas(target, 'expr') then
                     target {
                       expr: local temp = std.strReplace(target.expr, '${', '___DOLLAR_BRACE___');
-                            local replaced = std.strReplace(temp, '{', '{asserts_env=~"$env", asserts_site=~"$site", ');
-                            std.strReplace(replaced, '___DOLLAR_BRACE___', '${'),
+                           local replaced = std.strReplace(temp, '{', '{asserts_env=~"$env", asserts_site=~"$site", ');
+                           std.strReplace(replaced, '___DOLLAR_BRACE___', '${'),
                     }
                   else target
                   for target in panel.targets

--- a/grafana-cloud-integration-utils/util.libsonnet
+++ b/grafana-cloud-integration-utils/util.libsonnet
@@ -291,7 +291,9 @@ local integration_version_panel(version, statusPanelDataSource, height, width, x
             targets: [
               if std.objectHas(target, 'expr') then
                 target {
-                  expr: std.strReplace(target.expr, '{', '{asserts_env=~"$env", asserts_site=~"$site", '),
+                  expr: local temp = std.strReplace(target.expr, '${', '___DOLLAR_BRACE___');
+                        local replaced = std.strReplace(temp, '{', '{asserts_env=~"$env", asserts_site=~"$site", ');
+                        std.strReplace(replaced, '___DOLLAR_BRACE___', '${'),
                 }
               else target
               for target in panel.targets
@@ -308,7 +310,9 @@ local integration_version_panel(version, statusPanelDataSource, height, width, x
                 targets: [
                   if std.objectHas(target, 'expr') then
                     target {
-                      expr: std.strReplace(target.expr, '{', '{asserts_env=~"$env", asserts_site=~"$site", '),
+                      expr: local temp = std.strReplace(target.expr, '${', '___DOLLAR_BRACE___');
+                            local replaced = std.strReplace(temp, '{', '{asserts_env=~"$env", asserts_site=~"$site", ');
+                            std.strReplace(replaced, '___DOLLAR_BRACE___', '${'),
                     }
                   else target
                   for target in panel.targets


### PR DESCRIPTION
Current variable replacement replaces all `{` in a query which can lead to some corner cases like in Traefik dashboard where the following query 

```
sum by (alias) (\nlabel_replace(\n(increase(traefik_service_requests_total{job=~\"$job\", instance=~\"$instance\", service=~\"$service\", code!=\"\"}[$__interval] offset -$__interval )) > 0,\n  \"alias\", \"HTTP ${1}00-${1}99\", \"code\", \"(.).+\"\n))
```

was incorrectly transformed to 

```
sum by (alias) (
label_replace(
(increase(traefik_service_requests_total{asserts_env=~"$env", asserts_site=~"$site", job=~"$job", instance=~"$instance", service=~"$service", code!=""}[$__interval] offset -$__interval )) > 0,
  "alias", "HTTP ${asserts_env=~"$env", asserts_site=~"$site", 1}00-${asserts_env=~"$env", asserts_site=~"$site", 1}99", "code", "(.).+"
))
```

This PR makes this replacement more flexible. 

How it works:
1. Temporarily replace `${` with a placeholder `___DOLLAR_BRACE___`
1. Replace remaining `{` with the Asserts variables (only metric selector braces)
1. Restore the `${` placeholders back to their original form

> Note: This PR was co-authored by an AI agent (Cursor)