### PR TITLE
fix!(opensearch) change false-positive OpenSearch memory alerts (Switch from OS Memory to JVM heap)

### DIFF
--- a/opensearch-mixin/README.md
+++ b/opensearch-mixin/README.md
@@ -16,7 +16,7 @@ and the following alerts:
 - OpenSearchUnstableShardUnassigned
 - OpenSearchHighNodeDiskUsage (warning and critical)
 - OpenSearchHighNodeCpuUsage (warning and critical)
-- OpenSearchHighNodeMemoryUsage (warning and critical)
+- OpenSearchHighHeapMemoryUsage (warning and critical)
 - OpenSearchModerateRequestLatency
 - OpenSearchModerateIndexLatency
 
@@ -78,7 +78,7 @@ The OpenSearch search and index overview dashboard provides details on request p
 | OpenSearchUnstableShardUnassigned   | There are shards that have been detected as unassigned.                         |
 | OpenSearchHighNodeDiskUsage         | The node disk usage has exceeded the configured threshold (warning or critical). |
 | OpenSearchHighNodeCpuUsage          | The node CPU usage has exceeded the configured threshold (warning or critical).  |
-| OpenSearchHighNodeMemoryUsage       | The node memory usage has exceeded the configured threshold (warning or critical). |
+| OpenSearchHighHeapMemoryUsage       | The heap memory usage has exceeded the configured threshold (warning or critical). |
 | OpenSearchModerateRequestLatency    | The request latency has exceeded the warning threshold.                         |
 | OpenSearchModerateIndexLatency      | The index latency has exceeded the warning threshold.                           |
 
@@ -95,8 +95,8 @@ Default thresholds can be configured in `config.libsonnet`
     alertsCriticalDiskUsage: 80,
     alertsWarningCPUUsage: 70,
     alertsCriticalCPUUsage: 85,
-    alertsWarningMemoryUsage: 70,
-    alertsCriticalMemoryUsage: 85,
+    alertsWarningHeapMemoryUsage: 70,
+    alertsCriticalHeapMemoryUsage: 85,
     alertsWarningRequestLatency: 500,  // milliseconds
     alertsWarningIndexLatency: 500,  // milliseconds
   },

--- a/opensearch-mixin/alerts.libsonnet
+++ b/opensearch-mixin/alerts.libsonnet
@@ -135,34 +135,34 @@
             },
           },
           {
-            alert: 'OpenSearchHighNodeMemoryUsage',
+            alert: 'OpenSearchHighHeapMemoryUsage',
             expr: |||
-              sum without(nodeid) (opensearch_os_mem_used_percent{%(filteringSelector)s}) > %(alertsWarningMemoryUsage)s
+              sum without(nodeid) (opensearch_jvm_mem_heap_used_percent{%(filteringSelector)s}) > %(alertsWarningHeapMemoryUsage)s
             ||| % this.config,
             'for': '5m',
             labels: {
               severity: 'warning',
             },
             annotations: {
-              summary: 'The node memory usage has exceeded the warning threshold.',
+              summary: 'The heap memory usage has exceeded the warning threshold.',
               description: |||
-                {{$labels.node}} has had {{ printf "%%.0f" $value }}%% memory usage over the last 5m which is above the threshold of %(alertsWarningMemoryUsage)s.
+                {{$labels.node}} has had {{ printf "%%.0f" $value }}%% heap memory usage over the last 5m which is above the threshold of %(alertsWarningHeapMemoryUsage)s.
               ||| % this.config,
             },
           },
           {
-            alert: 'OpenSearchHighNodeMemoryUsage',
+            alert: 'OpenSearchHighHeapMemoryUsage',
             expr: |||
-              sum without(nodeid) (opensearch_os_mem_used_percent{%(filteringSelector)s}) > %(alertsCriticalMemoryUsage)s
+              sum without(nodeid) (opensearch_jvm_mem_heap_used_percent{%(filteringSelector)s}) > %(alertsCriticalHeapMemoryUsage)s
             ||| % this.config,
             'for': '5m',
             labels: {
               severity: 'critical',
             },
             annotations: {
-              summary: 'The node memory usage has exceeded the critical threshold.',
+              summary: 'The heap memory usage has exceeded the critical threshold.',
               description: |||
-                {{$labels.node}} has had {{ printf "%%.0f" $value }}%% memory usage over the last 5m which is above the threshold of %(alertsCriticalMemoryUsage)s.
+                {{$labels.node}} has had {{ printf "%%.0f" $value }}%% heap memory usage over the last 5m which is above the threshold of %(alertsCriticalHeapMemoryUsage)s.
               ||| % this.config,
             },
           },

--- a/opensearch-mixin/config.libsonnet
+++ b/opensearch-mixin/config.libsonnet
@@ -31,8 +31,8 @@
   alertsCriticalDiskUsage: 80,  // %
   alertsWarningCPUUsage: 70,  // %
   alertsCriticalCPUUsage: 85,  // %
-  alertsWarningMemoryUsage: 70,  // %
-  alertsCriticalMemoryUsage: 85,  // %
+  alertsWarningHeapMemoryUsage: 70,  // %
+  alertsCriticalHeapMemoryUsage: 85,  // %
   alertsWarningRequestLatency: 500,  // milliseconds
   alertsWarningIndexLatency: 500,  // milliseconds
 

--- a/opensearch-mixin/prometheus_rules_out/prometheus_alerts.yaml
+++ b/opensearch-mixin/prometheus_rules_out/prometheus_alerts.yaml
@@ -79,23 +79,23 @@ groups:
           for: 5m
           labels:
             severity: critical
-        - alert: OpenSearchHighNodeMemoryUsage
+        - alert: OpenSearchHighHeapMemoryUsage
           annotations:
             description: |
-                {{$labels.node}} has had {{ printf "%.0f" $value }}% memory usage over the last 5m which is above the threshold of 70.
-            summary: The node memory usage has exceeded the warning threshold.
+                {{$labels.node}} has had {{ printf "%.0f" $value }}% heap memory usage over the last 5m which is above the threshold of 70.
+            summary: The heap memory usage has exceeded the warning threshold.
           expr: |
-            sum without(nodeid) (opensearch_os_mem_used_percent{}) > 70
+            sum without(nodeid) (opensearch_jvm_mem_heap_used_percent{}) > 70
           for: 5m
           labels:
             severity: warning
-        - alert: OpenSearchHighNodeMemoryUsage
+        - alert: OpenSearchHighHeapMemoryUsage
           annotations:
             description: |
-                {{$labels.node}} has had {{ printf "%.0f" $value }}% memory usage over the last 5m which is above the threshold of 85.
-            summary: The node memory usage has exceeded the critical threshold.
+                {{$labels.node}} has had {{ printf "%.0f" $value }}% heap memory usage over the last 5m which is above the threshold of 85.
+            summary: The heap memory usage has exceeded the critical threshold.
           expr: |
-            sum without(nodeid) (opensearch_os_mem_used_percent{}) > 85
+            sum without(nodeid) (opensearch_jvm_mem_heap_used_percent{}) > 85
           for: 5m
           labels:
             severity: critical


### PR DESCRIPTION
The previous alerting rules evaluated `opensearch_os_mem_used_percent` metric. 

Because OpenSearch aggressively relies on the OS page cache to store Lucene segments for fast querying, this metric naturally could float above 95% up to 100%, while OS working perfectly normal.

This resulted in constant false-positive alerts.

On the contrary, in my environment, the actual K8s pod memory metrics showed a healthy working set (~10-11 GiB out of the 16 GiB limit).

This changes:
- Renamed the alert to OpenSearchHighJVMHeapUsage for clarity.
- Replaced the node-level OS memory metric with `opensearch_jvm_mem_heap_used_percent` to control JVM memory pressure instead.

more ref:
https://repost.aws/knowledge-center/opensearch-high-sysmemoryutilization
https://forum.opensearch.org/t/default-consumption-of-os-memory-usage/17542