### PR TITLE
temporal-mixin: add Billable Actions section to overview dashboard

### DIFF
--- a/temporal-mixin/dashboards/temporal-overview.json
+++ b/temporal-mixin/dashboards/temporal-overview.json
@@ -7578,7 +7578,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "(sum(avg_over_time(temporal_cloud_v1_billable_action_count{temporal_namespace=~\"$temporal_namespace\"}[30d])) * 30 * 24 * 3600) or vector(0)",
+          "expr": "sum(sum_over_time(temporal_cloud_v1_billable_action_count{temporal_namespace=~\"$temporal_namespace\"}[30d])/(30 * 24 * 60) * 30 * 24 * 60 * 60) or vector(0)",
           "legendFormat": "",
           "refId": "A"
         }
@@ -7646,7 +7646,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "(sum(avg_over_time(temporal_cloud_v1_billable_action_count{temporal_namespace=~\"$temporal_namespace\"}[7d])) * 7 * 24 * 3600) or vector(0)",
+          "expr": "sum(sum_over_time(temporal_cloud_v1_billable_action_count{temporal_namespace=~\"$temporal_namespace\"}[7d])/(7 * 24 * 60) * 7 * 24 * 60 * 60) or vector(0)",
           "legendFormat": "",
           "refId": "A"
         }
@@ -7714,7 +7714,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "(sum(avg_over_time(temporal_cloud_v1_billable_action_count{temporal_namespace=~\"$temporal_namespace\"}[$__range])) * $__range_s) or vector(0)",
+          "expr": "sum(sum_over_time(temporal_cloud_v1_billable_action_count{temporal_namespace=~\"$temporal_namespace\"}[$__range])/($__range_s / 60) * $__range_s) or vector(0)",
           "legendFormat": "",
           "refId": "A"
         }

--- a/temporal-mixin/dashboards/temporal-overview.json
+++ b/temporal-mixin/dashboards/temporal-overview.json
@@ -7714,7 +7714,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(sum_over_time(temporal_cloud_v1_billable_action_count{temporal_namespace=~\"$temporal_namespace\"}[$__range])/($__range_s / 60) * $__range_s) or vector(0)",
+          "expr": "sum(sum_over_time(temporal_cloud_v1_billable_action_count{temporal_namespace=~\"$temporal_namespace\"}[$__range])*60) or vector(0)",
           "legendFormat": "",
           "refId": "A"
         }

--- a/temporal-mixin/dashboards/temporal-overview.json
+++ b/temporal-mixin/dashboards/temporal-overview.json
@@ -7657,7 +7657,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "title": "Range Billable Actions",
+      "title": "Billable actions for current timespan",
       "description": "Estimated total billable actions within the selected dashboard time range",
       "type": "stat",
       "id": 129,

--- a/temporal-mixin/dashboards/temporal-overview.json
+++ b/temporal-mixin/dashboards/temporal-overview.json
@@ -5756,7 +5756,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 165
+        "y": 201
       },
       "id": 40,
       "panels": [],
@@ -5829,7 +5829,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 166
+        "y": 202
       },
       "id": 11,
       "options": {
@@ -5936,7 +5936,7 @@
         "h": 9,
         "w": 4,
         "x": 12,
-        "y": 166
+        "y": 202
       },
       "id": 42,
       "options": {
@@ -6043,7 +6043,7 @@
         "h": 9,
         "w": 4,
         "x": 16,
-        "y": 166
+        "y": 202
       },
       "id": 43,
       "options": {
@@ -6150,7 +6150,7 @@
         "h": 9,
         "w": 4,
         "x": 20,
-        "y": 166
+        "y": 202
       },
       "id": 44,
       "options": {
@@ -6197,7 +6197,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 175
+        "y": 211
       },
       "id": 19,
       "panels": [],
@@ -6296,7 +6296,7 @@
         "h": 9,
         "w": 11,
         "x": 0,
-        "y": 176
+        "y": 212
       },
       "id": 60,
       "options": {
@@ -6416,7 +6416,7 @@
         "h": 9,
         "w": 13,
         "x": 11,
-        "y": 176
+        "y": 212
       },
       "id": 6,
       "options": {
@@ -6523,7 +6523,7 @@
         "h": 9,
         "w": 11,
         "x": 0,
-        "y": 185
+        "y": 221
       },
       "id": 8,
       "options": {
@@ -6630,7 +6630,7 @@
         "h": 9,
         "w": 6,
         "x": 11,
-        "y": 185
+        "y": 221
       },
       "id": 61,
       "options": {
@@ -6737,7 +6737,7 @@
         "h": 9,
         "w": 7,
         "x": 17,
-        "y": 185
+        "y": 221
       },
       "id": 45,
       "options": {
@@ -6845,7 +6845,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 186
+        "y": 222
       },
       "id": 52,
       "options": {
@@ -6914,7 +6914,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 194
+        "y": 230
       },
       "id": 55,
       "panels": [],
@@ -6988,7 +6988,7 @@
         "h": 10,
         "w": 8,
         "x": 0,
-        "y": 202
+        "y": 238
       },
       "id": 30,
       "options": {
@@ -7117,7 +7117,7 @@
         "h": 10,
         "w": 8,
         "x": 8,
-        "y": 202
+        "y": 238
       },
       "id": 74,
       "options": {
@@ -7246,7 +7246,7 @@
         "h": 10,
         "w": 8,
         "x": 16,
-        "y": 202
+        "y": 238
       },
       "id": 35,
       "options": {
@@ -7307,6 +7307,812 @@
       ],
       "title": "SignalWithStartWorkflowExecution Latency",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "title": "Top 20 Billable Actions by Workflow Type",
+      "description": "Estimated billable action counts per workflow type and action type over the selected time range",
+      "type": "table",
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 180
+      },
+      "id": 125,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 10000
+              },
+              {
+                "color": "red",
+                "value": 100000
+              }
+            ]
+          },
+          "unit": "none",
+          "decimals": 0
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Est. Count"
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "gauge"
+                }
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "continuous-BlYlRd"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "footer": {
+          "show": false
+        },
+        "sortBy": [
+          {
+            "displayName": "Est. Daily Count",
+            "desc": true
+          }
+        ]
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "topk(20,\n  $__range_s *\n  sum by (temporal_workflow_type, action_type) (\n    avg_over_time(\n      temporal_cloud_v1_billable_action_count{\n        temporal_namespace=~\"$temporal_namespace\"\n      }[$__range:1m]\n    )\n  )\n)",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "renameByName": {
+              "temporal_workflow_type": "Workflow Type",
+              "action_type": "Action Type",
+              "Value": "Est. Count"
+            },
+            "indexByName": {
+              "temporal_workflow_type": 0,
+              "action_type": 1,
+              "Value": 2
+            }
+          }
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "title": "Billable Actions",
+      "description": "Billable action rate broken down by action type",
+      "type": "timeseries",
+      "id": 126,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 166
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "scheme",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": ""
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (action_type) (temporal_cloud_v1_billable_action_count{temporal_namespace=~\"$temporal_namespace\"})",
+          "legendFormat": "{{action_type}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "title": "30d Billable Actions",
+      "description": "Estimated total billable actions over the last 30 days",
+      "type": "stat",
+      "id": 127,
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 0,
+        "y": 175
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1000000
+              },
+              {
+                "color": "red",
+                "value": 10000000
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "(sum(avg_over_time(temporal_cloud_v1_billable_action_count{temporal_namespace=~\"$temporal_namespace\"}[30d])) * 30 * 24 * 3600) or vector(0)",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "title": "7d Billable Actions",
+      "description": "Estimated total billable actions over the last 7 days",
+      "type": "stat",
+      "id": 128,
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 8,
+        "y": 175
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1000000
+              },
+              {
+                "color": "red",
+                "value": 10000000
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "(sum(avg_over_time(temporal_cloud_v1_billable_action_count{temporal_namespace=~\"$temporal_namespace\"}[7d])) * 7 * 24 * 3600) or vector(0)",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "title": "Range Billable Actions",
+      "description": "Estimated total billable actions within the selected dashboard time range",
+      "type": "stat",
+      "id": 129,
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 16,
+        "y": 175
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1000000
+              },
+              {
+                "color": "red",
+                "value": 10000000
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "(sum(avg_over_time(temporal_cloud_v1_billable_action_count{temporal_namespace=~\"$temporal_namespace\"}[$__range])) * $__range_s) or vector(0)",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "title": "Billable Actions by Workflow Type",
+      "description": "Billable action rate broken down by workflow type",
+      "type": "timeseries",
+      "id": 130,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 166
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "scheme",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": ""
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (temporal_workflow_type) (temporal_cloud_v1_billable_action_count{temporal_namespace=~\"$temporal_namespace\"})",
+          "legendFormat": "{{temporal_workflow_type}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "title": "Action Rate vs. Baseline",
+      "description": "Current total action rate compared to 2x the 7-day average. When the current rate crosses the baseline, it may indicate a spike worth investigating.",
+      "type": "timeseries",
+      "id": 131,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 192
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "actions/sec",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "2x 7d baseline"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    10,
+                    10
+                  ],
+                  "fill": "dash"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "current rate"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 15
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "(sum(temporal_cloud_v1_billable_action_count{temporal_namespace=~\"$temporal_namespace\"}) or vector(0))",
+          "legendFormat": "current rate",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "2 * avg_over_time((sum(temporal_cloud_v1_billable_action_count{temporal_namespace=~\"$temporal_namespace\"}) or vector(0))[7d:1m])",
+          "legendFormat": "2x 7d baseline",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "title": "Heartbeat Ratio",
+      "description": "Percentage of total actions that are activity heartbeats. Above 25% may indicate over-frequent heartbeats.",
+      "type": "gauge",
+      "id": 132,
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 12,
+        "y": 192
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.15
+              },
+              {
+                "color": "red",
+                "value": 0.25
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "decimals": 1
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "(sum(temporal_cloud_v1_billable_action_count{temporal_namespace=~\"$temporal_namespace\",action_type=~\"record_activity_heartbeat|record_activity_heartbeat_by_id|record_standalone_activity_heartbeat|record_standalone_activity_heartbeat_by_id\"}) or vector(0)) / clamp_min((sum(temporal_cloud_v1_billable_action_count{temporal_namespace=~\"$temporal_namespace\"}) or vector(0)), 0.001)",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "title": "Retry Ratio",
+      "description": "Percentage of total actions that are activity retries. A high ratio may indicate downstream failures or misconfigured timeouts.",
+      "type": "gauge",
+      "id": 133,
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 18,
+        "y": 192
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.15
+              },
+              {
+                "color": "red",
+                "value": 0.25
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "decimals": 1
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "(sum(temporal_cloud_v1_billable_action_count{temporal_namespace=~\"$temporal_namespace\",action_type=\"retry_activity\"}) or vector(0)) / clamp_min((sum(temporal_cloud_v1_billable_action_count{temporal_namespace=~\"$temporal_namespace\"}) or vector(0)), 0.001)",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 165
+      },
+      "id": 137,
+      "panels": [],
+      "title": "Billable Actions",
+      "type": "row"
     }
   ],
   "preload": false,

--- a/temporal-mixin/dashboards/temporal-overview.json
+++ b/temporal-mixin/dashboards/temporal-overview.json
@@ -7399,7 +7399,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(20,\n  $__range_s *\n  sum by (temporal_workflow_type, action_type) (\n    avg_over_time(\n      temporal_cloud_v1_billable_action_count{\n        temporal_namespace=~\"$temporal_namespace\"\n      }[$__range:1m]\n    )\n  )\n)",
+          "expr": "topk(20,\n  $__range_s *\n  sum by (temporal_workflow_type, action_type) (\n    avg_over_time(\n      temporal_cloud_v1_billable_action_count{\n        temporal_namespace=~\"$temporal_namespace\"\n      }[$__range]\n    )\n  )\n)",
           "format": "table",
           "instant": true,
           "refId": "A"

--- a/temporal-mixin/dashboards/temporal-overview.json
+++ b/temporal-mixin/dashboards/temporal-overview.json
@@ -7957,7 +7957,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "2 * avg_over_time((sum(temporal_cloud_v1_billable_action_count{temporal_namespace=~\"$temporal_namespace\"}) or vector(0))[7d:1m])",
+          "expr": "2 * avg_over_time((sum(temporal_cloud_v1_billable_action_count{temporal_namespace=~\"$temporal_namespace\"}) or vector(0))[7d])",
           "legendFormat": "2x 7d baseline",
           "refId": "B"
         }

--- a/temporal-mixin/dashboards/temporal-overview.json
+++ b/temporal-mixin/dashboards/temporal-overview.json
@@ -7313,7 +7313,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "title": "Top 20 Billable Actions by Workflow Type",
+      "title": "Top 20 Billable Actions by Workflow Type And Action Type",
       "description": "Estimated billable action counts per workflow type and action type over the selected time range",
       "type": "table",
       "gridPos": {
@@ -7431,7 +7431,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "title": "Billable Actions",
+      "title": "Billable Actions by Action Type",
       "description": "Billable action rate broken down by action type",
       "type": "timeseries",
       "id": 126,
@@ -7969,7 +7969,7 @@
         "uid": "${datasource}"
       },
       "title": "Heartbeat Ratio",
-      "description": "Percentage of total actions that are activity heartbeats. Above 25% may indicate over-frequent heartbeats.",
+      "description": "Percentage of total actions that are activity heartbeats. Above 25% may indicate over-frequent heartbeats. See https://docs.temporal.io/develop/go/activities/timeouts#activity-heartbeats",
       "type": "gauge",
       "id": 132,
       "gridPos": {

--- a/temporal-mixin/dashboards/temporal-overview.json
+++ b/temporal-mixin/dashboards/temporal-overview.json
@@ -7488,7 +7488,7 @@
               }
             ]
           },
-          "unit": ""
+          "unit": "action/s"
         },
         "overrides": []
       },
@@ -7782,7 +7782,7 @@
               }
             ]
           },
-          "unit": ""
+          "unit": "action/s"
         },
         "overrides": []
       },
@@ -7957,7 +7957,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "2 * avg_over_time((sum(temporal_cloud_v1_billable_action_count{temporal_namespace=~\"$temporal_namespace\"}) or vector(0))[7d])",
+          "expr": "2 * (sum(avg_over_time(temporal_cloud_v1_billable_action_count{temporal_namespace=~\"$temporal_namespace\"}[7d])) or vector(0))",
           "legendFormat": "2x 7d baseline",
           "refId": "B"
         }
@@ -7969,7 +7969,7 @@
         "uid": "${datasource}"
       },
       "title": "Heartbeat Ratio",
-      "description": "Percentage of total actions that are activity heartbeats. Above 25% may indicate over-frequent heartbeats. See https://docs.temporal.io/develop/go/activities/timeouts#activity-heartbeats",
+      "description": "Percentage of total actions that are activity heartbeats. Refer to [Activity Heartbeats documentation](https://docs.temporal.io/develop/go/activities/timeouts#activity-heartbeats) for more details",
       "type": "gauge",
       "id": 132,
       "gridPos": {


### PR DESCRIPTION
## Summary

- Adds 9 new Grafana panels to the Temporal overview dashboard for monitoring billable action costs, organized under a new "Billable Actions" collapsible row section
- Cleans up datasource templating by removing environment-specific defaults and regex filters for better portability as a reusable mixin

## New Panels

| Panel | Type | Purpose |
|-------|------|---------|
| Billable Actions | timeseries | Rate by action type (stacked) |
| Billable Actions by Workflow Type | timeseries | Rate by workflow type (stacked) |
| 30d / 7d / Range Billable Actions | stat | Estimated total action counts |
| Top 20 Billable Actions by Workflow Type | table | Ranked breakdown with gauge cells |
| Action Rate vs. Baseline | timeseries | Current rate vs 2x 7d average |
| Heartbeat Ratio | gauge | % of actions that are heartbeats |
| Retry Ratio | gauge | % of actions that are retries |

<img width="1873" height="1024" alt="image" src="https://github.com/user-attachments/assets/4df9c9f0-8ac6-49b9-962f-0090c7ce7458" />


## Test plan

- [ ] Import dashboard into Grafana instance with Temporal Cloud metrics
- [ ] Verify all panels load data with `temporal_cloud_v1_billable_action_count` metric
- [ ] Confirm stat panels (30d/7d/range) show reasonable estimated totals
- [ ] Verify "Billable Actions" row collapses/expands correctly
- [ ] Check no panel overlaps in the dashboard layout
- [ ] Confirm datasource dropdown works without environment-specific defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)