### PR TITLE
fix(nginx-directory): bump default nginx to 1.31.1-alpine for CVE-2026-42945

### DIFF
--- a/nginx-directory/config.libsonnet
+++ b/nginx-directory/config.libsonnet
@@ -49,6 +49,6 @@
   },
 
   _images+:: {
-    nginx: 'nginx:1.15.1-alpine',
+    nginx: 'nginx:1.31.1-alpine@sha256:8b1e78743a03dbb2c95171cc58639fef29abc8816598e27fb910ed2e621e589a',
   },
 }


### PR DESCRIPTION
Bumps the default nginx image in `nginx-directory/config.libsonnet` from `nginx:1.15.1-alpine` (released 2018) to `nginx:1.31.1-alpine@sha256:8b1e78743a03dbb2c95171cc58639fef29abc8816598e27fb910ed2e621e589a` to clear **CVE-2026-42945** (nginx heap-buffer-overflow RCE).