### PR TITLE
Fix memcached dashboard hit rate query 

### DIFF
--- a/memcached-mixin/dashboards.libsonnet
+++ b/memcached-mixin/dashboards.libsonnet
@@ -18,7 +18,7 @@ local g = (import 'grafana-builder/grafana.libsonnet');
         g.row('Hits')
         .addPanel(
           g.panel('Hit Rate') +
-          g.queryPanel('sum(rate(memcached_commands_total{' + $._config.clusterLabel + '=~"$cluster", namespace=~"$namespace", job=~"$job", instance=~"$instance", command="get", status="hit"}[$__rate_interval])) / sum(rate(memcached_commands_total{' + $._config.clusterLabel + '=~"$cluster", namespace=~"$namespace", job=~"$job", command="get"}[$__rate_interval]))', 'Hit Rate') +
+          g.queryPanel('sum(rate(memcached_commands_total{' + $._config.clusterLabel + '=~"$cluster", namespace=~"$namespace", job=~"$job", instance=~"$instance", command="get", status="hit"}[$__rate_interval])) / sum(rate(memcached_commands_total{' + $._config.clusterLabel + '=~"$cluster", namespace=~"$namespace", job=~"$job", instance=~"$instance", command="get"}[$__rate_interval]))', 'Hit Rate') +
           { yaxes: g.yaxes('percentunit') },
         )
         .addPanel(

--- a/memcached-mixin/dashboards_out/memcached-overview.json
+++ b/memcached-mixin/dashboards_out/memcached-overview.json
@@ -45,7 +45,7 @@
                   "steppedLine": false,
                   "targets": [
                      {
-                        "expr": "sum(rate(memcached_commands_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", command=\"get\", status=\"hit\"}[$__rate_interval])) / sum(rate(memcached_commands_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", command=\"get\"}[$__rate_interval]))",
+                        "expr": "sum(rate(memcached_commands_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", command=\"get\", status=\"hit\"}[$__rate_interval])) / sum(rate(memcached_commands_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", command=\"get\"}[$__rate_interval]))",
                         "format": "time_series",
                         "legendFormat": "Hit Rate",
                         "legendLink": null


### PR DESCRIPTION
The hit rate query was missing the `instance` filter in denominator.