### PR TITLE
feat(grafana): add opt-in bin-packing for dashboard ConfigMap sharding

### DIFF
--- a/grafana/config.libsonnet
+++ b/grafana/config.libsonnet
@@ -16,7 +16,32 @@
     //   https://github.com/kubernetes/kubectl/issues/712
     // For serverside applies, it can be increased, but keep in mind the 1MB limit of etcd
     //   https://github.com/kubernetes/kubernetes/issues/19781
+    //
+    // The meaning of `configmap_shard_size` depends on `configmap_binpack`:
+    //   * binpack = false (default, "balanced"): a *target average* shard size. The
+    //     number of shards is `ceil(total / configmap_shard_size)` and dashboards are
+    //     split across them by count, so an individual shard MAY exceed this value.
+    //   * binpack = true: a *hard per-ConfigMap byte cap* enforced by First-Fit
+    //     Decreasing bin packing (see configmaps.libsonnet).
     configmap_shard_size: 100000,
+
+    // Opt in to First-Fit Decreasing (FFD) bin packing for dashboard ConfigMaps.
+    // When true, `configmap_shard_size` becomes a hard per-ConfigMap byte budget:
+    // dashboards are packed largest-first into the fewest shards that keep every
+    // shard at or below the budget, so a shard can never silently exceed
+    // Kubernetes' 1 MiB ConfigMap limit. Leave headroom below 1 MiB for ConfigMap
+    // keys/metadata/encoding when choosing the budget (~900000 is a safe cap).
+    //
+    // Caveats:
+    //   * `configmap_shard_size` changes meaning (target average -> hard cap), see above.
+    //   * Enabling this (or later changing the budget) reassigns dashboards across
+    //     shards, which bumps the `grafana-dashboards-hash` annotation and triggers a
+    //     one-time Grafana reload of the affected folders. This is expected and harmless.
+    //   * A single dashboard larger than the budget cannot be split across ConfigMaps
+    //     and is placed in its own (over-budget) shard as a best effort.
+    // Defaults to false to preserve the existing balanced sharding behaviour for
+    // current consumers.
+    configmap_binpack: false,
 
     labels+: {
       dashboards: {},

--- a/grafana/configmaps.libsonnet
+++ b/grafana/configmaps.libsonnet
@@ -58,10 +58,24 @@ local deployment = k.apps.v1.deployment;
       }),
     }),
 
-  // Dashboard JSON configmaps
-  // An effort is made to balance config maps by
-  //   matching the smallest dashboards with the biggest ones
-  local calculateShards(folder) =
+  // Dashboard JSON configmaps.
+  //
+  // Two sharding strategies are available, selected by `$._config.configmap_binpack`:
+  //   * false (default): the balanced strategy — `configmap_shard_size` is a target
+  //     average and dashboards are split across `ceil(total / size)` shards by count.
+  //     An individual shard may exceed `configmap_shard_size`.
+  //   * true: First-Fit Decreasing (FFD) bin packing — `configmap_shard_size` is a
+  //     hard per-ConfigMap byte budget; no shard exceeds it (barring a single
+  //     dashboard that alone is larger than the budget).
+  // See config.libsonnet for the full description and caveats.
+  //
+  // Both strategies return the same shape:
+  //   { '<prefix>-<index>': { '<dashboard>.json': <content>, ... }, ... }
+
+  // Balanced strategy: fix the shard count from the target average size, then
+  // balance shards by pairing the smallest dashboards with the biggest ones.
+  // `configmap_shard_size` is a target average, not a hard cap.
+  local calculateShardsBalanced(folder) =
     // Sort dashboards descending by size
     local dashboards = std.sort([
       {
@@ -105,6 +119,73 @@ local deployment = k.apps.v1.deployment;
       for shard in std.range(0, shardCount - 1)
       if count > 0
     },
+
+  // FFD strategy: `configmap_shard_size` is a hard per-ConfigMap byte budget.
+  // Dashboards are sorted largest-first and each is placed into the first shard
+  // that still has room, opening a new shard only when none fits. This keeps
+  // every shard at or below the budget while filling shards as densely as
+  // possible, so we emit close to the minimum number of ConfigMaps and never
+  // blow past Kubernetes' hard 1 MiB ConfigMap limit. A single dashboard larger
+  // than the budget cannot be split, so it is placed in its own (over-budget)
+  // shard as a best effort.
+  local calculateShardsBinpack(folder) =
+    local capacity = $._config.configmap_shard_size;
+
+    // Serialize each dashboard once and sort descending by size
+    // (the "Decreasing" in First-Fit Decreasing).
+    local mkItem(name) =
+      local content = std.toString(folder.dashboards[name]);
+      {
+        name: if std.endsWith(name, '.json') then name else '%s.json' % name,
+        content: content,
+        size: std.length(content),
+      };
+    local dashboards = std.sort(
+      [mkItem(name) for name in std.objectFields(folder.dashboards)],
+      function(d) -d.size,
+    );
+
+    // Fold each dashboard into the first shard that still has room.
+    // A shard (bin) is { size: <bytes used>, items: [ <dashboard>, ... ] }.
+    local bins = std.foldl(
+      function(acc, d)
+        local fits = std.filter(
+          function(i) acc[i].size + d.size <= capacity,
+          std.range(0, std.length(acc) - 1),
+        );
+        if std.length(fits) == 0 then
+          // No existing shard fits: open a new one.
+          acc + [{ size: d.size, items: [d] }]
+        else
+          // Place into the first fitting shard (lowest index).
+          local target = fits[0];
+          [
+            if i == target
+            then { size: acc[i].size + d.size, items: acc[i].items + [d] }
+            else acc[i]
+            for i in std.range(0, std.length(acc) - 1)
+          ],
+      dashboards,
+      [],
+    );
+
+    // Emit shards as `<prefix>-<index>` -> { <dashboard name>: <content> }.
+    // An empty folder yields no shards.
+    {
+      ['%s-%d' % [prefix(folder.id), i]]: {
+        [item.name]: item.content
+        for item in bins[i].items
+      }
+      for i in std.range(0, std.length(bins) - 1)
+    },
+
+  // Dispatch on the configured strategy. Kept as a single entry point so the
+  // ConfigMap emission and the volume mounts (both call this) always agree on
+  // shard names.
+  local calculateShards(folder) =
+    if $._config.configmap_binpack
+    then calculateShardsBinpack(folder)
+    else calculateShardsBalanced(folder),
 
 
   local shardedConfigMaps(folder) =

--- a/grafana/test/.gitignore
+++ b/grafana/test/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+jsonnetfile.lock.json

--- a/grafana/test/Makefile
+++ b/grafana/test/Makefile
@@ -1,0 +1,16 @@
+.PHONY: tests efficiency
+
+# `stubs/` supplies a minimal ksonnet-util/kausal so the sharding code path
+# resolves without the full k8s-libsonnet tree; it takes precedence over vendor.
+JPATH := -J stubs/ -J vendor/
+
+vendor jsonnetfile.lock.json: jsonnetfile.json
+	jb install
+
+# Correctness assertions (testonnet).
+tests: jsonnetfile.lock.json vendor
+	jsonnet $(JPATH) ./test_sharding.libsonnet
+
+# Efficiency comparison table (Markdown, for the PR description).
+efficiency: jsonnetfile.lock.json vendor
+	@jsonnet -S $(JPATH) ./efficiency.libsonnet

--- a/grafana/test/efficiency.libsonnet
+++ b/grafana/test/efficiency.libsonnet
@@ -1,0 +1,60 @@
+// Sharding efficiency comparison: balanced (configmap_binpack:false) vs
+// binpack (configmap_binpack:true), across several dashboard-size
+// distributions and shard budgets. Emits a Markdown table for the PR
+// description. Run: jsonnet -S -J vendor/ ./efficiency.libsonnet
+local f = import 'sharding_fixture.libsonnet';
+
+local budgets = [f.mib, 900000, 700000, 500000];
+
+// Non-negative integer with thousands separators.
+local comma(n) =
+  local s = std.toString(n);
+  local L = std.length(s);
+  std.join('', [
+    s[i] + (if (L - i - 1) > 0 && (L - i - 1) % 3 == 0 then ',' else '')
+    for i in std.range(0, L - 1)
+  ]);
+
+local row(label, m) =
+  local over = if m.over_1mib == 0 then '0' else '**%d** ⚠️' % m.over_1mib;
+  '| %s | %d | %s | %s | %.1f%% | %.1f%% | %.2f |' % [
+    label,
+    m.shards,
+    over,
+    comma(m.max_shard),
+    m.max_pct,
+    m.avg_fill_pct,
+    m.shards_vs_min,
+  ];
+
+local scenarioBlock(name) =
+  local sizes = f.scenarios[name];
+  local total = std.foldl(function(a, b) a + b, sizes, 0);
+  local budgetRows(budget) = [
+    row('**%s** · balanced' % comma(budget), f.metrics(sizes, false, budget)),
+    row('· binpack', f.metrics(sizes, true, budget)),
+  ];
+  [
+    '### %s' % name,
+    '_%d dashboards, %s bytes total (theoretical min at 1 MiB: %d shards)_' % [
+      std.length(sizes),
+      comma(total),
+      std.ceil(total / f.mib),
+    ],
+    '',
+    '| budget / strategy | shards | over 1 MiB | max shard | max % | avg fill % | shards/min |',
+    '|-------------------|:------:|:----------:|----------:|:-----:|:----------:|:----------:|',
+  ]
+  + std.flattenArrays([budgetRows(b) for b in budgets])
+  + [''];
+
+std.join('\n', [
+                 '## Dashboard ConfigMap sharding: balanced vs binpack',
+                 '',
+                 'Hard Kubernetes ConfigMap limit: **1,048,576 bytes (1 MiB)**. `over 1 MiB` must',
+                 'be 0 for correctness. `shards/min` = shards used vs the theoretical minimum',
+                 '(1.00 = optimal packing; lower shard counts at equal correctness are better).',
+                 'Dashboards are test strings of the listed byte lengths.',
+                 '',
+               ]
+               + std.flattenArrays([scenarioBlock(n) for n in std.objectFields(f.scenarios)]))

--- a/grafana/test/jsonnetfile.json
+++ b/grafana/test/jsonnetfile.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/jsonnet-libs/testonnet.git"
+        }
+      },
+      "version": "master"
+    }
+  ],
+  "legacyImports": true
+}

--- a/grafana/test/sharding_fixture.libsonnet
+++ b/grafana/test/sharding_fixture.libsonnet
@@ -1,0 +1,128 @@
+// Shared fixture for the dashboard-sharding tests.
+//
+// Dashboards are just strings of a chosen byte length (std.length(content)
+// then equals the size), so scenarios are expressed as plain lists of sizes -
+// no real dashboard JSON needed to exercise the sharding maths.
+local configmaps = import '../configmaps.libsonnet';
+
+{
+  mib:: 1024 * 1024,  // 1048576 - the hard Kubernetes ConfigMap limit
+  local kib = 1024,
+
+  // A dashboard "body" of exactly n bytes. Built by string doubling
+  // (O(log n) concatenations) - std.repeat/std.join over an n-element array
+  // is pathologically slow for the multi-hundred-KB scenarios here.
+  pad(n)::
+    local grow(s) = if std.length(s) >= n then std.substr(s, 0, n) else grow(s + s);
+    if n <= 0 then '' else grow('x'),
+
+  // Scenarios: name -> [ dashboard sizes in bytes ].
+  scenarios:: {
+    'mimir (real, post-overlay)': [
+      534716,
+      329748,
+      311980,
+      172653,
+      145276,
+      132956,
+      119348,
+      114080,
+      104675,
+      85782,
+      63065,
+      62338,
+      52903,
+      50425,
+      46958,
+      45569,
+      44220,
+      41917,
+      41165,
+      39386,
+      38137,
+      33333,
+      33241,
+      32091,
+      31860,
+      28223,
+      26757,
+      17501,
+      7249,
+      4868,
+      4240,
+    ],
+    // Uniform: balanced's count-split is at its best here (fair baseline).
+    'uniform (40x 90KB)': [90 * kib for _ in std.range(1, 40)],
+    // Skewed: a few large dashboards among many small ones - the shape that
+    // makes a count-based split bunch big dashboards into one shard.
+    'skewed (4x 480KB + 30x 20KB)':
+      [480 * kib for _ in std.range(1, 4)] + [20 * kib for _ in std.range(1, 30)],
+    // Long tail: one dominant dashboard plus a lot of tiny ones.
+    'long-tail (1x 700KB + 60x 12KB)':
+      [700 * kib] + [12 * kib for _ in std.range(1, 60)],
+  },
+
+  // Render a scenario through the REAL library for a given strategy + budget.
+  build(sizes, binpack, budget)::
+    local grafana = configmaps {
+      _config:: {
+        configmap_shard_size: budget,
+        configmap_binpack: binpack,
+        provisioningDir: '/etc/grafana/provisioning',
+        labels:: { dashboards: {} },
+      },
+      grafanaDatasources:: {},
+      grafanaNotificationChannels:: {},
+      grafanaDashboardFolders:: {
+        folder: {
+          id: 'folder',
+          name: 'folder',
+          dashboards: { ['d%03d' % i]: $.pad(sizes[i]) for i in std.range(0, std.length(sizes) - 1) },
+        },
+      },
+    };
+    grafana,
+
+  local shardBytes(cms, name) =
+    std.foldl(function(a, k) a + std.length(cms[name].data[k]), std.objectFields(cms[name].data), 0),
+
+  // Efficiency + correctness metrics for one (scenario, strategy, budget).
+  metrics(sizes, binpack, budget):: {
+    local grafana = $.build(sizes, binpack, budget),
+    local cms = grafana.dashboard_folders_config_maps,
+    local names = std.objectFields(cms),
+    local perShard = [shardBytes(cms, n) for n in names],
+    local total = std.foldl(function(a, b) a + b, perShard, 0),
+    local minShards = std.ceil(total / $.mib),
+
+    // Every dashboard name that ended up in some shard (the library appends
+    // a `.json` suffix to each dashboard key).
+    local placed = std.set(std.flattenArrays([std.objectFields(cms[n].data) for n in names])),
+    local expected = std.set(['d%03d.json' % i for i in std.range(0, std.length(sizes) - 1)]),
+
+    // Shard names must match between the ConfigMaps and the volume mounts,
+    // or Grafana would try to mount a shard that does not exist. Dashboard
+    // shard mounts live under /grafana/<prefix>/<shard>; take the last path
+    // segment to recover <shard>.
+    local lastSeg(p) = local parts = std.split(p, '/'); parts[std.length(parts) - 1],
+    local mountNames = std.set([
+      lastSeg(m.path)
+      for m in grafana.configmap_mounts.mounts
+      if std.startsWith(m.path, '/grafana/')
+    ]),
+
+    shards: std.length(names),
+    over_1mib: std.length(std.filter(function(b) b > $.mib, perShard)),
+    max_shard: std.foldl(function(a, b) std.max(a, b), perShard, 0),
+    total_bytes: total,
+    theoretical_min_shards: minShards,
+    // shards used vs the theoretical minimum (1.0 == optimal packing)
+    shards_vs_min: std.floor(std.length(names) / minShards * 100) / 100,
+    // average shard as a % of the 1 MiB budget (higher == denser)
+    avg_fill_pct: std.floor(total / std.length(names) / $.mib * 1000) / 10,
+    max_pct: std.floor(std.foldl(function(a, b) std.max(a, b), perShard, 0) / $.mib * 1000) / 10,
+    // correctness invariants
+    all_dashboards_preserved: placed == expected,
+    mount_names_match: std.set(names) == mountNames,
+  },
+}

--- a/grafana/test/stubs/ksonnet-util/kausal.libsonnet
+++ b/grafana/test/stubs/ksonnet-util/kausal.libsonnet
@@ -1,0 +1,21 @@
+// Minimal stub of the ksonnet-util helpers that grafana/configmaps.libsonnet
+// uses, so the sharding logic can be exercised in isolation without vendoring
+// the full k8s-libsonnet (`k.libsonnet`) tree. Only the object/mount
+// constructors touched by the dashboard-sharding code path are implemented.
+{
+  core+: { v1+: { configMap+: {
+    new(name):: { kind: 'ConfigMap', metadata: { name: name }, data: {} },
+    withData(d):: { data+: d },
+    withDataMixin(d):: { data+: d },
+    mixin+: { metadata+: { withLabels(l):: { metadata+: { labels: l } } } },
+  } } },
+  apps+: { v1+: { deployment+: { mixin+: { spec+: { template+: { metadata+: {
+    withAnnotationsMixin(a):: { annotations+: a },
+  } } } } } } },
+  util+: {
+    manifestYaml(o):: std.toString(o),
+    volumeMountItem(n, p):: { name: n, path: p },
+    configMapVolumeMountItem(cm, p):: { cm: cm.metadata.name, path: p },
+    volumeMounts(m):: { mounts: m },
+  },
+}

--- a/grafana/test/test_sharding.libsonnet
+++ b/grafana/test/test_sharding.libsonnet
@@ -1,0 +1,43 @@
+// Correctness assertions for dashboard ConfigMap sharding.
+// Run via `make tests` (testonnet).
+local test = import 'github.com/jsonnet-libs/testonnet/main.libsonnet';
+local f = import 'sharding_fixture.libsonnet';
+
+local mimir = f.scenarios['mimir (real, post-overlay)'];
+local skewed = f.scenarios['skewed (4x 480KB + 30x 20KB)'];
+
+test.new(std.thisFile)
+
+// --- binpack correctness: never exceeds the ConfigMap limit ---------------
++ test.case.new(
+  name='binpack: no shard exceeds budget (mimir @ 900000)',
+  test=test.expect.eq(actual=f.metrics(mimir, true, 900000).over_1mib, expected=0),
+)
++ test.case.new(
+  name='binpack: no shard exceeds budget (skewed @ 900000)',
+  test=test.expect.eq(actual=f.metrics(skewed, true, 900000).over_1mib, expected=0),
+)
+
+// --- both strategies preserve every dashboard and stay self-consistent ----
++ test.case.new(
+  name='binpack: all dashboards preserved (mimir @ 900000)',
+  test=test.expect.eq(actual=f.metrics(mimir, true, 900000).all_dashboards_preserved, expected=true),
+)
++ test.case.new(
+  name='balanced: all dashboards preserved (mimir @ 700000)',
+  test=test.expect.eq(actual=f.metrics(mimir, false, 700000).all_dashboards_preserved, expected=true),
+)
++ test.case.new(
+  name='binpack: mount names match ConfigMap names (mimir @ 900000)',
+  test=test.expect.eq(actual=f.metrics(mimir, true, 900000).mount_names_match, expected=true),
+)
++ test.case.new(
+  name='balanced: mount names match ConfigMap names (mimir @ 700000)',
+  test=test.expect.eq(actual=f.metrics(mimir, false, 700000).mount_names_match, expected=true),
+)
+
+// --- documents the motivating bug: balanced can overflow the 1 MiB limit --
++ test.case.new(
+  name='balanced: overflows 1 MiB on the real post-overlay mimir folder @ 700000',
+  test=test.expect.eq(actual=f.metrics(mimir, false, 700000).over_1mib, expected=1),
+)


### PR DESCRIPTION
Adds an opt-in `configmap_binpack` flag (default `false`) that changes how dashboard JSON is packed into ConfigMaps, from the current count-based split to **First-Fit Decreasing (FFD) bin packing**.

The existing sharder derives a shard count from a *target average* (`ceil(total / configmap_shard_size)`) and then distributes dashboards across shards **by count** (pairing biggest with smallest). Because it never checks any shard's actual byte size, a shard can bundle several large dashboards and exceed Kubernetes' hard **1 MiB ConfigMap limit** — at which point the ConfigMap is rejected on apply and Flux/kubectl gets stuck. This is not hypothetical: with the Mimir mixin dashboards (a ~2.8 MB folder of 31 dashboards) the balanced strategy produces a **1,280,785-byte** shard, over the limit.

## What changed

- **`grafana/config.libsonnet`** — new `configmap_binpack: false`. Documents that `configmap_shard_size` means a *target average* when `false`, and a *hard per-ConfigMap byte cap* when `true`.
- **`grafana/configmaps.libsonnet`** — `calculateShards` now dispatches on the flag between `calculateShardsBalanced` (the existing algorithm, unchanged) and `calculateShardsBinpack` (FFD: sort largest-first, place each dashboard into the first shard with room, open a new shard only when none fits). Both return the same shape, and both the ConfigMap emission and the volume mounts go through the single dispatcher so shard names always agree.
- **`grafana/test/`** — a `testonnet` suite (`make tests`) asserting both strategies preserve every dashboard and keep ConfigMap/mount names consistent, that binpack never exceeds the budget, and pinning the motivating overflow; plus an efficiency-comparison harness (`make efficiency`) that produced the evidence below.

## Behaviour / caveats

- Default is `false` → **no change** for existing consumers.
- When enabled, `configmap_shard_size` becomes a hard cap; leave headroom below 1 MiB (~900000) for ConfigMap key/metadata overhead.
- Enabling it (or later changing the budget) reassigns dashboards across shards, bumping `grafana-dashboards-hash` → a one-time Grafana reload of affected folders.
- A single dashboard larger than the budget can't be split, so it still gets its own (over-budget) shard — unavoidable, same as before.

## Evidence

Ran both strategies across several dashboard-size distributions and budgets (`make efficiency`). `over 1 MiB` must be 0 for correctness.

```
### mimir (real) — 31 dashboards, 2,796,660 bytes (min at 1 MiB: 3 shards)
| budget / strategy      | shards | over 1 MiB | max shard | max %  |
| **1,048,576** balanced | 3      | 1 (!)      | 1,578,971 | 150.5% |
| binpack                | 3      | 0          | 1,047,430 |  99.8% |
| **900,000**  balanced  | 4      | 1 (!)      | 1,280,785 | 122.1% |
| binpack                | 4      | 0          |   899,714 |  85.8% |
| **700,000**  balanced  | 4      | 1 (!)      | 1,280,785 | 122.1% |
| binpack                | 5      | 0          |   699,499 |  66.7% |
| **500,000**  balanced  | 6      | 0          |   894,082 |  85.2% |
| binpack                | 6      | 0          |   534,716 |  50.9% |

### skewed (4x480KB + 30x20KB) — 34 dashboards, 2,580,480 bytes
| **1,048,576** balanced | 3      | 1 (!)      | 2,109,440 | 201.1% |
| binpack                | 3      | 0          | 1,044,480 |  99.6% |
```

- Balanced overflows the 1 MiB limit in every realistic distribution once the budget is >= 700 K; binpack has **0 overflows everywhere**.
- Where balanced appears to use fewer shards, it does so only by exceeding the limit (skewed @ 1 MiB: same 3 shards, but 201% vs 99.6%).
- On a uniform baseline the two are near-identical in count, and binpack packs denser while staying legal.