### PR TITLE
use signals lib in netflow mixin for compatibility with beyla integration

### DIFF
--- a/netflow-mixin/dashboards/netflow-overview.libsonnet
+++ b/netflow-mixin/dashboards/netflow-overview.libsonnet
@@ -2,6 +2,7 @@ local g = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonn
 local var = g.dashboard.variable;
 
 local panels = import 'panels.libsonnet';
+local signals = import '../signals/main.libsonnet';
 
 
 local labelVar = function(label, title=label) var.query.new(label, 'network_io_bytes')
@@ -29,19 +30,11 @@ local dashboardUid = 'netflow-overview';
       + g.dashboard.time.withFrom($._config.dashboardPeriod)
       + g.dashboard.withRefresh($._config.dashboardRefresh)
       + g.dashboard.withTimezone($._config.dashboardTimezone)
-      + g.dashboard.withVariables([
-        var.datasource.new('prometheus_datasource', 'prometheus')
-        + var.query.generalOptions.withLabel('Prometheus data source'),
-        var.datasource.new('loki_datasource', 'loki')
-        + var.query.generalOptions.withLabel('Loki data source'),
-        labelVar('job', 'Job')
-        + var.query.generalOptions.showOnDashboard.withNothing(),
-        labelVar('device_name', 'Device name'),
-        labelVar('network_local_address', 'Source'),
-        labelVar('network_peer_address', 'Destination'),
-      ])
+      + g.dashboard.withVariables(
+        signals.getVariablesMultiChoice()
+      )
       + g.dashboard.withPanels([
-        panels.totalTraffic
+        panels.trafficRate
         + withPos(0, 1, 5, 15),
         panels.stats
         + withPos(15, 1, 5, 9),

--- a/netflow-mixin/dashboards/panels.libsonnet
+++ b/netflow-mixin/dashboards/panels.libsonnet
@@ -1,3 +1,4 @@
+local commonlib = import 'common-lib/common/main.libsonnet';
 local g = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';
 local timeSeries = g.panel.timeSeries;
 local stat = g.panel.stat;
@@ -11,74 +12,21 @@ local filters = |||
   network_peer_address=~"$network_peer_address",
   job=~"$job"
 |||;
+local signals = import '../signals/main.libsonnet';
 {
-  totalTraffic: timeSeries.new('Total traffic')
-                + timeSeries.panelOptions.withDescription('Total observed traffic, aggregated by receiving device')
-                + timeSeries.queryOptions.withInterval('1m')
-                + timeSeries.queryOptions.withTargets(
-                  [
-                    g.query.prometheus.new(
-                      '$prometheus_datasource',
-                      |||
-                        sum(network_io_by_flow_bytes{%s}) by (device_name)
-                      ||| % [filters],
-                    ),
-                  ]
-                )
-                + timeSeries.panelOptions.withTransparent(true)
-                + timeSeries.standardOptions.withUnit('bytes')
-                + timeSeries.fieldConfig.defaults.custom.withLineInterpolation('smooth')
-                + timeSeries.fieldConfig.defaults.custom.withAxisPlacement('right')
-                + timeSeries.options.legend.withShowLegend(false),
+  trafficRate: signals.trafficRate.asTimeSeries()
+               + timeSeries.panelOptions.withTransparent(true)
+               + timeSeries.fieldConfig.defaults.custom.withLineInterpolation('smooth')
+               + timeSeries.fieldConfig.defaults.custom.withAxisPlacement('right')
+               + timeSeries.options.legend.withShowLegend(false),
 
   stats: stat.new('')
          + stat.panelOptions.withDescription('Known sources, destinations, endpoints and total overall traffic')
          + stat.queryOptions.withInterval('1m')
-         + stat.queryOptions.withTargets(
-           [
-             g.query.prometheus.new(
-               '$prometheus_datasource',
-               |||
-                 count(count(network_io_by_flow_bytes{%s}) by (device_name))
-               ||| % [filters],
-             )
-             + g.query.prometheus.withLegendFormat('Collecting devices'),
-             g.query.prometheus.new(
-               '$prometheus_datasource',
-               |||
-                 count(count(network_io_by_flow_bytes{%s}) by (network_local_address))
-               ||| % [filters],
-             )
-             + g.query.prometheus.withLegendFormat('Sources'),
-             g.query.prometheus.new(
-               '$prometheus_datasource',
-               |||
-                 count(count(network_io_by_flow_bytes{%s}) by (network_peer_address))
-               ||| % [filters],
-             )
-             + g.query.prometheus.withLegendFormat('Destinations'),
-             g.query.prometheus.new(
-               '$prometheus_datasource',
-               |||
-                 sum(sum_over_time(network_io_by_flow_bytes{%s}[$__range]))
-               ||| % [filters],
-             )
-             + g.query.prometheus.withLegendFormat('Total observed traffic')
-             + g.query.prometheus.withRefId('TotalTraffic'),
-           ]
-         )
-         + stat.standardOptions.withOverrides([{
-           matcher: {
-             id: 'byFrameRefID',
-             options: 'TotalTraffic',
-           },
-           properties: [
-             {
-               id: 'unit',
-               value: 'bytes',
-             },
-           ],
-         }])
+         + signals.collectingDevices.asPanelMixin()
+         + signals.sources.asPanelMixin()
+         + signals.destinations.asPanelMixin()
+         + signals.totalTraffic.asPanelMixin()
          + stat.standardOptions.withMin(0)
          + { fieldConfig+: { defaults+: { fieldMinMax: true } } }
          + stat.standardOptions.color.withMode('palette-classic')
@@ -86,8 +34,7 @@ local filters = |||
          + stat.panelOptions.withTransparent(true),
 
 
-  topSources: table.new('Top sources')
-              + table.panelOptions.withDescription('Source adresses ordered by observed traffic during the time range')
+  topSources: signals.topSources.asTable()
               + table.standardOptions.withOverrides([
                 {
                   matcher: {
@@ -113,16 +60,7 @@ local filters = |||
               + table.standardOptions.color.withMode('fixed')
               + table.standardOptions.color.withFixedColor('green')
               + table.queryOptions.withInterval('1m')
-              + table.queryOptions.withTargets([
-                g.query.prometheus.new(
-                  '$prometheus_datasource',
-                  |||
-                    topk(5,network_io_by_flow_bytes{%s})
-                  ||| % [filters],
-                )
-                + g.query.prometheus.withFormat('table'),
-              ])
-              + table.queryOptions.withTransformationsMixin([
+              + table.queryOptions.withTransformations([
                 {
                   id: 'groupBy',
                   options: {
@@ -133,11 +71,11 @@ local filters = |||
                         ],
                         operation: 'aggregate',
                       },
-                      network_local_address: {
+                      src_cidr: {
                         aggregations: [],
                         operation: 'groupby',
                       },
-                      network_peer_address: {
+                      dst_cidr: {
                         aggregations: [
                           'distinctCount',
                         ],
@@ -159,14 +97,14 @@ local filters = |||
                     includeByName: {},
                     indexByName: {
                       'Value (sum)': 3,
-                      network_local_address: 0,
-                      'network_peer_address (distinctCount)': 2,
+                      src_cidr: 0,
+                      'dst_cidr (distinctCount)': 2,
                       'network_protocol_name (distinctCount)': 1,
                     },
                     renameByName: {
                       'Value (sum)': 'Bytes transferred',
-                      network_local_address: 'Source',
-                      'network_peer_address (distinctCount)': 'Destinations',
+                      src_cidr: 'Source',
+                      'dst_cidr (distinctCount)': 'Destinations',
                       'network_protocol_name (distinctCount)': 'Protocols',
                     },
                   },
@@ -204,13 +142,13 @@ local filters = |||
                                'distinctCount',
                              ],
                            },
-                           network_local_address: {
+                           src_cidr: {
                              aggregations: [
                                'distinctCount',
                              ],
                              operation: 'aggregate',
                            },
-                           network_peer_address: {
+                           dst_cidr: {
                              aggregations: [
                                'distinctCount',
                              ],
@@ -232,17 +170,17 @@ local filters = |||
                          includeByName: {},
                          indexByName: {
                            'Value (sum)': 3,
-                           'network_local_address (distinctCount)': 2,
-                           network_peer_address: 0,
+                           'src_cidr (distinctCount)': 2,
+                           dst_cidr: 0,
                            'network_protocol_name (distinctCount)': 1,
                          },
                          renameByName: {
                            'Value (sum)': 'Bytes Transferred',
                            'device_name (distinctCount)': 'Devices',
-                           network_local_address: 'Source',
-                           'network_local_address (distinctCount)': 'Sources',
-                           network_peer_address: 'Destination',
-                           'network_peer_address (distinctCount)': 'Devices',
+                           src_cidr: 'Source',
+                           'src_cidr (distinctCount)': 'Sources',
+                           dst_cidr: 'Destination',
+                           'dst_cidr (distinctCount)': 'Devices',
                            'network_protocol_name (distinctCount)': 'Protocols',
                          },
                        },
@@ -260,8 +198,7 @@ local filters = |||
                        },
                      },
                    ]),
-  conversationTotalBytes: table.new('Conversation total bytes')
-                          + table.panelOptions.withDescription('Source/Destination pairs and their total traffic across all dimensions. Ordered by total traffic during selected time range')
+  conversationTotalBytes: signals.conversationTraffic.asTable()
                           + table.standardOptions.withOverrides([
                             {
                               matcher: {
@@ -294,19 +231,6 @@ local filters = |||
                           + table.standardOptions.color.withMode('continuous-BlPu')
                           + table.standardOptions.withUnit('bytes')
                           + table.options.footer.withEnablePagination(true)
-                          + table.queryOptions.withInterval('1m')
-                          + table.queryOptions.withTargets([
-                            g.query.prometheus.new(
-                              '$prometheus_datasource',
-                              |||
-                                sum(
-                                  sum_over_time(network_io_by_flow_bytes{%s}[$__range])
-                                ) by (network_local_address,network_peer_address)
-                              ||| % [filters],
-                            )
-                            + g.query.prometheus.withInstant(true)
-                            + g.query.prometheus.withFormat('table'),
-                          ])
                           + table.queryOptions.withTransformations([
                             {
                               id: 'sortBy',
@@ -330,31 +254,22 @@ local filters = |||
                                 indexByName: {},
                                 renameByName: {
                                   Value: 'Bytes',
-                                  network_local_address: 'Source',
-                                  network_peer_address: 'Destination',
+                                  src_cidr: 'Source',
+                                  dst_cidr: 'Destination',
                                 },
                               },
                             },
                           ]),
 
-  conversationTraffic: timeSeries.new('Conversation traffic over time')
-                       + timeSeries.panelOptions.withDescription('Traffic distribution of source/destination pairs over time')
+  conversationTraffic: signals.conversationTrafficOverTime.asTimeSeries()
                        + timeSeries.panelOptions.withTransparent(true)
                        + timeSeries.standardOptions.withUnit('bytes')
                        + timeSeries.options.legend.withShowLegend(false)
                        + timeSeries.fieldConfig.defaults.custom.withLineInterpolation('smooth')
                        + timeSeries.fieldConfig.defaults.custom.withFillOpacity(80)
-                       + timeSeries.fieldConfig.defaults.custom.withStacking({ mode: 'normal', group: 'A' })
-                       + timeSeries.queryOptions.withInterval('1m')
-                       + timeSeries.queryOptions.withTargets([
-                         g.query.prometheus.new('$prometheus_datasource',
-                                                |||
-                                                  sum(network_io_by_flow_bytes{%s}) by (network_local_address,network_peer_address,device_name)
-                                                ||| % [filters]),
-                       ]),
+                       + timeSeries.fieldConfig.defaults.custom.withStacking({ mode: 'normal', group: 'A' }),
 
   conversationByPair: pieChart.new('Breakdown by source/destination pair')
-                      + pieChart.panelOptions.withDescription('Breakdown of total traffic between source/destination pairs observed during the selected time range')
                       + pieChart.panelOptions.withTransparent(true)
                       + pieChart.options.legend.withPlacement('right')
                       + pieChart.options.legend.withValues(['value'])
@@ -363,17 +278,9 @@ local filters = |||
                       + pieChart.options.reduceOptions.withValues(true)
                       + pieChart.queryOptions.withInterval('1m')
                       + pieChart.queryOptions.withTargets([
-                        g.query.prometheus.new(
-                          '$prometheus_datasource',
-                          |||
-                            sum(sum_over_time(network_io_by_flow_bytes{%s}[$__range])) by (network_local_address,network_peer_address)
-                          ||| % [filters],
-                        )
-                        + g.query.prometheus.withInstant(true)
-                        + g.query.prometheus.withFormat('table'),
+                        signals.conversationPairs.asTableTarget(),
                       ]),
-  protocolTotalBytes: table.new('Total bytes')
-                      + table.panelOptions.withDescription('List of protocols and the total amount of observed traffic during the selected time range')
+  protocolTotalBytes: signals.protocolTraffic.asTable()
                       + table.standardOptions.color.withMode('continuous-BlPu')
                       + table.standardOptions.withUnit('bytes')
                       + table.standardOptions.withOverrides([
@@ -393,17 +300,6 @@ local filters = |||
                             },
                           ],
                         },
-                      ])
-                      + table.queryOptions.withInterval('1m')
-                      + table.queryOptions.withTargets([
-                        g.query.prometheus.new(
-                          '$prometheus_datasource',
-                          |||
-                            sum(sum_over_time(network_io_by_flow_bytes{%s}[$__range])) by (network_protocol_name)
-                          ||| % [filters],
-                        )
-                        + g.query.prometheus.withInstant(true)
-                        + g.query.prometheus.withFormat('table'),
                       ])
                       + table.queryOptions.withTransformations([
                         {
@@ -442,35 +338,16 @@ local filters = |||
                         + pieChart.standardOptions.withUnit('bytes')
                         + pieChart.options.withPieType('donut')
                         + pieChart.options.reduceOptions.withValues(true)
-                        + pieChart.queryOptions.withInterval('1m')
                         + pieChart.queryOptions.withTargets([
-                          g.query.prometheus.new(
-                            '$prometheus_datasource',
-                            |||
-                              sum(sum_over_time(network_io_by_flow_bytes{%s}[$__range])) by (network_protocol_name)
-                            ||| % [filters],
-                          )
-                          + g.query.prometheus.withLegendFormat('{{network_protocol_name}}')
-                          + g.query.prometheus.withInstant(true),
+                          signals.protocolTraffic.asTableTarget()
+                          + g.query.prometheus.withLegendFormat('{{network_protocol_name}}'),
                         ]),
-  protocolOverTime: timeSeries.new('Protocol traffic over time')
-                    + pieChart.panelOptions.withDescription('Protocols and the amount of observed traffic over the selected time range')
+  protocolOverTime: signals.protocolOverTime.asTimeSeries()
                     + timeSeries.panelOptions.withTransparent(true)
-                    + timeSeries.standardOptions.withUnit('bytes')
                     + timeSeries.fieldConfig.defaults.custom.withDrawStyle('bars')
                     + timeSeries.fieldConfig.defaults.custom.withStacking({ mode: 'normal', group: 'A' })
                     + timeSeries.fieldConfig.defaults.custom.withFillOpacity(80)
-                    + timeSeries.queryOptions.withMaxDataPoints(20)
-                    + timeSeries.queryOptions.withInterval('1m')
-                    + timeSeries.queryOptions.withTargets([
-                      g.query.prometheus.new(
-                        '$prometheus_datasource',
-                        |||
-                          sum(sum_over_time(network_io_by_flow_bytes{%s}[$__interval])) by (network_protocol_name)
-                        ||| % [filters],
-                      )
-                      + g.query.prometheus.withLegendFormat('{{network_protocol_name}}'),
-                    ]),
+                    + timeSeries.queryOptions.withMaxDataPoints(20),
   topDestinationMap: geomap.new('Top destination')
                      + geomap.panelOptions.withDescription('Geographic heatmap showing the total amount of traffic to specific countries')
                      + geomap.standardOptions.withUnit('bytes')
@@ -500,23 +377,13 @@ local filters = |||
                          type: 'heatmap',
                        },
                      ])
-                     + geomap.queryOptions.withInterval('1m')
                      + geomap.queryOptions.withTargets([
-                       g.query.prometheus.new(
-                         '$prometheus_datasource',
-                         |||
-                           sum(sum_over_time(network_io_by_flow_bytes{%s,network_peer_country!="Private IP"}[$__range])) by (network_peer_country)
-                         ||| % [filters],
-                       )
-                       + g.query.prometheus.withFormat('table')
-                       + g.query.prometheus.withInstant(true),
+                       signals.trafficByDestination.asTableTarget(),
                      ]),
-  destinationsLegend: table.new('')
-                      + table.panelOptions.withDescription('Total traffic to specific countries during the selected time range')
+  destinationsLegend: signals.trafficByDestination.asTable()
                       + table.standardOptions.withUnit('bytes')
                       + table.standardOptions.color.withMode('continuous-BlPu')
                       + table.queryOptions.withInterval('1m')
-                      + table.queryOptions.withTargets(self.topDestinationMap.targets)
                       + table.options.footer.withEnablePagination(true)
                       + table.standardOptions.withOverrides([
                         {
@@ -574,8 +441,8 @@ local filters = |||
                             indexByName: {},
                             renameByName: {
                               Value: 'Bytes',
-                              network_peer_country: 'Country',
-                              network_local_country: 'Country',
+                              dst_country: 'Country',
+                              src_country: 'Country',
                             },
                           },
                         },
@@ -599,7 +466,7 @@ local filters = |||
                        options: 'A',
                      },
                      location: {
-                       lookup: 'network_local_country',
+                       lookup: 'src_country',
                        mode: 'lookup',
                      },
                      name: 'Destinations',
@@ -609,18 +476,12 @@ local filters = |||
                    },
                  ])
                  + geomap.queryOptions.withTargets([
-                   g.query.prometheus.new(
-                     '$prometheus_datasource',
-                     |||
-                       sum(sum_over_time(network_io_by_flow_bytes{%s,network_local_country!="Private IP"}[$__range])) by (network_local_country)
-                     ||| % [filters],
-                   )
-                   + g.query.prometheus.withFormat('table')
-                   + g.query.prometheus.withInstant(true),
+                   signals.trafficBySource.asTableTarget(),
                  ]),
   sourcesLegend: self.destinationsLegend
+                 + table.panelOptions.withTitle('Traffic by source')
                  + table.panelOptions.withDescription('Total traffic from specific countries during the selected time range')
-                 + table.queryOptions.withTargets(self.topSourcesMap.targets),
+                 + table.queryOptions.withTargets([signals.trafficBySource.asTableTarget()]),
   collectorLogs: logs.new('Collector logs')
                  + logs.panelOptions.withDescription('Logs of the ktranslate instance')
                  + logs.queryOptions.withTargets([
@@ -639,13 +500,6 @@ local filters = |||
                + stat.standardOptions.color.withMode('palette-classic')
                + stat.queryOptions.withInterval('1m')
                + stat.queryOptions.withTargets([
-                 g.query.prometheus.new(
-                   '$prometheus_datasource',
-                   |||
-                     sum(network_io_by_flow_bytes{%s}) by (device_name)
-                   ||| % [filters],
-                 )
-                 + g.query.prometheus.withLegendFormat('{{device_name}}'),
-
+                 signals.trafficRate.asTarget(),
                ]),
 }

--- a/netflow-mixin/dashboards_out/netflow-overview.json
+++ b/netflow-mixin/dashboards_out/netflow-overview.json
@@ -2,18 +2,31 @@
       "panels": [
          {
             "datasource": {
-               "type": "datasource",
-               "uid": "-- Mixed --"
+               "type": "prometheus",
+               "uid": "${prometheus_datasource}"
             },
-            "description": "Total observed traffic, aggregated by receiving device",
+            "description": "Total observed traffic, aggregated by collecting device",
             "fieldConfig": {
                "defaults": {
                   "custom": {
                      "axisPlacement": "right",
                      "lineInterpolation": "smooth"
-                  },
-                  "unit": "bytes"
-               }
+                  }
+               },
+               "overrides": [
+                  {
+                     "matcher": {
+                        "id": "byFrameRefID",
+                        "options": "Traffic rate"
+                     },
+                     "properties": [
+                        {
+                           "id": "unit",
+                           "value": "Bps"
+                        }
+                     ]
+                  }
+               ]
             },
             "gridPos": {
                "h": 5,
@@ -22,23 +35,26 @@
                "y": 1
             },
             "id": 1,
-            "interval": "1m",
             "options": {
                "legend": {
                   "showLegend": false
                }
             },
-            "pluginVersion": "v11.4.0",
+            "pluginVersion": "v11.0.0",
             "targets": [
                {
                   "datasource": {
                      "type": "prometheus",
-                     "uid": "$prometheus_datasource"
+                     "uid": "${prometheus_datasource}"
                   },
-                  "expr": "sum(network_io_by_flow_bytes{device_name=~\"$device_name\",\nnetwork_local_address=~\"$network_local_address\",\nnetwork_peer_address=~\"$network_peer_address\",\njob=~\"$job\"\n}) by (device_name)\n"
+                  "expr": "sum(irate(beyla_network_flow_bytes_total{job=~\"$job\",job=~\"$job\"}[$__rate_interval])) by (job)\nor\nsum(irate(obi_network_flow_bytes_total{job=~\"$job\",job=~\"$job\"}[$__rate_interval])) by (job)\nor\nsum(network_io_by_flow_bytes{job=~\"$job\",job=~\"$job\"}) by (device_name)",
+                  "format": "time_series",
+                  "instant": false,
+                  "legendFormat": "{{job}}: Traffic rate",
+                  "refId": "Traffic rate"
                }
             ],
-            "title": "Total traffic",
+            "title": "Traffic rate",
             "transparent": true,
             "type": "timeseries"
          },
@@ -60,7 +76,43 @@
                   {
                      "matcher": {
                         "id": "byFrameRefID",
-                        "options": "TotalTraffic"
+                        "options": "Collecting Devices"
+                     },
+                     "properties": [
+                        {
+                           "id": "unit",
+                           "value": "short"
+                        }
+                     ]
+                  },
+                  {
+                     "matcher": {
+                        "id": "byFrameRefID",
+                        "options": "Sources"
+                     },
+                     "properties": [
+                        {
+                           "id": "unit",
+                           "value": "short"
+                        }
+                     ]
+                  },
+                  {
+                     "matcher": {
+                        "id": "byFrameRefID",
+                        "options": "Destinations"
+                     },
+                     "properties": [
+                        {
+                           "id": "unit",
+                           "value": "short"
+                        }
+                     ]
+                  },
+                  {
+                     "matcher": {
+                        "id": "byFrameRefID",
+                        "options": "Total Traffic"
                      },
                      "properties": [
                         {
@@ -87,35 +139,46 @@
                {
                   "datasource": {
                      "type": "prometheus",
-                     "uid": "$prometheus_datasource"
+                     "uid": "${prometheus_datasource}"
                   },
-                  "expr": "count(count(network_io_by_flow_bytes{device_name=~\"$device_name\",\nnetwork_local_address=~\"$network_local_address\",\nnetwork_peer_address=~\"$network_peer_address\",\njob=~\"$job\"\n}) by (device_name))\n",
-                  "legendFormat": "Collecting devices"
+                  "expr": "count(count(beyla_network_flow_bytes_total{job=~\"$job\",job=~\"$job\"}) by (job))\nor\ncount(count(network_io_by_flow_bytes{job=~\"$job\",job=~\"$job\"}) by (device_name))\nor\ncount(count(obi_network_flow_bytes_total{job=~\"$job\",job=~\"$job\"}) by (job))",
+                  "format": "time_series",
+                  "instant": false,
+                  "legendFormat": "Collecting devices",
+                  "refId": "Collecting Devices"
                },
                {
                   "datasource": {
                      "type": "prometheus",
-                     "uid": "$prometheus_datasource"
+                     "uid": "${prometheus_datasource}"
                   },
-                  "expr": "count(count(network_io_by_flow_bytes{device_name=~\"$device_name\",\nnetwork_local_address=~\"$network_local_address\",\nnetwork_peer_address=~\"$network_peer_address\",\njob=~\"$job\"\n}) by (network_local_address))\n",
-                  "legendFormat": "Sources"
+                  "expr": "count(count(beyla_network_flow_bytes_total{job=~\"$job\",job=~\"$job\"}) by (src_cidr))\nor\ncount(count(network_io_by_flow_bytes{job=~\"$job\",job=~\"$job\"}) by (network_local_address))\nor\ncount(count(obi_network_flow_bytes_total{job=~\"$job\",job=~\"$job\"}) by (src_cidr))",
+                  "format": "time_series",
+                  "instant": false,
+                  "legendFormat": "Sources",
+                  "refId": "Sources"
                },
                {
                   "datasource": {
                      "type": "prometheus",
-                     "uid": "$prometheus_datasource"
+                     "uid": "${prometheus_datasource}"
                   },
-                  "expr": "count(count(network_io_by_flow_bytes{device_name=~\"$device_name\",\nnetwork_local_address=~\"$network_local_address\",\nnetwork_peer_address=~\"$network_peer_address\",\njob=~\"$job\"\n}) by (network_peer_address))\n",
-                  "legendFormat": "Destinations"
+                  "expr": "count(count(beyla_network_flow_bytes_total{job=~\"$job\",job=~\"$job\"}) by (dst_cidr))\nor\ncount(count(network_io_by_flow_bytes{job=~\"$job\",job=~\"$job\"}) by (network_peer_address))\nor\ncount(count(obi_network_flow_bytes_total{job=~\"$job\",job=~\"$job\"}) by (dst_cidr))",
+                  "format": "time_series",
+                  "instant": false,
+                  "legendFormat": "Destinations",
+                  "refId": "Destinations"
                },
                {
                   "datasource": {
                      "type": "prometheus",
-                     "uid": "$prometheus_datasource"
+                     "uid": "${prometheus_datasource}"
                   },
-                  "expr": "sum(sum_over_time(network_io_by_flow_bytes{device_name=~\"$device_name\",\nnetwork_local_address=~\"$network_local_address\",\nnetwork_peer_address=~\"$network_peer_address\",\njob=~\"$job\"\n}[$__range]))\n",
+                  "expr": "sum(increase(beyla_network_flow_bytes_total{job=~\"$job\",job=~\"$job\"}[$__range]))\nor\nsum(increase(obi_network_flow_bytes_total{job=~\"$job\",job=~\"$job\"}[$__range]))\nor\nsum(sum_over_time(network_io_by_flow_bytes{job=~\"$job\",job=~\"$job\"}[$__range]))",
+                  "format": "time_series",
+                  "instant": false,
                   "legendFormat": "Total observed traffic",
-                  "refId": "TotalTraffic"
+                  "refId": "Total Traffic"
                }
             ],
             "title": "",
@@ -124,8 +187,8 @@
          },
          {
             "datasource": {
-               "type": "datasource",
-               "uid": "-- Mixed --"
+               "type": "prometheus",
+               "uid": "${prometheus_datasource}"
             },
             "description": "Source adresses ordered by observed traffic during the time range",
             "fieldConfig": {
@@ -133,6 +196,9 @@
                   "color": {
                      "fixedColor": "green",
                      "mode": "fixed"
+                  },
+                  "custom": {
+                     "filterable": false
                   }
                },
                "overrides": [
@@ -166,15 +232,18 @@
             },
             "id": 3,
             "interval": "1m",
-            "pluginVersion": "v11.4.0",
+            "pluginVersion": "v11.0.0",
             "targets": [
                {
                   "datasource": {
                      "type": "prometheus",
-                     "uid": "$prometheus_datasource"
+                     "uid": "${prometheus_datasource}"
                   },
-                  "expr": "topk(5,network_io_by_flow_bytes{device_name=~\"$device_name\",\nnetwork_local_address=~\"$network_local_address\",\nnetwork_peer_address=~\"$network_peer_address\",\njob=~\"$job\"\n})\n",
-                  "format": "table"
+                  "expr": "topk(5,increase(beyla_network_flow_bytes_total{job=~\"$job\",job=~\"$job\"}[$__range]))\nor\ntopk(5,increase(obi_network_flow_bytes_total{job=~\"$job\",job=~\"$job\"}[$__range]))\nor\ntopk(5,network_io_by_flow_bytes{job=~\"$job\",job=~\"$job\"})",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "{{job}}: Top sources",
+                  "refId": "Top sources"
                }
             ],
             "title": "Top sources",
@@ -189,11 +258,7 @@
                            ],
                            "operation": "aggregate"
                         },
-                        "network_local_address": {
-                           "aggregations": [ ],
-                           "operation": "groupby"
-                        },
-                        "network_peer_address": {
+                        "dst_cidr": {
                            "aggregations": [
                               "distinctCount"
                            ],
@@ -204,6 +269,10 @@
                               "distinctCount"
                            ],
                            "operation": "aggregate"
+                        },
+                        "src_cidr": {
+                           "aggregations": [ ],
+                           "operation": "groupby"
                         }
                      }
                   }
@@ -215,15 +284,15 @@
                      "includeByName": { },
                      "indexByName": {
                         "Value (sum)": 3,
-                        "network_local_address": 0,
-                        "network_peer_address (distinctCount)": 2,
-                        "network_protocol_name (distinctCount)": 1
+                        "dst_cidr (distinctCount)": 2,
+                        "network_protocol_name (distinctCount)": 1,
+                        "src_cidr": 0
                      },
                      "renameByName": {
                         "Value (sum)": "Bytes transferred",
-                        "network_local_address": "Source",
-                        "network_peer_address (distinctCount)": "Destinations",
-                        "network_protocol_name (distinctCount)": "Protocols"
+                        "dst_cidr (distinctCount)": "Destinations",
+                        "network_protocol_name (distinctCount)": "Protocols",
+                        "src_cidr": "Source"
                      }
                   }
                },
@@ -244,8 +313,8 @@
          },
          {
             "datasource": {
-               "type": "datasource",
-               "uid": "-- Mixed --"
+               "type": "prometheus",
+               "uid": "${prometheus_datasource}"
             },
             "description": "Destination adresses ordered by observed traffic during the time range",
             "fieldConfig": {
@@ -253,6 +322,9 @@
                   "color": {
                      "fixedColor": "green",
                      "mode": "fixed"
+                  },
+                  "custom": {
+                     "filterable": false
                   }
                },
                "overrides": [
@@ -286,15 +358,18 @@
             },
             "id": 4,
             "interval": "1m",
-            "pluginVersion": "v11.4.0",
+            "pluginVersion": "v11.0.0",
             "targets": [
                {
                   "datasource": {
                      "type": "prometheus",
-                     "uid": "$prometheus_datasource"
+                     "uid": "${prometheus_datasource}"
                   },
-                  "expr": "topk(5,network_io_by_flow_bytes{device_name=~\"$device_name\",\nnetwork_local_address=~\"$network_local_address\",\nnetwork_peer_address=~\"$network_peer_address\",\njob=~\"$job\"\n})\n",
-                  "format": "table"
+                  "expr": "topk(5,increase(beyla_network_flow_bytes_total{job=~\"$job\",job=~\"$job\"}[$__range]))\nor\ntopk(5,increase(obi_network_flow_bytes_total{job=~\"$job\",job=~\"$job\"}[$__range]))\nor\ntopk(5,network_io_by_flow_bytes{job=~\"$job\",job=~\"$job\"})",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "{{job}}: Top sources",
+                  "refId": "Top sources"
                }
             ],
             "title": "Top destinations",
@@ -314,19 +389,19 @@
                               "distinctCount"
                            ]
                         },
-                        "network_local_address": {
-                           "aggregations": [
-                              "distinctCount"
-                           ],
-                           "operation": "aggregate"
-                        },
-                        "network_peer_address": {
+                        "dst_cidr": {
                            "aggregations": [
                               "distinctCount"
                            ],
                            "operation": "groupby"
                         },
                         "network_protocol_name": {
+                           "aggregations": [
+                              "distinctCount"
+                           ],
+                           "operation": "aggregate"
+                        },
+                        "src_cidr": {
                            "aggregations": [
                               "distinctCount"
                            ],
@@ -342,18 +417,18 @@
                      "includeByName": { },
                      "indexByName": {
                         "Value (sum)": 3,
-                        "network_local_address (distinctCount)": 2,
-                        "network_peer_address": 0,
-                        "network_protocol_name (distinctCount)": 1
+                        "dst_cidr": 0,
+                        "network_protocol_name (distinctCount)": 1,
+                        "src_cidr (distinctCount)": 2
                      },
                      "renameByName": {
                         "Value (sum)": "Bytes Transferred",
                         "device_name (distinctCount)": "Devices",
-                        "network_local_address": "Source",
-                        "network_local_address (distinctCount)": "Sources",
-                        "network_peer_address": "Destination",
-                        "network_peer_address (distinctCount)": "Devices",
-                        "network_protocol_name (distinctCount)": "Protocols"
+                        "dst_cidr": "Destination",
+                        "dst_cidr (distinctCount)": "Devices",
+                        "network_protocol_name (distinctCount)": "Protocols",
+                        "src_cidr": "Source",
+                        "src_cidr (distinctCount)": "Sources"
                      }
                   }
                },
@@ -386,14 +461,17 @@
          },
          {
             "datasource": {
-               "type": "datasource",
-               "uid": "-- Mixed --"
+               "type": "prometheus",
+               "uid": "${prometheus_datasource}"
             },
             "description": "Source/Destination pairs and their total traffic across all dimensions. Ordered by total traffic during selected time range",
             "fieldConfig": {
                "defaults": {
                   "color": {
                      "mode": "continuous-BlPu"
+                  },
+                  "custom": {
+                     "filterable": false
                   },
                   "unit": "bytes"
                },
@@ -434,22 +512,23 @@
                "y": 15
             },
             "id": 6,
-            "interval": "1m",
             "options": {
                "footer": {
                   "enablePagination": true
                }
             },
-            "pluginVersion": "v11.4.0",
+            "pluginVersion": "v11.0.0",
             "targets": [
                {
                   "datasource": {
                      "type": "prometheus",
-                     "uid": "$prometheus_datasource"
+                     "uid": "${prometheus_datasource}"
                   },
-                  "expr": "sum(\n  sum_over_time(network_io_by_flow_bytes{device_name=~\"$device_name\",\nnetwork_local_address=~\"$network_local_address\",\nnetwork_peer_address=~\"$network_peer_address\",\njob=~\"$job\"\n}[$__range])\n) by (network_local_address,network_peer_address)\n",
+                  "expr": "sum(increase(beyla_network_flow_bytes_total{job=~\"$job\",job=~\"$job\"}[$__range])) by (src_cidr,dst_cidr)\nor\nsum(increase(obi_network_flow_bytes_total{job=~\"$job\",job=~\"$job\"}[$__range])) by (src_cidr,dst_cidr)\nor\nsum(sum_over_time(network_io_by_flow_bytes{job=~\"$job\",job=~\"$job\"}[$__range])) by (network_local_address,network_peer_address)",
                   "format": "table",
-                  "instant": true
+                  "instant": true,
+                  "legendFormat": "{{job}}: Conversation total bytes",
+                  "refId": "Conversation total bytes"
                }
             ],
             "title": "Conversation total bytes",
@@ -476,8 +555,8 @@
                      "indexByName": { },
                      "renameByName": {
                         "Value": "Bytes",
-                        "network_local_address": "Source",
-                        "network_peer_address": "Destination"
+                        "dst_cidr": "Destination",
+                        "src_cidr": "Source"
                      }
                   }
                }
@@ -486,8 +565,8 @@
          },
          {
             "datasource": {
-               "type": "datasource",
-               "uid": "-- Mixed --"
+               "type": "prometheus",
+               "uid": "${prometheus_datasource}"
             },
             "description": "Traffic distribution of source/destination pairs over time",
             "fieldConfig": {
@@ -501,7 +580,21 @@
                      }
                   },
                   "unit": "bytes"
-               }
+               },
+               "overrides": [
+                  {
+                     "matcher": {
+                        "id": "byFrameRefID",
+                        "options": "Conversation traffic over time"
+                     },
+                     "properties": [
+                        {
+                           "id": "unit",
+                           "value": "Bps"
+                        }
+                     ]
+                  }
+               ]
             },
             "gridPos": {
                "h": 7,
@@ -510,20 +603,23 @@
                "y": 15
             },
             "id": 7,
-            "interval": "1m",
             "options": {
                "legend": {
                   "showLegend": false
                }
             },
-            "pluginVersion": "v11.4.0",
+            "pluginVersion": "v11.0.0",
             "targets": [
                {
                   "datasource": {
                      "type": "prometheus",
-                     "uid": "$prometheus_datasource"
+                     "uid": "${prometheus_datasource}"
                   },
-                  "expr": "sum(network_io_by_flow_bytes{device_name=~\"$device_name\",\nnetwork_local_address=~\"$network_local_address\",\nnetwork_peer_address=~\"$network_peer_address\",\njob=~\"$job\"\n}) by (network_local_address,network_peer_address,device_name)\n"
+                  "expr": "sum(irate(beyla_network_flow_bytes_total{job=~\"$job\",job=~\"$job\"}[$__rate_interval])) by (src_cidr,dst_cidr)\nor\nsum(irate(obi_network_flow_bytes_total{job=~\"$job\",job=~\"$job\"}[$__rate_interval])) by (src_cidr,dst_cidr)\nor\nsum(network_io_by_flow_bytes{job=~\"$job\",job=~\"$job\"}) by (network_local_address,network_peer_address,device_name) / 60",
+                  "format": "time_series",
+                  "instant": false,
+                  "legendFormat": "{{src_cidr}} -> {{ dst_cidr }} // {{job}}",
+                  "refId": "Conversation traffic over time"
                }
             ],
             "title": "Conversation traffic over time",
@@ -535,7 +631,6 @@
                "type": "datasource",
                "uid": "-- Mixed --"
             },
-            "description": "Breakdown of total traffic between source/destination pairs observed during the selected time range",
             "fieldConfig": {
                "defaults": {
                   "unit": "bytes"
@@ -566,11 +661,13 @@
                {
                   "datasource": {
                      "type": "prometheus",
-                     "uid": "$prometheus_datasource"
+                     "uid": "${prometheus_datasource}"
                   },
-                  "expr": "sum(sum_over_time(network_io_by_flow_bytes{device_name=~\"$device_name\",\nnetwork_local_address=~\"$network_local_address\",\nnetwork_peer_address=~\"$network_peer_address\",\njob=~\"$job\"\n}[$__range])) by (network_local_address,network_peer_address)\n",
+                  "expr": "sum(increase(beyla_network_flow_bytes_total{job=~\"$job\",job=~\"$job\"}[$__range])) by (src_cidr,dst_cidr,job)\nor\nsum(increase(obi_network_flow_bytes_total{job=~\"$job\",job=~\"$job\"}[$__range])) by (src_cidr,dst_cidr,job)\nor\nsum(sum_over_time(network_io_by_flow_bytes{job=~\"$job\",job=~\"$job\"}[$__range])) by (network_local_address, network_peer_address, device_name)",
                   "format": "table",
-                  "instant": true
+                  "instant": true,
+                  "legendFormat": "{{src_cidr}} -> {{ dst_cidr }} // {{job}}",
+                  "refId": "Breakdown by source/destination pair"
                }
             ],
             "title": "Breakdown by source/destination pair",
@@ -591,14 +688,17 @@
          },
          {
             "datasource": {
-               "type": "datasource",
-               "uid": "-- Mixed --"
+               "type": "prometheus",
+               "uid": "${prometheus_datasource}"
             },
             "description": "List of protocols and the total amount of observed traffic during the selected time range",
             "fieldConfig": {
                "defaults": {
                   "color": {
                      "mode": "continuous-BlPu"
+                  },
+                  "custom": {
+                     "filterable": false
                   },
                   "unit": "bytes"
                },
@@ -628,17 +728,18 @@
                "y": 31
             },
             "id": 10,
-            "interval": "1m",
-            "pluginVersion": "v11.4.0",
+            "pluginVersion": "v11.0.0",
             "targets": [
                {
                   "datasource": {
                      "type": "prometheus",
-                     "uid": "$prometheus_datasource"
+                     "uid": "${prometheus_datasource}"
                   },
-                  "expr": "sum(sum_over_time(network_io_by_flow_bytes{device_name=~\"$device_name\",\nnetwork_local_address=~\"$network_local_address\",\nnetwork_peer_address=~\"$network_peer_address\",\njob=~\"$job\"\n}[$__range])) by (network_protocol_name)\n",
+                  "expr": "sum(increase(beyla_network_flow_bytes_total{job=~\"$job\",job=~\"$job\"}[$__range])) by (network_protocol_name)\nor\nsum(increase(obi_network_flow_bytes_total{job=~\"$job\",job=~\"$job\"}[$__range])) by (network_protocol_name)\nor\nsum(sum_over_time(network_io_by_flow_bytes{job=~\"$job\",job=~\"$job\"}[$__range])) by (network_protocol_name)",
                   "format": "table",
-                  "instant": true
+                  "instant": true,
+                  "legendFormat": "{{network_protocol_name}}",
+                  "refId": "Total bytes"
                }
             ],
             "title": "Total bytes",
@@ -690,7 +791,6 @@
                "y": 31
             },
             "id": 11,
-            "interval": "1m",
             "options": {
                "legend": {
                   "displayMode": "table",
@@ -709,11 +809,13 @@
                {
                   "datasource": {
                      "type": "prometheus",
-                     "uid": "$prometheus_datasource"
+                     "uid": "${prometheus_datasource}"
                   },
-                  "expr": "sum(sum_over_time(network_io_by_flow_bytes{device_name=~\"$device_name\",\nnetwork_local_address=~\"$network_local_address\",\nnetwork_peer_address=~\"$network_peer_address\",\njob=~\"$job\"\n}[$__range])) by (network_protocol_name)\n",
+                  "expr": "sum(increase(beyla_network_flow_bytes_total{job=~\"$job\",job=~\"$job\"}[$__range])) by (network_protocol_name)\nor\nsum(increase(obi_network_flow_bytes_total{job=~\"$job\",job=~\"$job\"}[$__range])) by (network_protocol_name)\nor\nsum(sum_over_time(network_io_by_flow_bytes{job=~\"$job\",job=~\"$job\"}[$__range])) by (network_protocol_name)",
+                  "format": "table",
                   "instant": true,
-                  "legendFormat": "{{network_protocol_name}}"
+                  "legendFormat": "{{network_protocol_name}}",
+                  "refId": "Total bytes"
                }
             ],
             "title": "Distribution",
@@ -722,8 +824,8 @@
          },
          {
             "datasource": {
-               "type": "datasource",
-               "uid": "-- Mixed --"
+               "type": "prometheus",
+               "uid": "${prometheus_datasource}"
             },
             "description": "Protocols and the amount of observed traffic over the selected time range",
             "fieldConfig": {
@@ -735,9 +837,22 @@
                         "group": "A",
                         "mode": "normal"
                      }
-                  },
-                  "unit": "bytes"
-               }
+                  }
+               },
+               "overrides": [
+                  {
+                     "matcher": {
+                        "id": "byFrameRefID",
+                        "options": "Protocol traffic over time"
+                     },
+                     "properties": [
+                        {
+                           "id": "unit",
+                           "value": "bytes"
+                        }
+                     ]
+                  }
+               ]
             },
             "gridPos": {
                "h": 8,
@@ -746,17 +861,19 @@
                "y": 38
             },
             "id": 12,
-            "interval": "1m",
             "maxDataPoints": 20,
-            "pluginVersion": "v11.4.0",
+            "pluginVersion": "v11.0.0",
             "targets": [
                {
                   "datasource": {
                      "type": "prometheus",
-                     "uid": "$prometheus_datasource"
+                     "uid": "${prometheus_datasource}"
                   },
-                  "expr": "sum(sum_over_time(network_io_by_flow_bytes{device_name=~\"$device_name\",\nnetwork_local_address=~\"$network_local_address\",\nnetwork_peer_address=~\"$network_peer_address\",\njob=~\"$job\"\n}[$__interval])) by (network_protocol_name)\n",
-                  "legendFormat": "{{network_protocol_name}}"
+                  "expr": "sum(increase(beyla_network_flow_bytes_total{job=~\"$job\",job=~\"$job\"}[$__interval])) by (network_protocol_name)\nor\nsum(increase(obi_network_flow_bytes_total{job=~\"$job\",job=~\"$job\"}[$__interval])) by (network_protocol_name)\nor\nsum(sum_over_time(network_io_by_flow_bytes{job=~\"$job\",job=~\"$job\"}[$__interval])) by (network_protocol_name)",
+                  "format": "time_series",
+                  "instant": false,
+                  "legendFormat": "{{network_protocol_name}}",
+                  "refId": "Protocol traffic over time"
                }
             ],
             "title": "Protocol traffic over time",
@@ -796,7 +913,6 @@
                "y": 47
             },
             "id": 14,
-            "interval": "1m",
             "options": {
                "layers": [
                   {
@@ -829,11 +945,13 @@
                {
                   "datasource": {
                      "type": "prometheus",
-                     "uid": "$prometheus_datasource"
+                     "uid": "${prometheus_datasource}"
                   },
-                  "expr": "sum(sum_over_time(network_io_by_flow_bytes{device_name=~\"$device_name\",\nnetwork_local_address=~\"$network_local_address\",\nnetwork_peer_address=~\"$network_peer_address\",\njob=~\"$job\"\n,network_peer_country!=\"Private IP\"}[$__range])) by (network_peer_country)\n",
+                  "expr": "sum(increase(beyla_network_flow_bytes_total{job=~\"$job\",job=~\"$job\"}[$__range])) by (dst_country)\nor\nsum(increase(obi_network_flow_bytes_total{job=~\"$job\",job=~\"$job\"}[$__range])) by (dst_country)\nor\nsum(sum_over_time(network_io_by_flow_bytes{job=~\"$job\",job=~\"$job\",network_peer_country!=\"Private IP\"}[$__range])) by (network_peer_country)",
                   "format": "table",
-                  "instant": true
+                  "instant": true,
+                  "legendFormat": "{{job}}: Traffic by destination",
+                  "refId": "Traffic by destination"
                }
             ],
             "title": "Top destination",
@@ -841,14 +959,17 @@
          },
          {
             "datasource": {
-               "type": "datasource",
-               "uid": "-- Mixed --"
+               "type": "prometheus",
+               "uid": "${prometheus_datasource}"
             },
             "description": "Total traffic to specific countries during the selected time range",
             "fieldConfig": {
                "defaults": {
                   "color": {
                      "mode": "continuous-BlPu"
+                  },
+                  "custom": {
+                     "filterable": false
                   },
                   "unit": "bytes"
                },
@@ -899,19 +1020,21 @@
                   "enablePagination": true
                }
             },
-            "pluginVersion": "v11.4.0",
+            "pluginVersion": "v11.0.0",
             "targets": [
                {
                   "datasource": {
                      "type": "prometheus",
-                     "uid": "$prometheus_datasource"
+                     "uid": "${prometheus_datasource}"
                   },
-                  "expr": "sum(sum_over_time(network_io_by_flow_bytes{device_name=~\"$device_name\",\nnetwork_local_address=~\"$network_local_address\",\nnetwork_peer_address=~\"$network_peer_address\",\njob=~\"$job\"\n,network_peer_country!=\"Private IP\"}[$__range])) by (network_peer_country)\n",
+                  "expr": "sum(increase(beyla_network_flow_bytes_total{job=~\"$job\",job=~\"$job\"}[$__range])) by (dst_country)\nor\nsum(increase(obi_network_flow_bytes_total{job=~\"$job\",job=~\"$job\"}[$__range])) by (dst_country)\nor\nsum(sum_over_time(network_io_by_flow_bytes{job=~\"$job\",job=~\"$job\",network_peer_country!=\"Private IP\"}[$__range])) by (network_peer_country)",
                   "format": "table",
-                  "instant": true
+                  "instant": true,
+                  "legendFormat": "{{job}}: Traffic by destination",
+                  "refId": "Traffic by destination"
                }
             ],
-            "title": "",
+            "title": "Traffic by destination",
             "transformations": [
                {
                   "id": "sortBy",
@@ -935,8 +1058,8 @@
                      "indexByName": { },
                      "renameByName": {
                         "Value": "Bytes",
-                        "network_local_country": "Country",
-                        "network_peer_country": "Country"
+                        "dst_country": "Country",
+                        "src_country": "Country"
                      }
                   }
                }
@@ -964,7 +1087,6 @@
                "y": 47
             },
             "id": 16,
-            "interval": "1m",
             "options": {
                "layers": [
                   {
@@ -982,7 +1104,7 @@
                         "options": "A"
                      },
                      "location": {
-                        "lookup": "network_local_country",
+                        "lookup": "src_country",
                         "mode": "lookup"
                      },
                      "name": "Destinations",
@@ -997,11 +1119,13 @@
                {
                   "datasource": {
                      "type": "prometheus",
-                     "uid": "$prometheus_datasource"
+                     "uid": "${prometheus_datasource}"
                   },
-                  "expr": "sum(sum_over_time(network_io_by_flow_bytes{device_name=~\"$device_name\",\nnetwork_local_address=~\"$network_local_address\",\nnetwork_peer_address=~\"$network_peer_address\",\njob=~\"$job\"\n,network_local_country!=\"Private IP\"}[$__range])) by (network_local_country)\n",
+                  "expr": "sum(increase(beyla_network_flow_bytes_total{job=~\"$job\",job=~\"$job\"}[$__range])) by (src_country)\nor\nsum(increase(obi_network_flow_bytes_total{job=~\"$job\",job=~\"$job\"}[$__range])) by (src_country)\nor\nsum(sum_over_time(network_io_by_flow_bytes{job=~\"$job\",job=~\"$job\",network_local_country!=\"Private IP\"}[$__range])) by (network_local_country)",
                   "format": "table",
-                  "instant": true
+                  "instant": true,
+                  "legendFormat": "{{job}}: Traffic by Source",
+                  "refId": "Traffic by Source"
                }
             ],
             "title": "Top sources",
@@ -1009,14 +1133,17 @@
          },
          {
             "datasource": {
-               "type": "datasource",
-               "uid": "-- Mixed --"
+               "type": "prometheus",
+               "uid": "${prometheus_datasource}"
             },
             "description": "Total traffic from specific countries during the selected time range",
             "fieldConfig": {
                "defaults": {
                   "color": {
                      "mode": "continuous-BlPu"
+                  },
+                  "custom": {
+                     "filterable": false
                   },
                   "unit": "bytes"
                },
@@ -1067,19 +1194,21 @@
                   "enablePagination": true
                }
             },
-            "pluginVersion": "v11.4.0",
+            "pluginVersion": "v11.0.0",
             "targets": [
                {
                   "datasource": {
                      "type": "prometheus",
-                     "uid": "$prometheus_datasource"
+                     "uid": "${prometheus_datasource}"
                   },
-                  "expr": "sum(sum_over_time(network_io_by_flow_bytes{device_name=~\"$device_name\",\nnetwork_local_address=~\"$network_local_address\",\nnetwork_peer_address=~\"$network_peer_address\",\njob=~\"$job\"\n,network_local_country!=\"Private IP\"}[$__range])) by (network_local_country)\n",
+                  "expr": "sum(increase(beyla_network_flow_bytes_total{job=~\"$job\",job=~\"$job\"}[$__range])) by (src_country)\nor\nsum(increase(obi_network_flow_bytes_total{job=~\"$job\",job=~\"$job\"}[$__range])) by (src_country)\nor\nsum(sum_over_time(network_io_by_flow_bytes{job=~\"$job\",job=~\"$job\",network_local_country!=\"Private IP\"}[$__range])) by (network_local_country)",
                   "format": "table",
-                  "instant": true
+                  "instant": true,
+                  "legendFormat": "{{job}}: Traffic by Source",
+                  "refId": "Traffic by Source"
                }
             ],
-            "title": "",
+            "title": "Traffic by source",
             "transformations": [
                {
                   "id": "sortBy",
@@ -1103,8 +1232,8 @@
                      "indexByName": { },
                      "renameByName": {
                         "Value": "Bytes",
-                        "network_local_country": "Country",
-                        "network_peer_country": "Country"
+                        "dst_country": "Country",
+                        "src_country": "Country"
                      }
                   }
                }
@@ -1180,10 +1309,13 @@
                {
                   "datasource": {
                      "type": "prometheus",
-                     "uid": "$prometheus_datasource"
+                     "uid": "${prometheus_datasource}"
                   },
-                  "expr": "sum(network_io_by_flow_bytes{device_name=~\"$device_name\",\nnetwork_local_address=~\"$network_local_address\",\nnetwork_peer_address=~\"$network_peer_address\",\njob=~\"$job\"\n}) by (device_name)\n",
-                  "legendFormat": "{{device_name}}"
+                  "expr": "sum(irate(beyla_network_flow_bytes_total{job=~\"$job\",job=~\"$job\"}[$__rate_interval])) by (job)\nor\nsum(irate(obi_network_flow_bytes_total{job=~\"$job\",job=~\"$job\"}[$__rate_interval])) by (job)\nor\nsum(network_io_by_flow_bytes{job=~\"$job\",job=~\"$job\"}) by (device_name)",
+                  "format": "time_series",
+                  "instant": false,
+                  "legendFormat": "{{job}}: Traffic rate",
+                  "refId": "Traffic rate"
                }
             ],
             "title": "Devices sending flows",
@@ -1198,73 +1330,61 @@
       "templating": {
          "list": [
             {
-               "label": "Prometheus data source",
+               "label": "Data source",
                "name": "prometheus_datasource",
                "query": "prometheus",
-               "type": "datasource"
-            },
-            {
-               "label": "Loki data source",
-               "name": "loki_datasource",
-               "query": "loki",
+               "regex": "",
                "type": "datasource"
             },
             {
                "allValue": ".+",
                "datasource": {
                   "type": "prometheus",
-                  "uid": "$prometheus_datasource"
+                  "uid": "${prometheus_datasource}"
                },
-               "hide": 2,
                "includeAll": true,
                "label": "Job",
                "multi": true,
                "name": "job",
-               "query": "label_values(job)",
+               "query": "label_values({__name__=~\"obi_network_flow_bytes_total|network_io_by_flow_bytes|beyla_network_flow_bytes_total\"}, job)",
                "refresh": 2,
+               "sort": 1,
                "type": "query"
             },
             {
                "allValue": ".+",
                "datasource": {
                   "type": "prometheus",
-                  "uid": "$prometheus_datasource"
+                  "uid": "${prometheus_datasource}"
                },
                "includeAll": true,
-               "label": "Device name",
+               "label": "Job",
                "multi": true,
-               "name": "device_name",
-               "query": "label_values(device_name)",
+               "name": "job",
+               "query": "label_values({__name__=~\"obi_network_flow_bytes_total|network_io_by_flow_bytes|beyla_network_flow_bytes_total\",job=~\"$job\"}, job)",
                "refresh": 2,
+               "sort": 1,
                "type": "query"
             },
             {
-               "allValue": ".+",
                "datasource": {
                   "type": "prometheus",
-                  "uid": "$prometheus_datasource"
+                  "uid": "${prometheus_datasource}"
                },
-               "includeAll": true,
-               "label": "Source",
-               "multi": true,
-               "name": "network_local_address",
-               "query": "label_values(network_local_address)",
-               "refresh": 2,
-               "type": "query"
-            },
-            {
-               "allValue": ".+",
-               "datasource": {
-                  "type": "prometheus",
-                  "uid": "$prometheus_datasource"
-               },
-               "includeAll": true,
-               "label": "Destination",
-               "multi": true,
-               "name": "network_peer_address",
-               "query": "label_values(network_peer_address)",
-               "refresh": 2,
-               "type": "query"
+               "defaultKeys": [
+                  {
+                     "text": "src_cidr",
+                     "value": "src_cidr"
+                  },
+                  {
+                     "text": "dst_cidr",
+                     "value": "dst_cidr"
+                  }
+               ],
+               "description": "Add additional filters",
+               "label": "Ad hoc filters",
+               "name": "adhoc",
+               "type": "adhoc"
             }
          ]
       },

--- a/netflow-mixin/debug.jsonnet
+++ b/netflow-mixin/debug.jsonnet
@@ -1,0 +1,15 @@
+// debug file to use with grafanactl
+
+local mixin = (import 'mixin.libsonnet');
+local d = mixin.grafanaDashboards['netflow-overview.json'];
+{
+  apiVersion: 'dashboard.grafana.app/v1beta1',
+  kind: 'Dashboard',
+  metadata: {
+    name: d.uid,
+    annotations: {
+      'grafana.app/folder': '',
+    },
+  },
+  spec: d,
+}

--- a/netflow-mixin/jsonnetfile.json
+++ b/netflow-mixin/jsonnetfile.json
@@ -9,6 +9,15 @@
         }
       },
       "version": "main"
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": "common-lib"
+        }
+      },
+      "version": "master"
     }
   ],
   "legacyImports": true

--- a/netflow-mixin/signals/main.libsonnet
+++ b/netflow-mixin/signals/main.libsonnet
@@ -1,0 +1,293 @@
+local commonlib = import 'common-lib/common/main.libsonnet';
+
+
+local jsonSignals =
+  {
+    aggLevel: 'group',
+    groupLabels: ['job'],
+    instanceLabels: ['job'],
+    // filteringSelector: 'job=~"integrations/ktranslate-netflow|integrations/beyla-host-network"',
+    filteringSelector: '',
+    datasource: 'prometheus_datasource',
+    varAdHocEnabled: true,
+    // varAdHocLabels: ['network_local_address', 'network_peer_address'],
+    varAdHocLabels: ['src_cidr', 'dst_cidr'],
+    discoveryMetric: {
+      ktranslate: 'network_io_by_flow_bytes',
+      obi: 'obi_network_flow_bytes_total',
+      beyla: 'beyla_network_flow_bytes_total',
+    },
+    signals: {
+      trafficRate: {
+        name: 'Traffic rate',
+        type: 'raw',
+        aggLevel: 'instance',
+        description: 'Total observed traffic, aggregated by collecting device',
+        unit: 'Bps',
+        sources: {
+          local s = self,
+          ktranslate: {
+            expr: 'sum(network_io_by_flow_bytes{%(queriesSelector)s}) by (device_name)',
+          },
+          beyla: {
+            expr: 'sum(irate(beyla_network_flow_bytes_total{%(queriesSelector)s}[%(interval)s])) by (job)',
+          },
+          obi: {
+            expr: std.strReplace(s.beyla.expr, 'beyla', 'obi'),
+          },
+        },
+      },
+      collectingDevices: {
+        name: 'Collecting Devices',
+        type: 'raw',
+        aggLevel: 'instance',
+        description: 'Number of devices collecting flows',
+        unit: 'short',
+        sources: {
+          local s = self,
+          legend:: 'Collecting devices',
+          ktranslate: {
+            expr: 'count(count(network_io_by_flow_bytes{%(queriesSelector)s}) by (device_name))',
+            legendCustomTemplate: s.legend,
+          },
+          beyla: {
+            expr: 'count(count(beyla_network_flow_bytes_total{%(queriesSelector)s}) by (job))',
+            legendCustomTemplate: s.legend,
+          },
+          obi: {
+            expr: std.strReplace(s.beyla.expr, 'beyla', 'obi'),
+            legendCustomTemplate: s.legend,
+          },
+        },
+      },
+      sources: {
+        name: 'Sources',
+        type: 'raw',
+        aggLevel: 'instance',
+        description: 'Number of unique sources over the time range',
+        unit: 'short',
+        sources: {
+          local s = self,
+          legend:: 'Sources',
+          ktranslate: {
+            expr: 'count(count(network_io_by_flow_bytes{%(queriesSelector)s}) by (network_local_address))',
+            legendCustomTemplate: s.legend,
+          },
+          beyla: {
+            expr: 'count(count(beyla_network_flow_bytes_total{%(queriesSelector)s}) by (src_cidr))',
+            legendCustomTemplate: s.legend,
+          },
+          obi: {
+            expr: std.strReplace(s.beyla.expr, 'beyla', 'obi'),
+            legendCustomTemplate: s.legend,
+          },
+        },
+      },
+      destinations: {
+        name: 'Destinations',
+        type: 'raw',
+        aggLevel: 'instance',
+        description: 'Number of unique destinations over the time range',
+        unit: 'short',
+        sources: {
+          local s = self,
+          legend:: 'Destinations',
+          ktranslate: {
+            expr: 'count(count(network_io_by_flow_bytes{%(queriesSelector)s}) by (network_peer_address))',
+            legendCustomTemplate: s.legend,
+          },
+          beyla: {
+            expr: 'count(count(beyla_network_flow_bytes_total{%(queriesSelector)s}) by (dst_cidr))',
+            legendCustomTemplate: s.legend,
+          },
+          obi: {
+            expr: std.strReplace(s.beyla.expr, 'beyla', 'obi'),
+            legendCustomTemplate: s.legend,
+          },
+        },
+      },
+      totalTraffic: {
+        name: 'Total Traffic',
+        type: 'raw',
+        aggLevel: 'instance',
+        description: 'Number of unique destinations over the time range',
+        unit: 'bytes',
+        sources: {
+          local s = self,
+          legend:: 'Total observed traffic',
+          ktranslate: {
+            expr: 'sum(sum_over_time(network_io_by_flow_bytes{%(queriesSelector)s}[$__range]))',
+            legendCustomTemplate: s.legend,
+          },
+          beyla: {
+            expr: 'sum(increase(beyla_network_flow_bytes_total{%(queriesSelector)s}[$__range]))',
+            legendCustomTemplate: s.legend,
+          },
+          obi: {
+            expr: std.strReplace(s.beyla.expr, 'beyla', 'obi'),
+            legendCustomTemplate: s.legend,
+          },
+        },
+      },
+      topSources: {
+        name: 'Top sources',
+        type: 'raw',
+        description: 'Source adresses ordered by observed traffic during the time range',
+        unit: 'bytes',
+        sources: {
+          local s = self,
+          ktranslate: {
+            expr: 'topk(5,network_io_by_flow_bytes{%(queriesSelector)s})',
+          },
+          beyla: {
+            expr: 'topk(5,increase(beyla_network_flow_bytes_total{%(queriesSelector)s}[$__range]))',
+          },
+          obi: {
+            expr: std.strReplace(s.beyla.expr, 'beyla', 'obi'),
+          },
+        },
+      },
+      conversationTraffic: {
+        name: 'Conversation total bytes',
+        type: 'raw',
+        description: 'Source/Destination pairs and their total traffic across all dimensions. Ordered by total traffic during selected time range',
+        unit: 'bytes',
+        sources: {
+          local s = self,
+          ktranslate: {
+            expr: 'sum(sum_over_time(network_io_by_flow_bytes{%(queriesSelector)s}[$__range])) by (network_local_address,network_peer_address)',
+          },
+          beyla: {
+            expr: 'sum(increase(beyla_network_flow_bytes_total{%(queriesSelector)s}[$__range])) by (src_cidr,dst_cidr)',
+          },
+          obi: {
+            expr: std.strReplace(s.beyla.expr, 'beyla', 'obi'),
+          },
+        },
+      },
+      conversationTrafficOverTime: {
+        name: 'Conversation traffic over time',
+        type: 'raw',
+        description: 'Traffic distribution of source/destination pairs over time',
+        unit: 'Bps',
+        sources: {
+          local s = self,
+          ktranslate: {
+            expr: 'sum(network_io_by_flow_bytes{%(queriesSelector)s}) by (network_local_address,network_peer_address,device_name) / 60',
+            legendCustomTemplate: '{{network_local_address}} -> {{ network_peer_address }} // {{device_name}}',
+          },
+          beyla: {
+            expr: 'sum(irate(beyla_network_flow_bytes_total{%(queriesSelector)s}[%(interval)s])) by (src_cidr,dst_cidr)',
+            legendCustomTemplate: '{{src_cidr}} -> {{ dst_cidr }} // {{job}}',
+          },
+          obi: {
+            expr: std.strReplace(s.beyla.expr, 'beyla', 'obi'),
+            legendCustomTemplate: s.ktranslate.legendCustomTemplate,
+          },
+        },
+      },
+      conversationPairs: {
+        name: 'Breakdown by source/destination pair',
+        type: 'raw',
+        description: 'Breakdown of total traffic between source/destination pairs observed during the selected time range',
+        unit: 'bytes',
+        sources: {
+          local s = self,
+          ktranslate: {
+            expr: 'sum(sum_over_time(network_io_by_flow_bytes{%(queriesSelector)s}[$__range])) by (network_local_address, network_peer_address, device_name)',
+            legendCustomTemplate: '{{network_local_address}} -> {{ network_peer_address }} // {{device_name}}',
+          },
+          beyla: {
+            expr: 'sum(increase(beyla_network_flow_bytes_total{%(queriesSelector)s}[$__range])) by (src_cidr,dst_cidr,job)',
+            legendCustomTemplate: '{{src_cidr}} -> {{ dst_cidr }} // {{job}}',
+          },
+          obi: {
+            expr: std.strReplace(s.beyla.expr, 'beyla', 'obi'),
+            legendCustomTemplate: s.beyla.legendCustomTemplate,
+          },
+        },
+      },
+      protocolTraffic: {
+        name: 'Total bytes',
+        type: 'raw',
+        description: 'List of protocols and the total amount of observed traffic during the selected time range',
+        unit: 'bytes',
+        sources: {
+          local s = self,
+          legend:: '{{network_protocol_name}}',
+          ktranslate: {
+            expr: 'sum(sum_over_time(network_io_by_flow_bytes{%(queriesSelector)s}[$__range])) by (network_protocol_name)',
+            legendCustomTemplate: s.legend,
+          },
+          beyla: {
+            expr: 'sum(increase(beyla_network_flow_bytes_total{%(queriesSelector)s}[$__range])) by (network_protocol_name)',
+            legendCustomTemplate: s.legend,
+          },
+          obi: {
+            expr: std.strReplace(s.beyla.expr, 'beyla', 'obi'),
+            legendCustomTemplate: s.legend,
+          },
+        },
+      },
+      protocolOverTime: {
+        name: 'Protocol traffic over time',
+        type: 'raw',
+        description: 'Protocols and the amount of observed traffic over the selected time range',
+        unit: 'bytes',
+        sources: {
+          local s = self,
+          legend:: '{{network_protocol_name}}',
+          ktranslate: {
+            expr: 'sum(sum_over_time(network_io_by_flow_bytes{%(queriesSelector)s}[$__interval])) by (network_protocol_name)',
+            legendCustomTemplate: s.legend,
+          },
+          beyla: {
+            expr: 'sum(increase(beyla_network_flow_bytes_total{%(queriesSelector)s}[$__interval])) by (network_protocol_name)',
+            legendCustomTemplate: s.legend,
+          },
+          obi: {
+            expr: std.strReplace(s.beyla.expr, 'beyla', 'obi'),
+            legendCustomTemplate: s.legend,
+          },
+        },
+      },
+      trafficByDestination: {
+        name: 'Traffic by destination',
+        type: 'raw',
+        description: 'Total traffic to specific countries during the selected time range',
+        unit: 'bytes',
+        sources: {
+          local s = self,
+          ktranslate: {
+            expr: 'sum(sum_over_time(network_io_by_flow_bytes{%(queriesSelector)s,network_peer_country!="Private IP"}[$__range])) by (network_peer_country)',
+          },
+          beyla: {
+            expr: 'sum(increase(beyla_network_flow_bytes_total{%(queriesSelector)s}[$__range])) by (dst_country)',
+          },
+          obi: {
+            expr: std.strReplace(s.beyla.expr, 'beyla', 'obi'),
+          },
+        },
+      },
+      trafficBySource: {
+        name: 'Traffic by Source',
+        type: 'raw',
+        description: 'Total traffic from specific countries during the selected time range',
+        unit: 'bytes',
+        sources: {
+          local s = self,
+          ktranslate: {
+            expr: 'sum(sum_over_time(network_io_by_flow_bytes{%(queriesSelector)s,network_local_country!="Private IP"}[$__range])) by (network_local_country)',
+          },
+          beyla: {
+            expr: 'sum(increase(beyla_network_flow_bytes_total{%(queriesSelector)s}[$__range])) by (src_country)',
+          },
+          obi: {
+            expr: std.strReplace(s.beyla.expr, 'beyla', 'obi'),
+          },
+        },
+      },
+    },
+  };
+
+commonlib.signals.unmarshallJsonMulti(jsonSignals, type=['obi', 'ktranslate', 'beyla'])


### PR DESCRIPTION
OBI/Beyla supports network observability based on netflow. Due to the similarity in data produced, we can reuse the existing mixin to support the existing spec as well as metrics exposed by OBI/Beyla.

Since the existing metrics are based on gauges instead of counters, we cannot use the signals library for its full effect but have to resort to writing `raw` queries. Still, having everything in one place allows for a single "best-practice" dashboard for netflow analytics