### PR TITLE
fix(haproxy-mixin): read proxy status from the state label

### DIFF
--- a/haproxy-mixin/dashboards/dashboards.libsonnet
+++ b/haproxy-mixin/dashboards/dashboards.libsonnet
@@ -59,6 +59,9 @@ local g = import 'github.com/grafana/dashboard-spec/_gen/7.0/jsonnet/grafana.lib
     processConnectionRateLimit: 'haproxy_process_limit_connection_rate{%s}' % $._config.baseMatchers,
     processSessionRateLimit: 'haproxy_process_limit_session_rate{%s}' % $._config.baseMatchers,
     processSslRateLimit: 'haproxy_process_limit_ssl_rate{%s}' % $._config.baseMatchers,
+    // Since HAProxy 2.4 PROMEX emits one *_status series per possible state with a
+    // `state` label; all have value 0 except the actual state, which is 1.
+    // Filter with == 1 and read the status from the `state` label.
     backendStatus: 'haproxy_backend_status{%s} == 1' % $._config.baseMatchers,
     frontendStatus: 'haproxy_frontend_status{%s} == 1' % $._config.baseMatchers,
     serverStatus: 'haproxy_server_status{%s} == 1' % $._config.backendMatchers,

--- a/haproxy-mixin/dashboards/dashboards.libsonnet
+++ b/haproxy-mixin/dashboards/dashboards.libsonnet
@@ -59,9 +59,9 @@ local g = import 'github.com/grafana/dashboard-spec/_gen/7.0/jsonnet/grafana.lib
     processConnectionRateLimit: 'haproxy_process_limit_connection_rate{%s}' % $._config.baseMatchers,
     processSessionRateLimit: 'haproxy_process_limit_session_rate{%s}' % $._config.baseMatchers,
     processSslRateLimit: 'haproxy_process_limit_ssl_rate{%s}' % $._config.baseMatchers,
-    backendStatus: 'haproxy_backend_status{%s}' % $._config.baseMatchers,
-    frontendStatus: 'haproxy_frontend_status{%s}' % $._config.baseMatchers,
-    serverStatus: 'haproxy_server_status{%s}' % $._config.backendMatchers,
+    backendStatus: 'haproxy_backend_status{%s} == 1' % $._config.baseMatchers,
+    frontendStatus: 'haproxy_frontend_status{%s} == 1' % $._config.baseMatchers,
+    serverStatus: 'haproxy_server_status{%s} == 1' % $._config.backendMatchers,
     backendBytesInRate: 'rate(haproxy_backend_bytes_in_total{%s}[$__rate_interval])' % $._config.backendMatchers,
     backendBytesOutRate: 'rate(haproxy_backend_bytes_out_total{%s}[$__rate_interval])' % $._config.backendMatchers,
     backendHttpRequestRate: 'rate(haproxy_backend_http_requests_total{%s}[$__rate_interval])' % $._config.backendMatchers,
@@ -128,7 +128,7 @@ local g = import 'github.com/grafana/dashboard-spec/_gen/7.0/jsonnet/grafana.lib
       },
     },
 
-    // statusUpDownMixin relabels up and down status values and colors them for easy recognition.
+    // statusUpDownMixin relabels the state label values reported by HAProxy and colors them for easy recognition.
     statusUpDownMixin: {
       fieldConfig+: {
         overrides+: [{
@@ -136,25 +136,20 @@ local g = import 'github.com/grafana/dashboard-spec/_gen/7.0/jsonnet/grafana.lib
           properties: [
             {
               id: 'mappings',
-              value: [
-                { id: 1, type: 1, text: 'Down', value: '0' },
-                { id: 2, type: 1, text: 'Up', value: '1' },
-              ],
+              value: [{
+                type: 'value',
+                options: {
+                  UP: { text: 'Up', color: 'green', index: 0 },
+                  DOWN: { text: 'Down', color: 'red', index: 1 },
+                  MAINT: { text: 'Maintenance', color: 'blue', index: 2 },
+                  DRAIN: { text: 'Drain', color: 'orange', index: 3 },
+                  NOLB: { text: 'No load balancing', color: 'orange', index: 4 },
+                },
+              }],
             },
             {
               id: 'custom.displayMode',
               value: 'color-background',
-            },
-            {
-              id: 'thresholds',
-              value: {
-                mode: 'absolute',
-                steps: [
-                  { color: 'rgba(0,0,0,0)', value: null },
-                  { color: 'red', value: 0 },
-                  { color: 'green', value: 1 },
-                ],
-              },
             },
           ],
         }],
@@ -335,13 +330,14 @@ local g = import 'github.com/grafana/dashboard-spec/_gen/7.0/jsonnet/grafana.lib
             options: {
               excludeByName: {
                 Time: true,
+                Value: true,
                 __name__: true,
               },
               renameByName: {
                 instance: 'Instance',
                 job: 'Job',
                 proxy: 'Frontend',
-                Value: 'Status',
+                state: 'Status',
               },
             },
           },
@@ -372,13 +368,14 @@ local g = import 'github.com/grafana/dashboard-spec/_gen/7.0/jsonnet/grafana.lib
             options: {
               excludeByName: {
                 Time: true,
+                Value: true,
                 __name__: true,
               },
               renameByName: {
                 instance: 'Instance',
                 job: 'Job',
                 proxy: 'Backend',
-                Value: 'Status',
+                state: 'Status',
               },
             },
           },
@@ -410,6 +407,7 @@ local g = import 'github.com/grafana/dashboard-spec/_gen/7.0/jsonnet/grafana.lib
             options: {
               excludeByName: {
                 Time: true,
+                Value: true,
                 __name__: true,
               },
               renameByName: {
@@ -417,7 +415,7 @@ local g = import 'github.com/grafana/dashboard-spec/_gen/7.0/jsonnet/grafana.lib
                 job: 'Job',
                 proxy: 'Backend',
                 server: 'Server',
-                Value: 'Status',
+                state: 'Status',
               },
             },
           },

--- a/haproxy-mixin/dashboards_out/haproxy-backend.json
+++ b/haproxy-mixin/dashboards_out/haproxy-backend.json
@@ -40,42 +40,40 @@
                            "id": "mappings",
                            "value": [
                               {
-                                 "id": 1,
-                                 "text": "Down",
-                                 "type": 1,
-                                 "value": "0"
-                              },
-                              {
-                                 "id": 2,
-                                 "text": "Up",
-                                 "type": 1,
-                                 "value": "1"
+                                 "options": {
+                                    "DOWN": {
+                                       "color": "red",
+                                       "index": 1,
+                                       "text": "Down"
+                                    },
+                                    "DRAIN": {
+                                       "color": "orange",
+                                       "index": 3,
+                                       "text": "Drain"
+                                    },
+                                    "MAINT": {
+                                       "color": "blue",
+                                       "index": 2,
+                                       "text": "Maintenance"
+                                    },
+                                    "NOLB": {
+                                       "color": "orange",
+                                       "index": 4,
+                                       "text": "No load balancing"
+                                    },
+                                    "UP": {
+                                       "color": "green",
+                                       "index": 0,
+                                       "text": "Up"
+                                    }
+                                 },
+                                 "type": "value"
                               }
                            ]
                         },
                         {
                            "id": "custom.displayMode",
                            "value": "color-background"
-                        },
-                        {
-                           "id": "thresholds",
-                           "value": {
-                              "mode": "absolute",
-                              "steps": [
-                                 {
-                                    "color": "rgba(0,0,0,0)",
-                                    "value": null
-                                 },
-                                 {
-                                    "color": "red",
-                                    "value": 0
-                                 },
-                                 {
-                                    "color": "green",
-                                    "value": 1
-                                 }
-                              ]
-                           }
                         }
                      ]
                   }
@@ -98,7 +96,7 @@
             },
             "targets": [
                {
-                  "expr": "haproxy_server_status{instance=~\"$instance\",job=~\"$job\",proxy=~\"$backend\"}",
+                  "expr": "haproxy_server_status{instance=~\"$instance\",job=~\"$job\",proxy=~\"$backend\"} == 1",
                   "format": "table",
                   "instant": true,
                   "refID": "A"
@@ -110,14 +108,15 @@
                   "options": {
                      "excludeByName": {
                         "Time": true,
+                        "Value": true,
                         "__name__": true
                      },
                      "renameByName": {
-                        "Value": "Status",
                         "instance": "Instance",
                         "job": "Job",
                         "proxy": "Backend",
-                        "server": "Server"
+                        "server": "Server",
+                        "state": "Status"
                      }
                   }
                }

--- a/haproxy-mixin/dashboards_out/haproxy-overview.json
+++ b/haproxy-mixin/dashboards_out/haproxy-overview.json
@@ -190,42 +190,40 @@
                            "id": "mappings",
                            "value": [
                               {
-                                 "id": 1,
-                                 "text": "Down",
-                                 "type": 1,
-                                 "value": "0"
-                              },
-                              {
-                                 "id": 2,
-                                 "text": "Up",
-                                 "type": 1,
-                                 "value": "1"
+                                 "options": {
+                                    "DOWN": {
+                                       "color": "red",
+                                       "index": 1,
+                                       "text": "Down"
+                                    },
+                                    "DRAIN": {
+                                       "color": "orange",
+                                       "index": 3,
+                                       "text": "Drain"
+                                    },
+                                    "MAINT": {
+                                       "color": "blue",
+                                       "index": 2,
+                                       "text": "Maintenance"
+                                    },
+                                    "NOLB": {
+                                       "color": "orange",
+                                       "index": 4,
+                                       "text": "No load balancing"
+                                    },
+                                    "UP": {
+                                       "color": "green",
+                                       "index": 0,
+                                       "text": "Up"
+                                    }
+                                 },
+                                 "type": "value"
                               }
                            ]
                         },
                         {
                            "id": "custom.displayMode",
                            "value": "color-background"
-                        },
-                        {
-                           "id": "thresholds",
-                           "value": {
-                              "mode": "absolute",
-                              "steps": [
-                                 {
-                                    "color": "rgba(0,0,0,0)",
-                                    "value": null
-                                 },
-                                 {
-                                    "color": "red",
-                                    "value": 0
-                                 },
-                                 {
-                                    "color": "green",
-                                    "value": 1
-                                 }
-                              ]
-                           }
                         }
                      ]
                   }
@@ -248,7 +246,7 @@
             },
             "targets": [
                {
-                  "expr": "haproxy_frontend_status{instance=~\"$instance\",job=~\"$job\"}",
+                  "expr": "haproxy_frontend_status{instance=~\"$instance\",job=~\"$job\"} == 1",
                   "format": "table",
                   "instant": true,
                   "refID": "A"
@@ -260,13 +258,14 @@
                   "options": {
                      "excludeByName": {
                         "Time": true,
+                        "Value": true,
                         "__name__": true
                      },
                      "renameByName": {
-                        "Value": "Status",
                         "instance": "Instance",
                         "job": "Job",
-                        "proxy": "Frontend"
+                        "proxy": "Frontend",
+                        "state": "Status"
                      }
                   }
                }
@@ -312,42 +311,40 @@
                            "id": "mappings",
                            "value": [
                               {
-                                 "id": 1,
-                                 "text": "Down",
-                                 "type": 1,
-                                 "value": "0"
-                              },
-                              {
-                                 "id": 2,
-                                 "text": "Up",
-                                 "type": 1,
-                                 "value": "1"
+                                 "options": {
+                                    "DOWN": {
+                                       "color": "red",
+                                       "index": 1,
+                                       "text": "Down"
+                                    },
+                                    "DRAIN": {
+                                       "color": "orange",
+                                       "index": 3,
+                                       "text": "Drain"
+                                    },
+                                    "MAINT": {
+                                       "color": "blue",
+                                       "index": 2,
+                                       "text": "Maintenance"
+                                    },
+                                    "NOLB": {
+                                       "color": "orange",
+                                       "index": 4,
+                                       "text": "No load balancing"
+                                    },
+                                    "UP": {
+                                       "color": "green",
+                                       "index": 0,
+                                       "text": "Up"
+                                    }
+                                 },
+                                 "type": "value"
                               }
                            ]
                         },
                         {
                            "id": "custom.displayMode",
                            "value": "color-background"
-                        },
-                        {
-                           "id": "thresholds",
-                           "value": {
-                              "mode": "absolute",
-                              "steps": [
-                                 {
-                                    "color": "rgba(0,0,0,0)",
-                                    "value": null
-                                 },
-                                 {
-                                    "color": "red",
-                                    "value": 0
-                                 },
-                                 {
-                                    "color": "green",
-                                    "value": 1
-                                 }
-                              ]
-                           }
                         }
                      ]
                   }
@@ -362,7 +359,7 @@
             "id": 8,
             "targets": [
                {
-                  "expr": "haproxy_backend_status{instance=~\"$instance\",job=~\"$job\"}",
+                  "expr": "haproxy_backend_status{instance=~\"$instance\",job=~\"$job\"} == 1",
                   "format": "table",
                   "instant": true,
                   "refID": "A"
@@ -374,13 +371,14 @@
                   "options": {
                      "excludeByName": {
                         "Time": true,
+                        "Value": true,
                         "__name__": true
                      },
                      "renameByName": {
-                        "Value": "Status",
                         "instance": "Instance",
                         "job": "Job",
-                        "proxy": "Backend"
+                        "proxy": "Backend",
+                        "state": "Status"
                      }
                   }
                }

--- a/haproxy-mixin/development/haproxy.cfg
+++ b/haproxy-mixin/development/haproxy.cfg
@@ -13,7 +13,6 @@ frontend telemetry
     bind 0.0.0.0:80
     http-request use-service prometheus-exporter if { path /metrics }
     mode http
-    option http-use-htx
     option httplog
     stats enable
 


### PR DESCRIPTION

Fix the Frontend/Backend/Server status tables
Since HAProxy 2.4 the exporter emits haproxy_{frontend,backend,server}_status as one series per state with a state label, so every proxy rendered twice (as Up and Down) and the status color followed the sample value instead of the actual state.

- Filter the status queries with == 1 and build the Status column from the state label 
- Drop option `http-use-htx` from the dev HAProxy config