### PR TITLE
ci: skip test mixin job when no mixin changed

### DIFF
--- a/.github/workflows/test-mixins.yml
+++ b/.github/workflows/test-mixins.yml
@@ -68,6 +68,7 @@ jobs:
 
   lint-mixin:
     name: Test mixin
+    if: needs.check-for-changed-mixins.outputs.changed-mixins != '[]'
     runs-on: ubuntu-latest
     permissions:
       issues: write


### PR DESCRIPTION
an empty matrix is a workflow error, so the Mixin run goes red on any PR that touches no mixin dir (e.g. #1672, #1675, #1700).