### PR TITLE
fix: replace broken awesome-prometheus-alerts link

### DIFF
--- a/rabbitmq-mixin/README.md
+++ b/rabbitmq-mixin/README.md
@@ -5,7 +5,7 @@ For more information on the plugin please refer to [Monitoring with Prometheus &
 
 The dashboards were based on those available at RabbitMQ's Grafana organization profile. See [RabbitMQ Organization](https://grafana.com/orgs/rabbitmq/dashboards).
 
-The alerts were based on those published at [https://awesome-prometheus-alerts.grep.to/rules#rabbitmq](https://awesome-prometheus-alerts.grep.to/rules#rabbitmq).
+The alerts were based on those published at [https://samber.github.io/awesome-prometheus-alerts/rules#rabbitmq](https://samber.github.io/awesome-prometheus-alerts/rules#rabbitmq).
 
 To use them, you need to have `mixtool` and `jsonnetfmt` installed. If you have a working Go development environment, it's easiest to run the following:
 


### PR DESCRIPTION
Hi!

The `awesome-prometheus-alerts.grep.to` domain is no longer maintained: the site is gone and the domain now shows a parking page, so the link in this repo is broken.

This PR replaces it with the current home of the project:

https://samber.github.io/awesome-prometheus-alerts

No other changes. Thanks!
