### PR TITLE
Remove dashboard id from ceph-cluster.json

### DIFF
--- a/ceph-mixin/dashboards/ceph-cluster.json
+++ b/ceph-mixin/dashboards/ceph-cluster.json
@@ -25,7 +25,6 @@
   "editable": false,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 782,
   "links": [],
   "panels": [
     {

--- a/ceph-mixin/dashboards_out/ceph-cluster.json
+++ b/ceph-mixin/dashboards_out/ceph-cluster.json
@@ -25,7 +25,6 @@
       "editable": false,
       "fiscalYearStartMonth": 0,
       "graphTooltip": 0,
-      "id": 782,
       "links": [ ],
       "panels": [
          {


### PR DESCRIPTION
## Fixes #1127
Removed the hardcoded (fixed) dashboard ID from `ceph-mixin/dashboards/ceph-cluster.json`.
## Why?
Grafana assigns dashboard IDs dynamically to each instance. Keeping a hardcoded (fixed) dashboard ID can cause dashboard import/update failures when the ID differs for every Grafana instance.