### PR TITLE
Bump jsonnet to 0.22

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         with:
-          go-version: 1.23
+          go-version: 1.25
       - name: Tools cache
         id: tools-cache
         uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5
@@ -52,7 +52,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         with:
-          go-version: 1.23
+          go-version: 1.25
       - name: Restore Tools cache
         uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5
         with:
@@ -76,7 +76,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         with:
-          go-version: 1.23
+          go-version: 1.25
       - name: Restore Tools cache
         uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5
         with:

--- a/.github/workflows/test-mixins.yml
+++ b/.github/workflows/test-mixins.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         with:
-          go-version: 1.23
+          go-version: 1.25
       - name: Tools cache
         id: tools-cache
         uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5
@@ -98,7 +98,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         with:
-          go-version: 1.23
+          go-version: 1.25
       - name: Restore Tools cache
         uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5
         with:

--- a/Makefile
+++ b/Makefile
@@ -20,11 +20,11 @@ endif
 # Check if .github/workflows/*.yml need to be updated
 # when changing the install-ci-deps target.
 install-ci-deps: install-promtool
-	go install github.com/google/go-jsonnet/cmd/jsonnet@v0.20.0
-	go install github.com/google/go-jsonnet/cmd/jsonnetfmt@v0.20.0
-	go install github.com/google/go-jsonnet/cmd/jsonnet-lint@v0.20.0
+	go install github.com/google/go-jsonnet/cmd/jsonnet@v0.22.0
+	go install github.com/google/go-jsonnet/cmd/jsonnetfmt@v0.22.0
+	go install github.com/google/go-jsonnet/cmd/jsonnet-lint@v0.22.0
 	go install github.com/monitoring-mixins/mixtool/cmd/mixtool@main
-	go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@v0.5.1
+	go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@v0.6.0
 	go install github.com/grafana/grizzly/cmd/grr@latest
 	go install github.com/cloudflare/pint/cmd/pint@v0.70.0
 


### PR DESCRIPTION
The new version of jsonnet brings some nice features such as negative offset for arrays, removing the dependency on xtd package in some mixins: https://github.com/jsonnet-libs/xtd
jb is also updated to the latest version that fixes transient dependencies behaviour 
https://github.com/jsonnet-bundler/jsonnet-bundler/issues/160