### PR TITLE
feat(common-lib): add signals.collectMetricExprs() helper  

### DIFF
--- a/common-lib/common/signal/signal.libsonnet
+++ b/common-lib/common/signal/signal.libsonnet
@@ -382,4 +382,17 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
       else
         std.get(signalsJson.discoveryMetric, type, std.get(signalsJson.discoveryMetric, defaultSignalSource, 'up'))
     else 'up',
+
+  // Returns the templated PromQL expr for each signal; stub signals
+  // (asPanelExpression() == {}) are filtered out. No dedup here.
+  collectMetricExprs(signalsObj):
+    std.filter(
+      function(e) std.isString(e) && e != '',
+      [
+        signalsObj[s].asPanelExpression()
+        for s in std.objectFields(signalsObj)
+        if std.isObject(signalsObj[s])
+           && std.objectHas(signalsObj[s], 'asPanelExpression')
+      ]
+    ),
 }

--- a/common-lib/common/signal/test_collect_metric_exprs.libsonnet
+++ b/common-lib/common/signal/test_collect_metric_exprs.libsonnet
@@ -1,0 +1,79 @@
+local signal = import './signal.libsonnet';
+local test = import 'jsonnetunit/test.libsonnet';
+
+local jsonSignals = {
+  aggLevel: 'group',
+  groupLabels: ['job'],
+  instanceLabels: ['instance'],
+  filteringSelector: 'job="integrations/agent"',
+  aggKeepLabels: ['xxx'],
+  signals: {
+    abc: {
+      name: 'ABC',
+      type: 'gauge',
+      description: 'ABC',
+      unit: 's',
+      sources: {
+        prometheus: {
+          expr: 'abc{%(queriesSelector)s}',
+        },
+      },
+    },
+    bar: {
+      name: 'BAR',
+      type: 'counter',
+      description: 'BAR',
+      unit: 'ns',
+      sources: {
+        prometheus: {
+          expr: 'bar{%(queriesSelector)s}',
+        },
+      },
+    },
+    // optional signal with no matching source -> becomes a stub.
+    // asPanelExpression() returns {} and must be filtered out.
+    stubbed: {
+      name: 'Stubbed',
+      type: 'gauge',
+      description: 'stub',
+      unit: 'short',
+      optional: true,
+      sources: {
+        otel: {
+          expr: 'stubbed_otel_only{%(queriesSelector)s}',
+        },
+      },
+    },
+  },
+};
+
+local signals = signal.unmarshallJsonMulti(jsonSignals, 'prometheus');
+local exprs = signal.collectMetricExprs(signals);
+
+{
+  collectMetricExprs: {
+    raw:: exprs,
+    testResult: test.suite({
+      testCount: {
+        actual: std.length(exprs),
+        expect: 2,
+      },
+      testAllStrings: {
+        actual: std.all([std.isString(e) for e in exprs]),
+        expect: true,
+      },
+      testContainsAbc: {
+        actual: std.member(exprs, 'avg by (job,xxx) (\n  abc{job="integrations/agent",job=~"$job",instance=~"$instance"}\n)'),
+        expect: true,
+      },
+      testContainsBar: {
+        actual: std.any([std.length(std.findSubstr('bar{job="integrations/agent"', e)) > 0 for e in exprs]),
+        expect: true,
+      },
+      testNoEmptyObjects: {
+        actual: std.any([!std.isString(e) for e in exprs]),
+        expect: false,
+      },
+    }),
+  },
+}


### PR DESCRIPTION

## Description 
 
 Adds `collectMetricExprs(signalsObj)` to the signal lib. It returns the templated PromQL expression for each signal, with   
 stub signals filtered out. No deduplication, that's left to the caller.
                                                                     
  This is a building block for letting metric-extraction tooling pick up signal-defined metrics, additive only nothing calls it yet. Includes a test.