### PR TITLE
feat: preserve asserts_env and asserts_site in GCP and Azure alert rules

### DIFF
--- a/csp-mixin/alerts/azure-alerts.yml
+++ b/csp-mixin/alerts/azure-alerts.yml
@@ -3,7 +3,7 @@ groups:
     rules:
       - alert: AzureVMHighCpuUtilization
         expr: |
-          avg by (job,resourceGroup,subscriptionName,resourceName) (azure_microsoft_compute_virtualmachines_percentage_cpu_average_percent{job=~".+",resourceGroup=~".+",subscriptionName=~".+",resourceName=~".+"})  > 85
+          avg by (job,resourceGroup,subscriptionName,resourceName,asserts_env,asserts_site) (azure_microsoft_compute_virtualmachines_percentage_cpu_average_percent{job=~".+",resourceGroup=~".+",subscriptionName=~".+",resourceName=~".+"})  > 85
         for: 5m
         keep_firing_for: 10m
         labels:
@@ -18,7 +18,7 @@ groups:
 
       - alert: AzureVMUnavailable
         expr: |
-          avg by (job,resourceGroup,subscriptionName,resourceName) (azure_microsoft_compute_virtualmachines_vmavailabilitymetric_average_count{job=~".+",resourceGroup=~".+",subscriptionName=~".+",resourceName=~".+"}) != 1
+          avg by (job,resourceGroup,subscriptionName,resourceName,asserts_env,asserts_site) (azure_microsoft_compute_virtualmachines_vmavailabilitymetric_average_count{job=~".+",resourceGroup=~".+",subscriptionName=~".+",resourceName=~".+"}) != 1
         for: 5m
         keep_firing_for: 10m
         labels:
@@ -35,7 +35,7 @@ groups:
     rules:
       - alert: AzureDatabaseHighDtuConsumption
         expr: |
-          avg by (job,resourceGroup,subscriptionName,resourceName) (azure_microsoft_sql_servers_databases_dtu_consumption_percent_average_percent{job=~".+",resourceGroup=~".+",subscriptionName=~".+",resourceName=~".+"}) > 90
+          avg by (job,resourceGroup,subscriptionName,resourceName,asserts_env,asserts_site) (azure_microsoft_sql_servers_databases_dtu_consumption_percent_average_percent{job=~".+",resourceGroup=~".+",subscriptionName=~".+",resourceName=~".+"}) > 90
         for: 10m
         keep_firing_for: 10m
         labels:
@@ -50,7 +50,7 @@ groups:
 
       - alert: AzureDatabaseHighStorageUsage
         expr: |
-          avg by (job,resourceGroup,subscriptionName,resourceName) (azure_microsoft_sql_servers_databases_storage_percent_maximum_percent{job=~".+",resourceGroup=~".+",subscriptionName=~".+",resourceName=~".+"}) > 95
+          avg by (job,resourceGroup,subscriptionName,resourceName,asserts_env,asserts_site) (azure_microsoft_sql_servers_databases_storage_percent_maximum_percent{job=~".+",resourceGroup=~".+",subscriptionName=~".+",resourceName=~".+"}) > 95
         for: 15m
         keep_firing_for: 10m
         labels:
@@ -65,7 +65,7 @@ groups:
 
       - alert: AzureDatabaseHighDeadlockCount
         expr: |
-          sum by (job,resourceGroup,subscriptionName,resourceName) (rate(azure_microsoft_sql_servers_databases_deadlock_total_count{job=~".+",resourceGroup=~".+",subscriptionName=~".+",resourceName=~".+"}[5m])) > 5
+          sum by (job,resourceGroup,subscriptionName,resourceName,asserts_env,asserts_site) (rate(azure_microsoft_sql_servers_databases_deadlock_total_count{job=~".+",resourceGroup=~".+",subscriptionName=~".+",resourceName=~".+"}[5m])) > 5
         for: 10m
         keep_firing_for: 10m
         labels:
@@ -80,7 +80,7 @@ groups:
 
       - alert: AzureDatabaseHighUserCpuUsage
         expr: |
-          avg by (job,resourceGroup,subscriptionName,resourceName) (azure_microsoft_sql_servers_databases_cpu_percent_average_percent{job=~".+",resourceGroup=~".+",subscriptionName=~".+",resourceName=~".+"}) > 90
+          avg by (job,resourceGroup,subscriptionName,resourceName,asserts_env,asserts_site) (azure_microsoft_sql_servers_databases_cpu_percent_average_percent{job=~".+",resourceGroup=~".+",subscriptionName=~".+",resourceName=~".+"}) > 90
         for: 10m
         keep_firing_for: 10m
         labels:
@@ -95,7 +95,7 @@ groups:
 
       - alert: AzureDatabaseHighSystemFailedConnections
         expr: |
-          sum by (job,resourceGroup,subscriptionName,resourceName) (rate(azure_microsoft_sql_servers_databases_connection_failed_total_count{job=~".+",resourceGroup=~".+",subscriptionName=~".+",resourceName=~".+"}[5m])) > 10
+          sum by (job,resourceGroup,subscriptionName,resourceName,asserts_env,asserts_site) (rate(azure_microsoft_sql_servers_databases_connection_failed_total_count{job=~".+",resourceGroup=~".+",subscriptionName=~".+",resourceName=~".+"}[5m])) > 10
         for: 5m
         keep_firing_for: 10m
         labels:
@@ -110,7 +110,7 @@ groups:
 
       - alert: AzureDatabaseHighUserFailedConnections
         expr: |
-          sum by (job,resourceGroup,subscriptionName,resourceName) (rate(azure_microsoft_sql_servers_databases_connection_failed_user_error_total_count{job=~".+",resourceGroup=~".+",subscriptionName=~".+",resourceName=~".+"}[5m])) > 10
+          sum by (job,resourceGroup,subscriptionName,resourceName,asserts_env,asserts_site) (rate(azure_microsoft_sql_servers_databases_connection_failed_user_error_total_count{job=~".+",resourceGroup=~".+",subscriptionName=~".+",resourceName=~".+"}[5m])) > 10
         for: 15m
         keep_firing_for: 10m
         labels:
@@ -125,7 +125,7 @@ groups:
 
       - alert: AzureDatabaseHighWorkerUsage
         expr: |
-          avg by (job,resourceGroup,subscriptionName,resourceName) (azure_microsoft_sql_servers_databases_workers_percent_average_percent{job=~".+",resourceGroup=~".+",subscriptionName=~".+",resourceName=~".+"}) > 60
+          avg by (job,resourceGroup,subscriptionName,resourceName,asserts_env,asserts_site) (azure_microsoft_sql_servers_databases_workers_percent_average_percent{job=~".+",resourceGroup=~".+",subscriptionName=~".+",resourceName=~".+"}) > 60
         for: 5m
         keep_firing_for: 10m
         labels:
@@ -140,7 +140,7 @@ groups:
 
       - alert: AzureDatabaseHighDataIoUsage
         expr: |
-          avg by (job,resourceGroup,subscriptionName,resourceName) (azure_microsoft_sql_servers_databases_physical_data_read_percent_average_percent{job=~".+",resourceGroup=~".+",subscriptionName=~".+",resourceName=~".+"}) > 90
+          avg by (job,resourceGroup,subscriptionName,resourceName,asserts_env,asserts_site) (azure_microsoft_sql_servers_databases_physical_data_read_percent_average_percent{job=~".+",resourceGroup=~".+",subscriptionName=~".+",resourceName=~".+"}) > 90
         for: 15m
         keep_firing_for: 10m
         labels:
@@ -155,7 +155,7 @@ groups:
 
       - alert: AzureDatabaseLowTempdbLogSpace
         expr: |
-          avg by (job,resourceGroup,subscriptionName,resourceName) (azure_microsoft_sql_servers_databases_tempdb_log_used_percent_average_percent{job=~".+",resourceGroup=~".+",subscriptionName=~".+",resourceName=~".+"}) > 60
+          avg by (job,resourceGroup,subscriptionName,resourceName,asserts_env,asserts_site) (azure_microsoft_sql_servers_databases_tempdb_log_used_percent_average_percent{job=~".+",resourceGroup=~".+",subscriptionName=~".+",resourceName=~".+"}) > 60
         for: 5m
         keep_firing_for: 10m
         labels:

--- a/csp-mixin/alerts/gcp-alerts.yml
+++ b/csp-mixin/alerts/gcp-alerts.yml
@@ -3,7 +3,7 @@ groups:
     rules:
       - alert: GcpCEHighCpuUtilization
         expr: |
-          100 * avg by (job,project_id,instance_name) (stackdriver_gce_instance_compute_googleapis_com_instance_cpu_utilization{job=~".+",project_id=~".+",instance_name=~".+"}) > 85
+          100 * avg by (job,project_id,instance_name,asserts_env,asserts_site) (stackdriver_gce_instance_compute_googleapis_com_instance_cpu_utilization{job=~".+",project_id=~".+",instance_name=~".+"}) > 85
         for: 5m
         keep_firing_for: 10m
         labels:
@@ -18,7 +18,7 @@ groups:
 
       - alert: GcpCEHighIOLatency
         expr: |
-          avg by (job,project_id,instance_id)(stackdriver_gce_instance_compute_googleapis_com_instance_disk_average_io_latency{job=~".+",project_id=~".+",instance_id=~".+"}) > 5000
+          avg by (job,project_id,instance_id,asserts_env,asserts_site)(stackdriver_gce_instance_compute_googleapis_com_instance_disk_average_io_latency{job=~".+",project_id=~".+",instance_id=~".+"}) > 5000
         for: 5m
         keep_firing_for: 10m
         labels:
@@ -35,7 +35,7 @@ groups:
     rules:
       - alert: GcpCloudSQLHighCpu
         expr: |
-          100 * avg by (job,project_id,instance,database_id) (stackdriver_cloudsql_database_cloudsql_googleapis_com_database_cpu_utilization{job=~".+",project_id=~".+",instance=~".+", database_id=~".+"}) > 90
+          100 * avg by (job,project_id,instance,database_id,asserts_env,asserts_site) (stackdriver_cloudsql_database_cloudsql_googleapis_com_database_cpu_utilization{job=~".+",project_id=~".+",instance=~".+", database_id=~".+"}) > 90
         for: 5m
         keep_firing_for: 10m
         labels:
@@ -50,7 +50,7 @@ groups:
 
       - alert: GcpCloudSQLMemoryUsage
         expr: |
-          100 * avg by (job,project_id,instance,database_id) (stackdriver_cloudsql_database_cloudsql_googleapis_com_database_memory_utilization{job=~".+",project_id=~".+",instance=~".+", database_id=~".+"}) > 85
+          100 * avg by (job,project_id,instance,database_id,asserts_env,asserts_site) (stackdriver_cloudsql_database_cloudsql_googleapis_com_database_memory_utilization{job=~".+",project_id=~".+",instance=~".+", database_id=~".+"}) > 85
         for: 5m
         keep_firing_for: 10m
         labels:
@@ -65,7 +65,7 @@ groups:
 
       - alert: GcpCloudSQLDiskUsage
         expr: |
-          100 * avg by (job,project_id,instance,database_id) (stackdriver_cloudsql_database_cloudsql_googleapis_com_database_disk_utilization{job=~".+",project_id=~".+",instance=~".+", database_id=~".+"}) > 85
+          100 * avg by (job,project_id,instance,database_id,asserts_env,asserts_site) (stackdriver_cloudsql_database_cloudsql_googleapis_com_database_disk_utilization{job=~".+",project_id=~".+",instance=~".+", database_id=~".+"}) > 85
         for: 5m
         keep_firing_for: 10m
         labels:
@@ -80,7 +80,7 @@ groups:
 
       - alert: GcpCloudSQLActiveConnections
         expr: |
-          avg by (job,project_id,instance, database_id) (stackdriver_cloudsql_database_cloudsql_googleapis_com_database_mysql_threads{thread_kind="THREADS_CONNECTED", job=~".+",project_id=~".+",instance=~".+", database_id=~".+"}) > 0.9 * avg by (job,project_id,instance, database_id) (stackdriver_cloudsql_database_cloudsql_googleapis_com_database_mysql_max_connections{job=~".+",project_id=~".+",instance=~".+", database_id=~".+"})
+          avg by (job,project_id,instance,database_id,asserts_env,asserts_site) (stackdriver_cloudsql_database_cloudsql_googleapis_com_database_mysql_threads{thread_kind="THREADS_CONNECTED", job=~".+",project_id=~".+",instance=~".+", database_id=~".+"}) > 0.9 * avg by (job,project_id,instance,database_id,asserts_env,asserts_site) (stackdriver_cloudsql_database_cloudsql_googleapis_com_database_mysql_max_connections{job=~".+",project_id=~".+",instance=~".+", database_id=~".+"})
         for: 5m
         keep_firing_for: 10m
         labels:
@@ -95,7 +95,7 @@ groups:
 
       - alert: GcpCloudSQLAbortedConnections
         expr: |
-          sum by(job, instance, project_id, database_id)(rate(stackdriver_cloudsql_database_cloudsql_googleapis_com_database_mysql_aborted_connects_count[5m])) > 5
+          sum by(job, instance, project_id, database_id, asserts_env, asserts_site)(rate(stackdriver_cloudsql_database_cloudsql_googleapis_com_database_mysql_aborted_connects_count[5m])) > 5
         for: 5m
         keep_firing_for: 10m
         labels:
@@ -110,7 +110,7 @@ groups:
 
       - alert: GcpCloudSQLLagSecondsBehindMaster
         expr: |
-          avg by (job,project_id,instance, database_id) (stackdriver_cloudsql_database_cloudsql_googleapis_com_database_mysql_replication_seconds_behind_master) > 5
+          avg by (job,project_id,instance,database_id,asserts_env,asserts_site) (stackdriver_cloudsql_database_cloudsql_googleapis_com_database_mysql_replication_seconds_behind_master) > 5
         for: 5m
         keep_firing_for: 10m
         labels:
@@ -127,7 +127,7 @@ groups:
     rules:
       - alert: GcpPubSubNumUndeliveredMessages
         expr: |
-          avg by (job,project_id,instance)(stackdriver_pubsub_subscription_pubsub_googleapis_com_subscription_num_undelivered_messages{job=~".+",project_id=~".+",instance=~".+"}) > 1000
+          avg by (job,project_id,instance,asserts_env,asserts_site)(stackdriver_pubsub_subscription_pubsub_googleapis_com_subscription_num_undelivered_messages{job=~".+",project_id=~".+",instance=~".+"}) > 1000
         for: 5m
         keep_firing_for: 10m
         labels:
@@ -142,7 +142,7 @@ groups:
 
       - alert: GcpPubSubUnackedMessageAge
         expr: |
-          avg by (job,project_id,instance)(stackdriver_pubsub_subscription_pubsub_googleapis_com_subscription_oldest_unacked_message_age{job=~".+",project_id=~".+",instance=~".+"}) > 60
+          avg by (job,project_id,instance,asserts_env,asserts_site)(stackdriver_pubsub_subscription_pubsub_googleapis_com_subscription_oldest_unacked_message_age{job=~".+",project_id=~".+",instance=~".+"}) > 60
         for: 5m
         keep_firing_for: 10m
         labels:

--- a/csp-mixin/dashboards_out/azure-blobstorage.json
+++ b/csp-mixin/dashboards_out/azure-blobstorage.json
@@ -24,7 +24,8 @@
                   "color": {
                      "fixedColor": "text",
                      "mode": "fixed"
-                  }
+                  },
+                  "unit": "locale"
                },
                "overrides": [
                   {
@@ -48,7 +49,7 @@
                "y": 1
             },
             "id": 2,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -76,7 +77,8 @@
                   "color": {
                      "fixedColor": "text",
                      "mode": "fixed"
-                  }
+                  },
+                  "unit": "locale"
                },
                "overrides": [
                   {
@@ -100,7 +102,7 @@
                "y": 1
             },
             "id": 3,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -128,7 +130,8 @@
                   "color": {
                      "fixedColor": "text",
                      "mode": "fixed"
-                  }
+                  },
+                  "unit": "bytes"
                },
                "overrides": [
                   {
@@ -152,7 +155,7 @@
                "y": 1
             },
             "id": 4,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -177,8 +180,16 @@
             "description": "Total network throughput in bits for the selected timerange",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "minWidth": 100
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
                   },
                   "unit": "bytes"
                },
@@ -252,7 +263,7 @@
                "y": 8
             },
             "id": 5,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -316,6 +327,14 @@
             "description": "Number of objects stored.",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
                   "unit": "locale"
                },
                "overrides": [
@@ -352,7 +371,7 @@
                "y": 8
             },
             "id": 6,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -394,6 +413,14 @@
             "description": "Total bytes stored",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
                   "unit": "bytes"
                },
                "overrides": [
@@ -430,7 +457,7 @@
                "y": 8
             },
             "id": 7,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -484,6 +511,9 @@
             },
             "description": "Percent availability by API request.",
             "fieldConfig": {
+               "defaults": {
+                  "unit": "percent"
+               },
                "overrides": [
                   {
                      "matcher": {
@@ -512,7 +542,7 @@
                   "placement": "bottom"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -541,7 +571,8 @@
                      "stacking": {
                         "mode": "normal"
                      }
-                  }
+                  },
+                  "unit": ""
                },
                "overrides": [
                   {
@@ -565,7 +596,7 @@
                "y": 28
             },
             "id": 10,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -589,6 +620,9 @@
             },
             "description": "Percentage of api request failure by type",
             "fieldConfig": {
+               "defaults": {
+                  "unit": "percentunit"
+               },
                "overrides": [
                   {
                      "matcher": {
@@ -611,7 +645,7 @@
                "y": 28
             },
             "id": 11,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -646,9 +680,13 @@
                "type": "datasource",
                "uid": "-- Mixed --"
             },
-            "description": "Network traffic (bits per sec) measures data transmitted and received.",
+            "description": "received (avg): Total bytes received over the network  \n\ntransmitted (avg): Total bytes sent over the network",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "axisCenteredZero": false,
                      "axisLabel": "out(-) | in(+)",
@@ -663,13 +701,17 @@
                   },
                   "decimals": 1,
                   "noValue": "No traffic",
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
                   "unit": "bps"
                },
                "overrides": [
                   {
                      "matcher": {
                         "id": "byRegexp",
-                        "options": "/transmit|tx|out/"
+                        "options": "/transmit|tx|Tx|out/"
                      },
                      "properties": [
                         {
@@ -721,7 +763,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {

--- a/csp-mixin/dashboards_out/azure-elasticpool.json
+++ b/csp-mixin/dashboards_out/azure-elasticpool.json
@@ -20,6 +20,17 @@
             },
             "description": "Storage overview per elasticpool.",
             "fieldConfig": {
+               "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
+                  "unit": "bytes"
+               },
                "overrides": [
                   {
                      "matcher": {
@@ -78,7 +89,7 @@
                "y": 1
             },
             "id": 2,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -155,13 +166,22 @@
             "description": "CPU utilization per elastic pool.",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "fillOpacity": 30,
                      "gradientMode": "opacity",
                      "lineInterpolation": "smooth",
                      "lineWidth": 2,
                      "showPoints": "never"
-                  }
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
+                  "unit": "percent"
                },
                "overrides": [
                   {
@@ -195,7 +215,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -220,13 +240,22 @@
             "description": "Memory utilization per elastic pool.",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "fillOpacity": 30,
                      "gradientMode": "opacity",
                      "lineInterpolation": "smooth",
                      "lineWidth": 2,
                      "showPoints": "never"
-                  }
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
+                  "unit": "percent"
                },
                "overrides": [
                   {
@@ -260,7 +289,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -285,13 +314,22 @@
             "description": "eDTU utilization per elastic pool.",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "fillOpacity": 30,
                      "gradientMode": "opacity",
                      "lineInterpolation": "smooth",
                      "lineWidth": 2,
                      "showPoints": "never"
-                  }
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
+                  "unit": ""
                },
                "overrides": [
                   {
@@ -325,7 +363,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -350,6 +388,10 @@
             "description": "Average sessions per elastic pool.",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "fillOpacity": 30,
                      "gradientMode": "opacity",
@@ -359,7 +401,12 @@
                      "stacking": {
                         "mode": "normal"
                      }
-                  }
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
+                  "unit": ""
                },
                "overrides": [
                   {
@@ -393,7 +440,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {

--- a/csp-mixin/dashboards_out/azure-frontdoor.json
+++ b/csp-mixin/dashboards_out/azure-frontdoor.json
@@ -22,9 +22,19 @@
             "fieldConfig": {
                "defaults": {
                   "color": {
-                     "fixedColor": "text",
+                     "fixedColor": "#5794f2",
                      "mode": "fixed"
-                  }
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [
+                        {
+                           "color": "#5794f2",
+                           "value": null
+                        }
+                     ]
+                  },
+                  "unit": "short"
                },
                "overrides": [
                   {
@@ -48,7 +58,7 @@
                "y": 1
             },
             "id": 2,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -70,12 +80,21 @@
                "type": "prometheus",
                "uid": "${datasource}"
             },
-            "description": "Top 5 Endpoints with higher percentage of client requests for which the response status code is 4XX or 5XX",
+            "description": "Top 5 Endpoints by Errors (avg): Top 5 Endpoints with higher percentage of client requests for which the response status code is 4XX or 5XX  \n",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "filterable": false
-                  }
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
+                  "unit": "percent"
                },
                "overrides": [
                   {
@@ -137,7 +156,7 @@
                "y": 9
             },
             "id": 3,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -195,13 +214,22 @@
             "description": "The number of client requests served by the HTTP/S proxy",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "fillOpacity": 30,
                      "gradientMode": "opacity",
                      "lineInterpolation": "smooth",
                      "lineWidth": 2,
                      "showPoints": "never"
-                  }
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
+                  "unit": "short"
                },
                "overrides": [
                   {
@@ -236,7 +264,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -261,13 +289,22 @@
             "description": "The number of client requests served by the HTTP/S proxy grouped by country",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "fillOpacity": 30,
                      "gradientMode": "opacity",
                      "lineInterpolation": "smooth",
                      "lineWidth": 2,
                      "showPoints": "never"
-                  }
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
+                  "unit": "short"
                },
                "overrides": [ ]
             },
@@ -288,7 +325,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -313,13 +350,22 @@
             "description": "The number of client requests served by the HTTP/S proxy grouped by status group",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "fillOpacity": 30,
                      "gradientMode": "opacity",
                      "lineInterpolation": "smooth",
                      "lineWidth": 2,
                      "showPoints": "never"
-                  }
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
+                  "unit": "short"
                },
                "overrides": [ ]
             },
@@ -340,7 +386,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -362,16 +408,25 @@
                "type": "datasource",
                "uid": "-- Mixed --"
             },
-            "description": "",
+            "description": "4XX Errors percentage (avg):   \n\n5XX Errors percentage (avg): ",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "fillOpacity": 30,
                      "gradientMode": "opacity",
                      "lineInterpolation": "smooth",
                      "lineWidth": 2,
                      "showPoints": "never"
-                  }
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
+                  "unit": "percent"
                },
                "overrides": [
                   {
@@ -431,7 +486,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -464,9 +519,13 @@
                "type": "datasource",
                "uid": "-- Mixed --"
             },
-            "description": "The number of bytes sent as requests/responses from clients to AFDX and from HTTP/S proxy to clients.",
+            "description": "Requests size (avg): The number of bytes sent as requests from clients to AFDX.  \n\nResponses size (avg): The number of bytes sent as responses from HTTP/S proxy to clients.",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "axisLabel": "requests(-) | responses(+)",
                      "fillOpacity": 30,
@@ -474,6 +533,10 @@
                      "lineInterpolation": "smooth",
                      "lineWidth": 2,
                      "showPoints": "never"
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
                   },
                   "unit": "decbytes"
                },
@@ -513,7 +576,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -549,13 +612,22 @@
             "description": "The time calculated from when the client request was received by the HTTP/S proxy until the client acknowledged the last response byte from the HTTP/S proxy\tTotalLatency",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "fillOpacity": 30,
                      "gradientMode": "opacity",
                      "lineInterpolation": "smooth",
                      "lineWidth": 2,
                      "showPoints": "never"
-                  }
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
+                  "unit": "ms"
                },
                "overrides": [
                   {
@@ -590,7 +662,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -615,13 +687,22 @@
             "description": "The percentage of successful health probes from AFDX to backends.",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "fillOpacity": 30,
                      "gradientMode": "opacity",
                      "lineInterpolation": "smooth",
                      "lineWidth": 2,
                      "showPoints": "never"
-                  }
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
+                  "unit": "percent"
                },
                "overrides": [
                   {
@@ -686,7 +767,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -711,13 +792,22 @@
             "description": "The time calculated from when the request was sent by AFDX edge to the backend until AFDX received the last response byte from the backend.",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "fillOpacity": 30,
                      "gradientMode": "opacity",
                      "lineInterpolation": "smooth",
                      "lineWidth": 2,
                      "showPoints": "never"
-                  }
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
+                  "unit": "ms"
                },
                "overrides": [
                   {
@@ -752,7 +842,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -787,13 +877,22 @@
                   "description": "Number of requests by endpoints.",
                   "fieldConfig": {
                      "defaults": {
+                        "color": {
+                           "fixedColor": "#5794f2",
+                           "mode": "palette-classic"
+                        },
                         "custom": {
                            "fillOpacity": 30,
                            "gradientMode": "opacity",
                            "lineInterpolation": "smooth",
                            "lineWidth": 2,
                            "showPoints": "never"
-                        }
+                        },
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "short"
                      },
                      "overrides": [
                         {
@@ -827,7 +926,7 @@
                         "sort": "desc"
                      }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                      {
                         "datasource": {
@@ -852,13 +951,22 @@
                   "description": "The number of bytes sent as requests from clients to AFDX.",
                   "fieldConfig": {
                      "defaults": {
+                        "color": {
+                           "fixedColor": "#5794f2",
+                           "mode": "palette-classic"
+                        },
                         "custom": {
                            "fillOpacity": 30,
                            "gradientMode": "opacity",
                            "lineInterpolation": "smooth",
                            "lineWidth": 2,
                            "showPoints": "never"
-                        }
+                        },
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "decbytes"
                      },
                      "overrides": [
                         {
@@ -892,7 +1000,7 @@
                         "sort": "desc"
                      }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                      {
                         "datasource": {
@@ -917,13 +1025,22 @@
                   "description": "The number of bytes sent as responses from HTTP/S proxy to clients.",
                   "fieldConfig": {
                      "defaults": {
+                        "color": {
+                           "fixedColor": "#5794f2",
+                           "mode": "palette-classic"
+                        },
                         "custom": {
                            "fillOpacity": 30,
                            "gradientMode": "opacity",
                            "lineInterpolation": "smooth",
                            "lineWidth": 2,
                            "showPoints": "never"
-                        }
+                        },
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "decbytes"
                      },
                      "overrides": [
                         {
@@ -957,7 +1074,7 @@
                         "sort": "desc"
                      }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                      {
                         "datasource": {
@@ -982,13 +1099,22 @@
                   "description": "The time calculated from when the client request was received by the HTTP/S proxy until the client acknowledged the last response byte from the HTTP/S proxy\tTotalLatency",
                   "fieldConfig": {
                      "defaults": {
+                        "color": {
+                           "fixedColor": "#5794f2",
+                           "mode": "palette-classic"
+                        },
                         "custom": {
                            "fillOpacity": 30,
                            "gradientMode": "opacity",
                            "lineInterpolation": "smooth",
                            "lineWidth": 2,
                            "showPoints": "never"
-                        }
+                        },
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "ms"
                      },
                      "overrides": [
                         {
@@ -1022,7 +1148,7 @@
                         "sort": "desc"
                      }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                      {
                         "datasource": {
@@ -1047,13 +1173,22 @@
                   "description": "",
                   "fieldConfig": {
                      "defaults": {
+                        "color": {
+                           "fixedColor": "#5794f2",
+                           "mode": "palette-classic"
+                        },
                         "custom": {
                            "fillOpacity": 30,
                            "gradientMode": "opacity",
                            "lineInterpolation": "smooth",
                            "lineWidth": 2,
                            "showPoints": "never"
-                        }
+                        },
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "percent"
                      },
                      "overrides": [
                         {
@@ -1094,7 +1229,7 @@
                         "sort": "desc"
                      }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                      {
                         "datasource": {
@@ -1119,13 +1254,22 @@
                   "description": "The number of requests sent from AFDX to origin.",
                   "fieldConfig": {
                      "defaults": {
+                        "color": {
+                           "fixedColor": "#5794f2",
+                           "mode": "palette-classic"
+                        },
                         "custom": {
                            "fillOpacity": 30,
                            "gradientMode": "opacity",
                            "lineInterpolation": "smooth",
                            "lineWidth": 2,
                            "showPoints": "never"
-                        }
+                        },
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "short"
                      },
                      "overrides": [
                         {
@@ -1159,7 +1303,7 @@
                         "sort": "desc"
                      }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                      {
                         "datasource": {
@@ -1184,13 +1328,22 @@
                   "description": "The time calculated from when the request was sent by AFDX edge to the backend until AFDX received the last response byte from the backend.",
                   "fieldConfig": {
                      "defaults": {
+                        "color": {
+                           "fixedColor": "#5794f2",
+                           "mode": "palette-classic"
+                        },
                         "custom": {
                            "fillOpacity": 30,
                            "gradientMode": "opacity",
                            "lineInterpolation": "smooth",
                            "lineWidth": 2,
                            "showPoints": "never"
-                        }
+                        },
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "ms"
                      },
                      "overrides": [
                         {
@@ -1224,7 +1377,7 @@
                         "sort": "desc"
                      }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                      {
                         "datasource": {

--- a/csp-mixin/dashboards_out/azure-loadbalancer.json
+++ b/csp-mixin/dashboards_out/azure-loadbalancer.json
@@ -22,10 +22,19 @@
             "fieldConfig": {
                "defaults": {
                   "color": {
-                     "fixedColor": "text",
+                     "fixedColor": "#5794f2",
                      "mode": "thresholds"
                   },
                   "noValue": "0",
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [
+                        {
+                           "color": "#5794f2",
+                           "value": null
+                        }
+                     ]
+                  },
                   "unit": "short"
                },
                "overrides": [ ]
@@ -40,7 +49,7 @@
             "options": {
                "colorMode": "background_solid"
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -66,10 +75,19 @@
             "fieldConfig": {
                "defaults": {
                   "color": {
-                     "fixedColor": "text",
+                     "fixedColor": "#5794f2",
                      "mode": "thresholds"
                   },
                   "noValue": "0",
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [
+                        {
+                           "color": "#5794f2",
+                           "value": null
+                        }
+                     ]
+                  },
                   "unit": "short"
                },
                "overrides": [ ]
@@ -84,7 +102,7 @@
             "options": {
                "colorMode": "background_solid"
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -110,10 +128,19 @@
             "fieldConfig": {
                "defaults": {
                   "color": {
-                     "fixedColor": "text",
+                     "fixedColor": "#5794f2",
                      "mode": "thresholds"
                   },
                   "noValue": "0",
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [
+                        {
+                           "color": "#5794f2",
+                           "value": null
+                        }
+                     ]
+                  },
                   "unit": "decbytes"
                },
                "overrides": [ ]
@@ -128,7 +155,7 @@
             "options": {
                "colorMode": "background_solid"
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -154,10 +181,19 @@
             "fieldConfig": {
                "defaults": {
                   "color": {
-                     "fixedColor": "text",
+                     "fixedColor": "#5794f2",
                      "mode": "thresholds"
                   },
                   "noValue": "0",
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [
+                        {
+                           "color": "#5794f2",
+                           "value": null
+                        }
+                     ]
+                  },
                   "unit": "short"
                },
                "overrides": [ ]
@@ -172,7 +208,7 @@
             "options": {
                "colorMode": "background_solid"
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -210,6 +246,10 @@
             "description": "Total number of SYN Packets transmitted within time period",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "fillOpacity": 10,
                      "gradientMode": "none",
@@ -218,6 +258,10 @@
                      "showPoints": "never"
                   },
                   "noValue": "0",
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
                   "unit": "short"
                },
                "overrides": [ ]
@@ -239,7 +283,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -264,6 +308,10 @@
             "description": "Total number of Packets transmitted within time period",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "fillOpacity": 10,
                      "gradientMode": "none",
@@ -272,6 +320,10 @@
                      "showPoints": "never"
                   },
                   "noValue": "0",
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
                   "unit": "short"
                },
                "overrides": [ ]
@@ -293,7 +345,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -318,6 +370,10 @@
             "description": "Total number of Bytes transmitted within time period",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "fillOpacity": 10,
                      "gradientMode": "none",
@@ -326,6 +382,10 @@
                      "showPoints": "never"
                   },
                   "noValue": "0",
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
                   "unit": "decbytes"
                },
                "overrides": [ ]
@@ -347,7 +407,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -372,6 +432,10 @@
             "description": "Total number of new SNAT connections created within time period",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "fillOpacity": 10,
                      "gradientMode": "none",
@@ -380,6 +444,10 @@
                      "showPoints": "never"
                   },
                   "noValue": "0",
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
                   "unit": "short"
                },
                "overrides": [ ]
@@ -401,7 +469,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -436,9 +504,13 @@
                "type": "prometheus",
                "uid": "${datasource}"
             },
-            "description": "Total SNAT ports used and allocated within time period",
+            "description": "SNAT Ports (avg): Total SNAT ports used and allocated within time period  \n\nAllocated SNAT Ports (avg): Total number of SNAT ports allocated",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "fillOpacity": 30,
                      "gradientMode": "opacity",
@@ -447,6 +519,10 @@
                      "showPoints": "never"
                   },
                   "noValue": "0",
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
                   "unit": "short"
                },
                "overrides": [ ]
@@ -468,7 +544,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -501,7 +577,7 @@
                "type": "prometheus",
                "uid": "${datasource}"
             },
-            "description": "Total SNAT ports used at the current time",
+            "description": "Currently used SNAT ports (avg): Total SNAT ports used at the current time  \n\nAllocated SNAT Ports (avg): Total number of SNAT ports allocated",
             "fieldConfig": {
                "defaults": {
                   "color": {
@@ -519,7 +595,7 @@
                "y": 21
             },
             "id": 13,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {

--- a/csp-mixin/dashboards_out/azure-queuestorage.json
+++ b/csp-mixin/dashboards_out/azure-queuestorage.json
@@ -24,7 +24,8 @@
                   "color": {
                      "fixedColor": "text",
                      "mode": "fixed"
-                  }
+                  },
+                  "unit": "locale"
                },
                "overrides": [
                   {
@@ -48,7 +49,7 @@
                "y": 1
             },
             "id": 2,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -76,7 +77,8 @@
                   "color": {
                      "fixedColor": "text",
                      "mode": "fixed"
-                  }
+                  },
+                  "unit": "locale"
                },
                "overrides": [
                   {
@@ -100,7 +102,7 @@
                "y": 1
             },
             "id": 3,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -128,7 +130,8 @@
                   "color": {
                      "fixedColor": "text",
                      "mode": "fixed"
-                  }
+                  },
+                  "unit": "bytes"
                },
                "overrides": [
                   {
@@ -152,7 +155,7 @@
                "y": 1
             },
             "id": 4,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -177,8 +180,16 @@
             "description": "Total network throughput in bits for the selected timerange",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "minWidth": 100
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
                   },
                   "unit": "bytes"
                },
@@ -252,7 +263,7 @@
                "y": 8
             },
             "id": 5,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -316,6 +327,14 @@
             "description": "Number of messages stored.",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
                   "unit": "locale"
                },
                "overrides": [
@@ -352,7 +371,7 @@
                "y": 8
             },
             "id": 6,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -394,6 +413,14 @@
             "description": "Total bytes stored",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
                   "unit": "bytes"
                },
                "overrides": [
@@ -430,7 +457,7 @@
                "y": 8
             },
             "id": 7,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -471,6 +498,9 @@
             },
             "description": "Number of messages stored.",
             "fieldConfig": {
+               "defaults": {
+                  "unit": "locale"
+               },
                "overrides": [
                   {
                      "matcher": {
@@ -493,7 +523,7 @@
                "y": 15
             },
             "id": 8,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -530,6 +560,9 @@
             },
             "description": "Percent availability by API request.",
             "fieldConfig": {
+               "defaults": {
+                  "unit": "percent"
+               },
                "overrides": [
                   {
                      "matcher": {
@@ -558,7 +591,7 @@
                   "placement": "bottom"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -587,7 +620,8 @@
                      "stacking": {
                         "mode": "normal"
                      }
-                  }
+                  },
+                  "unit": ""
                },
                "overrides": [
                   {
@@ -611,7 +645,7 @@
                "y": 35
             },
             "id": 11,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -635,6 +669,9 @@
             },
             "description": "Percentage of api request failure by type",
             "fieldConfig": {
+               "defaults": {
+                  "unit": "percentunit"
+               },
                "overrides": [
                   {
                      "matcher": {
@@ -657,7 +694,7 @@
                "y": 35
             },
             "id": 12,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -692,9 +729,13 @@
                "type": "datasource",
                "uid": "-- Mixed --"
             },
-            "description": "Network traffic (bits per sec) measures data transmitted and received.",
+            "description": "received (avg): Total bytes received over the network  \n\ntransmitted (avg): Total bytes sent over the network",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "axisCenteredZero": false,
                      "axisLabel": "out(-) | in(+)",
@@ -709,13 +750,17 @@
                   },
                   "decimals": 1,
                   "noValue": "No traffic",
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
                   "unit": "bps"
                },
                "overrides": [
                   {
                      "matcher": {
                         "id": "byRegexp",
-                        "options": "/transmit|tx|out/"
+                        "options": "/transmit|tx|Tx|out/"
                      },
                      "properties": [
                         {
@@ -767,7 +812,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {

--- a/csp-mixin/dashboards_out/azure-sqldb.json
+++ b/csp-mixin/dashboards_out/azure-sqldb.json
@@ -21,13 +21,22 @@
             "description": "Count of successful connections by database",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "fillOpacity": 30,
                      "gradientMode": "opacity",
                      "lineInterpolation": "smooth",
                      "lineWidth": 2,
                      "showPoints": "never"
-                  }
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
+                  "unit": ""
                },
                "overrides": [
                   {
@@ -61,7 +70,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -86,13 +95,22 @@
             "description": "Count of deadlocks by database",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "fillOpacity": 30,
                      "gradientMode": "opacity",
                      "lineInterpolation": "smooth",
                      "lineWidth": 2,
                      "showPoints": "never"
-                  }
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
+                  "unit": ""
                },
                "overrides": [
                   {
@@ -126,7 +144,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -151,13 +169,22 @@
             "description": "Average number of sessions by database",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "fillOpacity": 30,
                      "gradientMode": "opacity",
                      "lineInterpolation": "smooth",
                      "lineWidth": 2,
                      "showPoints": "never"
-                  }
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
+                  "unit": ""
                },
                "overrides": [
                   {
@@ -191,7 +218,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -226,16 +253,25 @@
                "type": "prometheus",
                "uid": "${datasource}"
             },
-            "description": "Percent of CPU utilization by database. If database uses vCores, the vCore percent utilization is shown",
+            "description": "CPU utilization by database (avg): Percent of CPU utilization by database. If database uses vCores, the vCore percent utilization is shown  \n\nvCore utilization by database (avg): Percent of CPU utilization by database. If database uses vCores, the vCore percent utilization is shown",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "fillOpacity": 30,
                      "gradientMode": "opacity",
                      "lineInterpolation": "smooth",
                      "lineWidth": 2,
                      "showPoints": "never"
-                  }
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
+                  "unit": "percent"
                },
                "overrides": [
                   {
@@ -281,7 +317,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -317,6 +353,10 @@
             "description": "Bytes of storage by database",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "fillOpacity": 30,
                      "gradientMode": "opacity",
@@ -326,7 +366,12 @@
                      "stacking": {
                         "mode": "normal"
                      }
-                  }
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
+                  "unit": "bytes"
                },
                "overrides": [
                   {
@@ -360,7 +405,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -385,13 +430,22 @@
             "description": "Percent used of storage limitby database",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "fillOpacity": 30,
                      "gradientMode": "opacity",
                      "lineInterpolation": "smooth",
                      "lineWidth": 2,
                      "showPoints": "never"
-                  }
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
+                  "unit": "percent"
                },
                "overrides": [
                   {
@@ -425,7 +479,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -450,13 +504,22 @@
             "description": "Average number of DTUs utilized by database",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "fillOpacity": 30,
                      "gradientMode": "opacity",
                      "lineInterpolation": "smooth",
                      "lineWidth": 2,
                      "showPoints": "never"
-                  }
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
+                  "unit": ""
                },
                "overrides": [
                   {
@@ -490,7 +553,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -514,6 +577,17 @@
             },
             "description": "DTU utilization and limits by database",
             "fieldConfig": {
+               "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
+                  "unit": ""
+               },
                "overrides": [
                   {
                      "matcher": {
@@ -572,7 +646,7 @@
                "y": 26
             },
             "id": 10,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {

--- a/csp-mixin/dashboards_out/azure-virtualmachines.json
+++ b/csp-mixin/dashboards_out/azure-virtualmachines.json
@@ -22,9 +22,19 @@
             "fieldConfig": {
                "defaults": {
                   "color": {
-                     "fixedColor": "text",
+                     "fixedColor": "#5794f2",
                      "mode": "fixed"
-                  }
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [
+                        {
+                           "color": "#5794f2",
+                           "value": null
+                        }
+                     ]
+                  },
+                  "unit": "short"
                },
                "overrides": [
                   {
@@ -48,7 +58,7 @@
                "y": 1
             },
             "id": 2,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -70,12 +80,21 @@
                "type": "prometheus",
                "uid": "${datasource}"
             },
-            "description": "Measure of availability of virtual machines",
+            "description": "VM Availability (avg): Measure of availability of virtual machines  \n",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "filterable": false
-                  }
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
+                  "unit": "short"
                },
                "overrides": [
                   {
@@ -145,7 +164,7 @@
                "y": 1
             },
             "id": 3,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -185,12 +204,21 @@
                "type": "prometheus",
                "uid": "${datasource}"
             },
-            "description": "Fractional utilization of allocated CPU on an instance",
+            "description": "Top 5 Instances by CPU utilitization (avg): Fractional utilization of allocated CPU on an instance  \n",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "filterable": false
-                  }
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
+                  "unit": ""
                },
                "overrides": [
                   {
@@ -258,7 +286,7 @@
                "y": 9
             },
             "id": 4,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -304,11 +332,19 @@
                "type": "prometheus",
                "uid": "${datasource}"
             },
-            "description": "List of top 5 instances with less amount of physical memory immediately available for allocation.",
+            "description": "Top 5 Instances by Less available memory (avg): List of top 5 instances with less amount of physical memory immediately available for allocation.  \n",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "filterable": false
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
                   },
                   "unit": "decbytes"
                },
@@ -334,7 +370,7 @@
                "y": 9
             },
             "id": 5,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -383,11 +419,19 @@
                "type": "prometheus",
                "uid": "${datasource}"
             },
-            "description": "List of top 5 instances by disk read bytes",
+            "description": "Top 5 Instances by Disk read bytes (sum): List of top 5 instances by disk read bytes  \n",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "filterable": false
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
                   },
                   "unit": "decbytes"
                },
@@ -413,7 +457,7 @@
                "y": 17
             },
             "id": 6,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -459,11 +503,19 @@
                "type": "prometheus",
                "uid": "${datasource}"
             },
-            "description": "List of top 5 instances by disk write bytes",
+            "description": "Top 5 Instances by Disk write bytes (sum): List of top 5 instances by disk write bytes  \n",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "filterable": false
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
                   },
                   "unit": "decbytes"
                },
@@ -489,7 +541,7 @@
                "y": 17
             },
             "id": 7,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -535,12 +587,13 @@
                "type": "prometheus",
                "uid": "${datasource}"
             },
-            "description": "The percentage of allocated compute units that are currently in use by the Virtual Machine(s)",
+            "description": "CPU Utilization average (avg): The percentage of allocated compute units that are currently in use by the Virtual Machine(s)  \n\nAvailable memory (avg): Amount of physical memory, in bytes, immediately available for allocation to a process or for system use in the Virtual Machine  \n\nNetwork sent (sum): The number of bytes sent to all network interfaces by the Virtual Machine(s)  \n\nNetwork received (sum): The number of bytes received on all network interfaces by the Virtual Machine(s)  \n\nDisk read bytes (sum): Bytes read from disk during monitoring period  \n\nDisk write bytes (sum): Bytes written to disk during monitoring period",
             "fieldConfig": {
                "defaults": {
                   "custom": {
                      "filterable": false
-                  }
+                  },
+                  "unit": "percent"
                },
                "overrides": [
                   {
@@ -710,7 +763,7 @@
                "y": 25
             },
             "id": 8,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -819,9 +872,13 @@
                "type": "prometheus",
                "uid": "${datasource}"
             },
-            "description": "Bytes read/written from/to disk during monitoring period",
+            "description": "Disk read/write bytes (sum): Bytes read/written from/to disk during monitoring period  \n\nDisk write bytes (sum): Bytes written to disk during monitoring period",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "fillOpacity": 30,
                      "gradientMode": "opacity",
@@ -829,7 +886,12 @@
                      "lineWidth": 2,
                      "showPoints": "never"
                   },
-                  "noValue": "0"
+                  "noValue": "0",
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
+                  "unit": "decbytes"
                },
                "overrides": [
                   {
@@ -875,7 +937,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -908,9 +970,13 @@
                "type": "prometheus",
                "uid": "${datasource}"
             },
-            "description": "Disk read/write IOPS",
+            "description": "Disk read/write operations (avg): Disk read/write IOPS  \n\nDisk write operations (avg): Disk write IOPS",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "fillOpacity": 30,
                      "gradientMode": "opacity",
@@ -918,7 +984,12 @@
                      "lineWidth": 2,
                      "showPoints": "never"
                   },
-                  "noValue": "0"
+                  "noValue": "0",
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
+                  "unit": "cps"
                },
                "overrides": [
                   {
@@ -964,7 +1035,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -997,16 +1068,25 @@
                "type": "prometheus",
                "uid": "${datasource}"
             },
-            "description": "The number of bytes sent/received over the network.",
+            "description": "Network throughput sent/received (sum): The number of bytes sent/received over the network.  \n\nNetwork throughput received (sum): The number of bytes received over the network.",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "fillOpacity": 30,
                      "gradientMode": "opacity",
                      "lineInterpolation": "smooth",
                      "lineWidth": 2,
                      "showPoints": "never"
-                  }
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
+                  "unit": "decbytes"
                },
                "overrides": [
                   {
@@ -1052,7 +1132,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -1085,16 +1165,25 @@
                "type": "prometheus",
                "uid": "${datasource}"
             },
-            "description": "Number of current flows in the inbound/outbound direction",
+            "description": "Flows (sum): Number of current flows in the inbound/outbound direction  \n\nOutbound flows (sum): Number of current flows in the outbound direction",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "fillOpacity": 30,
                      "gradientMode": "opacity",
                      "lineInterpolation": "smooth",
                      "lineWidth": 2,
                      "showPoints": "never"
-                  }
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
+                  "unit": "cps"
                },
                "overrides": [
                   {
@@ -1140,7 +1229,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -1193,7 +1282,7 @@
                   "options": {
                      "content": "Use this section to look at one instance at a time by picking a value in the *ResourceName* picker at the top of the dashboard."
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.4.0",
                   "title": "Instances",
                   "type": "text"
                },
@@ -1205,6 +1294,10 @@
                   "description": "The percentage of allocated compute units that are currently in use by the Virtual Machine(s)",
                   "fieldConfig": {
                      "defaults": {
+                        "color": {
+                           "fixedColor": "#5794f2",
+                           "mode": "palette-classic"
+                        },
                         "custom": {
                            "fillOpacity": 30,
                            "gradientMode": "opacity",
@@ -1212,7 +1305,12 @@
                            "lineWidth": 2,
                            "showPoints": "never"
                         },
-                        "noValue": "0"
+                        "noValue": "0",
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "percent"
                      },
                      "overrides": [
                         {
@@ -1246,7 +1344,7 @@
                         "sort": "desc"
                      }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                      {
                         "datasource": {
@@ -1271,6 +1369,10 @@
                   "description": "Amount of physical memory, in bytes, immediately available for allocation to a process or for system use in the Virtual Machine",
                   "fieldConfig": {
                      "defaults": {
+                        "color": {
+                           "fixedColor": "#5794f2",
+                           "mode": "palette-classic"
+                        },
                         "custom": {
                            "fillOpacity": 30,
                            "gradientMode": "opacity",
@@ -1278,7 +1380,12 @@
                            "lineWidth": 2,
                            "showPoints": "never"
                         },
-                        "noValue": "0"
+                        "noValue": "0",
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "decbytes"
                      },
                      "overrides": [
                         {
@@ -1312,7 +1419,7 @@
                         "sort": "desc"
                      }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                      {
                         "datasource": {
@@ -1337,6 +1444,10 @@
                   "description": "Total number of credits consumed by the Virtual Machine.",
                   "fieldConfig": {
                      "defaults": {
+                        "color": {
+                           "fixedColor": "#5794f2",
+                           "mode": "palette-classic"
+                        },
                         "custom": {
                            "fillOpacity": 30,
                            "gradientMode": "opacity",
@@ -1344,7 +1455,12 @@
                            "lineWidth": 2,
                            "showPoints": "never"
                         },
-                        "noValue": "0"
+                        "noValue": "0",
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "cps"
                      },
                      "overrides": [
                         {
@@ -1378,7 +1494,7 @@
                         "sort": "desc"
                      }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                      {
                         "datasource": {
@@ -1403,6 +1519,10 @@
                   "description": "Total number of credits available to burst.",
                   "fieldConfig": {
                      "defaults": {
+                        "color": {
+                           "fixedColor": "#5794f2",
+                           "mode": "palette-classic"
+                        },
                         "custom": {
                            "fillOpacity": 30,
                            "gradientMode": "opacity",
@@ -1410,7 +1530,12 @@
                            "lineWidth": 2,
                            "showPoints": "never"
                         },
-                        "noValue": "0"
+                        "noValue": "0",
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "cps"
                      },
                      "overrides": [
                         {
@@ -1444,7 +1569,7 @@
                         "sort": "desc"
                      }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                      {
                         "datasource": {
@@ -1469,13 +1594,22 @@
                   "description": "The number of bytes received on all network interfaces by the Virtual Machine(s)",
                   "fieldConfig": {
                      "defaults": {
+                        "color": {
+                           "fixedColor": "#5794f2",
+                           "mode": "palette-classic"
+                        },
                         "custom": {
                            "fillOpacity": 30,
                            "gradientMode": "opacity",
                            "lineInterpolation": "smooth",
                            "lineWidth": 2,
                            "showPoints": "never"
-                        }
+                        },
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "decbytes"
                      },
                      "overrides": [
                         {
@@ -1509,7 +1643,7 @@
                         "sort": "desc"
                      }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                      {
                         "datasource": {
@@ -1534,13 +1668,22 @@
                   "description": "The number of bytes sent to all network interfaces by the Virtual Machine(s)",
                   "fieldConfig": {
                      "defaults": {
+                        "color": {
+                           "fixedColor": "#5794f2",
+                           "mode": "palette-classic"
+                        },
                         "custom": {
                            "fillOpacity": 30,
                            "gradientMode": "opacity",
                            "lineInterpolation": "smooth",
                            "lineWidth": 2,
                            "showPoints": "never"
-                        }
+                        },
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "decbytes"
                      },
                      "overrides": [
                         {
@@ -1574,7 +1717,7 @@
                         "sort": "desc"
                      }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                      {
                         "datasource": {
@@ -1599,6 +1742,10 @@
                   "description": "Bytes read from disk during monitoring period",
                   "fieldConfig": {
                      "defaults": {
+                        "color": {
+                           "fixedColor": "#5794f2",
+                           "mode": "palette-classic"
+                        },
                         "custom": {
                            "fillOpacity": 30,
                            "gradientMode": "opacity",
@@ -1606,7 +1753,12 @@
                            "lineWidth": 2,
                            "showPoints": "never"
                         },
-                        "noValue": "0"
+                        "noValue": "0",
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "decbytes"
                      },
                      "overrides": [
                         {
@@ -1640,7 +1792,7 @@
                         "sort": "desc"
                      }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                      {
                         "datasource": {
@@ -1665,6 +1817,10 @@
                   "description": "Bytes written to disk during monitoring period",
                   "fieldConfig": {
                      "defaults": {
+                        "color": {
+                           "fixedColor": "#5794f2",
+                           "mode": "palette-classic"
+                        },
                         "custom": {
                            "fillOpacity": 30,
                            "gradientMode": "opacity",
@@ -1672,7 +1828,12 @@
                            "lineWidth": 2,
                            "showPoints": "never"
                         },
-                        "noValue": "0"
+                        "noValue": "0",
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "decbytes"
                      },
                      "overrides": [
                         {
@@ -1706,7 +1867,7 @@
                         "sort": "desc"
                      }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                      {
                         "datasource": {
@@ -1731,6 +1892,10 @@
                   "description": "Disk read IOPS",
                   "fieldConfig": {
                      "defaults": {
+                        "color": {
+                           "fixedColor": "#5794f2",
+                           "mode": "palette-classic"
+                        },
                         "custom": {
                            "fillOpacity": 30,
                            "gradientMode": "opacity",
@@ -1738,7 +1903,12 @@
                            "lineWidth": 2,
                            "showPoints": "never"
                         },
-                        "noValue": "0"
+                        "noValue": "0",
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "cps"
                      },
                      "overrides": [
                         {
@@ -1772,7 +1942,7 @@
                         "sort": "desc"
                      }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                      {
                         "datasource": {
@@ -1797,6 +1967,10 @@
                   "description": "Disk write IOPS",
                   "fieldConfig": {
                      "defaults": {
+                        "color": {
+                           "fixedColor": "#5794f2",
+                           "mode": "palette-classic"
+                        },
                         "custom": {
                            "fillOpacity": 30,
                            "gradientMode": "opacity",
@@ -1804,7 +1978,12 @@
                            "lineWidth": 2,
                            "showPoints": "never"
                         },
-                        "noValue": "0"
+                        "noValue": "0",
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "cps"
                      },
                      "overrides": [
                         {
@@ -1838,7 +2017,7 @@
                         "sort": "desc"
                      }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                      {
                         "datasource": {
@@ -1863,13 +2042,22 @@
                   "description": "The number of current flows in the inbound direction (traffic going into the VM).",
                   "fieldConfig": {
                      "defaults": {
+                        "color": {
+                           "fixedColor": "#5794f2",
+                           "mode": "palette-classic"
+                        },
                         "custom": {
                            "fillOpacity": 30,
                            "gradientMode": "opacity",
                            "lineInterpolation": "smooth",
                            "lineWidth": 2,
                            "showPoints": "never"
-                        }
+                        },
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "cps"
                      },
                      "overrides": [
                         {
@@ -1903,7 +2091,7 @@
                         "sort": "desc"
                      }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                      {
                         "datasource": {
@@ -1928,13 +2116,22 @@
                   "description": "Number of current flows in the outbound direction",
                   "fieldConfig": {
                      "defaults": {
+                        "color": {
+                           "fixedColor": "#5794f2",
+                           "mode": "palette-classic"
+                        },
                         "custom": {
                            "fillOpacity": 30,
                            "gradientMode": "opacity",
                            "lineInterpolation": "smooth",
                            "lineWidth": 2,
                            "showPoints": "never"
-                        }
+                        },
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "cps"
                      },
                      "overrides": [
                         {
@@ -1968,7 +2165,7 @@
                         "sort": "desc"
                      }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                      {
                         "datasource": {

--- a/csp-mixin/dashboards_out/gcp-blobstorage.json
+++ b/csp-mixin/dashboards_out/gcp-blobstorage.json
@@ -24,7 +24,8 @@
                   "color": {
                      "fixedColor": "text",
                      "mode": "fixed"
-                  }
+                  },
+                  "unit": "locale"
                },
                "overrides": [
                   {
@@ -48,7 +49,7 @@
                "y": 1
             },
             "id": 2,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -76,7 +77,8 @@
                   "color": {
                      "fixedColor": "text",
                      "mode": "fixed"
-                  }
+                  },
+                  "unit": "locale"
                },
                "overrides": [
                   {
@@ -100,7 +102,7 @@
                "y": 1
             },
             "id": 3,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -128,7 +130,8 @@
                   "color": {
                      "fixedColor": "text",
                      "mode": "fixed"
-                  }
+                  },
+                  "unit": "bytes"
                },
                "overrides": [
                   {
@@ -152,7 +155,7 @@
                "y": 1
             },
             "id": 4,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -177,8 +180,16 @@
             "description": "Total network throughput in bits for the selected timerange",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "minWidth": 100
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
                   },
                   "unit": "bytes"
                },
@@ -252,7 +263,7 @@
                "y": 8
             },
             "id": 5,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -316,6 +327,14 @@
             "description": "Number of objects stored.",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
                   "unit": "locale"
                },
                "overrides": [
@@ -352,7 +371,7 @@
                "y": 8
             },
             "id": 6,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -394,6 +413,14 @@
             "description": "Total bytes stored",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
                   "unit": "bytes"
                },
                "overrides": [
@@ -430,7 +457,7 @@
                "y": 8
             },
             "id": 7,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -489,7 +516,8 @@
                      "stacking": {
                         "mode": "normal"
                      }
-                  }
+                  },
+                  "unit": ""
                },
                "overrides": [
                   {
@@ -513,7 +541,7 @@
                "y": 16
             },
             "id": 9,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -537,6 +565,9 @@
             },
             "description": "Percentage of api request failure by type",
             "fieldConfig": {
+               "defaults": {
+                  "unit": "percentunit"
+               },
                "overrides": [
                   {
                      "matcher": {
@@ -559,7 +590,7 @@
                "y": 16
             },
             "id": 10,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -594,9 +625,13 @@
                "type": "datasource",
                "uid": "-- Mixed --"
             },
-            "description": "Network traffic (bits per sec) measures data transmitted and received.",
+            "description": "received (avg): Total bytes received over the network  \n\ntransmitted (avg): Total bytes sent over the network",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "axisCenteredZero": false,
                      "axisLabel": "out(-) | in(+)",
@@ -611,13 +646,17 @@
                   },
                   "decimals": 1,
                   "noValue": "No traffic",
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
                   "unit": "bps"
                },
                "overrides": [
                   {
                      "matcher": {
                         "id": "byRegexp",
-                        "options": "/transmit|tx|out/"
+                        "options": "/transmit|tx|Tx|out/"
                      },
                      "properties": [
                         {
@@ -669,7 +708,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {

--- a/csp-mixin/dashboards_out/gcp-computeengine.json
+++ b/csp-mixin/dashboards_out/gcp-computeengine.json
@@ -24,7 +24,8 @@
                   "color": {
                      "fixedColor": "text",
                      "mode": "fixed"
-                  }
+                  },
+                  "unit": "short"
                },
                "overrides": [
                   {
@@ -52,7 +53,7 @@
                "y": 1
             },
             "id": 2,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -80,7 +81,8 @@
                   "color": {
                      "fixedColor": "text",
                      "mode": "fixed"
-                  }
+                  },
+                  "unit": "short"
                },
                "overrides": [
                   {
@@ -108,7 +110,7 @@
                "y": 1
             },
             "id": 3,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -130,12 +132,13 @@
                "type": "prometheus",
                "uid": "${datasource}"
             },
-            "description": "Fractional utilization of allocated CPU on an instance",
+            "description": "Top 5 Instances by CPU utilitization (sum): Fractional utilization of allocated CPU on an instance  \n",
             "fieldConfig": {
                "defaults": {
                   "custom": {
                      "filterable": false
-                  }
+                  },
+                  "unit": ""
                },
                "overrides": [
                   {
@@ -239,7 +242,7 @@
                "y": 9
             },
             "id": 4,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -297,12 +300,13 @@
                "type": "prometheus",
                "uid": "${datasource}"
             },
-            "description": "List of top 5 instances with system problems.",
+            "description": "Top 5 Instances by System problem (sum): List of top 5 instances with system problems.  \n",
             "fieldConfig": {
                "defaults": {
                   "custom": {
                      "filterable": false
-                  }
+                  },
+                  "unit": ""
                },
                "overrides": [
                   {
@@ -374,7 +378,7 @@
                "y": 9
             },
             "id": 5,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -432,7 +436,7 @@
                "type": "prometheus",
                "uid": "${datasource}"
             },
-            "description": "List of top 5 instances by disk read bytes",
+            "description": "Top 5 Instances by Disk read bytes (sum): List of top 5 instances by disk read bytes  \n",
             "fieldConfig": {
                "defaults": {
                   "custom": {
@@ -510,7 +514,7 @@
                "y": 17
             },
             "id": 6,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -568,7 +572,7 @@
                "type": "prometheus",
                "uid": "${datasource}"
             },
-            "description": "List of top 5 instances by disk write bytes",
+            "description": "Top 5 Instances by Disk write bytes (sum): List of top 5 instances by disk write bytes  \n",
             "fieldConfig": {
                "defaults": {
                   "custom": {
@@ -646,7 +650,7 @@
                "y": 17
             },
             "id": 7,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -915,7 +919,7 @@
                "y": 29
             },
             "id": 8,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -1020,8 +1024,11 @@
                "type": "prometheus",
                "uid": "${datasource}"
             },
-            "description": "Memory utilization",
+            "description": "Memory utilization (avg): Memory utilization  \n\nMemory utilization2 (avg): Memory used",
             "fieldConfig": {
+               "defaults": {
+                  "unit": "bytes"
+               },
                "overrides": [
                   {
                      "matcher": {
@@ -1056,7 +1063,7 @@
                "y": 37
             },
             "id": 9,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -1089,8 +1096,11 @@
                "type": "prometheus",
                "uid": "${datasource}"
             },
-            "description": "Packets sent/received over the network. Sampled every 60 seconds",
+            "description": "Sent/received packets (sum): Packets sent/received over the network. Sampled every 60 seconds  \n\nReceived packets (sum): Packets received over the network. Sampled every 60 seconds",
             "fieldConfig": {
+               "defaults": {
+                  "unit": "sishort"
+               },
                "overrides": [
                   {
                      "matcher": {
@@ -1125,7 +1135,7 @@
                "y": 37
             },
             "id": 10,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -1158,8 +1168,11 @@
                "type": "prometheus",
                "uid": "${datasource}"
             },
-            "description": "Count of bytes sent/received over the network. Sampled every 60 seconds",
+            "description": "Network throughput sent/received (avg): Count of bytes sent/received over the network. Sampled every 60 seconds  \n\nNetwork throughput received (avg): Count of bytes sent/received over the network. Sampled every 60 seconds",
             "fieldConfig": {
+               "defaults": {
+                  "unit": "bytes"
+               },
                "overrides": [
                   {
                      "matcher": {
@@ -1194,7 +1207,7 @@
                "y": 45
             },
             "id": 11,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -1227,8 +1240,11 @@
                "type": "prometheus",
                "uid": "${datasource}"
             },
-            "description": "Total count of bytes read/write from disk. Sampled every 60 seconds",
+            "description": "Disk read/write bytes (avg): Total count of bytes read/write from disk. Sampled every 60 seconds  \n\nDisk write bytes (avg): Total count of bytes read/write from disk. Sampled every 60 seconds",
             "fieldConfig": {
+               "defaults": {
+                  "unit": "bytes"
+               },
                "overrides": [
                   {
                      "matcher": {
@@ -1263,7 +1279,7 @@
                "y": 45
             },
             "id": 12,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -1316,7 +1332,7 @@
                   "options": {
                      "content": "Use this section to look at one instance at a time by picking a value in the *Instance* picker at the top of the dashboard."
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.4.0",
                   "title": "Instances",
                   "type": "text"
                },
@@ -1327,6 +1343,9 @@
                   },
                   "description": "Fractional utilization of allocated CPU on this instance.",
                   "fieldConfig": {
+                     "defaults": {
+                        "unit": "percentunit"
+                     },
                      "overrides": [
                         {
                            "matcher": {
@@ -1349,7 +1368,7 @@
                      "y": 66
                   },
                   "id": 15,
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                      {
                         "datasource": {
@@ -1373,6 +1392,9 @@
                   },
                   "description": "CPU usage, in seconds. For Container-Optimized OS, or Ubuntu running GKE.",
                   "fieldConfig": {
+                     "defaults": {
+                        "unit": "percent"
+                     },
                      "overrides": [
                         {
                            "matcher": {
@@ -1395,7 +1417,7 @@
                      "y": 66
                   },
                   "id": 16,
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                      {
                         "datasource": {
@@ -1419,6 +1441,9 @@
                   },
                   "description": "Bytes received from the network. Sampled every 60 seconds.",
                   "fieldConfig": {
+                     "defaults": {
+                        "unit": "bytes"
+                     },
                      "overrides": [
                         {
                            "matcher": {
@@ -1441,7 +1466,7 @@
                      "y": 74
                   },
                   "id": 17,
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                      {
                         "datasource": {
@@ -1465,6 +1490,9 @@
                   },
                   "description": "Bytes sent from the network. Sampled every 60 seconds.",
                   "fieldConfig": {
+                     "defaults": {
+                        "unit": "bytes"
+                     },
                      "overrides": [
                         {
                            "matcher": {
@@ -1487,7 +1515,7 @@
                      "y": 74
                   },
                   "id": 18,
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                      {
                         "datasource": {
@@ -1511,6 +1539,9 @@
                   },
                   "description": "Bytes read from disk. Sampled every 60 seconds.",
                   "fieldConfig": {
+                     "defaults": {
+                        "unit": "bytes"
+                     },
                      "overrides": [
                         {
                            "matcher": {
@@ -1533,7 +1564,7 @@
                      "y": 82
                   },
                   "id": 19,
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                      {
                         "datasource": {
@@ -1557,6 +1588,9 @@
                   },
                   "description": "Bytes written to disk. Sampled every 60 seconds.",
                   "fieldConfig": {
+                     "defaults": {
+                        "unit": "bytes"
+                     },
                      "overrides": [
                         {
                            "matcher": {
@@ -1579,7 +1613,7 @@
                      "y": 82
                   },
                   "id": 20,
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                      {
                         "datasource": {
@@ -1603,6 +1637,9 @@
                   },
                   "description": "Disk read IO operations. Sampled every 60 seconds.",
                   "fieldConfig": {
+                     "defaults": {
+                        "unit": "short"
+                     },
                      "overrides": [
                         {
                            "matcher": {
@@ -1625,7 +1662,7 @@
                      "y": 90
                   },
                   "id": 21,
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                      {
                         "datasource": {
@@ -1649,6 +1686,9 @@
                   },
                   "description": "Disk write IO operations. Sampled every 60 seconds.",
                   "fieldConfig": {
+                     "defaults": {
+                        "unit": "short"
+                     },
                      "overrides": [
                         {
                            "matcher": {
@@ -1671,7 +1711,7 @@
                      "y": 90
                   },
                   "id": 22,
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                      {
                         "datasource": {

--- a/csp-mixin/dashboards_out/gcp-loadbalancer.json
+++ b/csp-mixin/dashboards_out/gcp-loadbalancer.json
@@ -21,6 +21,10 @@
             "description": "Amount of requests sent by status code for the filters selected",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "fillOpacity": 10,
                      "gradientMode": "none",
@@ -29,6 +33,10 @@
                      "showPoints": "never"
                   },
                   "noValue": "0",
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
                   "unit": "reqps"
                },
                "overrides": [ ]
@@ -50,7 +58,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -75,6 +83,10 @@
             "description": "Amount of requests sent by country for the filters selected",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "fillOpacity": 10,
                      "gradientMode": "none",
@@ -83,6 +95,10 @@
                      "showPoints": "never"
                   },
                   "noValue": "0",
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
                   "unit": "short"
                },
                "overrides": [ ]
@@ -104,7 +120,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -129,6 +145,10 @@
             "description": "Amount of cache results for the filters selected",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "fillOpacity": 10,
                      "gradientMode": "none",
@@ -137,6 +157,10 @@
                      "showPoints": "never"
                   },
                   "noValue": "0",
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
                   "unit": "short"
                },
                "overrides": [ ]
@@ -158,7 +182,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -183,6 +207,10 @@
             "description": "Amount of requests by protocol for the filters selected",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "fillOpacity": 10,
                      "gradientMode": "none",
@@ -191,6 +219,10 @@
                      "showPoints": "never"
                   },
                   "noValue": "0",
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
                   "unit": "short"
                },
                "overrides": [ ]
@@ -212,7 +244,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -237,6 +269,10 @@
             "description": "Percentage of requests failing for the filters selected",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "fillOpacity": 10,
                      "gradientMode": "none",
@@ -246,6 +282,10 @@
                   },
                   "max": 1,
                   "min": 0,
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
                   "unit": "percentunit"
                },
                "overrides": [
@@ -288,7 +328,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -323,9 +363,13 @@
                "type": "prometheus",
                "uid": "${datasource}"
             },
-            "description": "Latency of all responses for the filters selected",
+            "description": "Total Response (avg): Latency of all responses for the filters selected  \n\nLatency 90 (avg): The total latency of responses  \n\nLatency 99 (avg): The total latency of responses  \n\nLatency Average (avg): Latency of return trip time for the frontend for the filters selected",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "fillOpacity": 10,
                      "gradientMode": "none",
@@ -334,6 +378,10 @@
                      "showPoints": "never"
                   },
                   "noValue": "0",
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
                   "unit": "ms"
                },
                "overrides": [
@@ -416,7 +464,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -471,9 +519,13 @@
                "type": "prometheus",
                "uid": "${datasource}"
             },
-            "description": "Latency of return trip time for the frontend for the filters selected",
+            "description": "Frontend RTT (avg): Latency of return trip time for the frontend for the filters selected  \n\nFrontend RTT Latency 90 (avg): Latency of return trip time for the frontend for the filters selected  \n\nFrontend RTT Latency 99 (avg): Latency of return trip time for the frontend for the filters selected",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "fillOpacity": 10,
                      "gradientMode": "none",
@@ -482,6 +534,10 @@
                      "showPoints": "never"
                   },
                   "noValue": "0",
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
                   "unit": "ms"
                },
                "overrides": [
@@ -549,7 +605,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -593,9 +649,13 @@
                "type": "prometheus",
                "uid": "${datasource}"
             },
-            "description": "Latency of responses for the backend for the filters selected",
+            "description": "Backend Response (avg): Latency of responses for the backend for the filters selected  \n\nBackend Response Latency 90 (avg): Latency of responses for the backend for the filters selected  \n\nBackend Response Latency 99 (avg): Latency of responses for the backend for the filters selected",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "fillOpacity": 10,
                      "gradientMode": "none",
@@ -604,6 +664,10 @@
                      "showPoints": "never"
                   },
                   "noValue": "0",
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
                   "unit": "ms"
                },
                "overrides": [
@@ -671,7 +735,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -728,9 +792,13 @@
                "type": "prometheus",
                "uid": "${datasource}"
             },
-            "description": "Total bytes sent/received by load balancer for the filters selected",
+            "description": "Total requests sent/received (avg): Total bytes sent/received by load balancer for the filters selected  \n\nTotal Requests received (avg): Total bytes received by load balancer for the filters selected",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "axisLabel": "out(-) | in(+)",
                      "fillOpacity": 10,
@@ -738,6 +806,10 @@
                      "lineInterpolation": "smooth",
                      "lineWidth": 2,
                      "showPoints": "never"
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
                   },
                   "unit": "short"
                },
@@ -795,7 +867,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -828,9 +900,13 @@
                "type": "prometheus",
                "uid": "${datasource}"
             },
-            "description": "Total bytes sent/received by backend for the filters selected",
+            "description": "Backend requests sent/received (avg): Total bytes sent/received by backend for the filters selected  \n\nBackend Total Requests received (avg): Total bytes sent/received by backend for the filters selected",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "axisLabel": "out(-) | in(+)",
                      "fillOpacity": 10,
@@ -838,6 +914,10 @@
                      "lineInterpolation": "smooth",
                      "lineWidth": 2,
                      "showPoints": "never"
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
                   },
                   "unit": "short"
                },
@@ -895,7 +975,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {

--- a/csp-mixin/dashboards_out/gcp-vpc.json
+++ b/csp-mixin/dashboards_out/gcp-vpc.json
@@ -24,7 +24,8 @@
                   "color": {
                      "fixedColor": "text",
                      "mode": "fixed"
-                  }
+                  },
+                  "unit": "short"
                },
                "overrides": [
                   {
@@ -48,7 +49,7 @@
                "y": 1
             },
             "id": 2,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -76,7 +77,8 @@
                   "color": {
                      "fixedColor": "text",
                      "mode": "fixed"
-                  }
+                  },
+                  "unit": "short"
                },
                "overrides": [
                   {
@@ -100,7 +102,7 @@
                "y": 1
             },
             "id": 3,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -125,7 +127,8 @@
             "description": "Rate in bytes of network egress on the fixed standard tier.",
             "fieldConfig": {
                "defaults": {
-                  "noValue": "0"
+                  "noValue": "0",
+                  "unit": "bps"
                },
                "overrides": [
                   {
@@ -149,7 +152,7 @@
                "y": 9
             },
             "id": 4,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -159,7 +162,7 @@
                   "expr": "avg by (job,traffic_source) (\n  stackdriver_networking_googleapis_com_location_networking_googleapis_com_fixed_standard_tier_usage{job=\"integrations/gcp\",job=~\"$job\",project_id=~\"$project_id\"}\n)",
                   "format": "time_series",
                   "instant": false,
-                  "legendFormat": "{{traffic_source}}: Fixed standard tier network egress",
+                  "legendFormat": "{{job}}: Fixed standard tier network egress ({{traffic_source}})",
                   "refId": "Fixed standard tier network egress"
                }
             ],
@@ -187,6 +190,14 @@
             "description": "Average throughput",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
                   "unit": "bps"
                },
                "overrides": [
@@ -223,7 +234,7 @@
                "y": 18
             },
             "id": 6,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -233,7 +244,7 @@
                   "expr": "topk(5,\n  avg by (job,service_name) (\n  stackdriver_google_service_gce_client_networking_googleapis_com_google_service_request_bytes_count{job=\"integrations/gcp\",job=~\"$job\",project_id=~\"$project_id\"} + stackdriver_google_service_gce_client_networking_googleapis_com_google_service_response_bytes_count{job=\"integrations/gcp\",job=~\"$job\",project_id=~\"$project_id\"}\n)\n)",
                   "format": "table",
                   "instant": true,
-                  "legendFormat": "{{service_name}}: Top 5 services by network throughput.",
+                  "legendFormat": "{{job}}: Top 5 services by network throughput. ({{service_name}})",
                   "refId": "Top 5 services by network throughput."
                }
             ],
@@ -265,6 +276,14 @@
             "description": "Average error rate",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
                   "unit": "percent"
                },
                "overrides": [
@@ -301,7 +320,7 @@
                "y": 18
             },
             "id": 7,
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -311,7 +330,7 @@
                   "expr": "topk(5,\n  avg by (job,service_name) (\n  (stackdriver_google_service_gce_client_networking_googleapis_com_google_service_request_bytes_count{job=\"integrations/gcp\",job=~\"$job\",project_id=~\"$project_id\", response_code_class=~\"500|400\"} + stackdriver_google_service_gce_client_networking_googleapis_com_google_service_response_bytes_count{job=\"integrations/gcp\",job=~\"$job\",project_id=~\"$project_id\", response_code_class=~\"500|400\"}) / (stackdriver_google_service_gce_client_networking_googleapis_com_google_service_request_bytes_count{job=\"integrations/gcp\",job=~\"$job\",project_id=~\"$project_id\"} + stackdriver_google_service_gce_client_networking_googleapis_com_google_service_response_bytes_count{job=\"integrations/gcp\",job=~\"$job\",project_id=~\"$project_id\"})\n)\n)",
                   "format": "table",
                   "instant": true,
-                  "legendFormat": "{{service_name}}: Top 5 services by network error response code",
+                  "legendFormat": "{{job}}: Top 5 services by network error response code ({{service_name}})",
                   "refId": "Top 5 services by network error response code"
                }
             ],
@@ -340,9 +359,13 @@
                "type": "datasource",
                "uid": "-- Mixed --"
             },
-            "description": "Network traffic (bits per sec) measures data transmitted and received.",
+            "description": "received (sum):   \n\ntransmitted (sum): ",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "axisCenteredZero": false,
                      "axisLabel": "out(-) | in(+)",
@@ -357,13 +380,17 @@
                   },
                   "decimals": 1,
                   "noValue": "No traffic",
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
                   "unit": "bps"
                },
                "overrides": [
                   {
                      "matcher": {
                         "id": "byRegexp",
-                        "options": "/transmit|tx|out/"
+                        "options": "/transmit|tx|Tx|out/"
                      },
                      "properties": [
                         {
@@ -415,7 +442,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -448,9 +475,13 @@
                "type": "datasource",
                "uid": "-- Mixed --"
             },
-            "description": "Network errors refer to issues that occur during the transmission of data across a network. \n\nThese errors can result from various factors, including physical issues, jitter, collisions, noise and interference.\n\nMonitoring network errors is essential for diagnosing and resolving issues, as they can indicate problems with network hardware or environmental factors affecting network quality.\n",
+            "description": "received (avg):   \n\ntransmitted (avg): ",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "fillOpacity": 30,
                      "gradientMode": "opacity",
@@ -460,7 +491,11 @@
                   },
                   "decimals": 1,
                   "noValue": "No errors",
-                  "unit": "pps"
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
+                  "unit": "percent"
                },
                "overrides": [
                   {
@@ -506,7 +541,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -539,9 +574,13 @@
                "type": "datasource",
                "uid": "-- Mixed --"
             },
-            "description": "Network traffic (bits per sec) measures data transmitted and received.",
+            "description": "received (sum):   \n\ntransmitted (sum): ",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "axisCenteredZero": false,
                      "axisLabel": "out(-) | in(+)",
@@ -556,13 +595,17 @@
                   },
                   "decimals": 1,
                   "noValue": "No traffic",
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
                   "unit": "bps"
                },
                "overrides": [
                   {
                      "matcher": {
                         "id": "byRegexp",
-                        "options": "/transmit|tx|out/"
+                        "options": "/transmit|tx|Tx|out/"
                      },
                      "properties": [
                         {
@@ -614,7 +657,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -624,7 +667,7 @@
                   "expr": "sum by (job,service_name) (\n  rate(stackdriver_google_service_gce_client_networking_googleapis_com_google_service_request_bytes_count{job=\"integrations/gcp\",job=~\"$job\",project_id=~\"$project_id\"}[$__rate_interval])\n)",
                   "format": "time_series",
                   "instant": false,
-                  "legendFormat": "{{service_name}}: received",
+                  "legendFormat": "{{job}}: received ({{service_name}})",
                   "refId": "received"
                },
                {
@@ -635,7 +678,7 @@
                   "expr": "sum by (job,service_name) (\n  rate(stackdriver_google_service_gce_client_networking_googleapis_com_google_service_response_bytes_count{job=\"integrations/gcp\",job=~\"$job\",project_id=~\"$project_id\"}[$__rate_interval])\n)",
                   "format": "time_series",
                   "instant": false,
-                  "legendFormat": "{{service_name}}: transmitted",
+                  "legendFormat": "{{job}}: transmitted ({{service_name}})",
                   "refId": "transmitted"
                }
             ],
@@ -647,9 +690,13 @@
                "type": "datasource",
                "uid": "-- Mixed --"
             },
-            "description": "Network traffic (bits per sec) measures data transmitted and received.",
+            "description": "received (sum):   \n\ntransmitted (sum): ",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "axisCenteredZero": false,
                      "axisLabel": "out(-) | in(+)",
@@ -664,13 +711,17 @@
                   },
                   "decimals": 1,
                   "noValue": "No traffic",
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
                   "unit": "bps"
                },
                "overrides": [
                   {
                      "matcher": {
                         "id": "byRegexp",
-                        "options": "/transmit|tx|out/"
+                        "options": "/transmit|tx|Tx|out/"
                      },
                      "properties": [
                         {
@@ -722,7 +773,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -732,7 +783,7 @@
                   "expr": "sum by (job,response_code_class) (\n  rate(stackdriver_google_service_gce_client_networking_googleapis_com_google_service_request_bytes_count{job=\"integrations/gcp\",job=~\"$job\",project_id=~\"$project_id\"}[$__rate_interval])\n)",
                   "format": "time_series",
                   "instant": false,
-                  "legendFormat": "{{response_code_class}}: received",
+                  "legendFormat": "{{job}}: received ({{response_code_class}})",
                   "refId": "received"
                },
                {
@@ -743,7 +794,7 @@
                   "expr": "sum by (job,response_code_class) (\n  rate(stackdriver_google_service_gce_client_networking_googleapis_com_google_service_response_bytes_count{job=\"integrations/gcp\",job=~\"$job\",project_id=~\"$project_id\"}[$__rate_interval])\n)",
                   "format": "time_series",
                   "instant": false,
-                  "legendFormat": "{{response_code_class}}: transmitted",
+                  "legendFormat": "{{job}}: transmitted ({{response_code_class}})",
                   "refId": "transmitted"
                }
             ],
@@ -768,9 +819,13 @@
                "type": "datasource",
                "uid": "-- Mixed --"
             },
-            "description": "Network traffic (bits per sec) measures data transmitted and received.",
+            "description": "transmitted (avg):   \n\nreceived (avg): ",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "axisCenteredZero": false,
                      "axisLabel": "out(-) | in(+)",
@@ -785,13 +840,17 @@
                   },
                   "decimals": 1,
                   "noValue": "No traffic",
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
                   "unit": "bps"
                },
                "overrides": [
                   {
                      "matcher": {
                         "id": "byRegexp",
-                        "options": "/transmit|tx|out/"
+                        "options": "/transmit|tx|Tx|out/"
                      },
                      "properties": [
                         {
@@ -843,7 +902,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -876,9 +935,13 @@
                "type": "datasource",
                "uid": "-- Mixed --"
             },
-            "description": "Network traffic (bits per sec) measures data transmitted and received.",
+            "description": "transmitted (avg):   \n\nreceived (avg): ",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "axisCenteredZero": false,
                      "axisLabel": "out(-) | in(+)",
@@ -893,13 +956,17 @@
                   },
                   "decimals": 1,
                   "noValue": "No traffic",
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
                   "unit": "bps"
                },
                "overrides": [
                   {
                      "matcher": {
                         "id": "byRegexp",
-                        "options": "/transmit|tx|out/"
+                        "options": "/transmit|tx|Tx|out/"
                      },
                      "properties": [
                         {
@@ -951,7 +1018,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -961,7 +1028,7 @@
                   "expr": "avg by (job,protocol) (\n  rate(stackdriver_vpn_tunnel_networking_googleapis_com_vpn_tunnel_egress_bytes_count{job=\"integrations/gcp\",job=~\"$job\",project_id=~\"$project_id\"}[$__rate_interval])\n)",
                   "format": "time_series",
                   "instant": false,
-                  "legendFormat": "{{protocol}}: transmitted",
+                  "legendFormat": "{{job}}: transmitted ({{protocol}})",
                   "refId": "transmitted"
                },
                {
@@ -972,7 +1039,7 @@
                   "expr": "avg by (job,protocol) (\n  rate(stackdriver_vpn_tunnel_networking_googleapis_com_vpn_tunnel_ingress_bytes_count{job=\"integrations/gcp\",job=~\"$job\",project_id=~\"$project_id\"}[$__rate_interval])\n)",
                   "format": "time_series",
                   "instant": false,
-                  "legendFormat": "{{protocol}}: received",
+                  "legendFormat": "{{job}}: received ({{protocol}})",
                   "refId": "received"
                }
             ],
@@ -984,9 +1051,13 @@
                "type": "datasource",
                "uid": "-- Mixed --"
             },
-            "description": "Network traffic (bits per sec) measures data transmitted and received.",
+            "description": "transmitted (avg):   \n\nreceived (avg): ",
             "fieldConfig": {
                "defaults": {
+                  "color": {
+                     "fixedColor": "#5794f2",
+                     "mode": "palette-classic"
+                  },
                   "custom": {
                      "axisCenteredZero": false,
                      "axisLabel": "out(-) | in(+)",
@@ -1001,13 +1072,17 @@
                   },
                   "decimals": 1,
                   "noValue": "No traffic",
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [ ]
+                  },
                   "unit": "bps"
                },
                "overrides": [
                   {
                      "matcher": {
                         "id": "byRegexp",
-                        "options": "/transmit|tx|out/"
+                        "options": "/transmit|tx|Tx|out/"
                      },
                      "properties": [
                         {
@@ -1059,7 +1134,7 @@
                   "sort": "desc"
                }
             },
-            "pluginVersion": "v11.0.0",
+            "pluginVersion": "v11.4.0",
             "targets": [
                {
                   "datasource": {
@@ -1069,7 +1144,7 @@
                   "expr": "avg by (job,local_resource_type) (\n  rate(stackdriver_vpn_tunnel_networking_googleapis_com_vpn_tunnel_egress_bytes_count{job=\"integrations/gcp\",job=~\"$job\",project_id=~\"$project_id\"}[$__rate_interval])\n)",
                   "format": "time_series",
                   "instant": false,
-                  "legendFormat": "{{local_resource_type}}: transmitted",
+                  "legendFormat": "{{job}}: transmitted ({{local_resource_type}})",
                   "refId": "transmitted"
                },
                {
@@ -1080,7 +1155,7 @@
                   "expr": "avg by (job,local_resource_type) (\n  rate(stackdriver_vpn_tunnel_networking_googleapis_com_vpn_tunnel_ingress_bytes_count{job=\"integrations/gcp\",job=~\"$job\",project_id=~\"$project_id\"}[$__rate_interval])\n)",
                   "format": "time_series",
                   "instant": false,
-                  "legendFormat": "{{local_resource_type}}: received",
+                  "legendFormat": "{{job}}: received ({{local_resource_type}})",
                   "refId": "received"
                }
             ],

--- a/csp-mixin/g.libsonnet
+++ b/csp-mixin/g.libsonnet
@@ -1,1 +1,1 @@
-import 'github.com/grafana/grafonnet/gen/grafonnet-v11.0.0/main.libsonnet'
+import 'github.com/grafana/grafonnet/gen/grafonnet-v11.4.0/main.libsonnet'

--- a/csp-mixin/prometheus_rules_out/prometheus_alerts.yaml
+++ b/csp-mixin/prometheus_rules_out/prometheus_alerts.yaml
@@ -7,7 +7,7 @@ groups:
             description: The VM {{ $labels.resourceName }} is under heavy load and may become unresponsive.
             summary: VM CPU utilization is too high.
           expr: |
-            avg by (job,resourceGroup,subscriptionName,resourceName) (azure_microsoft_compute_virtualmachines_percentage_cpu_average_percent{job=~".+",resourceGroup=~".+",subscriptionName=~".+",resourceName=~".+"})  > 85
+            avg by (job,resourceGroup,subscriptionName,resourceName,asserts_env,asserts_site) (azure_microsoft_compute_virtualmachines_percentage_cpu_average_percent{job=~".+",resourceGroup=~".+",subscriptionName=~".+",resourceName=~".+"})  > 85
           for: 5m
           keep_firing_for: 10m
           labels:
@@ -21,7 +21,7 @@ groups:
             description: The VM {{ $labels.resourceName }} is not functioning or crashed, which may require immediate action.
             summary: VM unavailable.
           expr: |
-            avg by (job,resourceGroup,subscriptionName,resourceName) (azure_microsoft_compute_virtualmachines_vmavailabilitymetric_average_count{job=~".+",resourceGroup=~".+",subscriptionName=~".+",resourceName=~".+"}) != 1
+            avg by (job,resourceGroup,subscriptionName,resourceName,asserts_env,asserts_site) (azure_microsoft_compute_virtualmachines_vmavailabilitymetric_average_count{job=~".+",resourceGroup=~".+",subscriptionName=~".+",resourceName=~".+"}) != 1
           for: 5m
           keep_firing_for: 10m
           labels:
@@ -37,7 +37,7 @@ groups:
             description: Check active queries and optimize indexes or consider scaling up DTUs to handle load in {{ $labels.resourceName }} database.
             summary: High database DTU consumption.
           expr: |
-            avg by (job,resourceGroup,subscriptionName,resourceName) (azure_microsoft_sql_servers_databases_dtu_consumption_percent_average_percent{job=~".+",resourceGroup=~".+",subscriptionName=~".+",resourceName=~".+"}) > 90
+            avg by (job,resourceGroup,subscriptionName,resourceName,asserts_env,asserts_site) (azure_microsoft_sql_servers_databases_dtu_consumption_percent_average_percent{job=~".+",resourceGroup=~".+",subscriptionName=~".+",resourceName=~".+"}) > 90
           for: 10m
           keep_firing_for: 10m
           labels:
@@ -51,7 +51,7 @@ groups:
             description: Archive or delete old data, or scale up storage capacity in {{ $labels.resourceName }} database.
             summary: High database Storage usage.
           expr: |
-            avg by (job,resourceGroup,subscriptionName,resourceName) (azure_microsoft_sql_servers_databases_storage_percent_maximum_percent{job=~".+",resourceGroup=~".+",subscriptionName=~".+",resourceName=~".+"}) > 95
+            avg by (job,resourceGroup,subscriptionName,resourceName,asserts_env,asserts_site) (azure_microsoft_sql_servers_databases_storage_percent_maximum_percent{job=~".+",resourceGroup=~".+",subscriptionName=~".+",resourceName=~".+"}) > 95
           for: 15m
           keep_firing_for: 10m
           labels:
@@ -65,7 +65,7 @@ groups:
             description: Check {{ $labels.resourceName }} database logs for deadlock details and optimize affected queries.
             summary: High database Deadlock count.
           expr: |
-            sum by (job,resourceGroup,subscriptionName,resourceName) (rate(azure_microsoft_sql_servers_databases_deadlock_total_count{job=~".+",resourceGroup=~".+",subscriptionName=~".+",resourceName=~".+"}[5m])) > 5
+            sum by (job,resourceGroup,subscriptionName,resourceName,asserts_env,asserts_site) (rate(azure_microsoft_sql_servers_databases_deadlock_total_count{job=~".+",resourceGroup=~".+",subscriptionName=~".+",resourceName=~".+"}[5m])) > 5
           for: 10m
           keep_firing_for: 10m
           labels:
@@ -79,7 +79,7 @@ groups:
             description: Identify high CPU queries on {{ $labels.resourceName }} database and optimize them.
             summary: High database User CPU usage.
           expr: |
-            avg by (job,resourceGroup,subscriptionName,resourceName) (azure_microsoft_sql_servers_databases_cpu_percent_average_percent{job=~".+",resourceGroup=~".+",subscriptionName=~".+",resourceName=~".+"}) > 90
+            avg by (job,resourceGroup,subscriptionName,resourceName,asserts_env,asserts_site) (azure_microsoft_sql_servers_databases_cpu_percent_average_percent{job=~".+",resourceGroup=~".+",subscriptionName=~".+",resourceName=~".+"}) > 90
           for: 10m
           keep_firing_for: 10m
           labels:
@@ -93,7 +93,7 @@ groups:
             description: Check network problems, firewall restrictions or high resource consumption affecting application access to the {{ $labels.resourceName }} database.
             summary: High number of database System Failed connections.
           expr: |
-            sum by (job,resourceGroup,subscriptionName,resourceName) (rate(azure_microsoft_sql_servers_databases_connection_failed_total_count{job=~".+",resourceGroup=~".+",subscriptionName=~".+",resourceName=~".+"}[5m])) > 10
+            sum by (job,resourceGroup,subscriptionName,resourceName,asserts_env,asserts_site) (rate(azure_microsoft_sql_servers_databases_connection_failed_total_count{job=~".+",resourceGroup=~".+",subscriptionName=~".+",resourceName=~".+"}[5m])) > 10
           for: 5m
           keep_firing_for: 10m
           labels:
@@ -107,7 +107,7 @@ groups:
             description: Check for authentication problems, network configuration errors, firewall issues, or resource constraints, affecting database accessibility for users on database {{ $labels.resourceName }}.
             summary: High number of database User Failed connections.
           expr: |
-            sum by (job,resourceGroup,subscriptionName,resourceName) (rate(azure_microsoft_sql_servers_databases_connection_failed_user_error_total_count{job=~".+",resourceGroup=~".+",subscriptionName=~".+",resourceName=~".+"}[5m])) > 10
+            sum by (job,resourceGroup,subscriptionName,resourceName,asserts_env,asserts_site) (rate(azure_microsoft_sql_servers_databases_connection_failed_user_error_total_count{job=~".+",resourceGroup=~".+",subscriptionName=~".+",resourceName=~".+"}[5m])) > 10
           for: 15m
           keep_firing_for: 10m
           labels:
@@ -121,7 +121,7 @@ groups:
             description: Look for long execution queries, review the number of concurrent queries and requests being sent to the database or check if there are any blocking sessions or deadlocks into the {{ $labels.resourceName }} database.
             summary: High database worker usage.
           expr: |
-            avg by (job,resourceGroup,subscriptionName,resourceName) (azure_microsoft_sql_servers_databases_workers_percent_average_percent{job=~".+",resourceGroup=~".+",subscriptionName=~".+",resourceName=~".+"}) > 60
+            avg by (job,resourceGroup,subscriptionName,resourceName,asserts_env,asserts_site) (azure_microsoft_sql_servers_databases_workers_percent_average_percent{job=~".+",resourceGroup=~".+",subscriptionName=~".+",resourceName=~".+"}) > 60
           for: 5m
           keep_firing_for: 10m
           labels:
@@ -135,7 +135,7 @@ groups:
             description: Review queries with high read or write activity, check if there are missing indexes or inefficient indexes that result in full table scans and assess the volume of transactions into the {{ $labels.resourceName }} database.
             summary: High database data IO usage.
           expr: |
-            avg by (job,resourceGroup,subscriptionName,resourceName) (azure_microsoft_sql_servers_databases_physical_data_read_percent_average_percent{job=~".+",resourceGroup=~".+",subscriptionName=~".+",resourceName=~".+"}) > 90
+            avg by (job,resourceGroup,subscriptionName,resourceName,asserts_env,asserts_site) (azure_microsoft_sql_servers_databases_physical_data_read_percent_average_percent{job=~".+",resourceGroup=~".+",subscriptionName=~".+",resourceName=~".+"}) > 90
           for: 15m
           keep_firing_for: 10m
           labels:
@@ -149,7 +149,7 @@ groups:
             description: Look for active sessions that might be using TempDB intensively, identify stored procedures or queries that create temporary tables or objects, and also look for long-running or memory-intensive queries that rely heavily on TempDB into the {{ $labels.resourceName }} database.
             summary: Low database tempdb log space.
           expr: |
-            avg by (job,resourceGroup,subscriptionName,resourceName) (azure_microsoft_sql_servers_databases_tempdb_log_used_percent_average_percent{job=~".+",resourceGroup=~".+",subscriptionName=~".+",resourceName=~".+"}) > 60
+            avg by (job,resourceGroup,subscriptionName,resourceName,asserts_env,asserts_site) (azure_microsoft_sql_servers_databases_tempdb_log_used_percent_average_percent{job=~".+",resourceGroup=~".+",subscriptionName=~".+",resourceName=~".+"}) > 60
           for: 5m
           keep_firing_for: 10m
           labels:
@@ -239,7 +239,7 @@ groups:
             description: The VM {{ $labels.instance_name }} is under heavy load and may become unresponsive.
             summary: VM CPU utilization is too high.
           expr: |
-            100 * avg by (job,project_id,instance_name) (stackdriver_gce_instance_compute_googleapis_com_instance_cpu_utilization{job=~".+",project_id=~".+",instance_name=~".+"}) > 85
+            100 * avg by (job,project_id,instance_name,asserts_env,asserts_site) (stackdriver_gce_instance_compute_googleapis_com_instance_cpu_utilization{job=~".+",project_id=~".+",instance_name=~".+"}) > 85
           for: 5m
           keep_firing_for: 10m
           labels:
@@ -253,7 +253,7 @@ groups:
             description: Check {{ $labels.instance_id }} VM for I/O bottlenecks and upgrade to SSD if necessary.
             summary: VM IO latency is too high.
           expr: |
-            avg by (job,project_id,instance_id)(stackdriver_gce_instance_compute_googleapis_com_instance_disk_average_io_latency{job=~".+",project_id=~".+",instance_id=~".+"}) > 5000
+            avg by (job,project_id,instance_id,asserts_env,asserts_site)(stackdriver_gce_instance_compute_googleapis_com_instance_disk_average_io_latency{job=~".+",project_id=~".+",instance_id=~".+"}) > 5000
           for: 5m
           keep_firing_for: 10m
           labels:
@@ -269,7 +269,7 @@ groups:
             description: Check {{ $labels.database_id }} database for high CPU queries and optimize them, or scale up the instance if sustained high usage.
             summary: Database CPU utilization is too high.
           expr: |
-            100 * avg by (job,project_id,instance,database_id) (stackdriver_cloudsql_database_cloudsql_googleapis_com_database_cpu_utilization{job=~".+",project_id=~".+",instance=~".+", database_id=~".+"}) > 90
+            100 * avg by (job,project_id,instance,database_id,asserts_env,asserts_site) (stackdriver_cloudsql_database_cloudsql_googleapis_com_database_cpu_utilization{job=~".+",project_id=~".+",instance=~".+", database_id=~".+"}) > 90
           for: 5m
           keep_firing_for: 10m
           labels:
@@ -283,7 +283,7 @@ groups:
             description: Review high-memory queries or add more memory to the {{ $labels.database_id }} instance.
             summary: Database memory utilization is too high.
           expr: |
-            100 * avg by (job,project_id,instance,database_id) (stackdriver_cloudsql_database_cloudsql_googleapis_com_database_memory_utilization{job=~".+",project_id=~".+",instance=~".+", database_id=~".+"}) > 85
+            100 * avg by (job,project_id,instance,database_id,asserts_env,asserts_site) (stackdriver_cloudsql_database_cloudsql_googleapis_com_database_memory_utilization{job=~".+",project_id=~".+",instance=~".+", database_id=~".+"}) > 85
           for: 5m
           keep_firing_for: 10m
           labels:
@@ -297,7 +297,7 @@ groups:
             description: Delete or archive unused data, or increase disk size to the {{ $labels.database_id }} database.
             summary: Database disk utilization is too high.
           expr: |
-            100 * avg by (job,project_id,instance,database_id) (stackdriver_cloudsql_database_cloudsql_googleapis_com_database_disk_utilization{job=~".+",project_id=~".+",instance=~".+", database_id=~".+"}) > 85
+            100 * avg by (job,project_id,instance,database_id,asserts_env,asserts_site) (stackdriver_cloudsql_database_cloudsql_googleapis_com_database_disk_utilization{job=~".+",project_id=~".+",instance=~".+", database_id=~".+"}) > 85
           for: 5m
           keep_firing_for: 10m
           labels:
@@ -311,7 +311,7 @@ groups:
             description: Investigate connection pooling settings and connection management in your {{ $labels.database_id }} application database.
             summary: Too many database active connections.
           expr: |
-            avg by (job,project_id,instance, database_id) (stackdriver_cloudsql_database_cloudsql_googleapis_com_database_mysql_threads{thread_kind="THREADS_CONNECTED", job=~".+",project_id=~".+",instance=~".+", database_id=~".+"}) > 0.9 * avg by (job,project_id,instance, database_id) (stackdriver_cloudsql_database_cloudsql_googleapis_com_database_mysql_max_connections{job=~".+",project_id=~".+",instance=~".+", database_id=~".+"})
+            avg by (job,project_id,instance,database_id,asserts_env,asserts_site) (stackdriver_cloudsql_database_cloudsql_googleapis_com_database_mysql_threads{thread_kind="THREADS_CONNECTED", job=~".+",project_id=~".+",instance=~".+", database_id=~".+"}) > 0.9 * avg by (job,project_id,instance,database_id,asserts_env,asserts_site) (stackdriver_cloudsql_database_cloudsql_googleapis_com_database_mysql_max_connections{job=~".+",project_id=~".+",instance=~".+", database_id=~".+"})
           for: 5m
           keep_firing_for: 10m
           labels:
@@ -325,7 +325,7 @@ groups:
             description: Verify credentials and network settings; check for firewall rules blocking connections for the {{ $labels.database_id }} database.
             summary: More than 5 MySQL failed connections in 5 minutes.
           expr: |
-            sum by(job, instance, project_id, database_id)(rate(stackdriver_cloudsql_database_cloudsql_googleapis_com_database_mysql_aborted_connects_count[5m])) > 5
+            sum by(job, instance, project_id, database_id, asserts_env, asserts_site)(rate(stackdriver_cloudsql_database_cloudsql_googleapis_com_database_mysql_aborted_connects_count[5m])) > 5
           for: 5m
           keep_firing_for: 10m
           labels:
@@ -339,7 +339,7 @@ groups:
             description: Check {{ $labels.database_id }} database for network latency between primary and replica; adjust configurations to optimize replication.
             summary: More than 5 seconds lag between database read replica and primary.
           expr: |
-            avg by (job,project_id,instance, database_id) (stackdriver_cloudsql_database_cloudsql_googleapis_com_database_mysql_replication_seconds_behind_master) > 5
+            avg by (job,project_id,instance,database_id,asserts_env,asserts_site) (stackdriver_cloudsql_database_cloudsql_googleapis_com_database_mysql_replication_seconds_behind_master) > 5
           for: 5m
           keep_firing_for: 10m
           labels:
@@ -355,7 +355,7 @@ groups:
             description: Scale up subscribers or adjust message processing capacity for the {{ $labels.instance }} instance.
             summary: More than 1000 unacknowledged messages for a PubSub subscription.
           expr: |
-            avg by (job,project_id,instance)(stackdriver_pubsub_subscription_pubsub_googleapis_com_subscription_num_undelivered_messages{job=~".+",project_id=~".+",instance=~".+"}) > 1000
+            avg by (job,project_id,instance,asserts_env,asserts_site)(stackdriver_pubsub_subscription_pubsub_googleapis_com_subscription_num_undelivered_messages{job=~".+",project_id=~".+",instance=~".+"}) > 1000
           for: 5m
           keep_firing_for: 10m
           labels:
@@ -369,7 +369,7 @@ groups:
             description: Investigate {{ $labels.instance }} instance and speed up message processing; ensure consumers can handle the load.
             summary: Unacknowledged messages for more than 60 seconds for a PubSub subscription.
           expr: |
-            avg by (job,project_id,instance)(stackdriver_pubsub_subscription_pubsub_googleapis_com_subscription_oldest_unacked_message_age{job=~".+",project_id=~".+",instance=~".+"}) > 60
+            avg by (job,project_id,instance,asserts_env,asserts_site)(stackdriver_pubsub_subscription_pubsub_googleapis_com_subscription_oldest_unacked_message_age{job=~".+",project_id=~".+",instance=~".+"}) > 60
           for: 5m
           keep_firing_for: 10m
           labels:


### PR DESCRIPTION
Added `asserts_env, asserts_site` to every `by()` aggregation clause in gcp and azure alerts.

Once these rules are deployed and new alert instances fire, they will carry `asserts_env` and `asserts_site` labels.


Also, update grafonnet from `v11.0.0` to `v11.4.0`