### PR TITLE
feat(nginx-directory): allow extra http config in ngifx.conf

### DIFF
--- a/nginx-directory/config.libsonnet
+++ b/nginx-directory/config.libsonnet
@@ -45,14 +45,12 @@
 
     // Extra directives injected at the top of the nginx `http {}` block, for
     // configuration that cannot live inside a `location {}`, e.g. `map` blocks.
-    extra_http_config: [],
+    extra_http_config: '',
     extra_http_config_rendered:
-      local entries = [
-        std.strReplace(std.rstripChars(entry, '\n'), '\n', '\n  ')  // indent by 2 spaces
-        for entry in self.extra_http_config
-        if std.rstripChars(entry, '\n') != ''
-      ];
-      if std.length(entries) == 0 then '' else '\n  ' + std.join('\n', entries),
+      if self.extra_http_config == ''
+      then ''
+      else '\n  '
+           + std.strReplace(std.rstripChars(self.extra_http_config, '\n'), '\n', '\n  '),  // indent by 2 spaces
 
     // Description shown below the title
     description: '',

--- a/nginx-directory/config.libsonnet
+++ b/nginx-directory/config.libsonnet
@@ -43,6 +43,17 @@
     // Allow for extra CSS to be injected.
     extra_css: '',
 
+    // Extra directives injected at the top of the nginx `http {}` block, for
+    // configuration that cannot live inside a `location {}`, e.g. `map` blocks.
+    extra_http_config: [],
+    extra_http_config_rendered:
+      local entries = [
+        std.strReplace(std.rstripChars(entry, '\n'), '\n', '\n  ')  // indent by 2 spaces
+        for entry in self.extra_http_config
+        if std.rstripChars(entry, '\n') != ''
+      ];
+      if std.length(entries) == 0 then '' else '\n  ' + std.join('\n', entries),
+
     // Description shown below the title
     description: '',
     description_html: if self.description != '' then '<p class="description">%s</p>' % self.description else '',

--- a/nginx-directory/files/nginx.conf
+++ b/nginx-directory/files/nginx.conf
@@ -7,7 +7,7 @@ events {
   worker_connections  4096;  ## Default: 1024
 }
 
-http {
+http {%(extra_http_config_rendered)s
   default_type application/octet-stream;
   log_format   main '%(log_format)s';
   access_log   /dev/stderr  main;


### PR DESCRIPTION
Allows additional directives to be added to http block. It indents the provided config by two spaces.


```
extra_http_config: |||
    map $uri $loki_tenant_id {
      default "";
      "~^/[^/]+/config/tenant/([^/]+)/v1/limits/?$" $1;
    }
  |||,

-- rendered as --

http {
  map $uri $loki_tenant_id {
    default "";
    "~^/[^/]+/config/tenant/([^/]+)/v1/limits/?$" $1;
  }
...
}
```