### PR TITLE
mysqld-exporter: use configMapVolumeMount to restart pods on config changes

### DIFF
--- a/mysqld-exporter/main.libsonnet
+++ b/mysqld-exporter/main.libsonnet
@@ -1,6 +1,6 @@
 local k = import 'ksonnet-util/kausal.libsonnet';
 local configMap = k.core.v1.configMap;
-local configVolumeMount = k.util.configVolumeMount;
+local configMapVolumeMount = k.util.configMapVolumeMount;
 local container = k.core.v1.container;
 
 {
@@ -54,7 +54,7 @@ local container = k.core.v1.container;
             DATA_SOURCE_NAME: '$(MYSQL_USER):$(MYSQL_PASSWORD)@tcp($(MYSQL_HOST):$(MYSQL_PORT))/?tls=$(MYSQL_TLS_MODE)',
           }),
         ]
-      ) + (if needsConfigFile then configVolumeMount(configMapName, '/conf') else {}),
+      ) + (if needsConfigFile then configMapVolumeMount(this.configMap, '/conf') else {}),
 
     service:
       k.util.serviceFor(this.deployment),


### PR DESCRIPTION
Switch from `configVolumeMount` (takes a name string, no hash tracking) to `configMapVolumeMount` (takes the configMap object), which injects a `<configmap-name>-hash` annotation on the pod template computed from the full configmap content.

Without this, pods mounting the configmap would not restart when its data changed, causing them to run with stale configuration until manually restarted.