### PR TITLE
chore(commonlib): panel requests.stat.errors use default palette color 

### DIFF
--- a/common-lib/CHANGELOG.md
+++ b/common-lib/CHANGELOG.md
@@ -1,6 +1,9 @@
+# 0.6.2
+- [Panels] chore: panel requests.stat.errors use default palette color if there are no errors and red color if erorrs > 0.
+
 # 0.6.1
-- [Signal] chore: bump grafonnet to 11.4.0
-- [Panels] chore: add tests for generic panels
+- [Signal] chore: bump grafonnet to 11.4.0.
+- [Panels] chore: add tests for generic panels.
 
 # 0.6.0
 - [Signal] feat: add new type of aggregation "aggKeepLabels" in addition to "group", "instance", "none".

--- a/common-lib/common/panels/requests/stat/errors.libsonnet
+++ b/common-lib/common/panels/requests/stat/errors.libsonnet
@@ -14,5 +14,21 @@ base {
     + stat.standardOptions.color.withMode(tokens.base.colors.mode.monochrome)
     + stat.standardOptions.color.withFixedColor(tokens.base.colors.palette.errors)
     + stat.standardOptions.withNoValue('No errors')
-    + stat.options.withGraphMode('none'),
+    + stat.options.withGraphMode('none')
+    // use default color if there are no errors
+    + stat.standardOptions.withMappingsMixin([
+      stat.standardOptions.mapping.SpecialValueMap.withType()
+      + stat.standardOptions.mapping.SpecialValueMap.options.withMatch('null')
+      + stat.standardOptions.mapping.SpecialValueMap.options.result.withIndex(0)
+      + stat.standardOptions.mapping.SpecialValueMap.options.result.withColor(tokens.base.colors.palette.default),
+      stat.standardOptions.mapping.ValueMap.withType()
+      + stat.standardOptions.mapping.ValueMap.withOptions(
+        {
+          '0': {
+            color: tokens.base.colors.palette.default,
+            index: 1,
+          },
+        }
+      ),
+    ]),
 }


### PR DESCRIPTION
panel `requests.stat.errors` use default palette color (defined in tokens) if there are no errors, and red color if errors > 0.