### PR TITLE
feat(mixin-utils): add opt-in lowercase for withRunbookURL anchors

### DIFF
--- a/mixin-utils/test/Makefile
+++ b/mixin-utils/test/Makefile
@@ -6,3 +6,4 @@ vendor jsonnetfile.lock.json: jsonnetfile.json
 tests: jsonnetfile.lock.json vendor
 	jsonnet -J vendor/ ./test_native-classic-histogram.libsonnet
 	jsonnet -J vendor/ ./test_remove_rules.libsonnet
+	jsonnet -J vendor/ ./test_runbook_url.libsonnet

--- a/mixin-utils/test/test_runbook_url.libsonnet
+++ b/mixin-utils/test/test_runbook_url.libsonnet
@@ -1,0 +1,128 @@
+local utils = import '../utils.libsonnet';
+local test = import 'github.com/jsonnet-libs/testonnet/main.libsonnet';
+
+local groups = [
+  {
+    name: 'group1',
+    rules: [
+      {
+        record: 'record1',
+      },
+      {
+        alert: 'MimirIngesterUnhealthy',
+        annotations: {
+          message: 'An ingester is unhealthy.',
+        },
+      },
+    ],
+  },
+  {
+    name: 'group2',
+    rules: [
+      {
+        alert: 'MemcachedDown',
+        annotations: {
+          runbook_url: 'https://example.com/stale',
+        },
+      },
+    ],
+  },
+];
+
+test.new(std.thisFile)
+
++ test.case.new(
+  'withRunbookURL keeps the alert name as-is by default',
+  test.expect.eq(
+    actual=utils.withRunbookURL('https://example.com/runbooks.md#%s', groups),
+    expected=[
+      {
+        name: 'group1',
+        rules: [
+          {
+            record: 'record1',
+          },
+          {
+            alert: 'MimirIngesterUnhealthy',
+            annotations: {
+              message: 'An ingester is unhealthy.',
+              runbook_url: 'https://example.com/runbooks.md#MimirIngesterUnhealthy',
+            },
+          },
+        ],
+      },
+      {
+        name: 'group2',
+        rules: [
+          {
+            alert: 'MemcachedDown',
+            annotations: {
+              runbook_url: 'https://example.com/runbooks.md#MemcachedDown',
+            },
+          },
+        ],
+      },
+    ]
+  )
+)
+
++ test.case.new(
+  'withRunbookURL lowercases the alert name when asked',
+  test.expect.eq(
+    actual=utils.withRunbookURL('https://example.com/runbooks.md#%s', groups, lowercase=true),
+    expected=[
+      {
+        name: 'group1',
+        rules: [
+          {
+            record: 'record1',
+          },
+          {
+            alert: 'MimirIngesterUnhealthy',
+            annotations: {
+              message: 'An ingester is unhealthy.',
+              runbook_url: 'https://example.com/runbooks.md#mimiringesterunhealthy',
+            },
+          },
+        ],
+      },
+      {
+        name: 'group2',
+        rules: [
+          {
+            alert: 'MemcachedDown',
+            annotations: {
+              runbook_url: 'https://example.com/runbooks.md#memcacheddown',
+            },
+          },
+        ],
+      },
+    ]
+  )
+)
+
++ test.case.new(
+  'withRunbookURL honours annotation_key together with lowercase',
+  test.expect.eq(
+    actual=utils.withRunbookURL(
+      'https://example.com/runbooks.md#%s',
+      [groups[1]],
+      annotation_key='runbook_url_internal',
+      lowercase=true,
+    ),
+    expected=[
+      {
+        name: 'group2',
+        rules: [
+          {
+            alert: 'MemcachedDown',
+            annotations: {
+              runbook_url: 'https://example.com/stale',
+              runbook_url_internal: 'https://example.com/runbooks.md#memcacheddown',
+            },
+          },
+        ],
+      },
+    ]
+  )
+)

--- a/mixin-utils/utils.libsonnet
+++ b/mixin-utils/utils.libsonnet
@@ -414,12 +414,16 @@ local g = import 'grafana-builder/grafana.libsonnet';
   // - url_format: an URL format for the runbook, the alert name will be substituted in the URL.
   // - groups: the list of rule groups containing alerts.
   // - annotation_key: the key to use for the annotation whose value will be the formatted runbook URL.
-  withRunbookURL(url_format, groups, annotation_key='runbook_url')::
+  // - lowercase: lowercase the alert name before substituting it. Markdown renderers such as
+  //   GitHub derive a heading's anchor by lowercasing it, so a mixed-case alert name lands at
+  //   the top of the runbook instead of at its section. Off by default, because anchors are
+  //   case-sensitive in some runbook formats (e.g. hand-written HTML anchors).
+  withRunbookURL(url_format, groups, annotation_key='runbook_url', lowercase=false)::
     local update_rule(rule) =
       if std.objectHas(rule, 'alert')
       then rule {
         annotations+: {
-          [annotation_key]: url_format % rule.alert,
+          [annotation_key]: url_format % (if lowercase then std.asciiLower(rule.alert) else rule.alert),
         },
       }
       else rule;


### PR DESCRIPTION
withRunbookURL substitutes the alert name into the URL verbatim. Markdown renderers such as GitHub derive a heading's anchor by lowercasing it, so a mixed-case alert name produces a fragment that never resolves and the reader lands at the top of the runbook instead of at the alert's section.