### PR TITLE
feat(prometheus): add withAutoReload() to replace watch sidecar

### DIFF
--- a/prometheus/prometheus.libsonnet
+++ b/prometheus/prometheus.libsonnet
@@ -27,6 +27,31 @@ local kausal = import 'ksonnet-util/kausal.libsonnet';
   prometheusAlerts+:: {},
   prometheusRules+:: {},
 
+  // withAutoReload replaces the weaveworks/watch sidecar with Prometheus's
+  // native auto-reload-config feature (available since v3.0). It adds
+  // 'auto-reload-config' to the enabled feature flags, configures the reload
+  // interval, and removes the 'watch' container from the StatefulSet.
+  withAutoReload(interval='30s'):: {
+    _config+:: {
+      prometheus_enabled_features+: ['auto-reload-config'],
+    },
+    prometheus_container+:: {
+      args+: ['--config.auto-reload-interval=%s' % interval],
+    },
+    prometheus_statefulset+: {
+      spec+: {
+        template+: {
+          spec+: {
+            containers: std.filter(
+              function(c) c.name != 'watch',
+              super.containers,
+            ),
+          },
+        },
+      },
+    },
+  },
+
   withHighAvailability(replicas=2):: ha_mixin(replicas),
 
   local configMap = k.core.v1.configMap,


### PR DESCRIPTION
## Summary

- Adds `withAutoReload(interval='30s')` mixin to the `prometheus` library
- Replaces the `weaveworks/watch` sidecar with Prometheus's native `auto-reload-config` feature (available since v3.0)
- Appends `auto-reload-config` to `prometheus_enabled_features`, adds `--config.auto-reload-interval` to the prometheus container args, and removes the `watch` container from the StatefulSet