### PR TITLE
fix(signals): collect metric exprs from grouped signals

### DIFF
--- a/common-lib/common/signal/signal.libsonnet
+++ b/common-lib/common/signal/signal.libsonnet
@@ -388,11 +388,14 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
   collectMetricExprs(signalsObj):
     std.filter(
       function(e) std.isString(e) && e != '',
-      [
-        signalsObj[s].asPanelExpression()
+      std.flattenArrays([
+        if std.isObject(signalsObj[s]) && std.objectHasAll(signalsObj[s], 'asPanelExpression') then
+          [signalsObj[s].asPanelExpression()]
+        else if std.isObject(signalsObj[s]) then
+          self.collectMetricExprs(signalsObj[s])
+        else
+          []
         for s in std.objectFields(signalsObj)
-        if std.isObject(signalsObj[s])
-           && std.objectHas(signalsObj[s], 'asPanelExpression')
-      ]
+      ])
     ),
 }

--- a/common-lib/common/signal/test_collect_metric_exprs.libsonnet
+++ b/common-lib/common/signal/test_collect_metric_exprs.libsonnet
@@ -80,15 +80,20 @@ local groupedExprs = signal.collectMetricExprs(groupedSignals);
         actual: std.any([!std.isString(e) for e in exprs]),
         expect: false,
       },
-      testGroupedCount: {
+    }),
+  },
+  collectMetricExprsGrouped: {
+    raw:: groupedExprs,
+    testResult: test.suite({
+      testCount: {
         actual: std.length(groupedExprs),
         expect: 4,
       },
-      testGroupedAllStrings: {
+      testAllStrings: {
         actual: std.all([std.isString(e) for e in groupedExprs]),
         expect: true,
       },
-      testGroupedContainsAbc: {
+      testContainsAbc: {
         actual: std.member(groupedExprs, 'avg by (job,xxx) (\n  abc{job="integrations/agent",job=~"$job",instance=~"$instance"}\n)'),
         expect: true,
       },

--- a/common-lib/common/signal/test_collect_metric_exprs.libsonnet
+++ b/common-lib/common/signal/test_collect_metric_exprs.libsonnet
@@ -50,6 +50,12 @@ local jsonSignals = {
 local signals = signal.unmarshallJsonMulti(jsonSignals, 'prometheus');
 local exprs = signal.collectMetricExprs(signals);
 
+local groupedSignals = {
+  overview: signal.unmarshallJsonMulti(jsonSignals, 'prometheus'),
+  instance: signal.unmarshallJsonMulti(jsonSignals, 'prometheus'),
+};
+local groupedExprs = signal.collectMetricExprs(groupedSignals);
+
 {
   collectMetricExprs: {
     raw:: exprs,
@@ -73,6 +79,18 @@ local exprs = signal.collectMetricExprs(signals);
       testNoEmptyObjects: {
         actual: std.any([!std.isString(e) for e in exprs]),
         expect: false,
+      },
+      testGroupedCount: {
+        actual: std.length(groupedExprs),
+        expect: 4,
+      },
+      testGroupedAllStrings: {
+        actual: std.all([std.isString(e) for e in groupedExprs]),
+        expect: true,
+      },
+      testGroupedContainsAbc: {
+        actual: std.member(groupedExprs, 'avg by (job,xxx) (\n  abc{job="integrations/agent",job=~"$job",instance=~"$instance"}\n)'),
+        expect: true,
       },
     }),
   },


### PR DESCRIPTION
## Description 

 Follow up on #1644. The previous version didn't pick up grouped signals `collectMetricExprs` now recurses into nested maps so both flat and grouped signals are collected.  