### PR TITLE
feat: add metrics-endpoint-observ-lib

### DIFF
--- a/metrics-endpoint-observ-lib/.lint
+++ b/metrics-endpoint-observ-lib/.lint
@@ -1,0 +1,7 @@
+exclusions:
+  target-job-rule:
+    reason: Use filteringSelector with static job
+  template-instance-rule:
+    reason: "instanceLabels must be single-select for single instance dashboards."
+  target-instance-rule:
+    reason: "'scrape_job' used as instance selector"

--- a/metrics-endpoint-observ-lib/Makefile
+++ b/metrics-endpoint-observ-lib/Makefile
@@ -1,0 +1,1 @@
+include ../Makefile_mixin

--- a/metrics-endpoint-observ-lib/README.md
+++ b/metrics-endpoint-observ-lib/README.md
@@ -1,0 +1,30 @@
+# Metrics-endpoint observability lib
+
+This lib can be used to generate dashboards, rows, or panels of metrics-endpoint scraping signals.
+
+## Import
+
+```sh
+jb init
+jb install https://github.com/grafana/jsonnet-libs/metrics-endpoint-observ-lib
+```
+
+## Usage
+
+This library is intended to be used together with other integrations to offer
+insight into the Grafana Cloud metrics endpoint scraping process.  As such, it
+can be modified to show branding and documentation of another integration:
+
+```jsonnet
+local observlib = import 'main.libsonnet';
+local mixin =
+  (observlib.new()
+   + observlib.withConfigMixin({
+     filteringSelector: 'job=~"some-specific-scrape"',
+     parentIntegration: {
+       name: 'My application',
+       id: 'my-application',
+       logoURL: '<application-logo-url>',
+     },
+   })).asMonitoringMixin();
+```

--- a/metrics-endpoint-observ-lib/config.libsonnet
+++ b/metrics-endpoint-observ-lib/config.libsonnet
@@ -1,0 +1,29 @@
+{
+  // any modular library should include as inputs:
+  // 'dashboardNamePrefix' - Use as prefix for all Dashboards and (optional) rule groups
+  // 'filteringSelector' - Static selector to apply to ALL dashboard variables of type query, panel queries, alerts and recording rules.
+  // 'groupLabels' - one or more labels that can be used to identify 'group' of instances. In simple cases, can be 'job' or 'cluster'.
+  // 'instanceLabels' - one or more labels that can be used to identify single entity of instances. In simple cases, can be 'instance' or 'pod'.
+  // 'uid' - UID to prefix all dashboards original uids
+  local this = self,
+  filteringSelector: 'job!=""',
+  groupLabels: ['job'],
+  instanceLabels: ['scrape_job'],
+  dashboardTags: [self.uid],
+  uid: 'metrics-endpoint',
+  dashboardNamePrefix: 'Metrics endpoint ',
+
+  // additional params can be added if needed
+  dashboardPeriod: 'now-1h',
+  dashboardTimezone: 'default',
+  dashboardRefresh: '1m',
+
+  metricsSource: ['prometheus'],
+  signals: (import './signals/metrics-endpoint.libsonnet')(this),
+
+  parentIntegration: {
+    id: 'metrics-endpoint',
+    name: 'Metrics Endpoint',
+    logoURL: 'https://storage.googleapis.com/grafanalabs-integration-logos/metrics-endpoint-prometheus.svg',
+  },
+}

--- a/metrics-endpoint-observ-lib/dashboards.libsonnet
+++ b/metrics-endpoint-observ-lib/dashboards.libsonnet
@@ -1,0 +1,49 @@
+local g = import './g.libsonnet';
+{
+  local root = self,
+  new(this):
+    local prefix = this.config.dashboardNamePrefix;
+    local links = this.grafana.links;
+    local tags = this.config.dashboardTags;
+    local uid = g.util.string.slugify(this.config.uid);
+    local signals = this.grafana.signals;
+    local annotations = this.grafana.annotations;
+    local refresh = this.config.dashboardRefresh;
+    local period = this.config.dashboardPeriod;
+    local timezone = this.config.dashboardTimezone;
+    {
+      'metrics-endpoint-overview.json':
+        g.dashboard.new(prefix + 'scrape overview')
+        + g.dashboard.withPanels(
+          g.util.grid.wrapPanels(
+            g.util.panel.resolveCollapsedFlagOnRows(
+              [
+                this.grafana.rows.overview,
+              ],
+            )
+          )
+        )
+        + root.applyCommon(
+          this.signals.getVariablesMultiChoice(),
+          uid + '-scrape-overview',
+          tags,
+          links { backToOverview+:: {} },
+          annotations,
+          timezone,
+          refresh,
+          period
+        ),
+    },
+
+  //Apply common options(uids, tags, annotations etc..) to all dashboards above
+  applyCommon(vars, uid, tags, links, annotations, timezone, refresh, period):
+    g.dashboard.withTags(tags)
+    + g.dashboard.withUid(uid)
+    + g.dashboard.withLinks(std.objectValues(links))
+    + g.dashboard.withTimezone(timezone)
+    + g.dashboard.withRefresh(refresh)
+    + g.dashboard.time.withFrom(period)
+    + g.dashboard.withVariables(vars)
+    + g.dashboard.withAnnotations(std.objectValues(annotations)),
+
+}

--- a/metrics-endpoint-observ-lib/dashboards_out/metrics-endpoint-overview.json
+++ b/metrics-endpoint-observ-lib/dashboards_out/metrics-endpoint-overview.json
@@ -1,0 +1,378 @@
+{
+      "annotations": {
+         "list": [ ]
+      },
+      "links": [ ],
+      "panels": [
+         {
+            "collapsed": false,
+            "gridPos": {
+               "h": 1,
+               "w": 0,
+               "x": 0,
+               "y": 0
+            },
+            "id": 1,
+            "panels": [ ],
+            "title": "Scrape overview",
+            "type": "row"
+         },
+         {
+            "datasource": {
+               "type": "datasource",
+               "uid": "-- Mixed --"
+            },
+            "gridPos": {
+               "h": 4,
+               "w": 5,
+               "x": 0,
+               "y": 1
+            },
+            "id": 2,
+            "options": {
+               "content": "<div style=\"width: 100%; height: 100%; display: flex; justify-content: center; align-items: center;\">\n  <img\n     style=\"width:auto;height:100%\"\n     src=\"https://storage.googleapis.com/grafanalabs-integration-logos/metrics-endpoint-prometheus.svg\">\n</div>\n"
+            },
+            "pluginVersion": "v11.4.0",
+            "title": "",
+            "transparent": true,
+            "type": "text"
+         },
+         {
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
+            },
+            "description": "Number of samples scraped. Every unique metric/label combination counts as a separate sample.",
+            "fieldConfig": {
+               "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "fixed"
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [
+                        {
+                           "color": "#5794f2",
+                           "value": null
+                        }
+                     ]
+                  },
+                  "unit": "short"
+               },
+               "overrides": [
+                  {
+                     "matcher": {
+                        "id": "byFrameRefID",
+                        "options": "Samples scraped"
+                     },
+                     "properties": [
+                        {
+                           "id": "unit",
+                           "value": "short"
+                        }
+                     ]
+                  }
+               ]
+            },
+            "gridPos": {
+               "h": 4,
+               "w": 19,
+               "x": 5,
+               "y": 1
+            },
+            "id": 3,
+            "pluginVersion": "v11.4.0",
+            "targets": [
+               {
+                  "datasource": {
+                     "type": "prometheus",
+                     "uid": "${datasource}"
+                  },
+                  "expr": "avg by (job,scrape_job) (\n  scrape_samples_scraped{job!=\"\",job=~\"$job\",scrape_job=~\"$scrape_job\"}\n)",
+                  "format": "time_series",
+                  "instant": false,
+                  "legendFormat": "{{scrape_job}}",
+                  "refId": "Samples scraped"
+               }
+            ],
+            "title": "Samples scraped",
+            "type": "stat"
+         },
+         {
+            "datasource": {
+               "type": "datasource",
+               "uid": "-- Mixed --"
+            },
+            "gridPos": {
+               "h": 9,
+               "w": 5,
+               "x": 0,
+               "y": 10
+            },
+            "id": 4,
+            "options": {
+               "content": "# Metrics scrape dashboard\nThis dashboard helps you analyze scrape metadata for the [Metrics Endpoint integration](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/integrations/integration-reference/integration-metrics-endpoint/).\nIt can help you debug issues with metrics not arriving or unexpected cardinality.\n\nFor metrics on Metrics Endpoint itself, refer to the [other dashboards provided by this integration](/dashboards/f/integration---metrics-endpoint).\n"
+            },
+            "pluginVersion": "v11.4.0",
+            "title": "",
+            "transparent": true,
+            "type": "text"
+         },
+         {
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
+            },
+            "description": "Top ten metrics with the highest cardinality. For more information on cardinality, refer to the [cardinality management dashboards](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/analyze-costs/metrics-costs/prometheus-metrics-costs/cardinality-management/)",
+            "fieldConfig": {
+               "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
+                  "custom": {
+                     "fillOpacity": 30,
+                     "gradientMode": "opacity",
+                     "lineInterpolation": "smooth",
+                     "lineWidth": 2,
+                     "showPoints": "never"
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
+                  "unit": "short"
+               },
+               "overrides": [
+                  {
+                     "matcher": {
+                        "id": "byFrameRefID",
+                        "options": "Highest cardinality metrics"
+                     },
+                     "properties": [
+                        {
+                           "id": "unit",
+                           "value": "short"
+                        }
+                     ]
+                  }
+               ]
+            },
+            "gridPos": {
+               "h": 9,
+               "w": 19,
+               "x": 5,
+               "y": 10
+            },
+            "id": 5,
+            "options": {
+               "legend": {
+                  "calcs": [
+                     "lastNotNull"
+                  ],
+                  "displayMode": "table",
+                  "placement": "right"
+               },
+               "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+               }
+            },
+            "pluginVersion": "v11.4.0",
+            "targets": [
+               {
+                  "datasource": {
+                     "type": "prometheus",
+                     "uid": "${datasource}"
+                  },
+                  "expr": "topk(10,count({job!=\"\",job=~\"$job\",scrape_job=~\"$scrape_job\"}) by (__name__))",
+                  "format": "time_series",
+                  "instant": false,
+                  "legendFormat": "{{ __name__ }}",
+                  "refId": "Highest cardinality metrics"
+               }
+            ],
+            "title": "Highest cardinality metrics",
+            "type": "timeseries"
+         },
+         {
+            "datasource": {
+               "type": "datasource",
+               "uid": "-- Mixed --"
+            },
+            "fieldConfig": {
+               "defaults": {
+                  "mappings": [
+                     {
+                        "options": {
+                           "0": {
+                              "color": "#ff7383",
+                              "index": 1,
+                              "text": "Error"
+                           },
+                           "1": {
+                              "color": "#73bf69",
+                              "index": 0,
+                              "text": "Ok"
+                           }
+                        },
+                        "type": "value"
+                     }
+                  ],
+                  "min": 0
+               }
+            },
+            "gridPos": {
+               "h": 9,
+               "w": 24,
+               "x": 0,
+               "y": 19
+            },
+            "id": 6,
+            "pluginVersion": "v11.4.0",
+            "targets": [
+               {
+                  "datasource": {
+                     "type": "prometheus",
+                     "uid": "${datasource}"
+                  },
+                  "expr": "max by (job,scrape_job) (\n  metrics_endpoint_export_response_success{job!=\"\",job=~\"$job\",scrape_job=~\"$scrape_job\"}\n)",
+                  "format": "time_series",
+                  "instant": false,
+                  "legendFormat": "{{scrape_job}}",
+                  "refId": "Scrape response"
+               }
+            ],
+            "title": "Scrape status",
+            "type": "state-timeline"
+         },
+         {
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
+            },
+            "description": "How long it takes for the metrics scrape to complete. Long durations might indicate issues with the endpoint.",
+            "fieldConfig": {
+               "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
+                  "custom": {
+                     "fillOpacity": 30,
+                     "gradientMode": "opacity",
+                     "lineInterpolation": "smooth",
+                     "lineWidth": 2,
+                     "showPoints": "never"
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
+                  "unit": "s"
+               },
+               "overrides": [
+                  {
+                     "matcher": {
+                        "id": "byFrameRefID",
+                        "options": "Scrape duration"
+                     },
+                     "properties": [
+                        {
+                           "id": "unit",
+                           "value": "s"
+                        }
+                     ]
+                  }
+               ]
+            },
+            "gridPos": {
+               "h": 9,
+               "w": 24,
+               "x": 0,
+               "y": 28
+            },
+            "id": 7,
+            "options": {
+               "legend": {
+                  "calcs": [ ],
+                  "displayMode": "list"
+               },
+               "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+               }
+            },
+            "pluginVersion": "v11.4.0",
+            "targets": [
+               {
+                  "datasource": {
+                     "type": "prometheus",
+                     "uid": "${datasource}"
+                  },
+                  "expr": "avg by (job,scrape_job) (\n  scrape_duration_seconds{job!=\"\",job=~\"$job\",scrape_job=~\"$scrape_job\"}\n)",
+                  "format": "time_series",
+                  "instant": false,
+                  "legendFormat": "{{scrape_job}}: Scrape duration",
+                  "refId": "Scrape duration"
+               }
+            ],
+            "title": "Scrape duration",
+            "type": "timeseries"
+         }
+      ],
+      "refresh": "1m",
+      "schemaVersion": 39,
+      "tags": [
+         "metrics-endpoint"
+      ],
+      "templating": {
+         "list": [
+            {
+               "label": "Data source",
+               "name": "datasource",
+               "query": "prometheus",
+               "regex": "",
+               "type": "datasource"
+            },
+            {
+               "allValue": ".+",
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "includeAll": true,
+               "label": "Job",
+               "multi": true,
+               "name": "job",
+               "query": "label_values({__name__=~\"metrics_endpoint_export_response_success\",job!=\"\"}, job)",
+               "refresh": 2,
+               "sort": 1,
+               "type": "query"
+            },
+            {
+               "allValue": ".+",
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "includeAll": true,
+               "label": "Scrape_job",
+               "multi": true,
+               "name": "scrape_job",
+               "query": "label_values({__name__=~\"metrics_endpoint_export_response_success\",job!=\"\",job=~\"$job\"}, scrape_job)",
+               "refresh": 2,
+               "sort": 1,
+               "type": "query"
+            }
+         ]
+      },
+      "time": {
+         "from": "now-1h",
+         "to": "now"
+      },
+      "timezone": "default",
+      "title": "Metrics endpoint scrape overview",
+      "uid": "metricsendpoint-scrape-overview"
+   }

--- a/metrics-endpoint-observ-lib/debug.jsonnet
+++ b/metrics-endpoint-observ-lib/debug.jsonnet
@@ -1,0 +1,27 @@
+// debug file to use with grafanactl
+// grafanactl resources serve --script 'jsonnet -J vendor ./debug.jsonnet' --watch ./
+
+local observlib = import 'main.libsonnet';
+local mixin =
+  (observlib.new()
+   + observlib.withConfigMixin({
+     filteringSelector: 'job=~"integrations/supabase/.+"',
+     parentIntegration: {
+       name: 'Supabase',
+       id: 'supabase',
+       logoURL: 'https://storage.googleapis.com/grafanalabs-integration-logos/supabase.svg',
+     },
+   })).asMonitoringMixin();
+
+local d = mixin.grafanaDashboards['metrics-endpoint-overview.json'];
+{
+  apiVersion: 'dashboard.grafana.app/v1beta1',
+  kind: 'Dashboard',
+  metadata: {
+    name: d.uid,
+    annotations: {
+      'grafana.app/folder': '',
+    },
+  },
+  spec: d,
+}

--- a/metrics-endpoint-observ-lib/g.libsonnet
+++ b/metrics-endpoint-observ-lib/g.libsonnet
@@ -1,0 +1,1 @@
+import 'github.com/grafana/grafonnet/gen/grafonnet-v11.4.0/main.libsonnet'

--- a/metrics-endpoint-observ-lib/jsonnetfile.json
+++ b/metrics-endpoint-observ-lib/jsonnetfile.json
@@ -1,0 +1,33 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": "common-lib"
+        }
+      },
+      "version": "master"
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/grafonnet.git",
+          "subdir": "gen/grafonnet-v11.4.0"
+        }
+      },
+      "version": "main"
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/jsonnet-libs/xtd.git",
+          "subdir": ""
+        }
+      },
+      "version": "master"
+    }
+  ],
+  "legacyImports": true
+}

--- a/metrics-endpoint-observ-lib/main.libsonnet
+++ b/metrics-endpoint-observ-lib/main.libsonnet
@@ -1,0 +1,40 @@
+local config = import './config.libsonnet';
+local dashboards = import './dashboards.libsonnet';
+local g = import './g.libsonnet';
+local panels = import './panels.libsonnet';
+local rows = import './rows.libsonnet';
+local commonlib = import 'common-lib/common/main.libsonnet';
+
+{
+
+  withConfigMixin(config): {
+    config+: config,
+  },
+
+  new(): {
+
+    local this = self,
+    config: config,
+    signals: commonlib.signals.unmarshallJsonMulti(this.config.signals, type=this.config.metricsSource),
+    grafana: {
+      annotations: {},
+      links: {},
+      panels: panels.new(this.signals, this.config.parentIntegration),
+      dashboards: dashboards.new(this),
+      rows: rows.new(this.grafana.panels),
+    },
+
+    prometheus: {
+      alerts: {},
+      recordingRules: {},
+    },
+
+    asMonitoringMixin(): {
+      grafanaDashboards+:: this.grafana.dashboards,
+      prometheusAlerts+:: this.prometheus.alerts,
+      prometheusRules+:: this.prometheus.recordingRules,
+    },
+
+  },
+
+}

--- a/metrics-endpoint-observ-lib/mixin.libsonnet
+++ b/metrics-endpoint-observ-lib/mixin.libsonnet
@@ -1,0 +1,8 @@
+local observlib = import './main.libsonnet';
+
+local metricsEndpoint =
+  observlib.new()
+  + observlib.withConfigMixin({});
+
+// populate monitoring-mixin:
+metricsEndpoint.asMonitoringMixin()

--- a/metrics-endpoint-observ-lib/panels.libsonnet
+++ b/metrics-endpoint-observ-lib/panels.libsonnet
@@ -1,0 +1,55 @@
+local g = import './g.libsonnet';
+local commonlib = import 'common-lib/common/main.libsonnet';
+{
+  new(signals, parentIntegration):
+    {
+      logo: g.panel.text.new('')
+            + g.panel.text.panelOptions.withTransparent(true)
+            + g.panel.text.options.withContent(|||
+              <div style="width: 100%%; height: 100%%; display: flex; justify-content: center; align-items: center;">
+                <img
+                   style="width:auto;height:100%%"
+                   src="%s">
+              </div>
+            ||| % parentIntegration.logoURL),
+      description: g.panel.text.new('')
+                   + g.panel.text.panelOptions.withTransparent(true)
+                   + g.panel.text.options.withContent(|||
+                     # Metrics scrape dashboard
+                     This dashboard helps you analyze scrape metadata for the [%(name)s integration](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/integrations/integration-reference/integration-%(id)s/).
+                     It can help you debug issues with metrics not arriving or unexpected cardinality.
+
+                     For metrics on %(name)s itself, refer to the [other dashboards provided by this integration](/dashboards/f/integration---%(id)s).
+                   ||| % parentIntegration),
+      scrapeStatus: g.panel.stateTimeline.new('Scrape status')
+                    + g.panel.stateTimeline.queryOptions.withTargets([signals.scrapeStatus.asTarget()])
+                    + g.panel.stateTimeline.standardOptions.withMin(0)
+                    + g.panel.stateTimeline.standardOptions.withMappings([
+                      g.panel.stateTimeline.standardOptions.mapping.ValueMap.withType()
+                      + g.panel.stateTimeline.standardOptions.mapping.ValueMap.withOptions({
+                        '0': {
+                          text: 'Error',
+                          index: 1,
+                          color: commonlib.tokens.base.colors.palette.errors,
+                        },
+                        '1': {
+                          text: 'Ok',
+                          index: 0,
+                          color: commonlib.tokens.base.colors.palette.ok,
+                        },
+                      }),
+                    ])
+      ,
+      samplesScraped: signals.samplesScraped.asStat()
+                      + commonlib.panels.generic.stat.base.stylize()
+      ,
+      topCardinality: signals.topCardinality.asTimeSeries()
+                      + commonlib.panels.generic.timeSeries.base.stylize()
+                      + g.panel.timeSeries.options.legend.withDisplayMode('table')
+                      + g.panel.timeSeries.options.legend.withPlacement('right')
+                      + g.panel.timeSeries.options.legend.withCalcs(['lastNotNull'])
+      ,
+      scrapeDuration: signals.scrapeDuration.asTimeSeries()
+                      + commonlib.panels.generic.timeSeries.base.stylize(),
+    },
+}

--- a/metrics-endpoint-observ-lib/rows.libsonnet
+++ b/metrics-endpoint-observ-lib/rows.libsonnet
@@ -1,0 +1,20 @@
+local g = import './g.libsonnet';
+
+{
+  new(panels):
+    {
+      overview:
+        g.panel.row.new('Scrape overview')
+        + g.panel.row.withCollapsed(false)
+        + g.panel.row.withPanels(
+          [
+            panels.logo { gridPos: { w: 5, h: 4 } },
+            panels.samplesScraped { gridPos: { w: 19, h: 4 } },
+            panels.description { gridPos: { w: 5, h: 9 } },
+            panels.topCardinality { gridPos: { w: 19, h: 9 } },
+            panels.scrapeStatus { gridPos: { w: 24, h: 9 } },
+            panels.scrapeDuration { gridPos: { w: 24, h: 9 } },
+          ]
+        ),
+    },
+}

--- a/metrics-endpoint-observ-lib/signals/metrics-endpoint.libsonnet
+++ b/metrics-endpoint-observ-lib/signals/metrics-endpoint.libsonnet
@@ -1,0 +1,67 @@
+function(this)
+  {
+    discoveryMetric: {
+      prometheus: 'metrics_endpoint_export_response_success',
+    },
+    filteringSelector: this.filteringSelector,
+    groupLabels: this.groupLabels,
+    instanceLabels: this.instanceLabels,
+    aggLevel: 'instance',  // group, instance, or none.
+    alertsInterval: '5m',
+    signals: {
+      scrapeStatus: {
+        name: 'Scrape response',
+        type: 'gauge',
+        description: 'Tracks if the last request to the provided URL was successful or not',
+        aggLevel: 'instance',
+        unit: 'short',
+        aggFunction: 'max',
+        sources: {
+          prometheus:
+            {
+              expr: 'metrics_endpoint_export_response_success{%(queriesSelector)s}',
+              legendCustomTemplate: '%(aggLegend)s',
+            },
+        },
+      },
+      samplesScraped: {
+        name: 'Samples scraped',
+        type: 'gauge',
+        description: 'Number of samples scraped. Every unique metric/label combination counts as a separate sample.',
+        unit: 'short',
+        sources: {
+          prometheus:
+            {
+              expr: 'scrape_samples_scraped{%(queriesSelector)s}',
+              legendCustomTemplate: '%(aggLegend)s',
+            },
+        },
+      },
+      topCardinality: {
+        name: 'Highest cardinality metrics',
+        type: 'raw',
+        description: 'Top ten metrics with the highest cardinality. For more information on cardinality, refer to the [cardinality management dashboards](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/analyze-costs/metrics-costs/prometheus-metrics-costs/cardinality-management/)',
+        unit: 'short',
+        sources: {
+          prometheus:
+            {
+              expr: 'topk(10,count({%(queriesSelector)s}) by (__name__))',
+              legendCustomTemplate: '{{ __name__ }}',
+            },
+        },
+      },
+      scrapeDuration: {
+        name: 'Scrape duration',
+        type: 'gauge',
+        description: 'How long it takes for the metrics scrape to complete. Long durations might indicate issues with the endpoint.',
+        unit: 's',
+        sources: {
+          prometheus:
+            {
+              expr: 'scrape_duration_seconds{%(queriesSelector)s}',
+            },
+        },
+      },
+
+    },
+  }


### PR DESCRIPTION
Adds a new observ-lib to give an overview on scrape statistics for metrics-endpoint based jobs in Grafana Cloud (e.g Supabase, Temporal, Anthropic + more to come)

Looks like this (without any filter):
<img width="1843" height="1341" alt="image" src="https://github.com/user-attachments/assets/46628f30-b47d-4719-b642-d20a420ef961" />

And can be customized to be shipped as part of specific integrations (also filters for relevant scrape jobs only):
<img width="1843" height="1338" alt="image" src="https://github.com/user-attachments/assets/c3931611-60a9-44e8-8a52-6db04c1f93bb" />
