### PR TITLE
fix(chore): include squid screenshots in readme for the mixin

### DIFF
--- a/squid-mixin/README.md
+++ b/squid-mixin/README.md
@@ -18,9 +18,9 @@ and the following alerts:
 
 The Squid overview dashboard provides details on both server and client HTTP, FTP, and other requests, caching hits and misses, and both cache and access logs.
 
-![First screenshot of the Squid overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/sap-hana/screenshots/squid_overview_1.png)
-![Second screenshot of the Squid overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/sap-hana/screenshots/squid_overview_2.png)
-![Screenshot of the Squid logs dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/sap-hana/screenshots/squid_logs.png)
+![First screenshot of the Squid overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/squid/screenshots/squid_overview_1.png)
+![Second screenshot of the Squid overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/squid/screenshots/squid_overview_2.png)
+![Screenshot of the Squid logs dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/squid/screenshots/squid_logs_1.png)
 
 Squid logs are enabled by default in the `config.libsonnet` and can be removed by setting `enableLokiLogs` to `false`. Then run `make` again to regenerate the dashboard:
 

--- a/squid-mixin/README.md
+++ b/squid-mixin/README.md
@@ -18,7 +18,9 @@ and the following alerts:
 
 The Squid overview dashboard provides details on both server and client HTTP, FTP, and other requests, caching hits and misses, and both cache and access logs.
 
-![TODO Dashboard screenshots]()
+![First screenshot of the Squid overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/sap-hana/screenshots/squid_overview_1.png)
+![Second screenshot of the Squid overview dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/sap-hana/screenshots/squid_overview_2.png)
+![Screenshot of the Squid logs dashboard](https://storage.googleapis.com/grafanalabs-integration-assets/sap-hana/screenshots/squid_logs.png)
 
 Squid logs are enabled by default in the `config.libsonnet` and can be removed by setting `enableLokiLogs` to `false`. Then run `make` again to regenerate the dashboard:
 

--- a/squid-mixin/dashboards_out/squid-overview.json
+++ b/squid-mixin/dashboards_out/squid-overview.json
@@ -71,7 +71,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -133,7 +133,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -195,7 +195,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -257,7 +257,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -319,7 +319,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -381,7 +381,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -443,7 +443,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -525,7 +525,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -610,7 +610,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -711,7 +711,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -802,7 +802,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -893,7 +893,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -984,7 +984,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -1059,7 +1059,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -1147,7 +1147,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {


### PR DESCRIPTION
Noticed that these screenshots were still marked TODO after the mixin has been released/used for a while. This PR updates the references to be (soon) available screenshots of the mixin.